### PR TITLE
quicksight: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -77,6 +77,7 @@ jobs:
       # Services
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/mq modern-check
+      - run: make TEST=./internal/service/quicksight/... modern-check
       - run: make TEST=./internal/service/sns modern-check
       - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/quicksight/account_subscription.go
+++ b/internal/service/quicksight/account_subscription.go
@@ -138,7 +138,7 @@ func resourceAccountSubscription() *schema.Resource {
 	}
 }
 
-func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -159,16 +159,16 @@ func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 		input.ActiveDirectoryName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("admin_group"); ok && len(v.([]interface{})) > 0 {
-		input.AdminGroup = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("admin_group"); ok && len(v.([]any)) > 0 {
+		input.AdminGroup = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("author_group"); ok && len(v.([]interface{})) > 0 {
-		input.AuthorGroup = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("author_group"); ok && len(v.([]any)) > 0 {
+		input.AuthorGroup = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("reader_group"); ok && len(v.([]interface{})) > 0 {
-		input.ReaderGroup = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("reader_group"); ok && len(v.([]any)) > 0 {
+		input.ReaderGroup = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk("contact_number"); ok {
@@ -214,7 +214,7 @@ func resourceAccountSubscriptionCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceAccountSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -239,7 +239,7 @@ func resourceAccountSubscriptionRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceAccountSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -307,7 +307,7 @@ func waitAccountSubscriptionDeleted(ctx context.Context, conn *quicksight.Client
 }
 
 func statusAccountSubscription(ctx context.Context, conn *quicksight.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findAccountSubscriptionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/analysis.go
+++ b/internal/service/quicksight/analysis.go
@@ -42,7 +42,7 @@ func resourceAnalysis() *schema.Resource {
 		DeleteWithoutTimeout: resourceAnalysisDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("recovery_window_in_days", 30) //nolint:mnd // 30days is the default value (see below)
 				return []*schema.ResourceData{d}, nil
 			},
@@ -117,7 +117,7 @@ func resourceAnalysis() *schema.Resource {
 	}
 }
 
-func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -134,20 +134,20 @@ func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta in
 		Tags:         getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("definition"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]interface{}))
+	if v, ok := d.GetOk("definition"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]any))
 	}
 
-	if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]interface{}))
+	if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrPermissions); ok && v.(*schema.Set).Len() != 0 {
 		input.Permissions = quicksightschema.ExpandResourcePermissions(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("source_entity"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(v.([]interface{}))
+	if v, ok := d.GetOk("source_entity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(v.([]any))
 	}
 
 	if v, ok := d.Get("theme_arn").(string); ok && v != "" {
@@ -169,7 +169,7 @@ func resourceAnalysisCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceAnalysisRead(ctx, d, meta)...)
 }
 
-func resourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -222,7 +222,7 @@ func resourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -239,13 +239,13 @@ func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("source_entity"); ok {
-			input.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(v.([]interface{}))
+			input.SourceEntity = quicksightschema.ExpandAnalysisSourceEntity(v.([]any))
 		} else {
-			input.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]interface{}))
+			input.Definition = quicksightschema.ExpandAnalysisDefinition(d.Get("definition").([]any))
 		}
 
-		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]interface{}))
+		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]any))
 		}
 
 		if v, ok := d.Get("theme_arn").(string); ok && v != "" {
@@ -291,7 +291,7 @@ func resourceAnalysisUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceAnalysisRead(ctx, d, meta)...)
 }
 
-func resourceAnalysisDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAnalysisDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -448,7 +448,7 @@ func findAnalysisPermissions(ctx context.Context, conn *quicksight.Client, input
 }
 
 func statusAnalysis(ctx context.Context, conn *quicksight.Client, awsAccountID, analysisID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findAnalysisByTwoPartKey(ctx, conn, awsAccountID, analysisID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/analysis_data_source.go
+++ b/internal/service/quicksight/analysis_data_source.go
@@ -71,7 +71,7 @@ func dataSourceAnalysis() *schema.Resource {
 	}
 }
 
-func dataSourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAnalysisRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/dashboard.go
+++ b/internal/service/quicksight/dashboard.go
@@ -124,7 +124,7 @@ const (
 	dashboardLatestVersion int64 = -1
 )
 
-func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -141,24 +141,24 @@ func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta i
 		Tags:         getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("dashboard_publish_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DashboardPublishOptions = quicksightschema.ExpandDashboardPublishOptions(d.Get("dashboard_publish_options").([]interface{}))
+	if v, ok := d.GetOk("dashboard_publish_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DashboardPublishOptions = quicksightschema.ExpandDashboardPublishOptions(d.Get("dashboard_publish_options").([]any))
 	}
 
-	if v, ok := d.GetOk("definition"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Definition = quicksightschema.ExpandDashboardDefinition(d.Get("definition").([]interface{}))
+	if v, ok := d.GetOk("definition"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Definition = quicksightschema.ExpandDashboardDefinition(d.Get("definition").([]any))
 	}
 
-	if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]interface{}))
+	if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrPermissions); ok && v.(*schema.Set).Len() != 0 {
 		input.Permissions = quicksightschema.ExpandResourcePermissions(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("source_entity"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SourceEntity = quicksightschema.ExpandDashboardSourceEntity(v.([]interface{}))
+	if v, ok := d.GetOk("source_entity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SourceEntity = quicksightschema.ExpandDashboardSourceEntity(v.([]any))
 	}
 
 	if v, ok := d.GetOk("version_description"); ok {
@@ -180,7 +180,7 @@ func resourceDashboardCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceDashboardRead(ctx, d, meta)...)
 }
 
-func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -240,7 +240,7 @@ func resourceDashboardRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -257,18 +257,18 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			VersionDescription: aws.String(d.Get("version_description").(string)),
 		}
 
-		if v, ok := d.GetOk("dashboard_publish_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			inputUD.DashboardPublishOptions = quicksightschema.ExpandDashboardPublishOptions(d.Get("dashboard_publish_options").([]interface{}))
+		if v, ok := d.GetOk("dashboard_publish_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			inputUD.DashboardPublishOptions = quicksightschema.ExpandDashboardPublishOptions(d.Get("dashboard_publish_options").([]any))
 		}
 
 		if v, ok := d.GetOk("source_entity"); ok {
-			inputUD.SourceEntity = quicksightschema.ExpandDashboardSourceEntity(v.([]interface{}))
+			inputUD.SourceEntity = quicksightschema.ExpandDashboardSourceEntity(v.([]any))
 		} else {
-			inputUD.Definition = quicksightschema.ExpandDashboardDefinition(d.Get("definition").([]interface{}))
+			inputUD.Definition = quicksightschema.ExpandDashboardDefinition(d.Get("definition").([]any))
 		}
 
-		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			inputUD.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]interface{}))
+		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			inputUD.Parameters = quicksightschema.ExpandParameters(d.Get(names.AttrParameters).([]any))
 		}
 
 		output, err := conn.UpdateDashboard(ctx, inputUD)
@@ -324,7 +324,7 @@ func resourceDashboardUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceDashboardRead(ctx, d, meta)...)
 }
 
-func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDashboardDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -468,7 +468,7 @@ func findDashboardPermissions(ctx context.Context, conn *quicksight.Client, inpu
 }
 
 func statusDashboard(ctx context.Context, conn *quicksight.Client, awsAccountID, dashboardID string, version int64) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDashboardByThreePartKey(ctx, conn, awsAccountID, dashboardID, version)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/data_set.go
+++ b/internal/service/quicksight/data_set.go
@@ -88,9 +88,9 @@ func resourceDataSet() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-			func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 				mode := diff.Get("import_mode").(string)
-				if v, ok := diff.Get("refresh_properties").([]interface{}); ok && v != nil && len(v) > 0 && mode == "DIRECT_QUERY" {
+				if v, ok := diff.Get("refresh_properties").([]any); ok && v != nil && len(v) > 0 && mode == "DIRECT_QUERY" {
 					return fmt.Errorf("refresh_properties cannot be set when import_mode is 'DIRECT_QUERY'")
 				}
 				return nil
@@ -99,7 +99,7 @@ func resourceDataSet() *schema.Resource {
 	}
 }
 
-func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -118,16 +118,16 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Tags:             getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("column_groups"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ColumnGroups = quicksightschema.ExpandColumnGroups(v.([]interface{}))
+	if v, ok := d.GetOk("column_groups"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ColumnGroups = quicksightschema.ExpandColumnGroups(v.([]any))
 	}
 
-	if v, ok := d.GetOk("column_level_permission_rules"); ok && len(v.([]interface{})) > 0 {
-		input.ColumnLevelPermissionRules = quicksightschema.ExpandColumnLevelPermissionRules(v.([]interface{}))
+	if v, ok := d.GetOk("column_level_permission_rules"); ok && len(v.([]any)) > 0 {
+		input.ColumnLevelPermissionRules = quicksightschema.ExpandColumnLevelPermissionRules(v.([]any))
 	}
 
-	if v, ok := d.GetOk("data_set_usage_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DataSetUsageConfiguration = quicksightschema.ExpandDataSetUsageConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("data_set_usage_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DataSetUsageConfiguration = quicksightschema.ExpandDataSetUsageConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("field_folders"); ok && v.(*schema.Set).Len() != 0 {
@@ -142,12 +142,12 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.Permissions = quicksightschema.ExpandResourcePermissions(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("row_level_permission_data_set"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.RowLevelPermissionDataSet = quicksightschema.ExpandRowLevelPermissionDataSet(v.([]interface{}))
+	if v, ok := d.GetOk("row_level_permission_data_set"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.RowLevelPermissionDataSet = quicksightschema.ExpandRowLevelPermissionDataSet(v.([]any))
 	}
 
-	if v, ok := d.GetOk("row_level_permission_tag_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.RowLevelPermissionTagConfiguration = quicksightschema.ExpandRowLevelPermissionTagConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("row_level_permission_tag_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.RowLevelPermissionTagConfiguration = quicksightschema.ExpandRowLevelPermissionTagConfiguration(v.([]any))
 	}
 
 	_, err := conn.CreateDataSet(ctx, input)
@@ -158,11 +158,11 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 
 	d.SetId(id)
 
-	if v, ok := d.GetOk("refresh_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("refresh_properties"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input := &quicksight.PutDataSetRefreshPropertiesInput{
 			AwsAccountId:             aws.String(awsAccountID),
 			DataSetId:                aws.String(dataSetID),
-			DataSetRefreshProperties: quicksightschema.ExpandDataSetRefreshProperties(v.([]interface{})),
+			DataSetRefreshProperties: quicksightschema.ExpandDataSetRefreshProperties(v.([]any)),
 		}
 
 		_, err := conn.PutDataSetRefreshProperties(ctx, input)
@@ -175,7 +175,7 @@ func resourceDataSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceDataSetRead(ctx, d, meta)...)
 }
 
-func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -254,7 +254,7 @@ func resourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -266,17 +266,17 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.HasChangesExcept(names.AttrPermissions, names.AttrTags, names.AttrTagsAll, "refresh_properties") {
 		input := &quicksight.UpdateDataSetInput{
 			AwsAccountId:                       aws.String(awsAccountID),
-			ColumnGroups:                       quicksightschema.ExpandColumnGroups(d.Get("column_groups").([]interface{})),
-			ColumnLevelPermissionRules:         quicksightschema.ExpandColumnLevelPermissionRules(d.Get("column_level_permission_rules").([]interface{})),
+			ColumnGroups:                       quicksightschema.ExpandColumnGroups(d.Get("column_groups").([]any)),
+			ColumnLevelPermissionRules:         quicksightschema.ExpandColumnLevelPermissionRules(d.Get("column_level_permission_rules").([]any)),
 			DataSetId:                          aws.String(dataSetID),
-			DataSetUsageConfiguration:          quicksightschema.ExpandDataSetUsageConfiguration(d.Get("data_set_usage_configuration").([]interface{})),
+			DataSetUsageConfiguration:          quicksightschema.ExpandDataSetUsageConfiguration(d.Get("data_set_usage_configuration").([]any)),
 			FieldFolders:                       quicksightschema.ExpandFieldFolders(d.Get("field_folders").(*schema.Set).List()),
 			ImportMode:                         awstypes.DataSetImportMode(d.Get("import_mode").(string)),
 			LogicalTableMap:                    quicksightschema.ExpandLogicalTableMap(d.Get("logical_table_map").(*schema.Set).List()),
 			Name:                               aws.String(d.Get(names.AttrName).(string)),
 			PhysicalTableMap:                   quicksightschema.ExpandPhysicalTableMap(d.Get("physical_table_map").(*schema.Set).List()),
-			RowLevelPermissionDataSet:          quicksightschema.ExpandRowLevelPermissionDataSet(d.Get("row_level_permission_data_set").([]interface{})),
-			RowLevelPermissionTagConfiguration: quicksightschema.ExpandRowLevelPermissionTagConfiguration(d.Get("row_level_permission_tag_configuration").([]interface{})),
+			RowLevelPermissionDataSet:          quicksightschema.ExpandRowLevelPermissionDataSet(d.Get("row_level_permission_data_set").([]any)),
+			RowLevelPermissionTagConfiguration: quicksightschema.ExpandRowLevelPermissionTagConfiguration(d.Get("row_level_permission_tag_configuration").([]any)),
 		}
 
 		_, err = conn.UpdateDataSet(ctx, input)
@@ -314,7 +314,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if d.HasChange("refresh_properties") {
 		o, n := d.GetChange("refresh_properties")
 
-		if old, new := o.([]interface{}), n.([]interface{}); len(old) == 1 && len(new) == 0 {
+		if old, new := o.([]any), n.([]any); len(old) == 1 && len(new) == 0 {
 			input := &quicksight.DeleteDataSetRefreshPropertiesInput{
 				AwsAccountId: aws.String(awsAccountID),
 				DataSetId:    aws.String(dataSetID),
@@ -343,7 +343,7 @@ func resourceDataSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceDataSetRead(ctx, d, meta)...)
 }
 
-func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/data_set_data_source.go
+++ b/internal/service/quicksight/data_set_data_source.go
@@ -69,7 +69,7 @@ func dataSourceDataSet() *schema.Resource {
 	}
 }
 
-func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/data_source.go
+++ b/internal/service/quicksight/data_source.go
@@ -97,7 +97,7 @@ func resourceDataSource() *schema.Resource {
 	}
 }
 
-func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -110,30 +110,30 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	input := &quicksight.CreateDataSourceInput{
 		AwsAccountId:         aws.String(awsAccountID),
 		DataSourceId:         aws.String(dataSourceID),
-		DataSourceParameters: quicksightschema.ExpandDataSourceParameters(d.Get(names.AttrParameters).([]interface{})),
+		DataSourceParameters: quicksightschema.ExpandDataSourceParameters(d.Get(names.AttrParameters).([]any)),
 		Name:                 aws.String(d.Get(names.AttrName).(string)),
 		Tags:                 getTagsIn(ctx),
 		Type:                 awstypes.DataSourceType(d.Get(names.AttrType).(string)),
 	}
 
-	if v, ok := d.GetOk("credentials"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Credentials = quicksightschema.ExpandDataSourceCredentials(v.([]interface{}))
+	if v, ok := d.GetOk("credentials"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Credentials = quicksightschema.ExpandDataSourceCredentials(v.([]any))
 	}
 
 	if v, ok := d.GetOk("permission"); ok && v.(*schema.Set).Len() != 0 {
 		input.Permissions = quicksightschema.ExpandResourcePermissions(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("ssl_properties"); ok && len(v.([]interface{})) != 0 && v.([]interface{})[0] != nil {
-		input.SslProperties = quicksightschema.ExpandSSLProperties(v.([]interface{}))
+	if v, ok := d.GetOk("ssl_properties"); ok && len(v.([]any)) != 0 && v.([]any)[0] != nil {
+		input.SslProperties = quicksightschema.ExpandSSLProperties(v.([]any))
 	}
 
-	if v, ok := d.GetOk("vpc_connection_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.VpcConnectionProperties = quicksightschema.ExpandVPCConnectionProperties(v.([]interface{}))
+	if v, ok := d.GetOk("vpc_connection_properties"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.VpcConnectionProperties = quicksightschema.ExpandVPCConnectionProperties(v.([]any))
 	}
 
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateDataSource(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -164,7 +164,7 @@ func resourceDataSourceCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
-func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -213,7 +213,7 @@ func resourceDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -229,24 +229,24 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 			Name:         aws.String(d.Get(names.AttrName).(string)),
 		}
 
-		if v, ok := d.GetOk("credentials"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Credentials = quicksightschema.ExpandDataSourceCredentials(v.([]interface{}))
+		if v, ok := d.GetOk("credentials"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.Credentials = quicksightschema.ExpandDataSourceCredentials(v.([]any))
 		}
 
-		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.DataSourceParameters = quicksightschema.ExpandDataSourceParameters(v.([]interface{}))
+		if v, ok := d.GetOk(names.AttrParameters); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.DataSourceParameters = quicksightschema.ExpandDataSourceParameters(v.([]any))
 		}
 
-		if v, ok := d.GetOk("ssl_properties"); ok && len(v.([]interface{})) != 0 && v.([]interface{})[0] != nil {
-			input.SslProperties = quicksightschema.ExpandSSLProperties(v.([]interface{}))
+		if v, ok := d.GetOk("ssl_properties"); ok && len(v.([]any)) != 0 && v.([]any)[0] != nil {
+			input.SslProperties = quicksightschema.ExpandSSLProperties(v.([]any))
 		}
 
-		if v, ok := d.GetOk("vpc_connection_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.VpcConnectionProperties = quicksightschema.ExpandVPCConnectionProperties(v.([]interface{}))
+		if v, ok := d.GetOk("vpc_connection_properties"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.VpcConnectionProperties = quicksightschema.ExpandVPCConnectionProperties(v.([]any))
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.UpdateDataSource(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -301,7 +301,7 @@ func resourceDataSourceUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDataSourceRead(ctx, d, meta)...)
 }
 
-func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataSourceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -407,7 +407,7 @@ func findDataSourcePermissions(ctx context.Context, conn *quicksight.Client, inp
 }
 
 func statusDataSource(ctx context.Context, conn *quicksight.Client, awsAccountID, dataSourceID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDataSourceByTwoPartKey(ctx, conn, awsAccountID, dataSourceID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/folder.go
+++ b/internal/service/quicksight/folder.go
@@ -113,7 +113,7 @@ func resourceFolder() *schema.Resource {
 	}
 }
 
-func resourceFolderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFolderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -153,7 +153,7 @@ func resourceFolderCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceFolderRead(ctx, d, meta)...)
 }
 
-func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -199,7 +199,7 @@ func resourceFolderRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -250,7 +250,7 @@ func resourceFolderUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceFolderRead(ctx, d, meta)...)
 }
 
-func resourceFolderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFolderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/group.go
+++ b/internal/service/quicksight/group.go
@@ -76,7 +76,7 @@ func resourceGroup() *schema.Resource {
 	}
 }
 
-func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -108,7 +108,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -138,7 +138,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -166,7 +166,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/group_data_source.go
+++ b/internal/service/quicksight/group_data_source.go
@@ -57,7 +57,7 @@ func dataSourceGroup() *schema.Resource {
 	}
 }
 
-func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/group_membership.go
+++ b/internal/service/quicksight/group_membership.go
@@ -73,7 +73,7 @@ func resourceGroupMembership() *schema.Resource {
 	}
 }
 
-func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -103,7 +103,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceGroupMembershipRead(ctx, d, meta)...)
 }
 
-func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -132,7 +132,7 @@ func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/iam_policy_assignment.go
+++ b/internal/service/quicksight/iam_policy_assignment.go
@@ -163,7 +163,7 @@ func (r *iamPolicyAssignmentResource) Create(ctx context.Context, req resource.C
 	plan.AssignmentID = flex.StringToFramework(ctx, out.AssignmentId)
 
 	// wait for IAM to propagate before returning
-	_, err = tfresource.RetryWhenNotFound(ctx, iamPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, iamPropagationTimeout, func() (any, error) {
 		return findIAMPolicyAssignmentByThreePartKey(ctx, conn, awsAccountID, namespace, assignmentName)
 	})
 	if err != nil {
@@ -308,7 +308,7 @@ func (r *iamPolicyAssignmentResource) Delete(ctx context.Context, req resource.D
 	}
 
 	// wait for IAM to propagate before returning
-	_, err = tfresource.RetryUntilNotFound(ctx, iamPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, iamPropagationTimeout, func() (any, error) {
 		return findIAMPolicyAssignmentByThreePartKey(ctx, conn, awsAccountID, namespace, assignmentName)
 	})
 	if err != nil {

--- a/internal/service/quicksight/namespace.go
+++ b/internal/service/quicksight/namespace.go
@@ -343,7 +343,7 @@ func waitNamespaceDeleted(ctx context.Context, conn *quicksight.Client, awsAccou
 }
 
 func statusNamespace(ctx context.Context, conn *quicksight.Client, awsAccountID, namespace string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findNamespaceByTwoPartKey(ctx, conn, awsAccountID, namespace)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/role_membership.go
+++ b/internal/service/quicksight/role_membership.go
@@ -6,6 +6,7 @@ package quicksight
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/quicksight"
@@ -198,10 +199,8 @@ func findRoleMembershipByMultiPartKey(ctx context.Context, conn *quicksight.Clie
 		return err
 	}
 
-	for _, m := range out {
-		if m == member {
-			return nil
-		}
+	if slices.Contains(out, member) {
+		return nil
 	}
 
 	return &retry.NotFoundError{

--- a/internal/service/quicksight/schema/analysis.go
+++ b/internal/service/quicksight/schema/analysis.go
@@ -136,26 +136,26 @@ func AnalysisSourceEntitySchema() *schema.Schema {
 	}
 }
 
-func ExpandAnalysisSourceEntity(tfList []interface{}) *awstypes.AnalysisSourceEntity {
+func ExpandAnalysisSourceEntity(tfList []any) *awstypes.AnalysisSourceEntity {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AnalysisSourceEntity{}
 
-	if v, ok := tfMap["source_template"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SourceTemplate = expandAnalysisSourceTemplate(v[0].(map[string]interface{}))
+	if v, ok := tfMap["source_template"].([]any); ok && len(v) > 0 {
+		apiObject.SourceTemplate = expandAnalysisSourceTemplate(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandAnalysisSourceTemplate(tfMap map[string]interface{}) *awstypes.AnalysisSourceTemplate {
+func expandAnalysisSourceTemplate(tfMap map[string]any) *awstypes.AnalysisSourceTemplate {
 	if tfMap == nil {
 		return nil
 	}
@@ -165,56 +165,56 @@ func expandAnalysisSourceTemplate(tfMap map[string]interface{}) *awstypes.Analys
 	if v, ok := tfMap[names.AttrARN].(string); ok && v != "" {
 		apiObject.Arn = aws.String(v)
 	}
-	if v, ok := tfMap["data_set_references"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_references"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetReferences = expandDataSetReferences(v)
 	}
 
 	return apiObject
 }
 
-func ExpandAnalysisDefinition(tfList []interface{}) *awstypes.AnalysisDefinition {
+func ExpandAnalysisDefinition(tfList []any) *awstypes.AnalysisDefinition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AnalysisDefinition{}
 
-	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
 	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.CalculatedFields = expandCalculatedFields(v.List())
 	}
-	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnConfigurations = expandColumnConfigurations(v)
 	}
-	if v, ok := tfMap["data_set_identifiers_declarations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_identifiers_declarations"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetIdentifierDeclarations = expandDataSetIdentifierDeclarations(v)
 	}
-	if v, ok := tfMap["filter_groups"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_groups"].([]any); ok && len(v) > 0 {
 		apiObject.FilterGroups = expandFilterGroups(v)
 	}
 	if v, ok := tfMap["parameter_declarations"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.ParameterDeclarations = expandParameterDeclarations(v.List())
 	}
-	if v, ok := tfMap["sheets"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheets"].([]any); ok && len(v) > 0 {
 		apiObject.Sheets = expandSheetDefinitions(v)
 	}
 
 	return apiObject
 }
 
-func FlattenAnalysisDefinition(apiObject *awstypes.AnalysisDefinition) []interface{} {
+func FlattenAnalysisDefinition(apiObject *awstypes.AnalysisDefinition) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AnalysisDefaults != nil {
 		tfMap["analysis_defaults"] = flattenAnalysisDefaults(apiObject.AnalysisDefaults)
@@ -238,5 +238,5 @@ func FlattenAnalysisDefinition(apiObject *awstypes.AnalysisDefinition) []interfa
 		tfMap["sheets"] = flattenSheetDefinitions(apiObject.Sheets)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/dashboard.go
+++ b/internal/service/quicksight/schema/dashboard.go
@@ -287,26 +287,26 @@ func DashboardSourceEntitySchema() *schema.Schema {
 	}
 }
 
-func ExpandDashboardSourceEntity(tfList []interface{}) *awstypes.DashboardSourceEntity {
+func ExpandDashboardSourceEntity(tfList []any) *awstypes.DashboardSourceEntity {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DashboardSourceEntity{}
 
-	if v, ok := tfMap["source_template"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SourceTemplate = expandDashboardSourceTemplate(v[0].(map[string]interface{}))
+	if v, ok := tfMap["source_template"].([]any); ok && len(v) > 0 {
+		apiObject.SourceTemplate = expandDashboardSourceTemplate(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandDashboardSourceTemplate(tfMap map[string]interface{}) *awstypes.DashboardSourceTemplate {
+func expandDashboardSourceTemplate(tfMap map[string]any) *awstypes.DashboardSourceTemplate {
 	if tfMap == nil {
 		return nil
 	}
@@ -316,97 +316,97 @@ func expandDashboardSourceTemplate(tfMap map[string]interface{}) *awstypes.Dashb
 	if v, ok := tfMap[names.AttrARN].(string); ok && v != "" {
 		apiObject.Arn = aws.String(v)
 	}
-	if v, ok := tfMap["data_set_references"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_references"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetReferences = expandDataSetReferences(v)
 	}
 
 	return apiObject
 }
 
-func ExpandDashboardDefinition(tfList []interface{}) *awstypes.DashboardVersionDefinition {
+func ExpandDashboardDefinition(tfList []any) *awstypes.DashboardVersionDefinition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DashboardVersionDefinition{}
 
-	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
 	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.CalculatedFields = expandCalculatedFields(v.List())
 	}
-	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnConfigurations = expandColumnConfigurations(v)
 	}
-	if v, ok := tfMap["data_set_identifiers_declarations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_identifiers_declarations"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetIdentifierDeclarations = expandDataSetIdentifierDeclarations(v)
 	}
-	if v, ok := tfMap["filter_groups"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_groups"].([]any); ok && len(v) > 0 {
 		apiObject.FilterGroups = expandFilterGroups(v)
 	}
 	if v, ok := tfMap["parameter_declarations"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.ParameterDeclarations = expandParameterDeclarations(v.List())
 	}
-	if v, ok := tfMap["sheets"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheets"].([]any); ok && len(v) > 0 {
 		apiObject.Sheets = expandSheetDefinitions(v)
 	}
 
 	return apiObject
 }
 
-func ExpandDashboardPublishOptions(tfList []interface{}) *awstypes.DashboardPublishOptions {
+func ExpandDashboardPublishOptions(tfList []any) *awstypes.DashboardPublishOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DashboardPublishOptions{}
 
-	if v, ok := tfMap["ad_hoc_filtering_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AdHocFilteringOption = expandAdHocFilteringOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["ad_hoc_filtering_option"].([]any); ok && len(v) > 0 {
+		apiObject.AdHocFilteringOption = expandAdHocFilteringOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["data_point_drill_up_down_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.DataPointDrillUpDownOption = expandDataPointDrillUpDownOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["data_point_drill_up_down_option"].([]any); ok && len(v) > 0 {
+		apiObject.DataPointDrillUpDownOption = expandDataPointDrillUpDownOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["data_point_menu_label_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.DataPointMenuLabelOption = expandDataPointMenuLabelOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["data_point_menu_label_option"].([]any); ok && len(v) > 0 {
+		apiObject.DataPointMenuLabelOption = expandDataPointMenuLabelOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["data_point_tooltip_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.DataPointTooltipOption = expandDataPointTooltipOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["data_point_tooltip_option"].([]any); ok && len(v) > 0 {
+		apiObject.DataPointTooltipOption = expandDataPointTooltipOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["export_to_csv_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ExportToCSVOption = expandExportToCSVOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["export_to_csv_option"].([]any); ok && len(v) > 0 {
+		apiObject.ExportToCSVOption = expandExportToCSVOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["export_with_hidden_fields_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ExportWithHiddenFieldsOption = expandExportWithHiddenFieldsOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["export_with_hidden_fields_option"].([]any); ok && len(v) > 0 {
+		apiObject.ExportWithHiddenFieldsOption = expandExportWithHiddenFieldsOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["sheet_controls_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SheetControlsOption = expandSheetControlsOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["sheet_controls_option"].([]any); ok && len(v) > 0 {
+		apiObject.SheetControlsOption = expandSheetControlsOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["sheet_layout_element_maximization_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SheetLayoutElementMaximizationOption = expandSheetLayoutElementMaximizationOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["sheet_layout_element_maximization_option"].([]any); ok && len(v) > 0 {
+		apiObject.SheetLayoutElementMaximizationOption = expandSheetLayoutElementMaximizationOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["visual_axis_sort_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.VisualAxisSortOption = expandVisualAxisSortOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["visual_axis_sort_option"].([]any); ok && len(v) > 0 {
+		apiObject.VisualAxisSortOption = expandVisualAxisSortOption(v[0].(map[string]any))
 	}
-	if v, ok := tfMap["visual_menu_option"].([]interface{}); ok && len(v) > 0 {
-		apiObject.VisualMenuOption = expandVisualMenuOption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["visual_menu_option"].([]any); ok && len(v) > 0 {
+		apiObject.VisualMenuOption = expandVisualMenuOption(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandAdHocFilteringOption(tfMap map[string]interface{}) *awstypes.AdHocFilteringOption {
+func expandAdHocFilteringOption(tfMap map[string]any) *awstypes.AdHocFilteringOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -420,7 +420,7 @@ func expandAdHocFilteringOption(tfMap map[string]interface{}) *awstypes.AdHocFil
 	return apiObject
 }
 
-func expandDataPointDrillUpDownOption(tfMap map[string]interface{}) *awstypes.DataPointDrillUpDownOption {
+func expandDataPointDrillUpDownOption(tfMap map[string]any) *awstypes.DataPointDrillUpDownOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -434,7 +434,7 @@ func expandDataPointDrillUpDownOption(tfMap map[string]interface{}) *awstypes.Da
 	return apiObject
 }
 
-func expandDataPointMenuLabelOption(tfMap map[string]interface{}) *awstypes.DataPointMenuLabelOption {
+func expandDataPointMenuLabelOption(tfMap map[string]any) *awstypes.DataPointMenuLabelOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -448,7 +448,7 @@ func expandDataPointMenuLabelOption(tfMap map[string]interface{}) *awstypes.Data
 	return apiObject
 }
 
-func expandDataPointTooltipOption(tfMap map[string]interface{}) *awstypes.DataPointTooltipOption {
+func expandDataPointTooltipOption(tfMap map[string]any) *awstypes.DataPointTooltipOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -462,7 +462,7 @@ func expandDataPointTooltipOption(tfMap map[string]interface{}) *awstypes.DataPo
 	return apiObject
 }
 
-func expandExportToCSVOption(tfMap map[string]interface{}) *awstypes.ExportToCSVOption {
+func expandExportToCSVOption(tfMap map[string]any) *awstypes.ExportToCSVOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -476,7 +476,7 @@ func expandExportToCSVOption(tfMap map[string]interface{}) *awstypes.ExportToCSV
 	return apiObject
 }
 
-func expandExportWithHiddenFieldsOption(tfMap map[string]interface{}) *awstypes.ExportWithHiddenFieldsOption {
+func expandExportWithHiddenFieldsOption(tfMap map[string]any) *awstypes.ExportWithHiddenFieldsOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -490,7 +490,7 @@ func expandExportWithHiddenFieldsOption(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func expandSheetLayoutElementMaximizationOption(tfMap map[string]interface{}) *awstypes.SheetLayoutElementMaximizationOption {
+func expandSheetLayoutElementMaximizationOption(tfMap map[string]any) *awstypes.SheetLayoutElementMaximizationOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -504,7 +504,7 @@ func expandSheetLayoutElementMaximizationOption(tfMap map[string]interface{}) *a
 	return apiObject
 }
 
-func expandSheetControlsOption(tfMap map[string]interface{}) *awstypes.SheetControlsOption {
+func expandSheetControlsOption(tfMap map[string]any) *awstypes.SheetControlsOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -518,7 +518,7 @@ func expandSheetControlsOption(tfMap map[string]interface{}) *awstypes.SheetCont
 	return apiObject
 }
 
-func expandVisualAxisSortOption(tfMap map[string]interface{}) *awstypes.VisualAxisSortOption {
+func expandVisualAxisSortOption(tfMap map[string]any) *awstypes.VisualAxisSortOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -532,7 +532,7 @@ func expandVisualAxisSortOption(tfMap map[string]interface{}) *awstypes.VisualAx
 	return apiObject
 }
 
-func expandVisualMenuOption(tfMap map[string]interface{}) *awstypes.VisualMenuOption {
+func expandVisualMenuOption(tfMap map[string]any) *awstypes.VisualMenuOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -546,12 +546,12 @@ func expandVisualMenuOption(tfMap map[string]interface{}) *awstypes.VisualMenuOp
 	return apiObject
 }
 
-func FlattenDashboardDefinition(apiObject *awstypes.DashboardVersionDefinition) []interface{} {
+func FlattenDashboardDefinition(apiObject *awstypes.DashboardVersionDefinition) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AnalysisDefaults != nil {
 		tfMap["analysis_defaults"] = flattenAnalysisDefaults(apiObject.AnalysisDefaults)
@@ -575,15 +575,15 @@ func FlattenDashboardDefinition(apiObject *awstypes.DashboardVersionDefinition) 
 		tfMap["sheets"] = flattenSheetDefinitions(apiObject.Sheets)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenDashboardPublishOptions(apiObject *awstypes.DashboardPublishOptions) []interface{} {
+func FlattenDashboardPublishOptions(apiObject *awstypes.DashboardPublishOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AdHocFilteringOption != nil {
 		tfMap["ad_hoc_filtering_option"] = flattenAdHocFilteringOption(apiObject.AdHocFilteringOption)
@@ -616,125 +616,125 @@ func FlattenDashboardPublishOptions(apiObject *awstypes.DashboardPublishOptions)
 		tfMap["visual_menu_option"] = flattenVisualMenuOption(apiObject.VisualMenuOption)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAdHocFilteringOption(apiObject *awstypes.AdHocFilteringOption) []interface{} {
+func flattenAdHocFilteringOption(apiObject *awstypes.AdHocFilteringOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPointDrillUpDownOption(apiObject *awstypes.DataPointDrillUpDownOption) []interface{} {
+func flattenDataPointDrillUpDownOption(apiObject *awstypes.DataPointDrillUpDownOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPointMenuLabelOption(apiObject *awstypes.DataPointMenuLabelOption) []interface{} {
+func flattenDataPointMenuLabelOption(apiObject *awstypes.DataPointMenuLabelOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPointTooltipOption(apiObject *awstypes.DataPointTooltipOption) []interface{} {
+func flattenDataPointTooltipOption(apiObject *awstypes.DataPointTooltipOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenExportToCSVOption(apiObject *awstypes.ExportToCSVOption) []interface{} {
+func flattenExportToCSVOption(apiObject *awstypes.ExportToCSVOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenExportWithHiddenFieldsOption(apiObject *awstypes.ExportWithHiddenFieldsOption) []interface{} {
+func flattenExportWithHiddenFieldsOption(apiObject *awstypes.ExportWithHiddenFieldsOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSheetControlsOption(apiObject *awstypes.SheetControlsOption) []interface{} {
+func flattenSheetControlsOption(apiObject *awstypes.SheetControlsOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility_state": apiObject.VisibilityState,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSheetLayoutElementMaximizationOption(apiObject *awstypes.SheetLayoutElementMaximizationOption) []interface{} {
+func flattenSheetLayoutElementMaximizationOption(apiObject *awstypes.SheetLayoutElementMaximizationOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisualAxisSortOption(apiObject *awstypes.VisualAxisSortOption) []interface{} {
+func flattenVisualAxisSortOption(apiObject *awstypes.VisualAxisSortOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisualMenuOption(apiObject *awstypes.VisualMenuOption) []interface{} {
+func flattenVisualMenuOption(apiObject *awstypes.VisualMenuOption) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"availability_status": apiObject.AvailabilityStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -604,7 +604,7 @@ func DataSetRefreshPropertiesSchema() *schema.Schema {
 	}
 }
 
-func ExpandColumnGroups(tfList []interface{}) []awstypes.ColumnGroup {
+func ExpandColumnGroups(tfList []any) []awstypes.ColumnGroup {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -612,7 +612,7 @@ func ExpandColumnGroups(tfList []interface{}) []awstypes.ColumnGroup {
 	var apiObjects []awstypes.ColumnGroup
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -628,28 +628,28 @@ func ExpandColumnGroups(tfList []interface{}) []awstypes.ColumnGroup {
 	return apiObjects
 }
 
-func expandColumnGroup(tfMap map[string]interface{}) *awstypes.ColumnGroup {
+func expandColumnGroup(tfMap map[string]any) *awstypes.ColumnGroup {
 	if len(tfMap) == 0 {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnGroup{}
 
-	if tfMapRaw, ok := tfMap["geo_spatial_column_group"].([]interface{}); ok {
-		apiObject.GeoSpatialColumnGroup = expandGeoSpatialColumnGroup(tfMapRaw[0].(map[string]interface{}))
+	if tfMapRaw, ok := tfMap["geo_spatial_column_group"].([]any); ok {
+		apiObject.GeoSpatialColumnGroup = expandGeoSpatialColumnGroup(tfMapRaw[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandGeoSpatialColumnGroup(tfMap map[string]interface{}) *awstypes.GeoSpatialColumnGroup {
+func expandGeoSpatialColumnGroup(tfMap map[string]any) *awstypes.GeoSpatialColumnGroup {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.GeoSpatialColumnGroup{}
 
-	if v, ok := tfMap["columns"].([]interface{}); ok {
+	if v, ok := tfMap["columns"].([]any); ok {
 		apiObject.Columns = flex.ExpandStringValueList(v)
 	}
 	if v, ok := tfMap["country_code"].(string); ok && v != "" {
@@ -662,7 +662,7 @@ func expandGeoSpatialColumnGroup(tfMap map[string]interface{}) *awstypes.GeoSpat
 	return apiObject
 }
 
-func ExpandColumnLevelPermissionRules(tfList []interface{}) []awstypes.ColumnLevelPermissionRule {
+func ExpandColumnLevelPermissionRules(tfList []any) []awstypes.ColumnLevelPermissionRule {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -670,17 +670,17 @@ func ExpandColumnLevelPermissionRules(tfList []interface{}) []awstypes.ColumnLev
 	var apiObjects []awstypes.ColumnLevelPermissionRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		apiObject := awstypes.ColumnLevelPermissionRule{}
 
-		if v, ok := tfMap["column_names"].([]interface{}); ok {
+		if v, ok := tfMap["column_names"].([]any); ok {
 			apiObject.ColumnNames = flex.ExpandStringValueList(v)
 		}
-		if v, ok := tfMap["principals"].([]interface{}); ok {
+		if v, ok := tfMap["principals"].([]any); ok {
 			apiObject.Principals = flex.ExpandStringValueList(v)
 		}
 
@@ -690,12 +690,12 @@ func ExpandColumnLevelPermissionRules(tfList []interface{}) []awstypes.ColumnLev
 	return apiObjects
 }
 
-func ExpandDataSetUsageConfiguration(tfList []interface{}) *awstypes.DataSetUsageConfiguration {
+func ExpandDataSetUsageConfiguration(tfList []any) *awstypes.DataSetUsageConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -712,7 +712,7 @@ func ExpandDataSetUsageConfiguration(tfList []interface{}) *awstypes.DataSetUsag
 	return apiObject
 }
 
-func ExpandFieldFolders(tfList []interface{}) map[string]awstypes.FieldFolder {
+func ExpandFieldFolders(tfList []any) map[string]awstypes.FieldFolder {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -720,14 +720,14 @@ func ExpandFieldFolders(tfList []interface{}) map[string]awstypes.FieldFolder {
 	apiObjects := make(map[string]awstypes.FieldFolder)
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		apiObject := awstypes.FieldFolder{}
 
-		if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["columns"].([]any); ok && len(v) > 0 {
 			apiObject.Columns = flex.ExpandStringValueList(v)
 		}
 		if v, ok := tfMap[names.AttrDescription].(string); ok {
@@ -740,7 +740,7 @@ func ExpandFieldFolders(tfList []interface{}) map[string]awstypes.FieldFolder {
 	return apiObjects
 }
 
-func ExpandLogicalTableMap(tfList []interface{}) map[string]awstypes.LogicalTable {
+func ExpandLogicalTableMap(tfList []any) map[string]awstypes.LogicalTable {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -748,7 +748,7 @@ func ExpandLogicalTableMap(tfList []interface{}) map[string]awstypes.LogicalTabl
 	apiObjects := make(map[string]awstypes.LogicalTable)
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -758,10 +758,10 @@ func ExpandLogicalTableMap(tfList []interface{}) map[string]awstypes.LogicalTabl
 		if v, ok := tfMap[names.AttrAlias].(string); ok {
 			apiObject.Alias = aws.String(v)
 		}
-		if v, ok := tfMap[names.AttrSource].([]interface{}); ok {
-			apiObject.Source = expandLogicalTableSource(v[0].(map[string]interface{}))
+		if v, ok := tfMap[names.AttrSource].([]any); ok {
+			apiObject.Source = expandLogicalTableSource(v[0].(map[string]any))
 		}
-		if v, ok := tfMap["data_transforms"].([]interface{}); ok {
+		if v, ok := tfMap["data_transforms"].([]any); ok {
 			apiObject.DataTransforms = expandTransformOperations(v)
 		}
 
@@ -771,7 +771,7 @@ func ExpandLogicalTableMap(tfList []interface{}) map[string]awstypes.LogicalTabl
 	return apiObjects
 }
 
-func expandLogicalTableSource(tfMap map[string]interface{}) *awstypes.LogicalTableSource {
+func expandLogicalTableSource(tfMap map[string]any) *awstypes.LogicalTableSource {
 	if tfMap == nil {
 		return nil
 	}
@@ -784,14 +784,14 @@ func expandLogicalTableSource(tfMap map[string]interface{}) *awstypes.LogicalTab
 	if v, ok := tfMap["physical_table_id"].(string); ok && v != "" {
 		apiObject.PhysicalTableId = aws.String(v)
 	}
-	if v, ok := tfMap["join_instruction"].([]interface{}); ok && len(v) > 0 {
-		apiObject.JoinInstruction = expandJoinInstruction(v[0].(map[string]interface{}))
+	if v, ok := tfMap["join_instruction"].([]any); ok && len(v) > 0 {
+		apiObject.JoinInstruction = expandJoinInstruction(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandJoinInstruction(tfMap map[string]interface{}) *awstypes.JoinInstruction {
+func expandJoinInstruction(tfMap map[string]any) *awstypes.JoinInstruction {
 	if tfMap == nil {
 		return nil
 	}
@@ -810,17 +810,17 @@ func expandJoinInstruction(tfMap map[string]interface{}) *awstypes.JoinInstructi
 	if v, ok := tfMap[names.AttrType].(string); ok {
 		apiObject.Type = awstypes.JoinType(v)
 	}
-	if v, ok := tfMap["left_join_key_properties"].(map[string]interface{}); ok {
+	if v, ok := tfMap["left_join_key_properties"].(map[string]any); ok {
 		apiObject.LeftJoinKeyProperties = expandJoinKeyProperties(v)
 	}
-	if v, ok := tfMap["right_join_key_properties"].(map[string]interface{}); ok {
+	if v, ok := tfMap["right_join_key_properties"].(map[string]any); ok {
 		apiObject.RightJoinKeyProperties = expandJoinKeyProperties(v)
 	}
 
 	return apiObject
 }
 
-func expandJoinKeyProperties(tfMap map[string]interface{}) *awstypes.JoinKeyProperties {
+func expandJoinKeyProperties(tfMap map[string]any) *awstypes.JoinKeyProperties {
 	if tfMap == nil {
 		return nil
 	}
@@ -834,7 +834,7 @@ func expandJoinKeyProperties(tfMap map[string]interface{}) *awstypes.JoinKeyProp
 	return apiObject
 }
 
-func expandTransformOperations(tfList []interface{}) []awstypes.TransformOperation {
+func expandTransformOperations(tfList []any) []awstypes.TransformOperation {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -842,7 +842,7 @@ func expandTransformOperations(tfList []interface{}) []awstypes.TransformOperati
 	var apiObjects []awstypes.TransformOperation
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -858,56 +858,56 @@ func expandTransformOperations(tfList []interface{}) []awstypes.TransformOperati
 	return apiObjects
 }
 
-func expandTransformOperation(tfMap map[string]interface{}) awstypes.TransformOperation {
+func expandTransformOperation(tfMap map[string]any) awstypes.TransformOperation {
 	if tfMap == nil {
 		return nil
 	}
 
 	var apiObject awstypes.TransformOperation
 
-	if v, ok := tfMap["cast_column_type_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cast_column_type_operation"].([]any); ok && len(v) > 0 {
 		if v := expandCastColumnTypeOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberCastColumnTypeOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["create_columns_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["create_columns_operation"].([]any); ok && len(v) > 0 {
 		if v := expandCreateColumnsOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberCreateColumnsOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["filter_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_operation"].([]any); ok && len(v) > 0 {
 		if v := expandFilterOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberFilterOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["project_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["project_operation"].([]any); ok && len(v) > 0 {
 		if v := expandProjectOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberProjectOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["rename_column_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rename_column_operation"].([]any); ok && len(v) > 0 {
 		if v := expandRenameColumnOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberRenameColumnOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["tag_column_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tag_column_operation"].([]any); ok && len(v) > 0 {
 		if v := expandTagColumnOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberTagColumnOperation{
 				Value: *v,
 			}
 		}
 	}
-	if v, ok := tfMap["untag_column_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["untag_column_operation"].([]any); ok && len(v) > 0 {
 		if v := expandUntagColumnOperation(v); v != nil {
 			apiObject = &awstypes.TransformOperationMemberUntagColumnOperation{
 				Value: *v,
@@ -918,12 +918,12 @@ func expandTransformOperation(tfMap map[string]interface{}) awstypes.TransformOp
 	return apiObject
 }
 
-func expandCastColumnTypeOperation(tfList []interface{}) *awstypes.CastColumnTypeOperation {
+func expandCastColumnTypeOperation(tfList []any) *awstypes.CastColumnTypeOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -943,26 +943,26 @@ func expandCastColumnTypeOperation(tfList []interface{}) *awstypes.CastColumnTyp
 	return apiObject
 }
 
-func expandCreateColumnsOperation(tfList []interface{}) *awstypes.CreateColumnsOperation {
+func expandCreateColumnsOperation(tfList []any) *awstypes.CreateColumnsOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CreateColumnsOperation{}
 
-	if v, ok := tfMap["columns"].([]interface{}); ok {
+	if v, ok := tfMap["columns"].([]any); ok {
 		apiObject.Columns = expandCalculatedColumns(v)
 	}
 
 	return apiObject
 }
 
-func expandCalculatedColumns(tfList []interface{}) []awstypes.CalculatedColumn {
+func expandCalculatedColumns(tfList []any) []awstypes.CalculatedColumn {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -970,7 +970,7 @@ func expandCalculatedColumns(tfList []interface{}) []awstypes.CalculatedColumn {
 	var apiObjects []awstypes.CalculatedColumn
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -986,7 +986,7 @@ func expandCalculatedColumns(tfList []interface{}) []awstypes.CalculatedColumn {
 	return apiObjects
 }
 
-func expandCalculatedColumn(tfMap map[string]interface{}) *awstypes.CalculatedColumn {
+func expandCalculatedColumn(tfMap map[string]any) *awstypes.CalculatedColumn {
 	if tfMap == nil {
 		return nil
 	}
@@ -1006,12 +1006,12 @@ func expandCalculatedColumn(tfMap map[string]interface{}) *awstypes.CalculatedCo
 	return apiObject
 }
 
-func expandFilterOperation(tfList []interface{}) *awstypes.FilterOperation {
+func expandFilterOperation(tfList []any) *awstypes.FilterOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1025,31 +1025,31 @@ func expandFilterOperation(tfList []interface{}) *awstypes.FilterOperation {
 	return apiObject
 }
 
-func expandProjectOperation(tfList []interface{}) *awstypes.ProjectOperation {
+func expandProjectOperation(tfList []any) *awstypes.ProjectOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ProjectOperation{}
 
-	if v, ok := tfMap["projected_columns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["projected_columns"].([]any); ok && len(v) > 0 {
 		apiObject.ProjectedColumns = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandRenameColumnOperation(tfList []interface{}) *awstypes.RenameColumnOperation {
+func expandRenameColumnOperation(tfList []any) *awstypes.RenameColumnOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1066,12 +1066,12 @@ func expandRenameColumnOperation(tfList []interface{}) *awstypes.RenameColumnOpe
 	return apiObject
 }
 
-func expandTagColumnOperation(tfList []interface{}) *awstypes.TagColumnOperation {
+func expandTagColumnOperation(tfList []any) *awstypes.TagColumnOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1081,14 +1081,14 @@ func expandTagColumnOperation(tfList []interface{}) *awstypes.TagColumnOperation
 	if v, ok := tfMap["column_name"].(string); ok {
 		apiObject.ColumnName = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrTags].([]interface{}); ok {
+	if v, ok := tfMap[names.AttrTags].([]any); ok {
 		apiObject.Tags = expandColumnTags(v)
 	}
 
 	return apiObject
 }
 
-func expandColumnTags(tfList []interface{}) []awstypes.ColumnTag {
+func expandColumnTags(tfList []any) []awstypes.ColumnTag {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1096,7 +1096,7 @@ func expandColumnTags(tfList []interface{}) []awstypes.ColumnTag {
 	var apiObjects []awstypes.ColumnTag
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1112,14 +1112,14 @@ func expandColumnTags(tfList []interface{}) []awstypes.ColumnTag {
 	return apiObjects
 }
 
-func expandColumnTag(tfMap map[string]interface{}) *awstypes.ColumnTag {
+func expandColumnTag(tfMap map[string]any) *awstypes.ColumnTag {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnTag{}
 
-	if v, ok := tfMap["column_description"].([]interface{}); ok {
+	if v, ok := tfMap["column_description"].([]any); ok {
 		apiObject.ColumnDescription = expandColumnDescription(v)
 	}
 	if v, ok := tfMap["column_geographic_role"].(string); ok {
@@ -1129,12 +1129,12 @@ func expandColumnTag(tfMap map[string]interface{}) *awstypes.ColumnTag {
 	return apiObject
 }
 
-func expandColumnDescription(tfList []interface{}) *awstypes.ColumnDescription {
+func expandColumnDescription(tfList []any) *awstypes.ColumnDescription {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1147,12 +1147,12 @@ func expandColumnDescription(tfList []interface{}) *awstypes.ColumnDescription {
 	return apiObject
 }
 
-func expandUntagColumnOperation(tfList []interface{}) *awstypes.UntagColumnOperation {
+func expandUntagColumnOperation(tfList []any) *awstypes.UntagColumnOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1162,40 +1162,40 @@ func expandUntagColumnOperation(tfList []interface{}) *awstypes.UntagColumnOpera
 	if v, ok := tfMap["column_name"].(string); ok {
 		apiObject.ColumnName = aws.String(v)
 	}
-	if v, ok := tfMap["tag_names"].([]interface{}); ok {
+	if v, ok := tfMap["tag_names"].([]any); ok {
 		apiObject.TagNames = flex.ExpandStringyValueList[awstypes.ColumnTagName](v)
 	}
 
 	return apiObject
 }
 
-func ExpandPhysicalTableMap(tfList []interface{}) map[string]awstypes.PhysicalTable {
+func ExpandPhysicalTableMap(tfList []any) map[string]awstypes.PhysicalTable {
 	apiObjects := make(map[string]awstypes.PhysicalTable)
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		var apiObject awstypes.PhysicalTable
 
-		if v, ok := tfMap["custom_sql"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			if v := expandCustomSQL(v[0].(map[string]interface{})); v != nil {
+		if v, ok := tfMap["custom_sql"].([]any); ok && len(v) > 0 && v[0] != nil {
+			if v := expandCustomSQL(v[0].(map[string]any)); v != nil {
 				apiObject = &awstypes.PhysicalTableMemberCustomSql{
 					Value: *v,
 				}
 			}
 		}
-		if v, ok := tfMap["relational_table"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			if v := expandRelationalTable(v[0].(map[string]interface{})); v != nil {
+		if v, ok := tfMap["relational_table"].([]any); ok && len(v) > 0 && v[0] != nil {
+			if v := expandRelationalTable(v[0].(map[string]any)); v != nil {
 				apiObject = &awstypes.PhysicalTableMemberRelationalTable{
 					Value: *v,
 				}
 			}
 		}
-		if v, ok := tfMap["s3_source"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			if v := expandS3Source(v[0].(map[string]interface{})); v != nil {
+		if v, ok := tfMap["s3_source"].([]any); ok && len(v) > 0 && v[0] != nil {
+			if v := expandS3Source(v[0].(map[string]any)); v != nil {
 				apiObject = &awstypes.PhysicalTableMemberS3Source{
 					Value: *v,
 				}
@@ -1208,14 +1208,14 @@ func ExpandPhysicalTableMap(tfList []interface{}) map[string]awstypes.PhysicalTa
 	return apiObjects
 }
 
-func expandCustomSQL(tfMap map[string]interface{}) *awstypes.CustomSql {
+func expandCustomSQL(tfMap map[string]any) *awstypes.CustomSql {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomSql{}
 
-	if v, ok := tfMap["columns"].([]interface{}); ok {
+	if v, ok := tfMap["columns"].([]any); ok {
 		apiObject.Columns = expandInputColumns(v)
 	}
 	if v, ok := tfMap["data_source_arn"].(string); ok {
@@ -1231,7 +1231,7 @@ func expandCustomSQL(tfMap map[string]interface{}) *awstypes.CustomSql {
 	return apiObject
 }
 
-func expandInputColumns(tfList []interface{}) []awstypes.InputColumn {
+func expandInputColumns(tfList []any) []awstypes.InputColumn {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1239,7 +1239,7 @@ func expandInputColumns(tfList []interface{}) []awstypes.InputColumn {
 	var apiObjects []awstypes.InputColumn
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1255,7 +1255,7 @@ func expandInputColumns(tfList []interface{}) []awstypes.InputColumn {
 	return apiObjects
 }
 
-func expandInputColumn(tfMap map[string]interface{}) *awstypes.InputColumn {
+func expandInputColumn(tfMap map[string]any) *awstypes.InputColumn {
 	if tfMap == nil {
 		return nil
 	}
@@ -1272,14 +1272,14 @@ func expandInputColumn(tfMap map[string]interface{}) *awstypes.InputColumn {
 	return apiObject
 }
 
-func expandRelationalTable(tfMap map[string]interface{}) *awstypes.RelationalTable {
+func expandRelationalTable(tfMap map[string]any) *awstypes.RelationalTable {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.RelationalTable{}
 
-	if v, ok := tfMap["input_columns"].([]interface{}); ok {
+	if v, ok := tfMap["input_columns"].([]any); ok {
 		apiObject.InputColumns = expandInputColumns(v)
 	}
 	if v, ok := tfMap["catalog"].(string); ok {
@@ -1298,17 +1298,17 @@ func expandRelationalTable(tfMap map[string]interface{}) *awstypes.RelationalTab
 	return apiObject
 }
 
-func expandS3Source(tfMap map[string]interface{}) *awstypes.S3Source {
+func expandS3Source(tfMap map[string]any) *awstypes.S3Source {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.S3Source{}
 
-	if v, ok := tfMap["input_columns"].([]interface{}); ok {
+	if v, ok := tfMap["input_columns"].([]any); ok {
 		apiObject.InputColumns = expandInputColumns(v)
 	}
-	if v, ok := tfMap["upload_settings"].(map[string]interface{}); ok {
+	if v, ok := tfMap["upload_settings"].(map[string]any); ok {
 		apiObject.UploadSettings = expandUploadSettings(v)
 	}
 	if v, ok := tfMap["data_source_arn"].(string); ok {
@@ -1318,7 +1318,7 @@ func expandS3Source(tfMap map[string]interface{}) *awstypes.S3Source {
 	return apiObject
 }
 
-func expandUploadSettings(tfMap map[string]interface{}) *awstypes.UploadSettings {
+func expandUploadSettings(tfMap map[string]any) *awstypes.UploadSettings {
 	if tfMap == nil {
 		return nil
 	}
@@ -1344,12 +1344,12 @@ func expandUploadSettings(tfMap map[string]interface{}) *awstypes.UploadSettings
 	return apiObject
 }
 
-func ExpandRowLevelPermissionDataSet(tfList []interface{}) *awstypes.RowLevelPermissionDataSet {
+func ExpandRowLevelPermissionDataSet(tfList []any) *awstypes.RowLevelPermissionDataSet {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1375,19 +1375,19 @@ func ExpandRowLevelPermissionDataSet(tfList []interface{}) *awstypes.RowLevelPer
 	return apiObject
 }
 
-func ExpandRowLevelPermissionTagConfiguration(tfList []interface{}) *awstypes.RowLevelPermissionTagConfiguration {
+func ExpandRowLevelPermissionTagConfiguration(tfList []any) *awstypes.RowLevelPermissionTagConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RowLevelPermissionTagConfiguration{}
 
-	if v, ok := tfMap["tag_rules"].([]interface{}); ok {
+	if v, ok := tfMap["tag_rules"].([]any); ok {
 		apiObject.TagRules = expandRowLevelPermissionTagRules(v)
 	}
 	if v, ok := tfMap[names.AttrStatus].(string); ok {
@@ -1397,69 +1397,69 @@ func ExpandRowLevelPermissionTagConfiguration(tfList []interface{}) *awstypes.Ro
 	return apiObject
 }
 
-func ExpandDataSetRefreshProperties(tfList []interface{}) *awstypes.DataSetRefreshProperties {
+func ExpandDataSetRefreshProperties(tfList []any) *awstypes.DataSetRefreshProperties {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DataSetRefreshProperties{}
 
-	if v, ok := tfMap["refresh_configuration"].([]interface{}); ok {
+	if v, ok := tfMap["refresh_configuration"].([]any); ok {
 		apiObject.RefreshConfiguration = expandRefreshConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandRefreshConfiguration(tfList []interface{}) *awstypes.RefreshConfiguration {
+func expandRefreshConfiguration(tfList []any) *awstypes.RefreshConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RefreshConfiguration{}
 
-	if v, ok := tfMap["incremental_refresh"].([]interface{}); ok {
+	if v, ok := tfMap["incremental_refresh"].([]any); ok {
 		apiObject.IncrementalRefresh = expandIncrementalRefresh(v)
 	}
 
 	return apiObject
 }
 
-func expandIncrementalRefresh(tfList []interface{}) *awstypes.IncrementalRefresh {
+func expandIncrementalRefresh(tfList []any) *awstypes.IncrementalRefresh {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.IncrementalRefresh{}
 
-	if v, ok := tfMap["lookback_window"].([]interface{}); ok {
+	if v, ok := tfMap["lookback_window"].([]any); ok {
 		apiObject.LookbackWindow = expandLookbackWindow(v)
 	}
 
 	return apiObject
 }
 
-func expandLookbackWindow(tfList []interface{}) *awstypes.LookbackWindow {
+func expandLookbackWindow(tfList []any) *awstypes.LookbackWindow {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1479,7 +1479,7 @@ func expandLookbackWindow(tfList []interface{}) *awstypes.LookbackWindow {
 	return apiObject
 }
 
-func expandRowLevelPermissionTagRules(tfList []interface{}) []awstypes.RowLevelPermissionTagRule {
+func expandRowLevelPermissionTagRules(tfList []any) []awstypes.RowLevelPermissionTagRule {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1487,7 +1487,7 @@ func expandRowLevelPermissionTagRules(tfList []interface{}) []awstypes.RowLevelP
 	var apiObjects []awstypes.RowLevelPermissionTagRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1503,7 +1503,7 @@ func expandRowLevelPermissionTagRules(tfList []interface{}) []awstypes.RowLevelP
 	return apiObjects
 }
 
-func expandRowLevelPermissionTagRule(tfMap map[string]interface{}) *awstypes.RowLevelPermissionTagRule {
+func expandRowLevelPermissionTagRule(tfMap map[string]any) *awstypes.RowLevelPermissionTagRule {
 	if tfMap == nil {
 		return nil
 	}
@@ -1526,15 +1526,15 @@ func expandRowLevelPermissionTagRule(tfMap map[string]interface{}) *awstypes.Row
 	return apiObject
 }
 
-func FlattenColumnGroups(apiObjects []awstypes.ColumnGroup) []interface{} {
+func FlattenColumnGroups(apiObjects []awstypes.ColumnGroup) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.GeoSpatialColumnGroup != nil {
 			tfMap["geo_spatial_column_group"] = flattenGeoSpatialColumnGroup(apiObject.GeoSpatialColumnGroup)
@@ -1546,15 +1546,15 @@ func FlattenColumnGroups(apiObjects []awstypes.ColumnGroup) []interface{} {
 	return tfList
 }
 
-func FlattenOutputColumns(apiObjects []awstypes.OutputColumn) []interface{} {
+func FlattenOutputColumns(apiObjects []awstypes.OutputColumn) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Description != nil {
 			tfMap[names.AttrDescription] = aws.ToString(apiObject.Description)
@@ -1570,12 +1570,12 @@ func FlattenOutputColumns(apiObjects []awstypes.OutputColumn) []interface{} {
 	return tfList
 }
 
-func flattenGeoSpatialColumnGroup(apiObject *awstypes.GeoSpatialColumnGroup) []interface{} {
+func flattenGeoSpatialColumnGroup(apiObject *awstypes.GeoSpatialColumnGroup) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = apiObject.Columns
@@ -1585,18 +1585,18 @@ func flattenGeoSpatialColumnGroup(apiObject *awstypes.GeoSpatialColumnGroup) []i
 		tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenColumnLevelPermissionRules(apiObjects []awstypes.ColumnLevelPermissionRule) []interface{} {
+func FlattenColumnLevelPermissionRules(apiObjects []awstypes.ColumnLevelPermissionRule) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnNames != nil {
 			tfMap["column_names"] = apiObject.ColumnNames
@@ -1611,28 +1611,28 @@ func FlattenColumnLevelPermissionRules(apiObjects []awstypes.ColumnLevelPermissi
 	return tfList
 }
 
-func FlattenDataSetUsageConfiguration(apiObject *awstypes.DataSetUsageConfiguration) []interface{} {
+func FlattenDataSetUsageConfiguration(apiObject *awstypes.DataSetUsageConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["disable_use_as_direct_query_source"] = apiObject.DisableUseAsDirectQuerySource
 	tfMap["disable_use_as_imported_source"] = apiObject.DisableUseAsImportedSource
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenFieldFolders(apiObjects map[string]awstypes.FieldFolder) []interface{} {
+func FlattenFieldFolders(apiObjects map[string]awstypes.FieldFolder) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for k, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"field_folders_id": k,
 		}
 
@@ -1649,15 +1649,15 @@ func FlattenFieldFolders(apiObjects map[string]awstypes.FieldFolder) []interface
 	return tfList
 }
 
-func FlattenLogicalTableMap(apiObjects map[string]awstypes.LogicalTable) []interface{} {
+func FlattenLogicalTableMap(apiObjects map[string]awstypes.LogicalTable) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for k, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"logical_table_map_id": k,
 		}
 
@@ -1677,15 +1677,15 @@ func FlattenLogicalTableMap(apiObjects map[string]awstypes.LogicalTable) []inter
 	return tfList
 }
 
-func flattenTransformOperations(apiObjects []awstypes.TransformOperation) []interface{} {
+func flattenTransformOperations(apiObjects []awstypes.TransformOperation) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		switch v := apiObject.(type) {
 		case *awstypes.TransformOperationMemberCastColumnTypeOperation:
@@ -1712,12 +1712,12 @@ func flattenTransformOperations(apiObjects []awstypes.TransformOperation) []inte
 	return tfList
 }
 
-func flattenCastColumnTypeOperation(apiObject *awstypes.CastColumnTypeOperation) []interface{} {
+func flattenCastColumnTypeOperation(apiObject *awstypes.CastColumnTypeOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
@@ -1727,32 +1727,32 @@ func flattenCastColumnTypeOperation(apiObject *awstypes.CastColumnTypeOperation)
 	}
 	tfMap["new_column_type"] = apiObject.NewColumnType
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCreateColumnsOperation(apiObject *awstypes.CreateColumnsOperation) []interface{} {
+func flattenCreateColumnsOperation(apiObject *awstypes.CreateColumnsOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenCalculatedColumns(apiObject.Columns)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCalculatedColumns(apiObjects []awstypes.CalculatedColumn) interface{} {
+func flattenCalculatedColumns(apiObjects []awstypes.CalculatedColumn) any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnId != nil {
 			tfMap["column_id"] = aws.ToString(apiObject.ColumnId)
@@ -1770,40 +1770,40 @@ func flattenCalculatedColumns(apiObjects []awstypes.CalculatedColumn) interface{
 	return tfList
 }
 
-func flattenFilterOperation(apiObject *awstypes.FilterOperation) []interface{} {
+func flattenFilterOperation(apiObject *awstypes.FilterOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionExpression != nil {
 		tfMap["condition_expression"] = aws.ToString(apiObject.ConditionExpression)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenProjectOperation(apiObject *awstypes.ProjectOperation) []interface{} {
+func flattenProjectOperation(apiObject *awstypes.ProjectOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ProjectedColumns != nil {
 		tfMap["projected_columns"] = apiObject.ProjectedColumns
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRenameColumnOperation(apiObject *awstypes.RenameColumnOperation) []interface{} {
+func flattenRenameColumnOperation(apiObject *awstypes.RenameColumnOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
@@ -1812,15 +1812,15 @@ func flattenRenameColumnOperation(apiObject *awstypes.RenameColumnOperation) []i
 		tfMap["new_column_name"] = aws.ToString(apiObject.NewColumnName)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTagColumnOperation(apiObject *awstypes.TagColumnOperation) []interface{} {
+func flattenTagColumnOperation(apiObject *awstypes.TagColumnOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
@@ -1829,18 +1829,18 @@ func flattenTagColumnOperation(apiObject *awstypes.TagColumnOperation) []interfa
 		tfMap[names.AttrTags] = flattenColumnTags(apiObject.Tags)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenColumnTags(apiObjects []awstypes.ColumnTag) []interface{} {
+func flattenColumnTags(apiObjects []awstypes.ColumnTag) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnDescription != nil {
 			tfMap["column_description"] = flattenColumnDescription(apiObject.ColumnDescription)
@@ -1853,26 +1853,26 @@ func flattenColumnTags(apiObjects []awstypes.ColumnTag) []interface{} {
 	return tfList
 }
 
-func flattenColumnDescription(apiObject *awstypes.ColumnDescription) []interface{} {
+func flattenColumnDescription(apiObject *awstypes.ColumnDescription) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Text != nil {
 		tfMap["text"] = aws.ToString(apiObject.Text)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenUntagColumnOperation(apiObject *awstypes.UntagColumnOperation) []interface{} {
+func flattenUntagColumnOperation(apiObject *awstypes.UntagColumnOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
@@ -1881,15 +1881,15 @@ func flattenUntagColumnOperation(apiObject *awstypes.UntagColumnOperation) []int
 		tfMap["tag_names"] = apiObject.TagNames
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLogicalTableSource(apiObject *awstypes.LogicalTableSource) []interface{} {
+func flattenLogicalTableSource(apiObject *awstypes.LogicalTableSource) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataSetArn != nil {
 		tfMap["data_set_arn"] = aws.ToString(apiObject.DataSetArn)
@@ -1901,15 +1901,15 @@ func flattenLogicalTableSource(apiObject *awstypes.LogicalTableSource) []interfa
 		tfMap["physical_table_id"] = aws.ToString(apiObject.PhysicalTableId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenJoinInstruction(apiObject *awstypes.JoinInstruction) []interface{} {
+func flattenJoinInstruction(apiObject *awstypes.JoinInstruction) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LeftJoinKeyProperties != nil {
 		tfMap["left_join_key_properties"] = flattenJoinKeyProperties(apiObject.LeftJoinKeyProperties)
@@ -1928,15 +1928,15 @@ func flattenJoinInstruction(apiObject *awstypes.JoinInstruction) []interface{} {
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenJoinKeyProperties(apiObject *awstypes.JoinKeyProperties) map[string]interface{} {
+func flattenJoinKeyProperties(apiObject *awstypes.JoinKeyProperties) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.UniqueKey != nil {
 		tfMap["unique_key"] = aws.ToBool(apiObject.UniqueKey)
@@ -1945,11 +1945,11 @@ func flattenJoinKeyProperties(apiObject *awstypes.JoinKeyProperties) map[string]
 	return tfMap
 }
 
-func FlattenPhysicalTableMap(apiObjects map[string]awstypes.PhysicalTable) []interface{} {
-	var tfList []interface{}
+func FlattenPhysicalTableMap(apiObjects map[string]awstypes.PhysicalTable) []any {
+	var tfList []any
 
 	for k, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"physical_table_map_id": k,
 		}
 
@@ -1970,12 +1970,12 @@ func FlattenPhysicalTableMap(apiObjects map[string]awstypes.PhysicalTable) []int
 	return tfList
 }
 
-func flattenCustomSQL(apiObject *awstypes.CustomSql) []interface{} {
+func flattenCustomSQL(apiObject *awstypes.CustomSql) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenInputColumns(apiObject.Columns)
@@ -1990,18 +1990,18 @@ func flattenCustomSQL(apiObject *awstypes.CustomSql) []interface{} {
 		tfMap["sql_query"] = aws.ToString(apiObject.SqlQuery)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenInputColumns(apiObjects []awstypes.InputColumn) []interface{} {
+func flattenInputColumns(apiObjects []awstypes.InputColumn) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Name != nil {
 			tfMap[names.AttrName] = aws.ToString(apiObject.Name)
@@ -2014,12 +2014,12 @@ func flattenInputColumns(apiObjects []awstypes.InputColumn) []interface{} {
 	return tfList
 }
 
-func flattenRelationalTable(apiObject *awstypes.RelationalTable) []interface{} {
+func flattenRelationalTable(apiObject *awstypes.RelationalTable) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Catalog != nil {
 		tfMap["catalog"] = aws.ToString(apiObject.Catalog)
@@ -2037,15 +2037,15 @@ func flattenRelationalTable(apiObject *awstypes.RelationalTable) []interface{} {
 		tfMap[names.AttrSchema] = aws.ToString(apiObject.Schema)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenS3Source(apiObject *awstypes.S3Source) []interface{} {
+func flattenS3Source(apiObject *awstypes.S3Source) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataSourceArn != nil {
 		tfMap["data_source_arn"] = aws.ToString(apiObject.DataSourceArn)
@@ -2057,15 +2057,15 @@ func flattenS3Source(apiObject *awstypes.S3Source) []interface{} {
 		tfMap["upload_settings"] = flattenUploadSettings(apiObject.UploadSettings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenUploadSettings(apiObject *awstypes.UploadSettings) []interface{} {
+func flattenUploadSettings(apiObject *awstypes.UploadSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ContainsHeader != nil {
 		tfMap["contains_header"] = aws.ToBool(apiObject.ContainsHeader)
@@ -2079,15 +2079,15 @@ func flattenUploadSettings(apiObject *awstypes.UploadSettings) []interface{} {
 	}
 	tfMap["text_qualifier"] = apiObject.TextQualifier
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenRowLevelPermissionDataSet(apiObject *awstypes.RowLevelPermissionDataSet) []interface{} {
+func FlattenRowLevelPermissionDataSet(apiObject *awstypes.RowLevelPermissionDataSet) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Arn != nil {
 		tfMap[names.AttrARN] = aws.ToString(apiObject.Arn)
@@ -2099,72 +2099,72 @@ func FlattenRowLevelPermissionDataSet(apiObject *awstypes.RowLevelPermissionData
 	tfMap["permission_policy"] = apiObject.PermissionPolicy
 	tfMap[names.AttrStatus] = apiObject.Status
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenRowLevelPermissionTagConfiguration(apiObject *awstypes.RowLevelPermissionTagConfiguration) []interface{} {
+func FlattenRowLevelPermissionTagConfiguration(apiObject *awstypes.RowLevelPermissionTagConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrStatus] = apiObject.Status
 	if apiObject.TagRules != nil {
 		tfMap["tag_rules"] = flattenRowLevelPermissionTagRules(apiObject.TagRules)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func FlattenDataSetRefreshProperties(apiObject *awstypes.DataSetRefreshProperties) interface{} {
+func FlattenDataSetRefreshProperties(apiObject *awstypes.DataSetRefreshProperties) any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.RefreshConfiguration != nil {
 		tfMap["refresh_configuration"] = flattenRefreshConfiguration(apiObject.RefreshConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRefreshConfiguration(apiObject *awstypes.RefreshConfiguration) interface{} {
+func flattenRefreshConfiguration(apiObject *awstypes.RefreshConfiguration) any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.IncrementalRefresh != nil {
 		tfMap["incremental_refresh"] = flattenIncrementalRefresh(apiObject.IncrementalRefresh)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenIncrementalRefresh(apiObject *awstypes.IncrementalRefresh) interface{} {
+func flattenIncrementalRefresh(apiObject *awstypes.IncrementalRefresh) any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LookbackWindow != nil {
 		tfMap["lookback_window"] = flattenLookbackWindow(apiObject.LookbackWindow)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLookbackWindow(apiObject *awstypes.LookbackWindow) interface{} {
+func flattenLookbackWindow(apiObject *awstypes.LookbackWindow) any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
@@ -2174,18 +2174,18 @@ func flattenLookbackWindow(apiObject *awstypes.LookbackWindow) interface{} {
 	}
 	tfMap["size_unit"] = apiObject.SizeUnit
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRowLevelPermissionTagRules(apiObjects []awstypes.RowLevelPermissionTagRule) []interface{} {
+func flattenRowLevelPermissionTagRules(apiObjects []awstypes.RowLevelPermissionTagRule) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnName != nil {
 			tfMap["column_name"] = aws.ToString(apiObject.ColumnName)

--- a/internal/service/quicksight/schema/data_source.go
+++ b/internal/service/quicksight/schema/data_source.go
@@ -602,12 +602,12 @@ func VPCConnectionPropertiesSchema() *schema.Schema {
 	}
 }
 
-func ExpandDataSourceCredentials(tfList []interface{}) *awstypes.DataSourceCredentials {
+func ExpandDataSourceCredentials(tfList []any) *awstypes.DataSourceCredentials {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -618,7 +618,7 @@ func ExpandDataSourceCredentials(tfList []interface{}) *awstypes.DataSourceCrede
 		apiObject.CopySourceArn = aws.String(v)
 	}
 
-	if v, ok := tfMap["credential_pair"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["credential_pair"].([]any); ok && len(v) > 0 {
 		apiObject.CredentialPair = expandCredentialPair(v)
 	}
 
@@ -629,14 +629,14 @@ func ExpandDataSourceCredentials(tfList []interface{}) *awstypes.DataSourceCrede
 	return apiObject
 }
 
-func expandCredentialPair(tfList []interface{}) *awstypes.CredentialPair {
+func expandCredentialPair(tfList []any) *awstypes.CredentialPair {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.CredentialPair{}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -652,20 +652,20 @@ func expandCredentialPair(tfList []interface{}) *awstypes.CredentialPair {
 	return apiObject
 }
 
-func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParameters {
+func ExpandDataSourceParameters(tfList []any) awstypes.DataSourceParameters {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	var apiObject awstypes.DataSourceParameters
 
-	if v, ok := tfMap["amazon_elasticsearch"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v, ok := tfMap["amazon_elasticsearch"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberAmazonElasticsearchParameters{}
 
 			if v, ok := tfMap[names.AttrDomain].(string); ok && v != "" {
@@ -676,8 +676,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["athena"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["athena"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberAthenaParameters{}
 
 			if v, ok := tfMap["work_group"].(string); ok && v != "" {
@@ -688,8 +688,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["aurora"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["aurora"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberAuroraParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -706,8 +706,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v, ok := tfMap["aurora_postgresql"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v, ok := tfMap["aurora_postgresql"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberAuroraPostgreSqlParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -724,8 +724,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["aws_iot_analytics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["aws_iot_analytics"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberAwsIotAnalyticsParameters{}
 
 			if v, ok := tfMap["data_set_name"].(string); ok && v != "" {
@@ -736,8 +736,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["databricks"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["databricks"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberDatabricksParameters{}
 
 			if v, ok := tfMap["host"].(string); ok && v != "" {
@@ -754,8 +754,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["jira"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["jira"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberJiraParameters{}
 
 			if v, ok := tfMap["site_base_url"].(string); ok && v != "" {
@@ -766,8 +766,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["maria_db"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["maria_db"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberMariaDbParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -784,8 +784,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["mysql"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["mysql"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberMySqlParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -802,8 +802,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["oracle"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["oracle"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberOracleParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -820,8 +820,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["postgresql"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["postgresql"].([]any); ok && len(v) > 0 && v[0] != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberPostgreSqlParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -838,8 +838,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["presto"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["presto"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberPrestoParameters{}
 
 			if v, ok := tfMap["catalog"].(string); ok && v != "" {
@@ -856,8 +856,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["rds"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["rds"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberRdsParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -871,8 +871,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["redshift"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["redshift"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberRedshiftParameters{}
 
 			if v, ok := tfMap["cluster_id"].(string); ok && v != "" {
@@ -892,12 +892,12 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["s3"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["s3"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberS3Parameters{}
 
-			if v, ok := tfMap["manifest_file_location"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-				if tfMap, ok := v[0].(map[string]interface{}); ok {
+			if v, ok := tfMap["manifest_file_location"].([]any); ok && len(v) > 0 && v[0] != nil {
+				if tfMap, ok := v[0].(map[string]any); ok {
 					apiObject := &awstypes.ManifestFileLocation{}
 
 					if v, ok := tfMap[names.AttrBucket].(string); ok && v != "" {
@@ -919,8 +919,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["service_now"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["service_now"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberServiceNowParameters{}
 
 			if v, ok := tfMap["site_base_url"].(string); ok && v != "" {
@@ -931,8 +931,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["snowflake"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["snowflake"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberSnowflakeParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -949,8 +949,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["spark"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["spark"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberSparkParameters{}
 
 			if v, ok := tfMap["host"].(string); ok && v != "" {
@@ -964,8 +964,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["sql_server"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["sql_server"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberSqlServerParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -982,8 +982,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["teradata"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["teradata"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberTeradataParameters{}
 
 			if v, ok := tfMap[names.AttrDatabase].(string); ok && v != "" {
@@ -1000,8 +1000,8 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 		}
 	}
 
-	if v := tfMap["twitter"].([]interface{}); ok && len(v) > 0 && v != nil {
-		if tfMap, ok := v[0].(map[string]interface{}); ok {
+	if v := tfMap["twitter"].([]any); ok && len(v) > 0 && v != nil {
+		if tfMap, ok := v[0].(map[string]any); ok {
 			ps := &awstypes.DataSourceParametersMemberTwitterParameters{}
 
 			if v, ok := tfMap["max_rows"].(int); ok {
@@ -1018,112 +1018,112 @@ func ExpandDataSourceParameters(tfList []interface{}) awstypes.DataSourceParamet
 	return apiObject
 }
 
-func FlattenDataSourceParameters(apiObject awstypes.DataSourceParameters) []interface{} {
+func FlattenDataSourceParameters(apiObject awstypes.DataSourceParameters) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	switch v := apiObject.(type) {
 	case *awstypes.DataSourceParametersMemberAmazonElasticsearchParameters:
-		tfMap["amazon_elasticsearch"] = []interface{}{
-			map[string]interface{}{
+		tfMap["amazon_elasticsearch"] = []any{
+			map[string]any{
 				names.AttrDomain: aws.ToString(v.Value.Domain),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberAthenaParameters:
-		tfMap["athena"] = []interface{}{
-			map[string]interface{}{
+		tfMap["athena"] = []any{
+			map[string]any{
 				"work_group": aws.ToString(v.Value.WorkGroup),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberAuroraParameters:
-		tfMap["aurora"] = []interface{}{
-			map[string]interface{}{
+		tfMap["aurora"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberAuroraPostgreSqlParameters:
-		tfMap["aurora_postgresql"] = []interface{}{
-			map[string]interface{}{
+		tfMap["aurora_postgresql"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberAwsIotAnalyticsParameters:
-		tfMap["aws_iot_analytics"] = []interface{}{
-			map[string]interface{}{
+		tfMap["aws_iot_analytics"] = []any{
+			map[string]any{
 				"data_set_name": aws.ToString(v.Value.DataSetName),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberDatabricksParameters:
-		tfMap["databricks"] = []interface{}{
-			map[string]interface{}{
+		tfMap["databricks"] = []any{
+			map[string]any{
 				"host":              aws.ToString(v.Value.Host),
 				names.AttrPort:      aws.ToInt32(v.Value.Port),
 				"sql_endpoint_path": aws.ToString(v.Value.SqlEndpointPath),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberJiraParameters:
-		tfMap["jira"] = []interface{}{
-			map[string]interface{}{
+		tfMap["jira"] = []any{
+			map[string]any{
 				"site_base_url": aws.ToString(v.Value.SiteBaseUrl),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberMariaDbParameters:
-		tfMap["maria_db"] = []interface{}{
-			map[string]interface{}{
+		tfMap["maria_db"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberMySqlParameters:
-		tfMap["mysql"] = []interface{}{
-			map[string]interface{}{
+		tfMap["mysql"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberOracleParameters:
-		tfMap["oracle"] = []interface{}{
-			map[string]interface{}{
+		tfMap["oracle"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberPostgreSqlParameters:
-		tfMap["postgresql"] = []interface{}{
-			map[string]interface{}{
+		tfMap["postgresql"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberPrestoParameters:
-		tfMap["postgresql"] = []interface{}{
-			map[string]interface{}{
+		tfMap["postgresql"] = []any{
+			map[string]any{
 				"catalog":      aws.ToString(v.Value.Catalog),
 				"host":         aws.ToString(v.Value.Host),
 				names.AttrPort: aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberRdsParameters:
-		tfMap["rds"] = []interface{}{
-			map[string]interface{}{
+		tfMap["rds"] = []any{
+			map[string]any{
 				names.AttrDatabase:   aws.ToString(v.Value.Database),
 				names.AttrInstanceID: aws.ToString(v.Value.InstanceId),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberRedshiftParameters:
-		tfMap["redshift"] = []interface{}{
-			map[string]interface{}{
+		tfMap["redshift"] = []any{
+			map[string]any{
 				"cluster_id":       aws.ToString(v.Value.ClusterId),
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
@@ -1131,10 +1131,10 @@ func FlattenDataSourceParameters(apiObject awstypes.DataSourceParameters) []inte
 			},
 		}
 	case *awstypes.DataSourceParametersMemberS3Parameters:
-		tfMap["s3"] = []interface{}{
-			map[string]interface{}{
-				"manifest_file_location": []interface{}{
-					map[string]interface{}{
+		tfMap["s3"] = []any{
+			map[string]any{
+				"manifest_file_location": []any{
+					map[string]any{
 						names.AttrBucket: aws.ToString(v.Value.ManifestFileLocation.Bucket),
 						names.AttrKey:    aws.ToString(v.Value.ManifestFileLocation.Key),
 					},
@@ -1143,45 +1143,45 @@ func FlattenDataSourceParameters(apiObject awstypes.DataSourceParameters) []inte
 			},
 		}
 	case *awstypes.DataSourceParametersMemberServiceNowParameters:
-		tfMap["service_now"] = []interface{}{
-			map[string]interface{}{
+		tfMap["service_now"] = []any{
+			map[string]any{
 				"site_base_url": aws.ToString(v.Value.SiteBaseUrl),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberSnowflakeParameters:
-		tfMap["snowflake"] = []interface{}{
-			map[string]interface{}{
+		tfMap["snowflake"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				"warehouse":        aws.ToString(v.Value.Warehouse),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberSparkParameters:
-		tfMap["snowflake"] = []interface{}{
-			map[string]interface{}{
+		tfMap["snowflake"] = []any{
+			map[string]any{
 				"host":         aws.ToString(v.Value.Host),
 				names.AttrPort: aws.ToInt32(v.Value.Port),
 			},
 		}
 	case *awstypes.DataSourceParametersMemberSqlServerParameters:
-		tfMap["sql_server"] = []interface{}{
-			map[string]interface{}{
+		tfMap["sql_server"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     v.Value.Port,
 			},
 		}
 	case *awstypes.DataSourceParametersMemberTeradataParameters:
-		tfMap["teradata"] = []interface{}{
-			map[string]interface{}{
+		tfMap["teradata"] = []any{
+			map[string]any{
 				names.AttrDatabase: aws.ToString(v.Value.Database),
 				"host":             aws.ToString(v.Value.Host),
 				names.AttrPort:     v.Value.Port,
 			},
 		}
 	case *awstypes.DataSourceParametersMemberTwitterParameters:
-		tfMap["teradata"] = []interface{}{
-			map[string]interface{}{
+		tfMap["teradata"] = []any{
+			map[string]any{
 				"max_rows": aws.ToInt32(v.Value.MaxRows),
 				"query":    aws.ToString(v.Value.Query),
 			},
@@ -1190,15 +1190,15 @@ func FlattenDataSourceParameters(apiObject awstypes.DataSourceParameters) []inte
 		return nil
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func ExpandSSLProperties(tfList []interface{}) *awstypes.SslProperties {
+func ExpandSSLProperties(tfList []any) *awstypes.SslProperties {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1212,24 +1212,24 @@ func ExpandSSLProperties(tfList []interface{}) *awstypes.SslProperties {
 	return apiObject
 }
 
-func FlattenSSLProperties(apiObject *awstypes.SslProperties) []interface{} {
+func FlattenSSLProperties(apiObject *awstypes.SslProperties) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"disable_ssl": apiObject.DisableSsl,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func ExpandVPCConnectionProperties(tfList []interface{}) *awstypes.VpcConnectionProperties {
+func ExpandVPCConnectionProperties(tfList []any) *awstypes.VpcConnectionProperties {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1243,16 +1243,16 @@ func ExpandVPCConnectionProperties(tfList []interface{}) *awstypes.VpcConnection
 	return apiObject
 }
 
-func FlattenVPCConnectionProperties(apiObject *awstypes.VpcConnectionProperties) []interface{} {
+func FlattenVPCConnectionProperties(apiObject *awstypes.VpcConnectionProperties) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.VpcConnectionArn != nil {
 		tfMap["vpc_connection_arn"] = aws.ToString(apiObject.VpcConnectionArn)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/dataset.go
+++ b/internal/service/quicksight/schema/dataset.go
@@ -44,7 +44,7 @@ var dataSetReferencesSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandDataSetIdentifierDeclarations(tfList []interface{}) []awstypes.DataSetIdentifierDeclaration {
+func expandDataSetIdentifierDeclarations(tfList []any) []awstypes.DataSetIdentifierDeclaration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -52,7 +52,7 @@ func expandDataSetIdentifierDeclarations(tfList []interface{}) []awstypes.DataSe
 	var apiObjects []awstypes.DataSetIdentifierDeclaration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -68,7 +68,7 @@ func expandDataSetIdentifierDeclarations(tfList []interface{}) []awstypes.DataSe
 	return apiObjects
 }
 
-func expandDataSetIdentifierDeclaration(tfMap map[string]interface{}) *awstypes.DataSetIdentifierDeclaration {
+func expandDataSetIdentifierDeclaration(tfMap map[string]any) *awstypes.DataSetIdentifierDeclaration {
 	if tfMap == nil {
 		return nil
 	}
@@ -85,15 +85,15 @@ func expandDataSetIdentifierDeclaration(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func flattenDataSetIdentifierDeclarations(apiObject []awstypes.DataSetIdentifierDeclaration) []interface{} {
+func flattenDataSetIdentifierDeclarations(apiObject []awstypes.DataSetIdentifierDeclaration) []any {
 	if len(apiObject) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObject {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataSetArn != nil {
 			tfMap["data_set_arn"] = aws.ToString(apiObject.DataSetArn)

--- a/internal/service/quicksight/schema/parameters.go
+++ b/internal/service/quicksight/schema/parameters.go
@@ -114,35 +114,35 @@ var stringNonEmptyRequiredSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func ExpandParameters(tfList []interface{}) *awstypes.Parameters {
+func ExpandParameters(tfList []any) *awstypes.Parameters {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.Parameters{}
 
-	if v, ok := tfMap["date_time_parameters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_parameters"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimeParameters = expandDateTimeParameters(v)
 	}
-	if v, ok := tfMap["decimal_parameters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["decimal_parameters"].([]any); ok && len(v) > 0 {
 		apiObject.DecimalParameters = expandDecimalParameters(v)
 	}
-	if v, ok := tfMap["integer_parameters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["integer_parameters"].([]any); ok && len(v) > 0 {
 		apiObject.IntegerParameters = expandIntegerParameters(v)
 	}
-	if v, ok := tfMap["string_parameters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["string_parameters"].([]any); ok && len(v) > 0 {
 		apiObject.StringParameters = expandStringParameters(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimeParameters(tfList []interface{}) []awstypes.DateTimeParameter {
+func expandDateTimeParameters(tfList []any) []awstypes.DateTimeParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -150,7 +150,7 @@ func expandDateTimeParameters(tfList []interface{}) []awstypes.DateTimeParameter
 	var apiObjects []awstypes.DateTimeParameter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -166,7 +166,7 @@ func expandDateTimeParameters(tfList []interface{}) []awstypes.DateTimeParameter
 	return apiObjects
 }
 
-func expandDateTimeParameter(tfMap map[string]interface{}) *awstypes.DateTimeParameter {
+func expandDateTimeParameter(tfMap map[string]any) *awstypes.DateTimeParameter {
 	if tfMap == nil {
 		return nil
 	}
@@ -176,14 +176,14 @@ func expandDateTimeParameter(tfMap map[string]interface{}) *awstypes.DateTimePar
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = flex.ExpandStringTimeValueList(v, time.RFC3339)
 	}
 
 	return apiObject
 }
 
-func expandDecimalParameters(tfList []interface{}) []awstypes.DecimalParameter {
+func expandDecimalParameters(tfList []any) []awstypes.DecimalParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -191,7 +191,7 @@ func expandDecimalParameters(tfList []interface{}) []awstypes.DecimalParameter {
 	var apiObjects []awstypes.DecimalParameter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -207,7 +207,7 @@ func expandDecimalParameters(tfList []interface{}) []awstypes.DecimalParameter {
 	return apiObjects
 }
 
-func expandDecimalParameter(tfMap map[string]interface{}) *awstypes.DecimalParameter {
+func expandDecimalParameter(tfMap map[string]any) *awstypes.DecimalParameter {
 	if tfMap == nil {
 		return nil
 	}
@@ -217,14 +217,14 @@ func expandDecimalParameter(tfMap map[string]interface{}) *awstypes.DecimalParam
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = flex.ExpandFloat64ValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandIntegerParameters(tfList []interface{}) []awstypes.IntegerParameter {
+func expandIntegerParameters(tfList []any) []awstypes.IntegerParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -232,7 +232,7 @@ func expandIntegerParameters(tfList []interface{}) []awstypes.IntegerParameter {
 	var apiObjects []awstypes.IntegerParameter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -248,7 +248,7 @@ func expandIntegerParameters(tfList []interface{}) []awstypes.IntegerParameter {
 	return apiObjects
 }
 
-func expandIntegerParameter(tfMap map[string]interface{}) *awstypes.IntegerParameter {
+func expandIntegerParameter(tfMap map[string]any) *awstypes.IntegerParameter {
 	if tfMap == nil {
 		return nil
 	}
@@ -258,14 +258,14 @@ func expandIntegerParameter(tfMap map[string]interface{}) *awstypes.IntegerParam
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = flex.ExpandInt64ValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandStringParameters(tfList []interface{}) []awstypes.StringParameter {
+func expandStringParameters(tfList []any) []awstypes.StringParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -273,7 +273,7 @@ func expandStringParameters(tfList []interface{}) []awstypes.StringParameter {
 	var apiObjects []awstypes.StringParameter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -289,7 +289,7 @@ func expandStringParameters(tfList []interface{}) []awstypes.StringParameter {
 	return apiObjects
 }
 
-func expandStringParameter(tfMap map[string]interface{}) *awstypes.StringParameter {
+func expandStringParameter(tfMap map[string]any) *awstypes.StringParameter {
 	if tfMap == nil {
 		return nil
 	}
@@ -299,7 +299,7 @@ func expandStringParameter(tfMap map[string]interface{}) *awstypes.StringParamet
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = flex.ExpandStringValueList(v)
 	}
 

--- a/internal/service/quicksight/schema/permissions.go
+++ b/internal/service/quicksight/schema/permissions.go
@@ -52,11 +52,11 @@ func PermissionsDataSourceSchema() *schema.Schema {
 	}
 }
 
-func ExpandResourcePermissions(tfList []interface{}) []awstypes.ResourcePermission {
+func ExpandResourcePermissions(tfList []any) []awstypes.ResourcePermission {
 	apiObjects := make([]awstypes.ResourcePermission, len(tfList))
 
 	for i, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.ResourcePermission{
 			Actions:   flex.ExpandStringValueSet(tfMap[names.AttrActions].(*schema.Set)),
@@ -69,15 +69,15 @@ func ExpandResourcePermissions(tfList []interface{}) []awstypes.ResourcePermissi
 	return apiObjects
 }
 
-func FlattenPermissions(apiObjects []awstypes.ResourcePermission) []interface{} {
+func FlattenPermissions(apiObjects []awstypes.ResourcePermission) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfList := make([]interface{}, 0)
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		if apiObject.Actions != nil {
 			tfMap[names.AttrActions] = apiObject.Actions
@@ -93,7 +93,7 @@ func FlattenPermissions(apiObjects []awstypes.ResourcePermission) []interface{} 
 	return tfList
 }
 
-func DiffPermissions(o, n []interface{}) ([]awstypes.ResourcePermission, []awstypes.ResourcePermission) {
+func DiffPermissions(o, n []any) ([]awstypes.ResourcePermission, []awstypes.ResourcePermission) {
 	old := ExpandResourcePermissions(o)
 	new := ExpandResourcePermissions(n)
 

--- a/internal/service/quicksight/schema/permissions_test.go
+++ b/internal/service/quicksight/schema/permissions_test.go
@@ -19,33 +19,33 @@ func TestDiffPermissions(t *testing.T) {
 
 	testCases := []struct {
 		name            string
-		oldPermissions  []interface{}
-		newPermissions  []interface{}
+		oldPermissions  []any
+		newPermissions  []any
 		expectedGrants  []awstypes.ResourcePermission
 		expectedRevokes []awstypes.ResourcePermission
 	}{
 		{
 			name:            "no changes;empty",
-			oldPermissions:  []interface{}{},
-			newPermissions:  []interface{}{},
+			oldPermissions:  []any{},
+			newPermissions:  []any{},
 			expectedGrants:  nil,
 			expectedRevokes: nil,
 		},
 		{
 			name: "no changes;same",
-			oldPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
 				},
 			},
-			newPermissions: []interface{}{
-				map[string]interface{}{
+			newPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
@@ -56,11 +56,11 @@ func TestDiffPermissions(t *testing.T) {
 		},
 		{
 			name:           "grant only",
-			oldPermissions: []interface{}{},
-			newPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{},
+			newPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
@@ -76,16 +76,16 @@ func TestDiffPermissions(t *testing.T) {
 		},
 		{
 			name: "revoke only",
-			oldPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
 				},
 			},
-			newPermissions: []interface{}{},
+			newPermissions: []any{},
 			expectedGrants: nil,
 			expectedRevokes: []awstypes.ResourcePermission{
 				{
@@ -96,18 +96,18 @@ func TestDiffPermissions(t *testing.T) {
 		},
 		{
 			name: "grant new action",
-			oldPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 					}),
 				},
 			},
-			newPermissions: []interface{}{
-				map[string]interface{}{
+			newPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
@@ -123,19 +123,19 @@ func TestDiffPermissions(t *testing.T) {
 		},
 		{
 			name: "revoke old action",
-			oldPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"oldAction",
 						"onlyOldAction",
 					}),
 				},
 			},
-			newPermissions: []interface{}{
-				map[string]interface{}{
+			newPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"oldAction",
 					}),
 				},
@@ -155,40 +155,40 @@ func TestDiffPermissions(t *testing.T) {
 		},
 		{
 			name: "multiple permissions",
-			oldPermissions: []interface{}{
-				map[string]interface{}{
+			oldPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrPrincipal: "principal2",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action3",
 						"action4",
 					}),
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrPrincipal: "principal3",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action5",
 					}),
 				},
 			},
-			newPermissions: []interface{}{
-				map[string]interface{}{
+			newPermissions: []any{
+				map[string]any{
 					names.AttrPrincipal: "principal1",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action1",
 						"action2",
 					}),
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrPrincipal: "principal2",
-					names.AttrActions: schema.NewSet(schema.HashString, []interface{}{
+					names.AttrActions: schema.NewSet(schema.HashString, []any{
 						"action3",
 						"action5",
 					}),

--- a/internal/service/quicksight/schema/template.go
+++ b/internal/service/quicksight/schema/template.go
@@ -649,28 +649,28 @@ func TemplateSourceEntitySchema() *schema.Schema {
 	}
 }
 
-func ExpandTemplateSourceEntity(tfList []interface{}) *awstypes.TemplateSourceEntity {
+func ExpandTemplateSourceEntity(tfList []any) *awstypes.TemplateSourceEntity {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TemplateSourceEntity{}
 
-	if v, ok := tfMap["source_analysis"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SourceAnalysis = expandSourceAnalysis(v[0].(map[string]interface{}))
-	} else if v, ok := tfMap["source_template"].([]interface{}); ok && len(v) > 0 {
-		apiObject.SourceTemplate = expandTemplateSourceTemplate(v[0].(map[string]interface{}))
+	if v, ok := tfMap["source_analysis"].([]any); ok && len(v) > 0 {
+		apiObject.SourceAnalysis = expandSourceAnalysis(v[0].(map[string]any))
+	} else if v, ok := tfMap["source_template"].([]any); ok && len(v) > 0 {
+		apiObject.SourceTemplate = expandTemplateSourceTemplate(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandSourceAnalysis(tfMap map[string]interface{}) *awstypes.TemplateSourceAnalysis {
+func expandSourceAnalysis(tfMap map[string]any) *awstypes.TemplateSourceAnalysis {
 	if tfMap == nil {
 		return nil
 	}
@@ -680,14 +680,14 @@ func expandSourceAnalysis(tfMap map[string]interface{}) *awstypes.TemplateSource
 	if v, ok := tfMap[names.AttrARN].(string); ok && v != "" {
 		apiObject.Arn = aws.String(v)
 	}
-	if v, ok := tfMap["data_set_references"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_references"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetReferences = expandDataSetReferences(v)
 	}
 
 	return apiObject
 }
 
-func expandDataSetReferences(tfList []interface{}) []awstypes.DataSetReference {
+func expandDataSetReferences(tfList []any) []awstypes.DataSetReference {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -695,7 +695,7 @@ func expandDataSetReferences(tfList []interface{}) []awstypes.DataSetReference {
 	var apiObjects []awstypes.DataSetReference
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -711,7 +711,7 @@ func expandDataSetReferences(tfList []interface{}) []awstypes.DataSetReference {
 	return apiObjects
 }
 
-func expandDataSetReference(tfMap map[string]interface{}) *awstypes.DataSetReference {
+func expandDataSetReference(tfMap map[string]any) *awstypes.DataSetReference {
 	if tfMap == nil {
 		return nil
 	}
@@ -728,7 +728,7 @@ func expandDataSetReference(tfMap map[string]interface{}) *awstypes.DataSetRefer
 	return apiObject
 }
 
-func expandTemplateSourceTemplate(tfMap map[string]interface{}) *awstypes.TemplateSourceTemplate {
+func expandTemplateSourceTemplate(tfMap map[string]any) *awstypes.TemplateSourceTemplate {
 	if tfMap == nil {
 		return nil
 	}
@@ -742,44 +742,44 @@ func expandTemplateSourceTemplate(tfMap map[string]interface{}) *awstypes.Templa
 	return apiObject
 }
 
-func ExpandTemplateDefinition(tfList []interface{}) *awstypes.TemplateVersionDefinition {
+func ExpandTemplateDefinition(tfList []any) *awstypes.TemplateVersionDefinition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TemplateVersionDefinition{}
 
-	if v, ok := tfMap["analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.AnalysisDefaults = expandAnalysisDefaults(v)
 	}
 	if v, ok := tfMap["calculated_fields"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.CalculatedFields = expandCalculatedFields(v.List())
 	}
-	if v, ok := tfMap["column_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnConfigurations = expandColumnConfigurations(v)
 	}
-	if v, ok := tfMap["data_set_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetConfigurations = expandDataSetConfigurations(v)
 	}
-	if v, ok := tfMap["filter_groups"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_groups"].([]any); ok && len(v) > 0 {
 		apiObject.FilterGroups = expandFilterGroups(v)
 	}
 	if v, ok := tfMap["parameters_declarations"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.ParameterDeclarations = expandParameterDeclarations(v.List())
 	}
-	if v, ok := tfMap["sheets"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheets"].([]any); ok && len(v) > 0 {
 		apiObject.Sheets = expandSheetDefinitions(v)
 	}
 
 	return apiObject
 }
 
-func expandCalculatedFields(tfList []interface{}) []awstypes.CalculatedField {
+func expandCalculatedFields(tfList []any) []awstypes.CalculatedField {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -787,7 +787,7 @@ func expandCalculatedFields(tfList []interface{}) []awstypes.CalculatedField {
 	var apiObjects []awstypes.CalculatedField
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -803,7 +803,7 @@ func expandCalculatedFields(tfList []interface{}) []awstypes.CalculatedField {
 	return apiObjects
 }
 
-func expandCalculatedField(tfMap map[string]interface{}) *awstypes.CalculatedField {
+func expandCalculatedField(tfMap map[string]any) *awstypes.CalculatedField {
 	if tfMap == nil {
 		return nil
 	}
@@ -823,7 +823,7 @@ func expandCalculatedField(tfMap map[string]interface{}) *awstypes.CalculatedFie
 	return apiObject
 }
 
-func expandColumnConfigurations(tfList []interface{}) []awstypes.ColumnConfiguration {
+func expandColumnConfigurations(tfList []any) []awstypes.ColumnConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -831,7 +831,7 @@ func expandColumnConfigurations(tfList []interface{}) []awstypes.ColumnConfigura
 	var apiObjects []awstypes.ColumnConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -847,18 +847,18 @@ func expandColumnConfigurations(tfList []interface{}) []awstypes.ColumnConfigura
 	return apiObjects
 }
 
-func expandColumnConfiguration(tfMap map[string]interface{}) *awstypes.ColumnConfiguration {
+func expandColumnConfiguration(tfMap map[string]any) *awstypes.ColumnConfiguration {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnConfiguration{}
 
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandFormatConfiguration(v)
 	}
 
@@ -869,12 +869,12 @@ func expandColumnConfiguration(tfMap map[string]interface{}) *awstypes.ColumnCon
 	return apiObject
 }
 
-func expandColumnIdentifier(tfList []interface{}) *awstypes.ColumnIdentifier {
+func expandColumnIdentifier(tfList []any) *awstypes.ColumnIdentifier {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -882,7 +882,7 @@ func expandColumnIdentifier(tfList []interface{}) *awstypes.ColumnIdentifier {
 	return expandColumnIdentifierInternal(tfMap)
 }
 
-func expandColumnIdentifierInternal(tfMap map[string]interface{}) *awstypes.ColumnIdentifier {
+func expandColumnIdentifierInternal(tfMap map[string]any) *awstypes.ColumnIdentifier {
 	apiObject := &awstypes.ColumnIdentifier{}
 
 	if v, ok := tfMap["data_set_identifier"].(string); ok && v != "" {
@@ -895,7 +895,7 @@ func expandColumnIdentifierInternal(tfMap map[string]interface{}) *awstypes.Colu
 	return apiObject
 }
 
-func expandColumnIdentifiers(tfList []interface{}) []awstypes.ColumnIdentifier {
+func expandColumnIdentifiers(tfList []any) []awstypes.ColumnIdentifier {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -903,7 +903,7 @@ func expandColumnIdentifiers(tfList []interface{}) []awstypes.ColumnIdentifier {
 	var apiObjects []awstypes.ColumnIdentifier
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -919,7 +919,7 @@ func expandColumnIdentifiers(tfList []interface{}) []awstypes.ColumnIdentifier {
 	return apiObjects
 }
 
-func expandDataSetConfigurations(tfList []interface{}) []awstypes.DataSetConfiguration {
+func expandDataSetConfigurations(tfList []any) []awstypes.DataSetConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -927,7 +927,7 @@ func expandDataSetConfigurations(tfList []interface{}) []awstypes.DataSetConfigu
 	var apiObjects []awstypes.DataSetConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -943,17 +943,17 @@ func expandDataSetConfigurations(tfList []interface{}) []awstypes.DataSetConfigu
 	return apiObjects
 }
 
-func expandDataSetConfiguration(tfMap map[string]interface{}) *awstypes.DataSetConfiguration {
+func expandDataSetConfiguration(tfMap map[string]any) *awstypes.DataSetConfiguration {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DataSetConfiguration{}
 
-	if v, ok := tfMap["column_group_schema_list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_group_schema_list"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnGroupSchemaList = expandColumnGroupSchemas(v)
 	}
-	if v, ok := tfMap["data_set_schema"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_set_schema"].([]any); ok && len(v) > 0 {
 		apiObject.DataSetSchema = expandDataSetSchema(v)
 	}
 	if v, ok := tfMap["placeholder"].(string); ok && v != "" {
@@ -963,7 +963,7 @@ func expandDataSetConfiguration(tfMap map[string]interface{}) *awstypes.DataSetC
 	return apiObject
 }
 
-func expandColumnGroupSchemas(tfList []interface{}) []awstypes.ColumnGroupSchema {
+func expandColumnGroupSchemas(tfList []any) []awstypes.ColumnGroupSchema {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -971,7 +971,7 @@ func expandColumnGroupSchemas(tfList []interface{}) []awstypes.ColumnGroupSchema
 	var apiObjects []awstypes.ColumnGroupSchema
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -987,14 +987,14 @@ func expandColumnGroupSchemas(tfList []interface{}) []awstypes.ColumnGroupSchema
 	return apiObjects
 }
 
-func expandColumnGroupSchema(tfMap map[string]interface{}) *awstypes.ColumnGroupSchema {
+func expandColumnGroupSchema(tfMap map[string]any) *awstypes.ColumnGroupSchema {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnGroupSchema{}
 
-	if v, ok := tfMap["column_group_schema_list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_group_schema_list"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnGroupColumnSchemaList = expandColumnGroupColumnSchemas(v)
 	}
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
@@ -1004,7 +1004,7 @@ func expandColumnGroupSchema(tfMap map[string]interface{}) *awstypes.ColumnGroup
 	return apiObject
 }
 
-func expandColumnGroupColumnSchemas(tfList []interface{}) []awstypes.ColumnGroupColumnSchema {
+func expandColumnGroupColumnSchemas(tfList []any) []awstypes.ColumnGroupColumnSchema {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1012,7 +1012,7 @@ func expandColumnGroupColumnSchemas(tfList []interface{}) []awstypes.ColumnGroup
 	var apiObjects []awstypes.ColumnGroupColumnSchema
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1028,7 +1028,7 @@ func expandColumnGroupColumnSchemas(tfList []interface{}) []awstypes.ColumnGroup
 	return apiObjects
 }
 
-func expandColumnGroupColumnSchema(tfMap map[string]interface{}) *awstypes.ColumnGroupColumnSchema {
+func expandColumnGroupColumnSchema(tfMap map[string]any) *awstypes.ColumnGroupColumnSchema {
 	if tfMap == nil {
 		return nil
 	}
@@ -1042,26 +1042,26 @@ func expandColumnGroupColumnSchema(tfMap map[string]interface{}) *awstypes.Colum
 	return apiObject
 }
 
-func expandDataSetSchema(tfList []interface{}) *awstypes.DataSetSchema {
+func expandDataSetSchema(tfList []any) *awstypes.DataSetSchema {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DataSetSchema{}
 
-	if v, ok := tfMap["column_schema_list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_schema_list"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnSchemaList = expandColumnSchemas(v)
 	}
 
 	return apiObject
 }
 
-func expandColumnSchemas(tfList []interface{}) []awstypes.ColumnSchema {
+func expandColumnSchemas(tfList []any) []awstypes.ColumnSchema {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1069,7 +1069,7 @@ func expandColumnSchemas(tfList []interface{}) []awstypes.ColumnSchema {
 	var apiObjects []awstypes.ColumnSchema
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1085,7 +1085,7 @@ func expandColumnSchemas(tfList []interface{}) []awstypes.ColumnSchema {
 	return apiObjects
 }
 
-func expandColumnSchema(tfMap map[string]interface{}) *awstypes.ColumnSchema {
+func expandColumnSchema(tfMap map[string]any) *awstypes.ColumnSchema {
 	if tfMap == nil {
 		return nil
 	}
@@ -1105,7 +1105,7 @@ func expandColumnSchema(tfMap map[string]interface{}) *awstypes.ColumnSchema {
 	return apiObject
 }
 
-func expandFilterGroups(tfList []interface{}) []awstypes.FilterGroup {
+func expandFilterGroups(tfList []any) []awstypes.FilterGroup {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1113,7 +1113,7 @@ func expandFilterGroups(tfList []interface{}) []awstypes.FilterGroup {
 	var apiObjects []awstypes.FilterGroup
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1129,7 +1129,7 @@ func expandFilterGroups(tfList []interface{}) []awstypes.FilterGroup {
 	return apiObjects
 }
 
-func expandFilterGroup(tfMap map[string]interface{}) *awstypes.FilterGroup {
+func expandFilterGroup(tfMap map[string]any) *awstypes.FilterGroup {
 	if tfMap == nil {
 		return nil
 	}
@@ -1145,22 +1145,22 @@ func expandFilterGroup(tfMap map[string]interface{}) *awstypes.FilterGroup {
 	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
 		apiObject.Status = awstypes.WidgetStatus(v)
 	}
-	if v, ok := tfMap["filters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filters"].([]any); ok && len(v) > 0 {
 		apiObject.Filters = expandFilters(v)
 	}
-	if v, ok := tfMap["scope_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scope_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ScopeConfiguration = expandFilterScopeConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandAggregationFunction(tfList []interface{}) *awstypes.AggregationFunction {
+func expandAggregationFunction(tfList []any) *awstypes.AggregationFunction {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1173,19 +1173,19 @@ func expandAggregationFunction(tfList []interface{}) *awstypes.AggregationFuncti
 	if v, ok := tfMap["date_aggregation_function"].(string); ok && v != "" {
 		apiObject.DateAggregationFunction = awstypes.DateAggregationFunction(v)
 	}
-	if v, ok := tfMap["numerical_aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numerical_aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.NumericalAggregationFunction = expandNumericalAggregationFunction(v)
 	}
 
 	return apiObject
 }
 
-func expandNumericalAggregationFunction(tfList []interface{}) *awstypes.NumericalAggregationFunction {
+func expandNumericalAggregationFunction(tfList []any) *awstypes.NumericalAggregationFunction {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1195,19 +1195,19 @@ func expandNumericalAggregationFunction(tfList []interface{}) *awstypes.Numerica
 	if v, ok := tfMap["simple_numerical_aggregation"].(string); ok && v != "" {
 		apiObject.SimpleNumericalAggregation = awstypes.SimpleNumericalAggregationFunction(v)
 	}
-	if v, ok := tfMap["percentile_aggregation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["percentile_aggregation"].([]any); ok && len(v) > 0 {
 		apiObject.PercentileAggregation = expandPercentileAggregation(v)
 	}
 
 	return apiObject
 }
 
-func expandPercentileAggregation(tfList []interface{}) *awstypes.PercentileAggregation {
+func expandPercentileAggregation(tfList []any) *awstypes.PercentileAggregation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1221,12 +1221,12 @@ func expandPercentileAggregation(tfList []interface{}) *awstypes.PercentileAggre
 	return apiObject
 }
 
-func expandRollingDateConfiguration(tfList []interface{}) *awstypes.RollingDateConfiguration {
+func expandRollingDateConfiguration(tfList []any) *awstypes.RollingDateConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1243,7 +1243,7 @@ func expandRollingDateConfiguration(tfList []interface{}) *awstypes.RollingDateC
 	return apiObject
 }
 
-func expandParameterDeclarations(tfList []interface{}) []awstypes.ParameterDeclaration {
+func expandParameterDeclarations(tfList []any) []awstypes.ParameterDeclaration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1251,7 +1251,7 @@ func expandParameterDeclarations(tfList []interface{}) []awstypes.ParameterDecla
 	var apiObjects []awstypes.ParameterDeclaration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1267,30 +1267,30 @@ func expandParameterDeclarations(tfList []interface{}) []awstypes.ParameterDecla
 	return apiObjects
 }
 
-func expandParameterDeclaration(tfMap map[string]interface{}) *awstypes.ParameterDeclaration {
+func expandParameterDeclaration(tfMap map[string]any) *awstypes.ParameterDeclaration {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ParameterDeclaration{}
 
-	if v, ok := tfMap["date_time_parameter_declaration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_parameter_declaration"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimeParameterDeclaration = expandDateTimeParameterDeclaration(v)
 	}
-	if v, ok := tfMap["decimal_parameter_declaration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["decimal_parameter_declaration"].([]any); ok && len(v) > 0 {
 		apiObject.DecimalParameterDeclaration = expandDecimalParameterDeclaration(v)
 	}
-	if v, ok := tfMap["integer_parameter_declaration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["integer_parameter_declaration"].([]any); ok && len(v) > 0 {
 		apiObject.IntegerParameterDeclaration = expandIntegerParameterDeclaration(v)
 	}
-	if v, ok := tfMap["string_parameter_declaration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["string_parameter_declaration"].([]any); ok && len(v) > 0 {
 		apiObject.StringParameterDeclaration = expandStringParameterDeclaration(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetDefinitions(tfList []interface{}) []awstypes.SheetDefinition {
+func expandSheetDefinitions(tfList []any) []awstypes.SheetDefinition {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1298,7 +1298,7 @@ func expandSheetDefinitions(tfList []interface{}) []awstypes.SheetDefinition {
 	var apiObjects []awstypes.SheetDefinition
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1314,12 +1314,12 @@ func expandSheetDefinitions(tfList []interface{}) []awstypes.SheetDefinition {
 	return apiObjects
 }
 
-func FlattenTemplateDefinition(apiObject *awstypes.TemplateVersionDefinition) []interface{} {
+func FlattenTemplateDefinition(apiObject *awstypes.TemplateVersionDefinition) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AnalysisDefaults != nil {
 		tfMap["analysis_defaults"] = flattenAnalysisDefaults(apiObject.AnalysisDefaults)
@@ -1343,18 +1343,18 @@ func FlattenTemplateDefinition(apiObject *awstypes.TemplateVersionDefinition) []
 		tfMap["sheets"] = flattenSheetDefinitions(apiObject.Sheets)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCalculatedFields(apiObjects []awstypes.CalculatedField) []interface{} {
+func flattenCalculatedFields(apiObjects []awstypes.CalculatedField) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataSetIdentifier != nil {
 			tfMap["data_set_identifier"] = aws.ToString(apiObject.DataSetIdentifier)
@@ -1372,15 +1372,15 @@ func flattenCalculatedFields(apiObjects []awstypes.CalculatedField) []interface{
 	return tfList
 }
 
-func flattenColumnConfigurations(apiObjects []awstypes.ColumnConfiguration) []interface{} {
+func flattenColumnConfigurations(apiObjects []awstypes.ColumnConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Column != nil {
 			tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1396,12 +1396,12 @@ func flattenColumnConfigurations(apiObjects []awstypes.ColumnConfiguration) []in
 	return tfList
 }
 
-func flattenColumnIdentifier(apiObject *awstypes.ColumnIdentifier) []interface{} {
+func flattenColumnIdentifier(apiObject *awstypes.ColumnIdentifier) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.ColumnName != nil {
 		tfMap["column_name"] = aws.ToString(apiObject.ColumnName)
 	}
@@ -1409,18 +1409,18 @@ func flattenColumnIdentifier(apiObject *awstypes.ColumnIdentifier) []interface{}
 		tfMap["data_set_identifier"] = aws.ToString(apiObject.DataSetIdentifier)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataSetConfigurations(apiObjects []awstypes.DataSetConfiguration) []interface{} {
+func flattenDataSetConfigurations(apiObjects []awstypes.DataSetConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnGroupSchemaList != nil {
 			tfMap["column_group_schema_list"] = flattenColumnGroupSchemas(apiObject.ColumnGroupSchemaList)
@@ -1438,15 +1438,15 @@ func flattenDataSetConfigurations(apiObjects []awstypes.DataSetConfiguration) []
 	return tfList
 }
 
-func flattenColumnGroupSchemas(apiObjects []awstypes.ColumnGroupSchema) []interface{} {
+func flattenColumnGroupSchemas(apiObjects []awstypes.ColumnGroupSchema) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnGroupColumnSchemaList != nil {
 			tfMap["column_group_column_schema_list"] = flattenColumnGroupColumnSchemas(apiObject.ColumnGroupColumnSchemaList)
@@ -1461,15 +1461,15 @@ func flattenColumnGroupSchemas(apiObjects []awstypes.ColumnGroupSchema) []interf
 	return tfList
 }
 
-func flattenColumnGroupColumnSchemas(apiObjects []awstypes.ColumnGroupColumnSchema) []interface{} {
+func flattenColumnGroupColumnSchemas(apiObjects []awstypes.ColumnGroupColumnSchema) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Name != nil {
 			tfMap[names.AttrName] = aws.ToString(apiObject.Name)
@@ -1481,29 +1481,29 @@ func flattenColumnGroupColumnSchemas(apiObjects []awstypes.ColumnGroupColumnSche
 	return tfList
 }
 
-func flattenDataSetSchema(apiObject *awstypes.DataSetSchema) []interface{} {
+func flattenDataSetSchema(apiObject *awstypes.DataSetSchema) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnSchemaList != nil {
 		tfMap["column_schema_list"] = flattenColumnSchemas(apiObject.ColumnSchemaList)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenColumnSchemas(apiObjects []awstypes.ColumnSchema) []interface{} {
+func flattenColumnSchemas(apiObjects []awstypes.ColumnSchema) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataType != nil {
 			tfMap["data_type"] = aws.ToString(apiObject.DataType)
@@ -1521,15 +1521,15 @@ func flattenColumnSchemas(apiObjects []awstypes.ColumnSchema) []interface{} {
 	return tfList
 }
 
-func flattenFilterGroups(apiObjects []awstypes.FilterGroup) []interface{} {
+func flattenFilterGroups(apiObjects []awstypes.FilterGroup) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		tfMap["cross_dataset"] = apiObject.CrossDataset
 		if apiObject.FilterGroupId != nil {
@@ -1549,12 +1549,12 @@ func flattenFilterGroups(apiObjects []awstypes.FilterGroup) []interface{} {
 	return tfList
 }
 
-func flattenAggregationFunction(apiObject *awstypes.AggregationFunction) []interface{} {
+func flattenAggregationFunction(apiObject *awstypes.AggregationFunction) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["categorical_aggregation_function"] = apiObject.CategoricalAggregationFunction
 	tfMap["date_aggregation_function"] = apiObject.DateAggregationFunction
@@ -1562,44 +1562,44 @@ func flattenAggregationFunction(apiObject *awstypes.AggregationFunction) []inter
 		tfMap["numerical_aggregation_function"] = flattenNumericalAggregationFunction(apiObject.NumericalAggregationFunction)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericalAggregationFunction(apiObject *awstypes.NumericalAggregationFunction) []interface{} {
+func flattenNumericalAggregationFunction(apiObject *awstypes.NumericalAggregationFunction) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PercentileAggregation != nil {
 		tfMap["percentile_aggregation"] = flattenPercentileAggregation(apiObject.PercentileAggregation)
 	}
 	tfMap["simple_numerical_aggregation"] = apiObject.SimpleNumericalAggregation
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPercentileAggregation(apiObject *awstypes.PercentileAggregation) []interface{} {
+func flattenPercentileAggregation(apiObject *awstypes.PercentileAggregation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PercentileValue != nil {
 		tfMap["percentile_value"] = aws.ToFloat64(apiObject.PercentileValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRollingDateConfiguration(apiObject *awstypes.RollingDateConfiguration) []interface{} {
+func flattenRollingDateConfiguration(apiObject *awstypes.RollingDateConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataSetIdentifier != nil {
 		tfMap["data_set_identifier"] = aws.ToString(apiObject.DataSetIdentifier)
@@ -1608,18 +1608,18 @@ func flattenRollingDateConfiguration(apiObject *awstypes.RollingDateConfiguratio
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterDeclarations(apiObjects []awstypes.ParameterDeclaration) []interface{} {
+func flattenParameterDeclarations(apiObjects []awstypes.ParameterDeclaration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DateTimeParameterDeclaration != nil {
 			tfMap["date_time_parameter_declaration"] = flattenDateTimeParameterDeclaration(apiObject.DateTimeParameterDeclaration)
@@ -1639,15 +1639,15 @@ func flattenParameterDeclarations(apiObjects []awstypes.ParameterDeclaration) []
 	return tfList
 }
 
-func flattenSheetDefinitions(apiObjects []awstypes.SheetDefinition) []interface{} {
+func flattenSheetDefinitions(apiObjects []awstypes.SheetDefinition) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"sheet_id": aws.ToString(apiObject.SheetId),
 		}
 
@@ -1686,15 +1686,15 @@ func flattenSheetDefinitions(apiObjects []awstypes.SheetDefinition) []interface{
 	return tfList
 }
 
-func flattenTextBoxes(apiObjects []awstypes.SheetTextBox) []interface{} {
+func flattenTextBoxes(apiObjects []awstypes.SheetTextBox) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"sheet_text_box_id": aws.ToString(apiObject.SheetTextBoxId),
 		}
 

--- a/internal/service/quicksight/schema/template_control.go
+++ b/internal/service/quicksight/schema/template_control.go
@@ -312,44 +312,44 @@ var placeholderOptionsSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandFilterControl(tfMap map[string]interface{}) *awstypes.FilterControl {
+func expandFilterControl(tfMap map[string]any) *awstypes.FilterControl {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.FilterControl{}
 
-	if v, ok := tfMap["date_time_picker"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_picker"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimePicker = expandFilterDateTimePickerControl(v)
 	}
-	if v, ok := tfMap["dropdown"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dropdown"].([]any); ok && len(v) > 0 {
 		apiObject.Dropdown = expandFilterDropDownControl(v)
 	}
-	if v, ok := tfMap["list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["list"].([]any); ok && len(v) > 0 {
 		apiObject.List = expandFilterListControl(v)
 	}
-	if v, ok := tfMap["relative_date_time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["relative_date_time"].([]any); ok && len(v) > 0 {
 		apiObject.RelativeDateTime = expandFilterRelativeDateTimeControl(v)
 	}
-	if v, ok := tfMap["slider"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["slider"].([]any); ok && len(v) > 0 {
 		apiObject.Slider = expandFilterSliderControl(v)
 	}
-	if v, ok := tfMap["text_area"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_area"].([]any); ok && len(v) > 0 {
 		apiObject.TextArea = expandFilterTextAreaControl(v)
 	}
-	if v, ok := tfMap["text_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_field"].([]any); ok && len(v) > 0 {
 		apiObject.TextField = expandFilterTextFieldControl(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterDateTimePickerControl(tfList []interface{}) *awstypes.FilterDateTimePickerControl {
+func expandFilterDateTimePickerControl(tfList []any) *awstypes.FilterDateTimePickerControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -368,19 +368,19 @@ func expandFilterDateTimePickerControl(tfList []interface{}) *awstypes.FilterDat
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.SheetControlDateTimePickerType(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandDateTimePickerControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimePickerControlDisplayOptions(tfList []interface{}) *awstypes.DateTimePickerControlDisplayOptions {
+func expandDateTimePickerControlDisplayOptions(tfList []any) *awstypes.DateTimePickerControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -390,19 +390,19 @@ func expandDateTimePickerControlDisplayOptions(tfList []interface{}) *awstypes.D
 	if v, ok := tfMap["date_time_format"].(string); ok && v != "" {
 		apiObject.DateTimeFormat = aws.String(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterDropDownControl(tfList []interface{}) *awstypes.FilterDropDownControl {
+func expandFilterDropDownControl(tfList []any) *awstypes.FilterDropDownControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -421,39 +421,39 @@ func expandFilterDropDownControl(tfList []interface{}) *awstypes.FilterDropDownC
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.SheetControlListType(v)
 	}
-	if v, ok := tfMap["cascading_control_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cascading_control_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CascadingControlConfiguration = expandCascadingControlConfiguration(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandDropDownControlDisplayOptions(v)
 	}
-	if v, ok := tfMap["selectable_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selectable_values"].([]any); ok && len(v) > 0 {
 		apiObject.SelectableValues = expandFilterSelectableValues(v)
 	}
 
 	return apiObject
 }
 
-func expandCascadingControlConfiguration(tfList []interface{}) *awstypes.CascadingControlConfiguration {
+func expandCascadingControlConfiguration(tfList []any) *awstypes.CascadingControlConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CascadingControlConfiguration{}
 
-	if v, ok := tfMap["source_controls"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["source_controls"].([]any); ok && len(v) > 0 {
 		apiObject.SourceControls = expandCascadingControlSources(v)
 	}
 
 	return apiObject
 }
 
-func expandCascadingControlSources(tfList []interface{}) []awstypes.CascadingControlSource {
+func expandCascadingControlSources(tfList []any) []awstypes.CascadingControlSource {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -461,7 +461,7 @@ func expandCascadingControlSources(tfList []interface{}) []awstypes.CascadingCon
 	var apiObjects []awstypes.CascadingControlSource
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -477,7 +477,7 @@ func expandCascadingControlSources(tfList []interface{}) []awstypes.CascadingCon
 	return apiObjects
 }
 
-func expandCascadingControlSource(tfMap map[string]interface{}) *awstypes.CascadingControlSource {
+func expandCascadingControlSource(tfMap map[string]any) *awstypes.CascadingControlSource {
 	if tfMap == nil {
 		return nil
 	}
@@ -487,41 +487,41 @@ func expandCascadingControlSource(tfMap map[string]interface{}) *awstypes.Cascad
 	if v, ok := tfMap["source_sheet_control_id"].(string); ok && v != "" {
 		apiObject.SourceSheetControlId = aws.String(v)
 	}
-	if v, ok := tfMap["column_to_match"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_to_match"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnToMatch = expandColumnIdentifier(v)
 	}
 
 	return apiObject
 }
 
-func expandDropDownControlDisplayOptions(tfList []interface{}) *awstypes.DropDownControlDisplayOptions {
+func expandDropDownControlDisplayOptions(tfList []any) *awstypes.DropDownControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DropDownControlDisplayOptions{}
 
-	if v, ok := tfMap["select_all_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["select_all_options"].([]any); ok && len(v) > 0 {
 		apiObject.SelectAllOptions = expandListControlSelectAllOptions(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandListControlSelectAllOptions(tfList []interface{}) *awstypes.ListControlSelectAllOptions {
+func expandListControlSelectAllOptions(tfList []any) *awstypes.ListControlSelectAllOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -535,31 +535,31 @@ func expandListControlSelectAllOptions(tfList []interface{}) *awstypes.ListContr
 	return apiObject
 }
 
-func expandFilterSelectableValues(tfList []interface{}) *awstypes.FilterSelectableValues {
+func expandFilterSelectableValues(tfList []any) *awstypes.FilterSelectableValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilterSelectableValues{}
 
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok {
+	if v, ok := tfMap[names.AttrValues].([]any); ok {
 		apiObject.Values = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterListControl(tfList []interface{}) *awstypes.FilterListControl {
+func expandFilterListControl(tfList []any) *awstypes.FilterListControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -578,50 +578,50 @@ func expandFilterListControl(tfList []interface{}) *awstypes.FilterListControl {
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.SheetControlListType(v)
 	}
-	if v, ok := tfMap["cascading_control_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cascading_control_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CascadingControlConfiguration = expandCascadingControlConfiguration(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandListControlDisplayOptions(v)
 	}
-	if v, ok := tfMap["selectable_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selectable_values"].([]any); ok && len(v) > 0 {
 		apiObject.SelectableValues = expandFilterSelectableValues(v)
 	}
 
 	return apiObject
 }
 
-func expandListControlDisplayOptions(tfList []interface{}) *awstypes.ListControlDisplayOptions {
+func expandListControlDisplayOptions(tfList []any) *awstypes.ListControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ListControlDisplayOptions{}
 
-	if v, ok := tfMap["select_all_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["select_all_options"].([]any); ok && len(v) > 0 {
 		apiObject.SelectAllOptions = expandListControlSelectAllOptions(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
-	if v, ok := tfMap["search_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["search_options"].([]any); ok && len(v) > 0 {
 		apiObject.SearchOptions = expandListControlSearchOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandListControlSearchOptions(tfList []interface{}) *awstypes.ListControlSearchOptions {
+func expandListControlSearchOptions(tfList []any) *awstypes.ListControlSearchOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -635,12 +635,12 @@ func expandListControlSearchOptions(tfList []interface{}) *awstypes.ListControlS
 	return apiObject
 }
 
-func expandFilterRelativeDateTimeControl(tfList []interface{}) *awstypes.FilterRelativeDateTimeControl {
+func expandFilterRelativeDateTimeControl(tfList []any) *awstypes.FilterRelativeDateTimeControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -656,19 +656,19 @@ func expandFilterRelativeDateTimeControl(tfList []interface{}) *awstypes.FilterR
 	if v, ok := tfMap["title"].(string); ok && v != "" {
 		apiObject.Title = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandRelativeDateTimeControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandRelativeDateTimeControlDisplayOptions(tfList []interface{}) *awstypes.RelativeDateTimeControlDisplayOptions {
+func expandRelativeDateTimeControlDisplayOptions(tfList []any) *awstypes.RelativeDateTimeControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -678,19 +678,19 @@ func expandRelativeDateTimeControlDisplayOptions(tfList []interface{}) *awstypes
 	if v, ok := tfMap["date_time_format"].(string); ok && v != "" {
 		apiObject.DateTimeFormat = aws.String(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterSliderControl(tfList []interface{}) *awstypes.FilterSliderControl {
+func expandFilterSliderControl(tfList []any) *awstypes.FilterSliderControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -718,38 +718,38 @@ func expandFilterSliderControl(tfList []interface{}) *awstypes.FilterSliderContr
 	if v, ok := tfMap["step_size"].(float64); ok {
 		apiObject.StepSize = v
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandSliderControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandSliderControlDisplayOptions(tfList []interface{}) *awstypes.SliderControlDisplayOptions {
+func expandSliderControlDisplayOptions(tfList []any) *awstypes.SliderControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SliderControlDisplayOptions{}
 
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterTextAreaControl(tfList []interface{}) *awstypes.FilterTextAreaControl {
+func expandFilterTextAreaControl(tfList []any) *awstypes.FilterTextAreaControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -768,41 +768,41 @@ func expandFilterTextAreaControl(tfList []interface{}) *awstypes.FilterTextAreaC
 	if v, ok := tfMap["delimiter"].(string); ok && v != "" {
 		apiObject.Delimiter = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandTextAreaControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTextAreaControlDisplayOptions(tfList []interface{}) *awstypes.TextAreaControlDisplayOptions {
+func expandTextAreaControlDisplayOptions(tfList []any) *awstypes.TextAreaControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TextAreaControlDisplayOptions{}
 
-	if v, ok := tfMap["placeholder_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["placeholder_options"].([]any); ok && len(v) > 0 {
 		apiObject.PlaceholderOptions = expandTextControlPlaceholderOptions(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTextControlPlaceholderOptions(tfList []interface{}) *awstypes.TextControlPlaceholderOptions {
+func expandTextControlPlaceholderOptions(tfList []any) *awstypes.TextControlPlaceholderOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -816,12 +816,12 @@ func expandTextControlPlaceholderOptions(tfList []interface{}) *awstypes.TextCon
 	return apiObject
 }
 
-func expandFilterTextFieldControl(tfList []interface{}) *awstypes.FilterTextFieldControl {
+func expandFilterTextFieldControl(tfList []any) *awstypes.FilterTextFieldControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -837,70 +837,70 @@ func expandFilterTextFieldControl(tfList []interface{}) *awstypes.FilterTextFiel
 	if v, ok := tfMap["title"].(string); ok && v != "" {
 		apiObject.Title = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandTextFieldControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTextFieldControlDisplayOptions(tfList []interface{}) *awstypes.TextFieldControlDisplayOptions {
+func expandTextFieldControlDisplayOptions(tfList []any) *awstypes.TextFieldControlDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TextFieldControlDisplayOptions{}
 
-	if v, ok := tfMap["placeholder_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["placeholder_options"].([]any); ok && len(v) > 0 {
 		apiObject.PlaceholderOptions = expandTextControlPlaceholderOptions(v)
 	}
-	if v, ok := tfMap["title_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title_options"].([]any); ok && len(v) > 0 {
 		apiObject.TitleOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterControl(tfMap map[string]interface{}) *awstypes.ParameterControl {
+func expandParameterControl(tfMap map[string]any) *awstypes.ParameterControl {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ParameterControl{}
 
-	if v, ok := tfMap["date_time_picker"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_picker"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimePicker = expandParameterDateTimePickerControl(v)
 	}
-	if v, ok := tfMap["dropdown"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dropdown"].([]any); ok && len(v) > 0 {
 		apiObject.Dropdown = expandParameterDropDownControl(v)
 	}
-	if v, ok := tfMap["list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["list"].([]any); ok && len(v) > 0 {
 		apiObject.List = expandParameterListControl(v)
 	}
-	if v, ok := tfMap["slider"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["slider"].([]any); ok && len(v) > 0 {
 		apiObject.Slider = expandParameterSliderControl(v)
 	}
-	if v, ok := tfMap["text_area"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_area"].([]any); ok && len(v) > 0 {
 		apiObject.TextArea = expandParameterTextAreaControl(v)
 	}
-	if v, ok := tfMap["text_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_field"].([]any); ok && len(v) > 0 {
 		apiObject.TextField = expandParameterTextFieldControl(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterDateTimePickerControl(tfList []interface{}) *awstypes.ParameterDateTimePickerControl {
+func expandParameterDateTimePickerControl(tfList []any) *awstypes.ParameterDateTimePickerControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -916,19 +916,19 @@ func expandParameterDateTimePickerControl(tfList []interface{}) *awstypes.Parame
 	if v, ok := tfMap["title"].(string); ok && v != "" {
 		apiObject.Title = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandDateTimePickerControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterDropDownControl(tfList []interface{}) *awstypes.ParameterDropDownControl {
+func expandParameterDropDownControl(tfList []any) *awstypes.ParameterDropDownControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -947,25 +947,25 @@ func expandParameterDropDownControl(tfList []interface{}) *awstypes.ParameterDro
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.SheetControlListType(v)
 	}
-	if v, ok := tfMap["cascading_control_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cascading_control_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CascadingControlConfiguration = expandCascadingControlConfiguration(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandDropDownControlDisplayOptions(v)
 	}
-	if v, ok := tfMap["selectable_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selectable_values"].([]any); ok && len(v) > 0 {
 		apiObject.SelectableValues = expandParameterSelectableValues(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterListControl(tfList []interface{}) *awstypes.ParameterListControl {
+func expandParameterListControl(tfList []any) *awstypes.ParameterListControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -984,25 +984,25 @@ func expandParameterListControl(tfList []interface{}) *awstypes.ParameterListCon
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.SheetControlListType(v)
 	}
-	if v, ok := tfMap["cascading_control_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cascading_control_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CascadingControlConfiguration = expandCascadingControlConfiguration(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandListControlDisplayOptions(v)
 	}
-	if v, ok := tfMap["selectable_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selectable_values"].([]any); ok && len(v) > 0 {
 		apiObject.SelectableValues = expandParameterSelectableValues(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterSliderControl(tfList []interface{}) *awstypes.ParameterSliderControl {
+func expandParameterSliderControl(tfList []any) *awstypes.ParameterSliderControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1027,19 +1027,19 @@ func expandParameterSliderControl(tfList []interface{}) *awstypes.ParameterSlide
 	if v, ok := tfMap["step_size"].(float64); ok {
 		apiObject.StepSize = v
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandSliderControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterTextAreaControl(tfList []interface{}) *awstypes.ParameterTextAreaControl {
+func expandParameterTextAreaControl(tfList []any) *awstypes.ParameterTextAreaControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1058,19 +1058,19 @@ func expandParameterTextAreaControl(tfList []interface{}) *awstypes.ParameterTex
 	if v, ok := tfMap["delimiter"].(string); ok && v != "" {
 		apiObject.Delimiter = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandTextAreaControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterTextFieldControl(tfList []interface{}) *awstypes.ParameterTextFieldControl {
+func expandParameterTextFieldControl(tfList []any) *awstypes.ParameterTextFieldControl {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1086,22 +1086,22 @@ func expandParameterTextFieldControl(tfList []interface{}) *awstypes.ParameterTe
 	if v, ok := tfMap["title"].(string); ok && v != "" {
 		apiObject.Title = aws.String(v)
 	}
-	if v, ok := tfMap["display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_options"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayOptions = expandTextFieldControlDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func flattenFilterControls(apiObjects []awstypes.FilterControl) []interface{} {
+func flattenFilterControls(apiObjects []awstypes.FilterControl) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DateTimePicker != nil {
 			tfMap["date_time_picker"] = flattenFilterDateTimePickerControl(apiObject.DateTimePicker)
@@ -1131,12 +1131,12 @@ func flattenFilterControls(apiObjects []awstypes.FilterControl) []interface{} {
 	return tfList
 }
 
-func flattenFilterDateTimePickerControl(apiObject *awstypes.FilterDateTimePickerControl) []interface{} {
+func flattenFilterDateTimePickerControl(apiObject *awstypes.FilterDateTimePickerControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1147,15 +1147,15 @@ func flattenFilterDateTimePickerControl(apiObject *awstypes.FilterDateTimePicker
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateTimePickerControlDisplayOptions(apiObject *awstypes.DateTimePickerControlDisplayOptions) []interface{} {
+func flattenDateTimePickerControlDisplayOptions(apiObject *awstypes.DateTimePickerControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateTimeFormat != nil {
 		tfMap["date_time_format"] = aws.ToString(apiObject.DateTimeFormat)
@@ -1164,15 +1164,15 @@ func flattenDateTimePickerControlDisplayOptions(apiObject *awstypes.DateTimePick
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLabelOptions(apiObject *awstypes.LabelOptions) []interface{} {
+func flattenLabelOptions(apiObject *awstypes.LabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomLabel != nil {
 		tfMap["custom_label"] = aws.ToString(apiObject.CustomLabel)
@@ -1182,15 +1182,15 @@ func flattenLabelOptions(apiObject *awstypes.LabelOptions) []interface{} {
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFontConfiguration(apiObject *awstypes.FontConfiguration) []interface{} {
+func flattenFontConfiguration(apiObject *awstypes.FontConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FontColor != nil {
 		tfMap["font_color"] = aws.ToString(apiObject.FontColor)
@@ -1204,39 +1204,39 @@ func flattenFontConfiguration(apiObject *awstypes.FontConfiguration) []interface
 		tfMap["font_weight"] = flattenFontWeight(apiObject.FontWeight)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFontSize(apiObject *awstypes.FontSize) []interface{} {
+func flattenFontSize(apiObject *awstypes.FontSize) []any {
 	if apiObject == nil || apiObject.Relative == "" {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"relative": apiObject.Relative,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFontWeight(apiObject *awstypes.FontWeight) []interface{} {
+func flattenFontWeight(apiObject *awstypes.FontWeight) []any {
 	if apiObject == nil || apiObject.Name == "" {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrName: apiObject.Name,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterDropDownControl(apiObject *awstypes.FilterDropDownControl) []interface{} {
+func flattenFilterDropDownControl(apiObject *awstypes.FilterDropDownControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1253,32 +1253,32 @@ func flattenFilterDropDownControl(apiObject *awstypes.FilterDropDownControl) []i
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCascadingControlConfiguration(apiObject *awstypes.CascadingControlConfiguration) []interface{} {
+func flattenCascadingControlConfiguration(apiObject *awstypes.CascadingControlConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SourceControls != nil {
 		tfMap["source_controls"] = flattenCascadingControlSource(apiObject.SourceControls)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCascadingControlSource(apiObjects []awstypes.CascadingControlSource) []interface{} {
+func flattenCascadingControlSource(apiObjects []awstypes.CascadingControlSource) []any {
 	if apiObjects == nil {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnToMatch != nil {
 			tfMap["column_to_match"] = flattenColumnIdentifier(apiObject.ColumnToMatch)
@@ -1293,12 +1293,12 @@ func flattenCascadingControlSource(apiObjects []awstypes.CascadingControlSource)
 	return tfList
 }
 
-func flattenDropDownControlDisplayOptions(apiObject *awstypes.DropDownControlDisplayOptions) []interface{} {
+func flattenDropDownControlDisplayOptions(apiObject *awstypes.DropDownControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SelectAllOptions != nil {
 		tfMap["select_all_options"] = flattenListControlSelectAllOptions(apiObject.SelectAllOptions)
@@ -1307,41 +1307,41 @@ func flattenDropDownControlDisplayOptions(apiObject *awstypes.DropDownControlDis
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenListControlSelectAllOptions(apiObject *awstypes.ListControlSelectAllOptions) []interface{} {
+func flattenListControlSelectAllOptions(apiObject *awstypes.ListControlSelectAllOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterSelectableValues(apiObject *awstypes.FilterSelectableValues) []interface{} {
+func flattenFilterSelectableValues(apiObject *awstypes.FilterSelectableValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Values != nil {
 		tfMap[names.AttrValues] = apiObject.Values
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterListControl(apiObject *awstypes.FilterListControl) []interface{} {
+func flattenFilterListControl(apiObject *awstypes.FilterListControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1358,15 +1358,15 @@ func flattenFilterListControl(apiObject *awstypes.FilterListControl) []interface
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenListControlDisplayOptions(apiObject *awstypes.ListControlDisplayOptions) []interface{} {
+func flattenListControlDisplayOptions(apiObject *awstypes.ListControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SearchOptions != nil {
 		tfMap["search_options"] = flattenListControlSearchOptions(apiObject.SearchOptions)
@@ -1378,27 +1378,27 @@ func flattenListControlDisplayOptions(apiObject *awstypes.ListControlDisplayOpti
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenListControlSearchOptions(apiObject *awstypes.ListControlSearchOptions) []interface{} {
+func flattenListControlSearchOptions(apiObject *awstypes.ListControlSearchOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterRelativeDateTimeControl(apiObject *awstypes.FilterRelativeDateTimeControl) []interface{} {
+func flattenFilterRelativeDateTimeControl(apiObject *awstypes.FilterRelativeDateTimeControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1408,15 +1408,15 @@ func flattenFilterRelativeDateTimeControl(apiObject *awstypes.FilterRelativeDate
 		tfMap["display_options"] = flattenRelativeDateTimeControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRelativeDateTimeControlDisplayOptions(apiObject *awstypes.RelativeDateTimeControlDisplayOptions) []interface{} {
+func flattenRelativeDateTimeControlDisplayOptions(apiObject *awstypes.RelativeDateTimeControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateTimeFormat != nil {
 		tfMap["date_time_format"] = aws.ToString(apiObject.DateTimeFormat)
@@ -1425,15 +1425,15 @@ func flattenRelativeDateTimeControlDisplayOptions(apiObject *awstypes.RelativeDa
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterSliderControl(apiObject *awstypes.FilterSliderControl) []interface{} {
+func flattenFilterSliderControl(apiObject *awstypes.FilterSliderControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1447,29 +1447,29 @@ func flattenFilterSliderControl(apiObject *awstypes.FilterSliderControl) []inter
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSliderControlDisplayOptions(apiObject *awstypes.SliderControlDisplayOptions) []interface{} {
+func flattenSliderControlDisplayOptions(apiObject *awstypes.SliderControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TitleOptions != nil {
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterTextAreaControl(apiObject *awstypes.FilterTextAreaControl) []interface{} {
+func flattenFilterTextAreaControl(apiObject *awstypes.FilterTextAreaControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1482,15 +1482,15 @@ func flattenFilterTextAreaControl(apiObject *awstypes.FilterTextAreaControl) []i
 		tfMap["display_options"] = flattenTextAreaControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTextAreaControlDisplayOptions(apiObject *awstypes.TextAreaControlDisplayOptions) []interface{} {
+func flattenTextAreaControlDisplayOptions(apiObject *awstypes.TextAreaControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PlaceholderOptions != nil {
 		tfMap["placeholder_options"] = flattenTextControlPlaceholderOptions(apiObject.PlaceholderOptions)
@@ -1499,27 +1499,27 @@ func flattenTextAreaControlDisplayOptions(apiObject *awstypes.TextAreaControlDis
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTextControlPlaceholderOptions(apiObject *awstypes.TextControlPlaceholderOptions) []interface{} {
+func flattenTextControlPlaceholderOptions(apiObject *awstypes.TextControlPlaceholderOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterTextFieldControl(apiObject *awstypes.FilterTextFieldControl) []interface{} {
+func flattenFilterTextFieldControl(apiObject *awstypes.FilterTextFieldControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"filter_control_id": aws.ToString(apiObject.FilterControlId),
 		"source_filter_id":  aws.ToString(apiObject.SourceFilterId),
 		"title":             aws.ToString(apiObject.Title),
@@ -1529,15 +1529,15 @@ func flattenFilterTextFieldControl(apiObject *awstypes.FilterTextFieldControl) [
 		tfMap["display_options"] = flattenTextFieldControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTextFieldControlDisplayOptions(apiObject *awstypes.TextFieldControlDisplayOptions) []interface{} {
+func flattenTextFieldControlDisplayOptions(apiObject *awstypes.TextFieldControlDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PlaceholderOptions != nil {
 		tfMap["placeholder_options"] = flattenTextControlPlaceholderOptions(apiObject.PlaceholderOptions)
@@ -1546,5 +1546,5 @@ func flattenTextFieldControlDisplayOptions(apiObject *awstypes.TextFieldControlD
 		tfMap["title_options"] = flattenLabelOptions(apiObject.TitleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/template_filter.go
+++ b/internal/service/quicksight/schema/template_filter.go
@@ -496,7 +496,7 @@ var filterScopeConfigurationSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandFilters(tfList []interface{}) []awstypes.Filter {
+func expandFilters(tfList []any) []awstypes.Filter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -504,7 +504,7 @@ func expandFilters(tfList []interface{}) []awstypes.Filter {
 	var apiObjects []awstypes.Filter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -520,44 +520,44 @@ func expandFilters(tfList []interface{}) []awstypes.Filter {
 	return apiObjects
 }
 
-func expandFilter(tfMap map[string]interface{}) *awstypes.Filter {
+func expandFilter(tfMap map[string]any) *awstypes.Filter {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.Filter{}
 
-	if v, ok := tfMap["category_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_filter"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryFilter = expandCategoryFilter(v)
 	}
-	if v, ok := tfMap["numeric_equality_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_equality_filter"].([]any); ok && len(v) > 0 {
 		apiObject.NumericEqualityFilter = expandNumericEqualityFilter(v)
 	}
-	if v, ok := tfMap["numeric_range_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_range_filter"].([]any); ok && len(v) > 0 {
 		apiObject.NumericRangeFilter = expandNumericRangeFilter(v)
 	}
-	if v, ok := tfMap["relative_dates_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["relative_dates_filter"].([]any); ok && len(v) > 0 {
 		apiObject.RelativeDatesFilter = expandRelativeDatesFilter(v)
 	}
-	if v, ok := tfMap["time_equality_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time_equality_filter"].([]any); ok && len(v) > 0 {
 		apiObject.TimeEqualityFilter = expandTimeEqualityFilter(v)
 	}
-	if v, ok := tfMap["time_range_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time_range_filter"].([]any); ok && len(v) > 0 {
 		apiObject.TimeRangeFilter = expandTimeRangeFilter(v)
 	}
-	if v, ok := tfMap["top_bottom_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["top_bottom_filter"].([]any); ok && len(v) > 0 {
 		apiObject.TopBottomFilter = expandTopBottomFilter(v)
 	}
 
 	return apiObject
 }
 
-func expandCategoryFilter(tfList []interface{}) *awstypes.CategoryFilter {
+func expandCategoryFilter(tfList []any) *awstypes.CategoryFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -567,47 +567,47 @@ func expandCategoryFilter(tfList []interface{}) *awstypes.CategoryFilter {
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap[names.AttrConfiguration].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrConfiguration].([]any); ok && len(v) > 0 {
 		apiObject.Configuration = expandCategoryFilterConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandCategoryFilterConfiguration(tfList []interface{}) *awstypes.CategoryFilterConfiguration {
+func expandCategoryFilterConfiguration(tfList []any) *awstypes.CategoryFilterConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CategoryFilterConfiguration{}
 
-	if v, ok := tfMap["custom_filter_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_filter_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CustomFilterConfiguration = expandCustomFilterConfiguration(v)
 	}
-	if v, ok := tfMap["custom_filter_list_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_filter_list_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CustomFilterListConfiguration = expandCustomFilterListConfiguration(v)
 	}
-	if v, ok := tfMap["filter_list_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_list_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FilterListConfiguration = expandFilterListConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandCustomFilterConfiguration(tfList []interface{}) *awstypes.CustomFilterConfiguration {
+func expandCustomFilterConfiguration(tfList []any) *awstypes.CustomFilterConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -633,19 +633,19 @@ func expandCustomFilterConfiguration(tfList []interface{}) *awstypes.CustomFilte
 	return apiObject
 }
 
-func expandCustomFilterListConfiguration(tfList []interface{}) *awstypes.CustomFilterListConfiguration {
+func expandCustomFilterListConfiguration(tfList []any) *awstypes.CustomFilterListConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomFilterListConfiguration{}
 
-	if v, ok := tfMap["category_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_values"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryValues = flex.ExpandStringValueList(v)
 	}
 	if v, ok := tfMap["match_operator"].(string); ok && v != "" {
@@ -661,19 +661,19 @@ func expandCustomFilterListConfiguration(tfList []interface{}) *awstypes.CustomF
 	return apiObject
 }
 
-func expandFilterListConfiguration(tfList []interface{}) *awstypes.FilterListConfiguration {
+func expandFilterListConfiguration(tfList []any) *awstypes.FilterListConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilterListConfiguration{}
 
-	if v, ok := tfMap["category_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_values"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryValues = flex.ExpandStringValueList(v)
 	}
 	if v, ok := tfMap["match_operator"].(string); ok && v != "" {
@@ -686,12 +686,12 @@ func expandFilterListConfiguration(tfList []interface{}) *awstypes.FilterListCon
 	return apiObject
 }
 
-func expandNumericEqualityFilter(tfList []interface{}) *awstypes.NumericEqualityFilter {
+func expandNumericEqualityFilter(tfList []any) *awstypes.NumericEqualityFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -701,7 +701,7 @@ func expandNumericEqualityFilter(tfList []interface{}) *awstypes.NumericEquality
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["match_operator"].(string); ok && v != "" {
@@ -719,52 +719,52 @@ func expandNumericEqualityFilter(tfList []interface{}) *awstypes.NumericEquality
 	if v, ok := tfMap[names.AttrValue].(float64); ok {
 		apiObject.Value = aws.Float64(v)
 	}
-	if v, ok := tfMap["aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationFunction = expandAggregationFunction(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterScopeConfiguration(tfList []interface{}) *awstypes.FilterScopeConfiguration {
+func expandFilterScopeConfiguration(tfList []any) *awstypes.FilterScopeConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilterScopeConfiguration{}
 
-	if v, ok := tfMap["selected_sheets"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selected_sheets"].([]any); ok && len(v) > 0 {
 		apiObject.SelectedSheets = expandSelectedSheetsFilterScopeConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSelectedSheetsFilterScopeConfiguration(tfList []interface{}) *awstypes.SelectedSheetsFilterScopeConfiguration {
+func expandSelectedSheetsFilterScopeConfiguration(tfList []any) *awstypes.SelectedSheetsFilterScopeConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SelectedSheetsFilterScopeConfiguration{}
 
-	if v, ok := tfMap["sheet_visual_scoping_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheet_visual_scoping_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.SheetVisualScopingConfigurations = expandSheetVisualScopingConfigurations(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetVisualScopingConfigurations(tfList []interface{}) []awstypes.SheetVisualScopingConfiguration {
+func expandSheetVisualScopingConfigurations(tfList []any) []awstypes.SheetVisualScopingConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -772,7 +772,7 @@ func expandSheetVisualScopingConfigurations(tfList []interface{}) []awstypes.She
 	var apiObjects []awstypes.SheetVisualScopingConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -788,7 +788,7 @@ func expandSheetVisualScopingConfigurations(tfList []interface{}) []awstypes.She
 	return apiObjects
 }
 
-func expandSheetVisualScopingConfiguration(tfMap map[string]interface{}) *awstypes.SheetVisualScopingConfiguration {
+func expandSheetVisualScopingConfiguration(tfMap map[string]any) *awstypes.SheetVisualScopingConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -808,12 +808,12 @@ func expandSheetVisualScopingConfiguration(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func expandNumericRangeFilter(tfList []interface{}) *awstypes.NumericRangeFilter {
+func expandNumericRangeFilter(tfList []any) *awstypes.NumericRangeFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -823,7 +823,7 @@ func expandNumericRangeFilter(tfList []interface{}) *awstypes.NumericRangeFilter
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["null_option"].(string); ok && v != "" {
@@ -832,7 +832,7 @@ func expandNumericRangeFilter(tfList []interface{}) *awstypes.NumericRangeFilter
 	if v, ok := tfMap["select_all_options"].(string); ok && v != "" {
 		apiObject.SelectAllOptions = awstypes.NumericFilterSelectAllOptions(v)
 	}
-	if v, ok := tfMap["aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationFunction = expandAggregationFunction(v)
 	}
 	if v, ok := tfMap["include_maximum"].(bool); ok {
@@ -841,22 +841,22 @@ func expandNumericRangeFilter(tfList []interface{}) *awstypes.NumericRangeFilter
 	if v, ok := tfMap["include_minimum"].(bool); ok {
 		apiObject.IncludeMinimum = aws.Bool(v)
 	}
-	if v, ok := tfMap["range_maximum"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range_maximum"].([]any); ok && len(v) > 0 {
 		apiObject.RangeMaximum = expandNumericRangeFilterValue(v)
 	}
-	if v, ok := tfMap["range_minimum"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range_minimum"].([]any); ok && len(v) > 0 {
 		apiObject.RangeMinimum = expandNumericRangeFilterValue(v)
 	}
 
 	return apiObject
 }
 
-func expandNumericRangeFilterValue(tfList []interface{}) *awstypes.NumericRangeFilterValue {
+func expandNumericRangeFilterValue(tfList []any) *awstypes.NumericRangeFilterValue {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -873,12 +873,12 @@ func expandNumericRangeFilterValue(tfList []interface{}) *awstypes.NumericRangeF
 	return apiObject
 }
 
-func expandRelativeDatesFilter(tfList []interface{}) *awstypes.RelativeDatesFilter {
+func expandRelativeDatesFilter(tfList []any) *awstypes.RelativeDatesFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -888,7 +888,7 @@ func expandRelativeDatesFilter(tfList []interface{}) *awstypes.RelativeDatesFilt
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["null_option"].(string); ok && v != "" {
@@ -909,22 +909,22 @@ func expandRelativeDatesFilter(tfList []interface{}) *awstypes.RelativeDatesFilt
 	if v, ok := tfMap["relative_date_value"].(int); ok {
 		apiObject.RelativeDateValue = aws.Int32(int32(v))
 	}
-	if v, ok := tfMap["anchor_date_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["anchor_date_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.AnchorDateConfiguration = expandAnchorDateConfiguration(v)
 	}
-	if v, ok := tfMap["exclude_period_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["exclude_period_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ExcludePeriodConfiguration = expandExcludePeriodConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandAnchorDateConfiguration(tfList []interface{}) *awstypes.AnchorDateConfiguration {
+func expandAnchorDateConfiguration(tfList []any) *awstypes.AnchorDateConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -941,12 +941,12 @@ func expandAnchorDateConfiguration(tfList []interface{}) *awstypes.AnchorDateCon
 	return apiObject
 }
 
-func expandExcludePeriodConfiguration(tfList []interface{}) *awstypes.ExcludePeriodConfiguration {
+func expandExcludePeriodConfiguration(tfList []any) *awstypes.ExcludePeriodConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -966,12 +966,12 @@ func expandExcludePeriodConfiguration(tfList []interface{}) *awstypes.ExcludePer
 	return apiObject
 }
 
-func expandTimeEqualityFilter(tfList []interface{}) *awstypes.TimeEqualityFilter {
+func expandTimeEqualityFilter(tfList []any) *awstypes.TimeEqualityFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -981,7 +981,7 @@ func expandTimeEqualityFilter(tfList []interface{}) *awstypes.TimeEqualityFilter
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
@@ -998,12 +998,12 @@ func expandTimeEqualityFilter(tfList []interface{}) *awstypes.TimeEqualityFilter
 	return apiObject
 }
 
-func expandTimeRangeFilter(tfList []interface{}) *awstypes.TimeRangeFilter {
+func expandTimeRangeFilter(tfList []any) *awstypes.TimeRangeFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1013,7 +1013,7 @@ func expandTimeRangeFilter(tfList []interface{}) *awstypes.TimeRangeFilter {
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["null_option"].(string); ok && v != "" {
@@ -1022,7 +1022,7 @@ func expandTimeRangeFilter(tfList []interface{}) *awstypes.TimeRangeFilter {
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
 		apiObject.TimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["exclude_period_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["exclude_period_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ExcludePeriodConfiguration = expandExcludePeriodConfiguration(v)
 	}
 	if v, ok := tfMap["include_maximum"].(bool); ok {
@@ -1031,22 +1031,22 @@ func expandTimeRangeFilter(tfList []interface{}) *awstypes.TimeRangeFilter {
 	if v, ok := tfMap["include_minimum"].(bool); ok {
 		apiObject.IncludeMinimum = aws.Bool(v)
 	}
-	if v, ok := tfMap["range_maximum_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range_maximum_value"].([]any); ok && len(v) > 0 {
 		apiObject.RangeMaximumValue = expandTimeRangeFilterValue(v)
 	}
-	if v, ok := tfMap["range_minimum_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range_minimum_value"].([]any); ok && len(v) > 0 {
 		apiObject.RangeMinimumValue = expandTimeRangeFilterValue(v)
 	}
 
 	return apiObject
 }
 
-func expandTimeRangeFilterValue(tfList []interface{}) *awstypes.TimeRangeFilterValue {
+func expandTimeRangeFilterValue(tfList []any) *awstypes.TimeRangeFilterValue {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1060,19 +1060,19 @@ func expandTimeRangeFilterValue(tfList []interface{}) *awstypes.TimeRangeFilterV
 		t, _ := time.Parse(time.RFC3339, v) // Format validated with validateFunc
 		apiObject.StaticValue = aws.Time(t)
 	}
-	if v, ok := tfMap["rolling_date"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rolling_date"].([]any); ok && len(v) > 0 {
 		apiObject.RollingDate = expandRollingDateConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTopBottomFilter(tfList []interface{}) *awstypes.TopBottomFilter {
+func expandTopBottomFilter(tfList []any) *awstypes.TopBottomFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1082,7 +1082,7 @@ func expandTopBottomFilter(tfList []interface{}) *awstypes.TopBottomFilter {
 	if v, ok := tfMap["filter_id"].(string); ok && v != "" {
 		apiObject.FilterId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap["limit"].(int); ok {
@@ -1094,14 +1094,14 @@ func expandTopBottomFilter(tfList []interface{}) *awstypes.TopBottomFilter {
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
 		apiObject.TimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["aggregation_sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationSortConfigurations = expandAggregationSortConfigurations(v)
 	}
 
 	return apiObject
 }
 
-func expandAggregationSortConfigurations(tfList []interface{}) []awstypes.AggregationSortConfiguration {
+func expandAggregationSortConfigurations(tfList []any) []awstypes.AggregationSortConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1109,7 +1109,7 @@ func expandAggregationSortConfigurations(tfList []interface{}) []awstypes.Aggreg
 	var apiObjects []awstypes.AggregationSortConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1125,7 +1125,7 @@ func expandAggregationSortConfigurations(tfList []interface{}) []awstypes.Aggreg
 	return apiObjects
 }
 
-func expandAggregationSortConfiguration(tfMap map[string]interface{}) *awstypes.AggregationSortConfiguration {
+func expandAggregationSortConfiguration(tfMap map[string]any) *awstypes.AggregationSortConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -1135,17 +1135,17 @@ func expandAggregationSortConfiguration(tfMap map[string]interface{}) *awstypes.
 	if v, ok := tfMap["sort_direction"].(string); ok && v != "" {
 		apiObject.SortDirection = awstypes.SortDirection(v)
 	}
-	if v, ok := tfMap["aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationFunction = expandAggregationFunction(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 
 	return apiObject
 }
 
-func expandDrillDownFilters(tfList []interface{}) []awstypes.DrillDownFilter {
+func expandDrillDownFilters(tfList []any) []awstypes.DrillDownFilter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1153,7 +1153,7 @@ func expandDrillDownFilters(tfList []interface{}) []awstypes.DrillDownFilter {
 	var apiObjects []awstypes.DrillDownFilter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1169,61 +1169,61 @@ func expandDrillDownFilters(tfList []interface{}) []awstypes.DrillDownFilter {
 	return apiObjects
 }
 
-func expandDrillDownFilter(tfMap map[string]interface{}) *awstypes.DrillDownFilter {
+func expandDrillDownFilter(tfMap map[string]any) *awstypes.DrillDownFilter {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DrillDownFilter{}
 
-	if v, ok := tfMap["category_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_filter"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryFilter = expandCategoryDrillDownFilter(v)
 	}
-	if v, ok := tfMap["numeric_equality_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_equality_filter"].([]any); ok && len(v) > 0 {
 		apiObject.NumericEqualityFilter = expandNumericEqualityDrillDownFilter(v)
 	}
-	if v, ok := tfMap["time_range_filter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time_range_filter"].([]any); ok && len(v) > 0 {
 		apiObject.TimeRangeFilter = expandTimeRangeDrillDownFilter(v)
 	}
 
 	return apiObject
 }
 
-func expandCategoryDrillDownFilter(tfList []interface{}) *awstypes.CategoryDrillDownFilter {
+func expandCategoryDrillDownFilter(tfList []any) *awstypes.CategoryDrillDownFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CategoryDrillDownFilter{}
 
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["category_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_values"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryValues = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandNumericEqualityDrillDownFilter(tfList []interface{}) *awstypes.NumericEqualityDrillDownFilter {
+func expandNumericEqualityDrillDownFilter(tfList []any) *awstypes.NumericEqualityDrillDownFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.NumericEqualityDrillDownFilter{}
 
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 	if v, ok := tfMap[names.AttrValue].(float64); ok {
@@ -1233,12 +1233,12 @@ func expandNumericEqualityDrillDownFilter(tfList []interface{}) *awstypes.Numeri
 	return apiObject
 }
 
-func expandTimeRangeDrillDownFilter(tfList []interface{}) *awstypes.TimeRangeDrillDownFilter {
+func expandTimeRangeDrillDownFilter(tfList []any) *awstypes.TimeRangeDrillDownFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1256,22 +1256,22 @@ func expandTimeRangeDrillDownFilter(tfList []interface{}) *awstypes.TimeRangeDri
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
 		apiObject.TimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 
 	return apiObject
 }
 
-func flattenFilters(apiObjects []awstypes.Filter) []interface{} {
+func flattenFilters(apiObjects []awstypes.Filter) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.CategoryFilter != nil {
 			tfMap["category_filter"] = flattenCategoryFilter(apiObject.CategoryFilter)
@@ -1301,12 +1301,12 @@ func flattenFilters(apiObjects []awstypes.Filter) []interface{} {
 	return tfList
 }
 
-func flattenCategoryFilter(apiObject *awstypes.CategoryFilter) []interface{} {
+func flattenCategoryFilter(apiObject *awstypes.CategoryFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
 	}
@@ -1317,15 +1317,15 @@ func flattenCategoryFilter(apiObject *awstypes.CategoryFilter) []interface{} {
 		tfMap["filter_id"] = aws.ToString(apiObject.FilterId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCategoryFilterConfiguration(apiObject *awstypes.CategoryFilterConfiguration) []interface{} {
+func flattenCategoryFilterConfiguration(apiObject *awstypes.CategoryFilterConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomFilterConfiguration != nil {
 		tfMap["custom_filter_configuration"] = flattenCustomFilterConfiguration(apiObject.CustomFilterConfiguration)
@@ -1337,15 +1337,15 @@ func flattenCategoryFilterConfiguration(apiObject *awstypes.CategoryFilterConfig
 		tfMap["filter_list_configuration"] = flattenFilterListConfiguration(apiObject.FilterListConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomFilterConfiguration(apiObject *awstypes.CustomFilterConfiguration) []interface{} {
+func flattenCustomFilterConfiguration(apiObject *awstypes.CustomFilterConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryValue != nil {
 		tfMap["category_value"] = aws.ToString(apiObject.CategoryValue)
@@ -1357,15 +1357,15 @@ func flattenCustomFilterConfiguration(apiObject *awstypes.CustomFilterConfigurat
 	}
 	tfMap["select_all_options"] = apiObject.SelectAllOptions
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomFilterListConfiguration(apiObject *awstypes.CustomFilterListConfiguration) []interface{} {
+func flattenCustomFilterListConfiguration(apiObject *awstypes.CustomFilterListConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryValues != nil {
 		tfMap["category_values"] = apiObject.CategoryValues
@@ -1374,15 +1374,15 @@ func flattenCustomFilterListConfiguration(apiObject *awstypes.CustomFilterListCo
 	tfMap["null_option"] = apiObject.NullOption
 	tfMap["select_all_options"] = apiObject.SelectAllOptions
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterListConfiguration(apiObject *awstypes.FilterListConfiguration) []interface{} {
+func flattenFilterListConfiguration(apiObject *awstypes.FilterListConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryValues != nil {
 		tfMap["category_values"] = apiObject.CategoryValues
@@ -1390,15 +1390,15 @@ func flattenFilterListConfiguration(apiObject *awstypes.FilterListConfiguration)
 	tfMap["match_operator"] = apiObject.MatchOperator
 	tfMap["select_all_options"] = apiObject.SelectAllOptions
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericEqualityFilter(apiObject *awstypes.NumericEqualityFilter) []interface{} {
+func flattenNumericEqualityFilter(apiObject *awstypes.NumericEqualityFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AggregationFunction != nil {
 		tfMap["aggregation_function"] = flattenAggregationFunction(apiObject.AggregationFunction)
@@ -1419,15 +1419,15 @@ func flattenNumericEqualityFilter(apiObject *awstypes.NumericEqualityFilter) []i
 		tfMap[names.AttrValue] = aws.ToFloat64(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericRangeFilter(apiObject *awstypes.NumericRangeFilter) []interface{} {
+func flattenNumericRangeFilter(apiObject *awstypes.NumericRangeFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AggregationFunction != nil {
 		tfMap["aggregation_function"] = flattenAggregationFunction(apiObject.AggregationFunction)
@@ -1453,15 +1453,15 @@ func flattenNumericRangeFilter(apiObject *awstypes.NumericRangeFilter) []interfa
 	}
 	tfMap["select_all_options"] = apiObject.SelectAllOptions
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericRangeFilterValue(apiObject *awstypes.NumericRangeFilterValue) []interface{} {
+func flattenNumericRangeFilterValue(apiObject *awstypes.NumericRangeFilterValue) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Parameter != nil {
 		tfMap[names.AttrParameter] = aws.ToString(apiObject.Parameter)
@@ -1470,15 +1470,15 @@ func flattenNumericRangeFilterValue(apiObject *awstypes.NumericRangeFilterValue)
 		tfMap["static_value"] = aws.ToFloat64(apiObject.StaticValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRelativeDatesFilter(apiObject *awstypes.RelativeDatesFilter) []interface{} {
+func flattenRelativeDatesFilter(apiObject *awstypes.RelativeDatesFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AnchorDateConfiguration != nil {
 		tfMap["anchor_date_configuration"] = flattenAnchorDateConfiguration(apiObject.AnchorDateConfiguration)
@@ -1503,30 +1503,30 @@ func flattenRelativeDatesFilter(apiObject *awstypes.RelativeDatesFilter) []inter
 	}
 	tfMap["time_granularity"] = apiObject.TimeGranularity
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAnchorDateConfiguration(apiObject *awstypes.AnchorDateConfiguration) []interface{} {
+func flattenAnchorDateConfiguration(apiObject *awstypes.AnchorDateConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["anchor_option"] = apiObject.AnchorOption
 	if apiObject.ParameterName != nil {
 		tfMap["parameter_name"] = aws.ToString(apiObject.ParameterName)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenExcludePeriodConfiguration(apiObject *awstypes.ExcludePeriodConfiguration) []interface{} {
+func flattenExcludePeriodConfiguration(apiObject *awstypes.ExcludePeriodConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Amount != nil {
 		tfMap["amount"] = aws.ToInt32(apiObject.Amount)
@@ -1534,15 +1534,15 @@ func flattenExcludePeriodConfiguration(apiObject *awstypes.ExcludePeriodConfigur
 	tfMap["granularity"] = apiObject.Granularity
 	tfMap[names.AttrStatus] = apiObject.Status
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTimeEqualityFilter(apiObject *awstypes.TimeEqualityFilter) []interface{} {
+func flattenTimeEqualityFilter(apiObject *awstypes.TimeEqualityFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1558,15 +1558,15 @@ func flattenTimeEqualityFilter(apiObject *awstypes.TimeEqualityFilter) []interfa
 		tfMap[names.AttrValue] = apiObject.Value.Format(time.RFC3339)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTimeRangeFilter(apiObject *awstypes.TimeRangeFilter) []interface{} {
+func flattenTimeRangeFilter(apiObject *awstypes.TimeRangeFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1592,15 +1592,15 @@ func flattenTimeRangeFilter(apiObject *awstypes.TimeRangeFilter) []interface{} {
 	}
 	tfMap["time_granularity"] = apiObject.TimeGranularity
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTimeRangeFilterValue(apiObject *awstypes.TimeRangeFilterValue) []interface{} {
+func flattenTimeRangeFilterValue(apiObject *awstypes.TimeRangeFilterValue) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Parameter != nil {
 		tfMap[names.AttrParameter] = aws.ToString(apiObject.Parameter)
@@ -1612,15 +1612,15 @@ func flattenTimeRangeFilterValue(apiObject *awstypes.TimeRangeFilterValue) []int
 		tfMap["static_value"] = apiObject.StaticValue.Format(time.RFC3339)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTopBottomFilter(apiObject *awstypes.TopBottomFilter) []interface{} {
+func flattenTopBottomFilter(apiObject *awstypes.TopBottomFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AggregationSortConfigurations != nil {
 		tfMap["aggregation_sort_configuration"] = flattenAggregationSortConfigurations(apiObject.AggregationSortConfigurations)
@@ -1639,18 +1639,18 @@ func flattenTopBottomFilter(apiObject *awstypes.TopBottomFilter) []interface{} {
 	}
 	tfMap["time_granularity"] = apiObject.TimeGranularity
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAggregationSortConfigurations(apiObjects []awstypes.AggregationSortConfiguration) []interface{} {
+func flattenAggregationSortConfigurations(apiObjects []awstypes.AggregationSortConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.AggregationFunction != nil {
 			tfMap["aggregation_function"] = flattenAggregationFunction(apiObject.AggregationFunction)
@@ -1666,43 +1666,43 @@ func flattenAggregationSortConfigurations(apiObjects []awstypes.AggregationSortC
 	return tfList
 }
 
-func flattenFilterScopeConfiguration(apiObject *awstypes.FilterScopeConfiguration) []interface{} {
+func flattenFilterScopeConfiguration(apiObject *awstypes.FilterScopeConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SelectedSheets != nil {
 		tfMap["selected_sheets"] = flattenSelectedSheetsFilterScopeConfiguration(apiObject.SelectedSheets)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSelectedSheetsFilterScopeConfiguration(apiObject *awstypes.SelectedSheetsFilterScopeConfiguration) []interface{} {
+func flattenSelectedSheetsFilterScopeConfiguration(apiObject *awstypes.SelectedSheetsFilterScopeConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SheetVisualScopingConfigurations != nil {
 		tfMap["sheet_visual_scoping_configurations"] = flattenSheetVisualScopingConfigurations(apiObject.SheetVisualScopingConfigurations)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSheetVisualScopingConfigurations(apiObjects []awstypes.SheetVisualScopingConfiguration) []interface{} {
+func flattenSheetVisualScopingConfigurations(apiObjects []awstypes.SheetVisualScopingConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		tfMap[names.AttrScope] = apiObject.Scope
 		if apiObject.SheetId != nil {

--- a/internal/service/quicksight/schema/template_format.go
+++ b/internal/service/quicksight/schema/template_format.go
@@ -268,37 +268,37 @@ var formatConfigurationSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandFormatConfiguration(tfList []interface{}) *awstypes.FormatConfiguration {
+func expandFormatConfiguration(tfList []any) *awstypes.FormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FormatConfiguration{}
 
-	if v, ok := tfMap["date_time_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimeFormatConfiguration = expandDateTimeFormatConfiguration(v)
 	}
-	if v, ok := tfMap["number_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["number_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NumberFormatConfiguration = expandNumberFormatConfiguration(v)
 	}
-	if v, ok := tfMap["string_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["string_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.StringFormatConfiguration = expandStringFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimeFormatConfiguration(tfList []interface{}) *awstypes.DateTimeFormatConfiguration {
+func expandDateTimeFormatConfiguration(tfList []any) *awstypes.DateTimeFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -308,22 +308,22 @@ func expandDateTimeFormatConfiguration(tfList []interface{}) *awstypes.DateTimeF
 	if v, ok := tfMap["date_time_format"].(string); ok && v != "" {
 		apiObject.DateTimeFormat = aws.String(v)
 	}
-	if v, ok := tfMap["null_value_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueFormatConfiguration = expandNullValueFormatConfiguration(v)
 	}
-	if v, ok := tfMap["numeric_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NumericFormatConfiguration = expandNumericFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandNullValueFormatConfiguration(tfList []interface{}) *awstypes.NullValueFormatConfiguration {
+func expandNullValueFormatConfiguration(tfList []any) *awstypes.NullValueFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -337,50 +337,50 @@ func expandNullValueFormatConfiguration(tfList []interface{}) *awstypes.NullValu
 	return apiObject
 }
 
-func expandNumericFormatConfiguration(tfList []interface{}) *awstypes.NumericFormatConfiguration {
+func expandNumericFormatConfiguration(tfList []any) *awstypes.NumericFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.NumericFormatConfiguration{}
 
-	if v, ok := tfMap["currency_display_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["currency_display_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CurrencyDisplayFormatConfiguration = expandCurrencyDisplayFormatConfiguration(v)
 	}
-	if v, ok := tfMap["number_display_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["number_display_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NumberDisplayFormatConfiguration = expandNumberDisplayFormatConfiguration(v)
 	}
-	if v, ok := tfMap["percentage_display_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["percentage_display_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PercentageDisplayFormatConfiguration = expandPercentageDisplayFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandCurrencyDisplayFormatConfiguration(tfList []interface{}) *awstypes.CurrencyDisplayFormatConfiguration {
+func expandCurrencyDisplayFormatConfiguration(tfList []any) *awstypes.CurrencyDisplayFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CurrencyDisplayFormatConfiguration{}
 
-	if v, ok := tfMap["decimal_places_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["decimal_places_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DecimalPlacesConfiguration = expandDecimalPlacesConfiguration(v)
 	}
-	if v, ok := tfMap["negative_value_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["negative_value_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NegativeValueConfiguration = expandNegativeValueConfiguration(v)
 	}
-	if v, ok := tfMap["null_value_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueFormatConfiguration = expandNullValueFormatConfiguration(v)
 	}
 	if v, ok := tfMap["number_scale"].(string); ok && v != "" {
@@ -389,7 +389,7 @@ func expandCurrencyDisplayFormatConfiguration(tfList []interface{}) *awstypes.Cu
 	if v, ok := tfMap[names.AttrPrefix].(string); ok && v != "" {
 		apiObject.Prefix = aws.String(v)
 	}
-	if v, ok := tfMap["separator_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["separator_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SeparatorConfiguration = expandNumericSeparatorConfiguration(v)
 	}
 	if v, ok := tfMap["suffix"].(string); ok && v != "" {
@@ -402,12 +402,12 @@ func expandCurrencyDisplayFormatConfiguration(tfList []interface{}) *awstypes.Cu
 	return apiObject
 }
 
-func expandDecimalPlacesConfiguration(tfList []interface{}) *awstypes.DecimalPlacesConfiguration {
+func expandDecimalPlacesConfiguration(tfList []any) *awstypes.DecimalPlacesConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -421,12 +421,12 @@ func expandDecimalPlacesConfiguration(tfList []interface{}) *awstypes.DecimalPla
 	return apiObject
 }
 
-func expandNegativeValueConfiguration(tfList []interface{}) *awstypes.NegativeValueConfiguration {
+func expandNegativeValueConfiguration(tfList []any) *awstypes.NegativeValueConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -440,12 +440,12 @@ func expandNegativeValueConfiguration(tfList []interface{}) *awstypes.NegativeVa
 	return apiObject
 }
 
-func expandNumericSeparatorConfiguration(tfList []interface{}) *awstypes.NumericSeparatorConfiguration {
+func expandNumericSeparatorConfiguration(tfList []any) *awstypes.NumericSeparatorConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -455,19 +455,19 @@ func expandNumericSeparatorConfiguration(tfList []interface{}) *awstypes.Numeric
 	if v, ok := tfMap["decimal_separator"].(string); ok {
 		apiObject.DecimalSeparator = awstypes.NumericSeparatorSymbol(v)
 	}
-	if v, ok := tfMap["thousands_separator"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["thousands_separator"].([]any); ok && len(v) > 0 {
 		apiObject.ThousandsSeparator = expandThousandSeparatorOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandThousandSeparatorOptions(tfList []interface{}) *awstypes.ThousandSeparatorOptions {
+func expandThousandSeparatorOptions(tfList []any) *awstypes.ThousandSeparatorOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -484,53 +484,53 @@ func expandThousandSeparatorOptions(tfList []interface{}) *awstypes.ThousandSepa
 	return apiObject
 }
 
-func expandNumberFormatConfiguration(tfList []interface{}) *awstypes.NumberFormatConfiguration {
+func expandNumberFormatConfiguration(tfList []any) *awstypes.NumberFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.NumberFormatConfiguration{}
 
-	if v, ok := tfMap["numeric_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandNumericFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandStringFormatConfiguration(tfList []interface{}) *awstypes.StringFormatConfiguration {
+func expandStringFormatConfiguration(tfList []any) *awstypes.StringFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.StringFormatConfiguration{}
 
-	if v, ok := tfMap["null_value_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueFormatConfiguration = expandNullValueFormatConfiguration(v)
 	}
-	if v, ok := tfMap["numeric_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NumericFormatConfiguration = expandNumericFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandLabelOptions(tfList []interface{}) *awstypes.LabelOptions {
+func expandLabelOptions(tfList []any) *awstypes.LabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -543,19 +543,19 @@ func expandLabelOptions(tfList []interface{}) *awstypes.LabelOptions {
 	if v, ok := tfMap["visibility"].(string); ok {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandFontConfiguration(tfList []interface{}) *awstypes.FontConfiguration {
+func expandFontConfiguration(tfList []any) *awstypes.FontConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -571,22 +571,22 @@ func expandFontConfiguration(tfList []interface{}) *awstypes.FontConfiguration {
 	if v, ok := tfMap["font_style"].(string); ok && v != "" {
 		apiObject.FontStyle = awstypes.FontStyle(v)
 	}
-	if v, ok := tfMap["font_size"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_size"].([]any); ok && len(v) > 0 {
 		apiObject.FontSize = expandFontSize(v)
 	}
-	if v, ok := tfMap["font_weight"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_weight"].([]any); ok && len(v) > 0 {
 		apiObject.FontWeight = expandFontWeight(v)
 	}
 
 	return apiObject
 }
 
-func expandFontSize(tfList []interface{}) *awstypes.FontSize {
+func expandFontSize(tfList []any) *awstypes.FontSize {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -600,12 +600,12 @@ func expandFontSize(tfList []interface{}) *awstypes.FontSize {
 	return apiObject
 }
 
-func expandFontWeight(tfList []interface{}) *awstypes.FontWeight {
+func expandFontWeight(tfList []any) *awstypes.FontWeight {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -619,34 +619,34 @@ func expandFontWeight(tfList []interface{}) *awstypes.FontWeight {
 	return apiObject
 }
 
-func expandComparisonFormatConfiguration(tfList []interface{}) *awstypes.ComparisonFormatConfiguration {
+func expandComparisonFormatConfiguration(tfList []any) *awstypes.ComparisonFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ComparisonFormatConfiguration{}
 
-	if v, ok := tfMap["number_display_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["number_display_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NumberDisplayFormatConfiguration = expandNumberDisplayFormatConfiguration(v)
 	}
-	if v, ok := tfMap["percentage_display_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["percentage_display_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PercentageDisplayFormatConfiguration = expandPercentageDisplayFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandNumberDisplayFormatConfiguration(tfList []interface{}) *awstypes.NumberDisplayFormatConfiguration {
+func expandNumberDisplayFormatConfiguration(tfList []any) *awstypes.NumberDisplayFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -662,28 +662,28 @@ func expandNumberDisplayFormatConfiguration(tfList []interface{}) *awstypes.Numb
 	if v, ok := tfMap["suffix"].(string); ok && v != "" {
 		apiObject.Suffix = aws.String(v)
 	}
-	if v, ok := tfMap["decimal_places_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["decimal_places_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DecimalPlacesConfiguration = expandDecimalPlacesConfiguration(v)
 	}
-	if v, ok := tfMap["negative_value_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["negative_value_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NegativeValueConfiguration = expandNegativeValueConfiguration(v)
 	}
-	if v, ok := tfMap["null_value_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueFormatConfiguration = expandNullValueFormatConfiguration(v)
 	}
-	if v, ok := tfMap["separator_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["separator_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SeparatorConfiguration = expandNumericSeparatorConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandPercentageDisplayFormatConfiguration(tfList []interface{}) *awstypes.PercentageDisplayFormatConfiguration {
+func expandPercentageDisplayFormatConfiguration(tfList []any) *awstypes.PercentageDisplayFormatConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -696,28 +696,28 @@ func expandPercentageDisplayFormatConfiguration(tfList []interface{}) *awstypes.
 	if v, ok := tfMap["suffix"].(string); ok && v != "" {
 		apiObject.Suffix = aws.String(v)
 	}
-	if v, ok := tfMap["decimal_places_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["decimal_places_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DecimalPlacesConfiguration = expandDecimalPlacesConfiguration(v)
 	}
-	if v, ok := tfMap["negative_value_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["negative_value_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NegativeValueConfiguration = expandNegativeValueConfiguration(v)
 	}
-	if v, ok := tfMap["null_value_format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueFormatConfiguration = expandNullValueFormatConfiguration(v)
 	}
-	if v, ok := tfMap["separator_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["separator_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SeparatorConfiguration = expandNumericSeparatorConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func flattenFormatConfiguration(apiObject *awstypes.FormatConfiguration) []interface{} {
+func flattenFormatConfiguration(apiObject *awstypes.FormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateTimeFormatConfiguration != nil {
 		tfMap["date_time_format_configuration"] = flattenDateTimeFormatConfiguration(apiObject.DateTimeFormatConfiguration)
@@ -729,15 +729,15 @@ func flattenFormatConfiguration(apiObject *awstypes.FormatConfiguration) []inter
 		tfMap["string_format_configuration"] = flattenStringFormatConfiguration(apiObject.StringFormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateTimeFormatConfiguration(apiObject *awstypes.DateTimeFormatConfiguration) []interface{} {
+func flattenDateTimeFormatConfiguration(apiObject *awstypes.DateTimeFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateTimeFormat != nil {
 		tfMap["date_time_format"] = aws.ToString(apiObject.DateTimeFormat)
@@ -749,29 +749,29 @@ func flattenDateTimeFormatConfiguration(apiObject *awstypes.DateTimeFormatConfig
 		tfMap["numeric_format_configuration"] = flattenNumericFormatConfiguration(apiObject.NumericFormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNullValueFormatConfiguration(apiObject *awstypes.NullValueFormatConfiguration) []interface{} {
+func flattenNullValueFormatConfiguration(apiObject *awstypes.NullValueFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.NullString != nil {
 		tfMap["null_string"] = aws.ToString(apiObject.NullString)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericFormatConfiguration(apiObject *awstypes.NumericFormatConfiguration) []interface{} {
+func flattenNumericFormatConfiguration(apiObject *awstypes.NumericFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CurrencyDisplayFormatConfiguration != nil {
 		tfMap["currency_display_format_configuration"] = flattenCurrencyDisplayFormatConfiguration(apiObject.CurrencyDisplayFormatConfiguration)
@@ -783,15 +783,15 @@ func flattenNumericFormatConfiguration(apiObject *awstypes.NumericFormatConfigur
 		tfMap["percentage_display_format_configuration"] = flattenPercentageDisplayFormatConfiguration(apiObject.PercentageDisplayFormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCurrencyDisplayFormatConfiguration(apiObject *awstypes.CurrencyDisplayFormatConfiguration) []interface{} {
+func flattenCurrencyDisplayFormatConfiguration(apiObject *awstypes.CurrencyDisplayFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DecimalPlacesConfiguration != nil {
 		tfMap["decimal_places_configuration"] = flattenDecimalPlacesConfiguration(apiObject.DecimalPlacesConfiguration)
@@ -816,41 +816,41 @@ func flattenCurrencyDisplayFormatConfiguration(apiObject *awstypes.CurrencyDispl
 		tfMap["symbol"] = aws.ToString(apiObject.Symbol)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDecimalPlacesConfiguration(apiObject *awstypes.DecimalPlacesConfiguration) []interface{} {
+func flattenDecimalPlacesConfiguration(apiObject *awstypes.DecimalPlacesConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DecimalPlaces != nil {
 		tfMap["decimal_places"] = aws.ToInt64(apiObject.DecimalPlaces)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNegativeValueConfiguration(apiObject *awstypes.NegativeValueConfiguration) []interface{} {
+func flattenNegativeValueConfiguration(apiObject *awstypes.NegativeValueConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"display_mode": apiObject.DisplayMode,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericSeparatorConfiguration(apiObject *awstypes.NumericSeparatorConfiguration) []interface{} {
+func flattenNumericSeparatorConfiguration(apiObject *awstypes.NumericSeparatorConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"decimal_separator": apiObject.DecimalSeparator,
 	}
 
@@ -858,27 +858,27 @@ func flattenNumericSeparatorConfiguration(apiObject *awstypes.NumericSeparatorCo
 		tfMap["thousands_separator"] = flattenThousandSeparatorOptions(apiObject.ThousandsSeparator)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
-func flattenThousandSeparatorOptions(apiObject *awstypes.ThousandSeparatorOptions) []interface{} {
+func flattenThousandSeparatorOptions(apiObject *awstypes.ThousandSeparatorOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"symbol":     apiObject.Symbol,
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumberDisplayFormatConfiguration(apiObject *awstypes.NumberDisplayFormatConfiguration) []interface{} {
+func flattenNumberDisplayFormatConfiguration(apiObject *awstypes.NumberDisplayFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DecimalPlacesConfiguration != nil {
 		tfMap["decimal_places_configuration"] = flattenDecimalPlacesConfiguration(apiObject.DecimalPlacesConfiguration)
@@ -900,15 +900,15 @@ func flattenNumberDisplayFormatConfiguration(apiObject *awstypes.NumberDisplayFo
 		tfMap["suffix"] = aws.ToString(apiObject.Suffix)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPercentageDisplayFormatConfiguration(apiObject *awstypes.PercentageDisplayFormatConfiguration) []interface{} {
+func flattenPercentageDisplayFormatConfiguration(apiObject *awstypes.PercentageDisplayFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DecimalPlacesConfiguration != nil {
 		tfMap["decimal_places_configuration"] = flattenDecimalPlacesConfiguration(apiObject.DecimalPlacesConfiguration)
@@ -929,29 +929,29 @@ func flattenPercentageDisplayFormatConfiguration(apiObject *awstypes.PercentageD
 		tfMap["suffix"] = aws.ToString(apiObject.Suffix)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumberFormatConfiguration(apiObject *awstypes.NumberFormatConfiguration) []interface{} {
+func flattenNumberFormatConfiguration(apiObject *awstypes.NumberFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FormatConfiguration != nil {
 		tfMap["numeric_format_configuration"] = flattenNumericFormatConfiguration(apiObject.FormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenStringFormatConfiguration(apiObject *awstypes.StringFormatConfiguration) []interface{} {
+func flattenStringFormatConfiguration(apiObject *awstypes.StringFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.NullValueFormatConfiguration != nil {
 		tfMap["null_value_format_configuration"] = flattenNullValueFormatConfiguration(apiObject.NullValueFormatConfiguration)
@@ -960,5 +960,5 @@ func flattenStringFormatConfiguration(apiObject *awstypes.StringFormatConfigurat
 		tfMap["numeric_format_configuration"] = flattenNumericFormatConfiguration(apiObject.NumericFormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/template_parameter.go
+++ b/internal/service/quicksight/schema/template_parameter.go
@@ -415,12 +415,12 @@ func parameterNameSchema(required bool) *schema.Schema {
 	}
 }
 
-func expandDateTimeParameterDeclaration(tfList []interface{}) *awstypes.DateTimeParameterDeclaration {
+func expandDateTimeParameterDeclaration(tfList []any) *awstypes.DateTimeParameterDeclaration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -430,75 +430,75 @@ func expandDateTimeParameterDeclaration(tfList []interface{}) *awstypes.DateTime
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap["default_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_values"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultValues = expandDateTimeDefaultValues(v)
 	}
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
 		apiObject.TimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["values_when_unset"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["values_when_unset"].([]any); ok && len(v) > 0 {
 		apiObject.ValueWhenUnset = expandDateTimeValueWhenUnsetConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimeDefaultValues(tfList []interface{}) *awstypes.DateTimeDefaultValues {
+func expandDateTimeDefaultValues(tfList []any) *awstypes.DateTimeDefaultValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DateTimeDefaultValues{}
 
-	if v, ok := tfMap["dynamic_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dynamic_value"].([]any); ok && len(v) > 0 {
 		apiObject.DynamicValue = expandDynamicDefaultValue(v)
 	}
-	if v, ok := tfMap["rolling_date"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rolling_date"].([]any); ok && len(v) > 0 {
 		apiObject.RollingDate = expandRollingDateConfiguration(v)
 	}
-	if v, ok := tfMap["static_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["static_values"].([]any); ok && len(v) > 0 {
 		apiObject.StaticValues = flex.ExpandStringTimeValueList(v, time.RFC3339)
 	}
 
 	return apiObject
 }
 
-func expandDynamicDefaultValue(tfList []interface{}) *awstypes.DynamicDefaultValue {
+func expandDynamicDefaultValue(tfList []any) *awstypes.DynamicDefaultValue {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DynamicDefaultValue{}
 
-	if v, ok := tfMap["default_value_column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_value_column"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultValueColumn = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["group_name_column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["group_name_column"].([]any); ok && len(v) > 0 {
 		apiObject.GroupNameColumn = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["user_name_column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["user_name_column"].([]any); ok && len(v) > 0 {
 		apiObject.UserNameColumn = expandColumnIdentifier(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimeValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.DateTimeValueWhenUnsetConfiguration {
+func expandDateTimeValueWhenUnsetConfiguration(tfList []any) *awstypes.DateTimeValueWhenUnsetConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -516,12 +516,12 @@ func expandDateTimeValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.D
 	return apiObject
 }
 
-func expandDecimalParameterDeclaration(tfList []interface{}) *awstypes.DecimalParameterDeclaration {
+func expandDecimalParameterDeclaration(tfList []any) *awstypes.DecimalParameterDeclaration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -534,22 +534,22 @@ func expandDecimalParameterDeclaration(tfList []interface{}) *awstypes.DecimalPa
 	if v, ok := tfMap["parameter_value_type"].(string); ok && v != "" {
 		apiObject.ParameterValueType = awstypes.ParameterValueType(v)
 	}
-	if v, ok := tfMap["default_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_values"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultValues = expandDecimalDefaultValues(v)
 	}
-	if v, ok := tfMap["values_when_unset"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["values_when_unset"].([]any); ok && len(v) > 0 {
 		apiObject.ValueWhenUnset = expandDecimalValueWhenUnsetConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDecimalValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.DecimalValueWhenUnsetConfiguration {
+func expandDecimalValueWhenUnsetConfiguration(tfList []any) *awstypes.DecimalValueWhenUnsetConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -566,34 +566,34 @@ func expandDecimalValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.De
 	return apiObject
 }
 
-func expandDecimalDefaultValues(tfList []interface{}) *awstypes.DecimalDefaultValues {
+func expandDecimalDefaultValues(tfList []any) *awstypes.DecimalDefaultValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DecimalDefaultValues{}
 
-	if v, ok := tfMap["dynamic_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dynamic_value"].([]any); ok && len(v) > 0 {
 		apiObject.DynamicValue = expandDynamicDefaultValue(v)
 	}
-	if v, ok := tfMap["static_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["static_values"].([]any); ok && len(v) > 0 {
 		apiObject.StaticValues = flex.ExpandFloat64ValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandIntegerParameterDeclaration(tfList []interface{}) *awstypes.IntegerParameterDeclaration {
+func expandIntegerParameterDeclaration(tfList []any) *awstypes.IntegerParameterDeclaration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -606,22 +606,22 @@ func expandIntegerParameterDeclaration(tfList []interface{}) *awstypes.IntegerPa
 	if v, ok := tfMap["parameter_value_type"].(string); ok && v != "" {
 		apiObject.ParameterValueType = awstypes.ParameterValueType(v)
 	}
-	if v, ok := tfMap["default_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_values"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultValues = expandIntegerDefaultValues(v)
 	}
-	if v, ok := tfMap["values_when_unset"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["values_when_unset"].([]any); ok && len(v) > 0 {
 		apiObject.ValueWhenUnset = expandIntegerValueWhenUnsetConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandIntegerValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.IntegerValueWhenUnsetConfiguration {
+func expandIntegerValueWhenUnsetConfiguration(tfList []any) *awstypes.IntegerValueWhenUnsetConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -638,34 +638,34 @@ func expandIntegerValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.In
 	return apiObject
 }
 
-func expandIntegerDefaultValues(tfList []interface{}) *awstypes.IntegerDefaultValues {
+func expandIntegerDefaultValues(tfList []any) *awstypes.IntegerDefaultValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.IntegerDefaultValues{}
 
-	if v, ok := tfMap["dynamic_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dynamic_value"].([]any); ok && len(v) > 0 {
 		apiObject.DynamicValue = expandDynamicDefaultValue(v)
 	}
-	if v, ok := tfMap["static_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["static_values"].([]any); ok && len(v) > 0 {
 		apiObject.StaticValues = flex.ExpandInt64ValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandStringParameterDeclaration(tfList []interface{}) *awstypes.StringParameterDeclaration {
+func expandStringParameterDeclaration(tfList []any) *awstypes.StringParameterDeclaration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -678,22 +678,22 @@ func expandStringParameterDeclaration(tfList []interface{}) *awstypes.StringPara
 	if v, ok := tfMap["parameter_value_type"].(string); ok && v != "" {
 		apiObject.ParameterValueType = awstypes.ParameterValueType(v)
 	}
-	if v, ok := tfMap["default_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_values"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultValues = expandStringDefaultValues(v)
 	}
-	if v, ok := tfMap["values_when_unset"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["values_when_unset"].([]any); ok && len(v) > 0 {
 		apiObject.ValueWhenUnset = expandStringValueWhenUnsetConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandStringValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.StringValueWhenUnsetConfiguration {
+func expandStringValueWhenUnsetConfiguration(tfList []any) *awstypes.StringValueWhenUnsetConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -710,56 +710,56 @@ func expandStringValueWhenUnsetConfiguration(tfList []interface{}) *awstypes.Str
 	return apiObject
 }
 
-func expandStringDefaultValues(tfList []interface{}) *awstypes.StringDefaultValues {
+func expandStringDefaultValues(tfList []any) *awstypes.StringDefaultValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.StringDefaultValues{}
 
-	if v, ok := tfMap["dynamic_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dynamic_value"].([]any); ok && len(v) > 0 {
 		apiObject.DynamicValue = expandDynamicDefaultValue(v)
 	}
-	if v, ok := tfMap["static_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["static_values"].([]any); ok && len(v) > 0 {
 		apiObject.StaticValues = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterSelectableValues(tfList []interface{}) *awstypes.ParameterSelectableValues {
+func expandParameterSelectableValues(tfList []any) *awstypes.ParameterSelectableValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ParameterSelectableValues{}
 
-	if v, ok := tfMap["link_to_data_set_column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["link_to_data_set_column"].([]any); ok && len(v) > 0 {
 		apiObject.LinkToDataSetColumn = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func flattenDateTimeParameterDeclaration(apiObject *awstypes.DateTimeParameterDeclaration) []interface{} {
+func flattenDateTimeParameterDeclaration(apiObject *awstypes.DateTimeParameterDeclaration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultValues != nil {
 		tfMap["default_values"] = flattenDateTimeDefaultValues(apiObject.DefaultValues)
@@ -772,15 +772,15 @@ func flattenDateTimeParameterDeclaration(apiObject *awstypes.DateTimeParameterDe
 		tfMap["values_when_unset"] = flattenDateTimeValueWhenUnsetConfiguration(apiObject.ValueWhenUnset)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateTimeDefaultValues(apiObject *awstypes.DateTimeDefaultValues) []interface{} {
+func flattenDateTimeDefaultValues(apiObject *awstypes.DateTimeDefaultValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
@@ -792,15 +792,15 @@ func flattenDateTimeDefaultValues(apiObject *awstypes.DateTimeDefaultValues) []i
 		tfMap["static_values"] = flex.FlattenTimeStringValueList(apiObject.StaticValues, time.RFC3339)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDynamicDefaultValue(apiObject *awstypes.DynamicDefaultValue) []interface{} {
+func flattenDynamicDefaultValue(apiObject *awstypes.DynamicDefaultValue) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultValueColumn != nil {
 		tfMap["default_value_column"] = flattenColumnIdentifier(apiObject.DefaultValueColumn)
@@ -812,30 +812,30 @@ func flattenDynamicDefaultValue(apiObject *awstypes.DynamicDefaultValue) []inter
 		tfMap["user_name_column"] = flattenColumnIdentifier(apiObject.UserNameColumn)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateTimeValueWhenUnsetConfiguration(apiObject *awstypes.DateTimeValueWhenUnsetConfiguration) []interface{} {
+func flattenDateTimeValueWhenUnsetConfiguration(apiObject *awstypes.DateTimeValueWhenUnsetConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValue != nil {
 		tfMap["custom_value"] = apiObject.CustomValue.Format(time.RFC3339)
 	}
 	tfMap["value_when_unset_option"] = apiObject.ValueWhenUnsetOption
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDecimalParameterDeclaration(apiObject *awstypes.DecimalParameterDeclaration) []interface{} {
+func flattenDecimalParameterDeclaration(apiObject *awstypes.DecimalParameterDeclaration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultValues != nil {
 		tfMap["default_values"] = flattenDecimalDefaultValues(apiObject.DefaultValues)
@@ -848,15 +848,15 @@ func flattenDecimalParameterDeclaration(apiObject *awstypes.DecimalParameterDecl
 		tfMap["values_when_unset"] = flattenDecimalValueWhenUnsetConfiguration(apiObject.ValueWhenUnset)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDecimalDefaultValues(apiObject *awstypes.DecimalDefaultValues) []interface{} {
+func flattenDecimalDefaultValues(apiObject *awstypes.DecimalDefaultValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
@@ -865,30 +865,30 @@ func flattenDecimalDefaultValues(apiObject *awstypes.DecimalDefaultValues) []int
 		tfMap["static_values"] = apiObject.StaticValues
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDecimalValueWhenUnsetConfiguration(apiObject *awstypes.DecimalValueWhenUnsetConfiguration) []interface{} {
+func flattenDecimalValueWhenUnsetConfiguration(apiObject *awstypes.DecimalValueWhenUnsetConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValue != nil {
 		tfMap["custom_value"] = aws.ToFloat64(apiObject.CustomValue)
 	}
 	tfMap["value_when_unset_option"] = apiObject.ValueWhenUnsetOption
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenIntegerParameterDeclaration(apiObject *awstypes.IntegerParameterDeclaration) []interface{} {
+func flattenIntegerParameterDeclaration(apiObject *awstypes.IntegerParameterDeclaration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultValues != nil {
 		tfMap["default_values"] = flattenIntegerDefaultValues(apiObject.DefaultValues)
@@ -901,15 +901,15 @@ func flattenIntegerParameterDeclaration(apiObject *awstypes.IntegerParameterDecl
 		tfMap["values_when_unset"] = flattenIntegerValueWhenUnsetConfiguration(apiObject.ValueWhenUnset)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenIntegerDefaultValues(apiObject *awstypes.IntegerDefaultValues) []interface{} {
+func flattenIntegerDefaultValues(apiObject *awstypes.IntegerDefaultValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
@@ -918,30 +918,30 @@ func flattenIntegerDefaultValues(apiObject *awstypes.IntegerDefaultValues) []int
 		tfMap["static_values"] = apiObject.StaticValues
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenIntegerValueWhenUnsetConfiguration(apiObject *awstypes.IntegerValueWhenUnsetConfiguration) []interface{} {
+func flattenIntegerValueWhenUnsetConfiguration(apiObject *awstypes.IntegerValueWhenUnsetConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValue != nil {
 		tfMap["custom_value"] = aws.ToInt64(apiObject.CustomValue)
 	}
 	tfMap["value_when_unset_option"] = apiObject.ValueWhenUnsetOption
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenStringParameterDeclaration(apiObject *awstypes.StringParameterDeclaration) []interface{} {
+func flattenStringParameterDeclaration(apiObject *awstypes.StringParameterDeclaration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultValues != nil {
 		tfMap["default_values"] = flattenStringDefaultValues(apiObject.DefaultValues)
@@ -954,15 +954,15 @@ func flattenStringParameterDeclaration(apiObject *awstypes.StringParameterDeclar
 		tfMap["values_when_unset"] = flattenStringValueWhenUnsetConfiguration(apiObject.ValueWhenUnset)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenStringDefaultValues(apiObject *awstypes.StringDefaultValues) []interface{} {
+func flattenStringDefaultValues(apiObject *awstypes.StringDefaultValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DynamicValue != nil {
 		tfMap["dynamic_value"] = flattenDynamicDefaultValue(apiObject.DynamicValue)
@@ -971,15 +971,15 @@ func flattenStringDefaultValues(apiObject *awstypes.StringDefaultValues) []inter
 		tfMap["static_values"] = apiObject.StaticValues
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenStringValueWhenUnsetConfiguration(apiObject *awstypes.StringValueWhenUnsetConfiguration) []interface{} {
+func flattenStringValueWhenUnsetConfiguration(apiObject *awstypes.StringValueWhenUnsetConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValue != nil {
 		tfMap["custom_value"] = aws.ToString(apiObject.CustomValue)
@@ -987,18 +987,18 @@ func flattenStringValueWhenUnsetConfiguration(apiObject *awstypes.StringValueWhe
 
 	tfMap["value_when_unset_option"] = apiObject.ValueWhenUnsetOption
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterControls(apiObjects []awstypes.ParameterControl) []interface{} {
+func flattenParameterControls(apiObjects []awstypes.ParameterControl) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DateTimePicker != nil {
 			tfMap["date_time_picker"] = flattenParameterDateTimePickerControl(apiObject.DateTimePicker)
@@ -1025,12 +1025,12 @@ func flattenParameterControls(apiObjects []awstypes.ParameterControl) []interfac
 	return tfList
 }
 
-func flattenParameterDateTimePickerControl(apiObject *awstypes.ParameterDateTimePickerControl) []interface{} {
+func flattenParameterDateTimePickerControl(apiObject *awstypes.ParameterDateTimePickerControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1040,15 +1040,15 @@ func flattenParameterDateTimePickerControl(apiObject *awstypes.ParameterDateTime
 		tfMap["display_options"] = flattenDateTimePickerControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterDropDownControl(apiObject *awstypes.ParameterDropDownControl) []interface{} {
+func flattenParameterDropDownControl(apiObject *awstypes.ParameterDropDownControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1065,15 +1065,15 @@ func flattenParameterDropDownControl(apiObject *awstypes.ParameterDropDownContro
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterSelectableValues(apiObject *awstypes.ParameterSelectableValues) []interface{} {
+func flattenParameterSelectableValues(apiObject *awstypes.ParameterSelectableValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LinkToDataSetColumn != nil {
 		tfMap["link_to_data_set_column"] = flattenColumnIdentifier(apiObject.LinkToDataSetColumn)
@@ -1082,15 +1082,15 @@ func flattenParameterSelectableValues(apiObject *awstypes.ParameterSelectableVal
 		tfMap[names.AttrValues] = apiObject.Values
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterListControl(apiObject *awstypes.ParameterListControl) []interface{} {
+func flattenParameterListControl(apiObject *awstypes.ParameterListControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1107,15 +1107,15 @@ func flattenParameterListControl(apiObject *awstypes.ParameterListControl) []int
 	}
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterSliderControl(apiObject *awstypes.ParameterSliderControl) []interface{} {
+func flattenParameterSliderControl(apiObject *awstypes.ParameterSliderControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1128,15 +1128,15 @@ func flattenParameterSliderControl(apiObject *awstypes.ParameterSliderControl) [
 		tfMap["display_options"] = flattenSliderControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterTextAreaControl(apiObject *awstypes.ParameterTextAreaControl) []interface{} {
+func flattenParameterTextAreaControl(apiObject *awstypes.ParameterTextAreaControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1149,15 +1149,15 @@ func flattenParameterTextAreaControl(apiObject *awstypes.ParameterTextAreaContro
 		tfMap["display_options"] = flattenTextAreaControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenParameterTextFieldControl(apiObject *awstypes.ParameterTextFieldControl) []interface{} {
+func flattenParameterTextFieldControl(apiObject *awstypes.ParameterTextFieldControl) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_control_id":  aws.ToString(apiObject.ParameterControlId),
 		"source_parameter_name": aws.ToString(apiObject.SourceParameterName),
 		"title":                 aws.ToString(apiObject.Title),
@@ -1167,5 +1167,5 @@ func flattenParameterTextFieldControl(apiObject *awstypes.ParameterTextFieldCont
 		tfMap["display_options"] = flattenTextFieldControlDisplayOptions(apiObject.DisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/template_sheet.go
+++ b/internal/service/quicksight/schema/template_sheet.go
@@ -574,42 +574,42 @@ var spacingSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandAnalysisDefaults(tfList []interface{}) *awstypes.AnalysisDefaults {
+func expandAnalysisDefaults(tfList []any) *awstypes.AnalysisDefaults {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AnalysisDefaults{}
 
-	if v, ok := tfMap["default_new_sheet_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_new_sheet_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultNewSheetConfiguration = expandDefaultNewSheetConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDefaultNewSheetConfiguration(tfList []interface{}) *awstypes.DefaultNewSheetConfiguration {
+func expandDefaultNewSheetConfiguration(tfList []any) *awstypes.DefaultNewSheetConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultNewSheetConfiguration{}
 
-	if v, ok := tfMap["interactive_layout_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["interactive_layout_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.InteractiveLayoutConfiguration = expandDefaultInteractiveLayoutConfiguration(v)
 	}
 
-	if v, ok := tfMap["paginated_layout_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["paginated_layout_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PaginatedLayoutConfiguration = expandDefaultPaginatedLayoutConfiguration(v)
 	}
 
@@ -620,73 +620,73 @@ func expandDefaultNewSheetConfiguration(tfList []interface{}) *awstypes.DefaultN
 	return apiObject
 }
 
-func expandDefaultInteractiveLayoutConfiguration(tfList []interface{}) *awstypes.DefaultInteractiveLayoutConfiguration {
+func expandDefaultInteractiveLayoutConfiguration(tfList []any) *awstypes.DefaultInteractiveLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultInteractiveLayoutConfiguration{}
 
-	if v, ok := tfMap["free_form"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["free_form"].([]any); ok && len(v) > 0 {
 		apiObject.FreeForm = expandDefaultFreeFormLayoutConfiguration(v)
 	}
 
-	if v, ok := tfMap["grid"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["grid"].([]any); ok && len(v) > 0 {
 		apiObject.Grid = expandDefaultGridLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDefaultFreeFormLayoutConfiguration(tfList []interface{}) *awstypes.DefaultFreeFormLayoutConfiguration {
+func expandDefaultFreeFormLayoutConfiguration(tfList []any) *awstypes.DefaultFreeFormLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultFreeFormLayoutConfiguration{}
 
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandFreeFormLayoutCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormLayoutCanvasSizeOptions(tfList []interface{}) *awstypes.FreeFormLayoutCanvasSizeOptions {
+func expandFreeFormLayoutCanvasSizeOptions(tfList []any) *awstypes.FreeFormLayoutCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FreeFormLayoutCanvasSizeOptions{}
 
-	if v, ok := tfMap["screen_canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["screen_canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.ScreenCanvasSizeOptions = expandFreeFormLayoutScreenCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormLayoutScreenCanvasSizeOptions(tfList []interface{}) *awstypes.FreeFormLayoutScreenCanvasSizeOptions {
+func expandFreeFormLayoutScreenCanvasSizeOptions(tfList []any) *awstypes.FreeFormLayoutScreenCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -700,50 +700,50 @@ func expandFreeFormLayoutScreenCanvasSizeOptions(tfList []interface{}) *awstypes
 	return apiObject
 }
 
-func expandDefaultGridLayoutConfiguration(tfList []interface{}) *awstypes.DefaultGridLayoutConfiguration {
+func expandDefaultGridLayoutConfiguration(tfList []any) *awstypes.DefaultGridLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultGridLayoutConfiguration{}
 
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandGridLayoutCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGridLayoutCanvasSizeOptions(tfList []interface{}) *awstypes.GridLayoutCanvasSizeOptions {
+func expandGridLayoutCanvasSizeOptions(tfList []any) *awstypes.GridLayoutCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GridLayoutCanvasSizeOptions{}
 
-	if v, ok := tfMap["screen_canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["screen_canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.ScreenCanvasSizeOptions = expandGridLayoutScreenCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGridLayoutScreenCanvasSizeOptions(tfList []interface{}) *awstypes.GridLayoutScreenCanvasSizeOptions {
+func expandGridLayoutScreenCanvasSizeOptions(tfList []any) *awstypes.GridLayoutScreenCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -760,76 +760,76 @@ func expandGridLayoutScreenCanvasSizeOptions(tfList []interface{}) *awstypes.Gri
 	return apiObject
 }
 
-func expandDefaultPaginatedLayoutConfiguration(tfList []interface{}) *awstypes.DefaultPaginatedLayoutConfiguration {
+func expandDefaultPaginatedLayoutConfiguration(tfList []any) *awstypes.DefaultPaginatedLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultPaginatedLayoutConfiguration{}
 
-	if v, ok := tfMap["section_based"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["section_based"].([]any); ok && len(v) > 0 {
 		apiObject.SectionBased = expandDefaultSectionBasedLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDefaultSectionBasedLayoutConfiguration(tfList []interface{}) *awstypes.DefaultSectionBasedLayoutConfiguration {
+func expandDefaultSectionBasedLayoutConfiguration(tfList []any) *awstypes.DefaultSectionBasedLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DefaultSectionBasedLayoutConfiguration{}
 
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandSectionBasedLayoutCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandSectionBasedLayoutCanvasSizeOptions(tfList []interface{}) *awstypes.SectionBasedLayoutCanvasSizeOptions {
+func expandSectionBasedLayoutCanvasSizeOptions(tfList []any) *awstypes.SectionBasedLayoutCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SectionBasedLayoutCanvasSizeOptions{}
 
-	if v, ok := tfMap["paper_canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["paper_canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.PaperCanvasSizeOptions = expandSectionBasedLayoutPaperCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandSectionBasedLayoutPaperCanvasSizeOptions(tfList []interface{}) *awstypes.SectionBasedLayoutPaperCanvasSizeOptions {
+func expandSectionBasedLayoutPaperCanvasSizeOptions(tfList []any) *awstypes.SectionBasedLayoutPaperCanvasSizeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SectionBasedLayoutPaperCanvasSizeOptions{}
 
-	if v, ok := tfMap["paper_margin"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["paper_margin"].([]any); ok && len(v) > 0 {
 		apiObject.PaperMargin = expandSpacing(v)
 	}
 	if v, ok := tfMap["paper_orientation"].(string); ok && v != "" {
@@ -842,12 +842,12 @@ func expandSectionBasedLayoutPaperCanvasSizeOptions(tfList []interface{}) *awsty
 	return apiObject
 }
 
-func expandSpacing(tfList []interface{}) *awstypes.Spacing {
+func expandSpacing(tfList []any) *awstypes.Spacing {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -873,7 +873,7 @@ func expandSpacing(tfList []interface{}) *awstypes.Spacing {
 	return apiObject
 }
 
-func expandSheetDefinition(tfMap map[string]interface{}) *awstypes.SheetDefinition {
+func expandSheetDefinition(tfMap map[string]any) *awstypes.SheetDefinition {
 	if tfMap == nil {
 		return nil
 	}
@@ -895,29 +895,29 @@ func expandSheetDefinition(tfMap map[string]interface{}) *awstypes.SheetDefiniti
 	if v, ok := tfMap["title"].(string); ok && v != "" {
 		apiObject.Title = aws.String(v)
 	}
-	if v, ok := tfMap["filter_controls"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_controls"].([]any); ok && len(v) > 0 {
 		apiObject.FilterControls = expandFilterControls(v)
 	}
-	if v, ok := tfMap["layouts"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["layouts"].([]any); ok && len(v) > 0 {
 		apiObject.Layouts = expandLayouts(v)
 	}
-	if v, ok := tfMap["parameter_controls"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["parameter_controls"].([]any); ok && len(v) > 0 {
 		apiObject.ParameterControls = expandParameterControls(v)
 	}
-	if v, ok := tfMap["sheet_control_layouts"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheet_control_layouts"].([]any); ok && len(v) > 0 {
 		apiObject.SheetControlLayouts = expandSheetControlLayouts(v)
 	}
-	if v, ok := tfMap["text_boxes"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_boxes"].([]any); ok && len(v) > 0 {
 		apiObject.TextBoxes = expandSheetTextBoxes(v)
 	}
-	if v, ok := tfMap["visuals"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visuals"].([]any); ok && len(v) > 0 {
 		apiObject.Visuals = expandVisuals(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterControls(tfList []interface{}) []awstypes.FilterControl {
+func expandFilterControls(tfList []any) []awstypes.FilterControl {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -925,7 +925,7 @@ func expandFilterControls(tfList []interface{}) []awstypes.FilterControl {
 	var apiObjects []awstypes.FilterControl
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -941,7 +941,7 @@ func expandFilterControls(tfList []interface{}) []awstypes.FilterControl {
 	return apiObjects
 }
 
-func expandLayouts(tfList []interface{}) []awstypes.Layout {
+func expandLayouts(tfList []any) []awstypes.Layout {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -949,7 +949,7 @@ func expandLayouts(tfList []interface{}) []awstypes.Layout {
 	var apiObjects []awstypes.Layout
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -965,68 +965,68 @@ func expandLayouts(tfList []interface{}) []awstypes.Layout {
 	return apiObjects
 }
 
-func expandLayout(tfMap map[string]interface{}) *awstypes.Layout {
+func expandLayout(tfMap map[string]any) *awstypes.Layout {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.Layout{}
 
-	if v, ok := tfMap[names.AttrConfiguration].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrConfiguration].([]any); ok && len(v) > 0 {
 		apiObject.Configuration = expandLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandLayoutConfiguration(tfList []interface{}) *awstypes.LayoutConfiguration {
+func expandLayoutConfiguration(tfList []any) *awstypes.LayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LayoutConfiguration{}
 
-	if v, ok := tfMap["free_form_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["free_form_layout"].([]any); ok && len(v) > 0 {
 		apiObject.FreeFormLayout = expandFreeFormLayoutConfiguration(v)
 	}
-	if v, ok := tfMap["grid_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["grid_layout"].([]any); ok && len(v) > 0 {
 		apiObject.GridLayout = expandGridLayoutConfiguration(v)
 	}
-	if v, ok := tfMap["section_based_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["section_based_layout"].([]any); ok && len(v) > 0 {
 		apiObject.SectionBasedLayout = expandSectionBasedLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormLayoutConfiguration(tfList []interface{}) *awstypes.FreeFormLayoutConfiguration {
+func expandFreeFormLayoutConfiguration(tfList []any) *awstypes.FreeFormLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FreeFormLayoutConfiguration{}
 
-	if v, ok := tfMap["elements"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["elements"].([]any); ok && len(v) > 0 {
 		apiObject.Elements = expandFreeFormLayoutElements(v)
 	}
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandFreeFormLayoutCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormLayoutElements(tfList []interface{}) []awstypes.FreeFormLayoutElement {
+func expandFreeFormLayoutElements(tfList []any) []awstypes.FreeFormLayoutElement {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1034,7 +1034,7 @@ func expandFreeFormLayoutElements(tfList []interface{}) []awstypes.FreeFormLayou
 	var apiObjects []awstypes.FreeFormLayoutElement
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1050,7 +1050,7 @@ func expandFreeFormLayoutElements(tfList []interface{}) []awstypes.FreeFormLayou
 	return apiObjects
 }
 
-func expandFreeFormLayoutElement(tfMap map[string]interface{}) *awstypes.FreeFormLayoutElement {
+func expandFreeFormLayoutElement(tfMap map[string]any) *awstypes.FreeFormLayoutElement {
 	if tfMap == nil {
 		return nil
 	}
@@ -1078,31 +1078,31 @@ func expandFreeFormLayoutElement(tfMap map[string]interface{}) *awstypes.FreeFor
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["background_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["background_style"].([]any); ok && len(v) > 0 {
 		apiObject.BackgroundStyle = expandFreeFormLayoutElementBackgroundStyle(v)
 	}
-	if v, ok := tfMap["border_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["border_style"].([]any); ok && len(v) > 0 {
 		apiObject.BorderStyle = expandFreeFormLayoutElementBorderStyle(v)
 	}
-	if v, ok := tfMap["loading_animation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["loading_animation"].([]any); ok && len(v) > 0 {
 		apiObject.LoadingAnimation = expandLoadingAnimation(v)
 	}
-	if v, ok := tfMap["rendering_rules"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rendering_rules"].([]any); ok && len(v) > 0 {
 		apiObject.RenderingRules = expandSheetElementRenderingRules(v)
 	}
-	if v, ok := tfMap["selected_border_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selected_border_style"].([]any); ok && len(v) > 0 {
 		apiObject.SelectedBorderStyle = expandFreeFormLayoutElementBorderStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormLayoutElementBackgroundStyle(tfList []interface{}) *awstypes.FreeFormLayoutElementBackgroundStyle {
+func expandFreeFormLayoutElementBackgroundStyle(tfList []any) *awstypes.FreeFormLayoutElementBackgroundStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1119,12 +1119,12 @@ func expandFreeFormLayoutElementBackgroundStyle(tfList []interface{}) *awstypes.
 	return apiObject
 }
 
-func expandFreeFormLayoutElementBorderStyle(tfList []interface{}) *awstypes.FreeFormLayoutElementBorderStyle {
+func expandFreeFormLayoutElementBorderStyle(tfList []any) *awstypes.FreeFormLayoutElementBorderStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1141,12 +1141,12 @@ func expandFreeFormLayoutElementBorderStyle(tfList []interface{}) *awstypes.Free
 	return apiObject
 }
 
-func expandLoadingAnimation(tfList []interface{}) *awstypes.LoadingAnimation {
+func expandLoadingAnimation(tfList []any) *awstypes.LoadingAnimation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1160,7 +1160,7 @@ func expandLoadingAnimation(tfList []interface{}) *awstypes.LoadingAnimation {
 	return apiObject
 }
 
-func expandSheetElementRenderingRules(tfList []interface{}) []awstypes.SheetElementRenderingRule {
+func expandSheetElementRenderingRules(tfList []any) []awstypes.SheetElementRenderingRule {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1168,7 +1168,7 @@ func expandSheetElementRenderingRules(tfList []interface{}) []awstypes.SheetElem
 	var apiObjects []awstypes.SheetElementRenderingRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1184,7 +1184,7 @@ func expandSheetElementRenderingRules(tfList []interface{}) []awstypes.SheetElem
 	return apiObjects
 }
 
-func expandSheetElementRenderingRule(tfMap map[string]interface{}) *awstypes.SheetElementRenderingRule {
+func expandSheetElementRenderingRule(tfMap map[string]any) *awstypes.SheetElementRenderingRule {
 	if tfMap == nil {
 		return nil
 	}
@@ -1194,19 +1194,19 @@ func expandSheetElementRenderingRule(tfMap map[string]interface{}) *awstypes.She
 	if v, ok := tfMap[names.AttrExpression].(string); ok && v != "" {
 		apiObject.Expression = aws.String(v)
 	}
-	if v, ok := tfMap["configuration_overrides"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["configuration_overrides"].([]any); ok && len(v) > 0 {
 		apiObject.ConfigurationOverrides = expandSheetElementConfigurationOverrides(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetElementConfigurationOverrides(tfList []interface{}) *awstypes.SheetElementConfigurationOverrides {
+func expandSheetElementConfigurationOverrides(tfList []any) *awstypes.SheetElementConfigurationOverrides {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1220,29 +1220,29 @@ func expandSheetElementConfigurationOverrides(tfList []interface{}) *awstypes.Sh
 	return apiObject
 }
 
-func expandGridLayoutConfiguration(tfList []interface{}) *awstypes.GridLayoutConfiguration {
+func expandGridLayoutConfiguration(tfList []any) *awstypes.GridLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GridLayoutConfiguration{}
 
-	if v, ok := tfMap["elements"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["elements"].([]any); ok && len(v) > 0 {
 		apiObject.Elements = expandGridLayoutElements(v)
 	}
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandGridLayoutCanvasSizeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGridLayoutElements(tfList []interface{}) []awstypes.GridLayoutElement {
+func expandGridLayoutElements(tfList []any) []awstypes.GridLayoutElement {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1250,7 +1250,7 @@ func expandGridLayoutElements(tfList []interface{}) []awstypes.GridLayoutElement
 	var apiObjects []awstypes.GridLayoutElement
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1266,7 +1266,7 @@ func expandGridLayoutElements(tfList []interface{}) []awstypes.GridLayoutElement
 	return apiObjects
 }
 
-func expandGridLayoutElement(tfMap map[string]interface{}) *awstypes.GridLayoutElement {
+func expandGridLayoutElement(tfMap map[string]any) *awstypes.GridLayoutElement {
 	if tfMap == nil {
 		return nil
 	}
@@ -1299,35 +1299,35 @@ func expandGridLayoutElement(tfMap map[string]interface{}) *awstypes.GridLayoutE
 	return apiObject
 }
 
-func expandSectionBasedLayoutConfiguration(tfList []interface{}) *awstypes.SectionBasedLayoutConfiguration {
+func expandSectionBasedLayoutConfiguration(tfList []any) *awstypes.SectionBasedLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SectionBasedLayoutConfiguration{}
 
-	if v, ok := tfMap["body_sections"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["body_sections"].([]any); ok && len(v) > 0 {
 		apiObject.BodySections = expandBodySectionConfigurations(v)
 	}
-	if v, ok := tfMap["canvas_size_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["canvas_size_options"].([]any); ok && len(v) > 0 {
 		apiObject.CanvasSizeOptions = expandSectionBasedLayoutCanvasSizeOptions(v)
 	}
-	if v, ok := tfMap["footer_sections"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["footer_sections"].([]any); ok && len(v) > 0 {
 		apiObject.FooterSections = expandHeaderFooterSectionConfigurations(v)
 	}
-	if v, ok := tfMap["header_sections"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["header_sections"].([]any); ok && len(v) > 0 {
 		apiObject.HeaderSections = expandHeaderFooterSectionConfigurations(v)
 	}
 
 	return apiObject
 }
 
-func expandBodySectionConfigurations(tfList []interface{}) []awstypes.BodySectionConfiguration {
+func expandBodySectionConfigurations(tfList []any) []awstypes.BodySectionConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1335,7 +1335,7 @@ func expandBodySectionConfigurations(tfList []interface{}) []awstypes.BodySectio
 	var apiObjects []awstypes.BodySectionConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1351,7 +1351,7 @@ func expandBodySectionConfigurations(tfList []interface{}) []awstypes.BodySectio
 	return apiObjects
 }
 
-func expandBodySectionConfiguration(tfMap map[string]interface{}) *awstypes.BodySectionConfiguration {
+func expandBodySectionConfiguration(tfMap map[string]any) *awstypes.BodySectionConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -1361,101 +1361,101 @@ func expandBodySectionConfiguration(tfMap map[string]interface{}) *awstypes.Body
 	if v, ok := tfMap["section_id"].(string); ok && v != "" {
 		apiObject.SectionId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrContent].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrContent].([]any); ok && len(v) > 0 {
 		apiObject.Content = expandBodySectionContent(v)
 	}
-	if v, ok := tfMap["page_break_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["page_break_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PageBreakConfiguration = expandSectionPageBreakConfiguration(v)
 	}
-	if v, ok := tfMap["style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["style"].([]any); ok && len(v) > 0 {
 		apiObject.Style = expandSectionStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandBodySectionContent(tfList []interface{}) *awstypes.BodySectionContent {
+func expandBodySectionContent(tfList []any) *awstypes.BodySectionContent {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BodySectionContent{}
 
-	if v, ok := tfMap["layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["layout"].([]any); ok && len(v) > 0 {
 		apiObject.Layout = expandSectionLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSectionLayoutConfiguration(tfList []interface{}) *awstypes.SectionLayoutConfiguration {
+func expandSectionLayoutConfiguration(tfList []any) *awstypes.SectionLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SectionLayoutConfiguration{}
 
-	if v, ok := tfMap["free_form_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["free_form_layout"].([]any); ok && len(v) > 0 {
 		apiObject.FreeFormLayout = expandFreeFormSectionLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandFreeFormSectionLayoutConfiguration(tfList []interface{}) *awstypes.FreeFormSectionLayoutConfiguration {
+func expandFreeFormSectionLayoutConfiguration(tfList []any) *awstypes.FreeFormSectionLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FreeFormSectionLayoutConfiguration{}
 
-	if v, ok := tfMap["elements"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["elements"].([]any); ok && len(v) > 0 {
 		apiObject.Elements = expandFreeFormLayoutElements(v)
 	}
 
 	return apiObject
 }
 
-func expandSectionPageBreakConfiguration(tfList []interface{}) *awstypes.SectionPageBreakConfiguration {
+func expandSectionPageBreakConfiguration(tfList []any) *awstypes.SectionPageBreakConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SectionPageBreakConfiguration{}
 
-	if v, ok := tfMap["after"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["after"].([]any); ok && len(v) > 0 {
 		apiObject.After = expandSectionAfterPageBreak(v)
 	}
 
 	return apiObject
 }
 
-func expandSectionAfterPageBreak(tfList []interface{}) *awstypes.SectionAfterPageBreak {
+func expandSectionAfterPageBreak(tfList []any) *awstypes.SectionAfterPageBreak {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1469,12 +1469,12 @@ func expandSectionAfterPageBreak(tfList []interface{}) *awstypes.SectionAfterPag
 	return apiObject
 }
 
-func expandSectionStyle(tfList []interface{}) *awstypes.SectionStyle {
+func expandSectionStyle(tfList []any) *awstypes.SectionStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1484,14 +1484,14 @@ func expandSectionStyle(tfList []interface{}) *awstypes.SectionStyle {
 	if v, ok := tfMap["height"].(string); ok && v != "" {
 		apiObject.Height = aws.String(v)
 	}
-	if v, ok := tfMap["padding"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["padding"].([]any); ok && len(v) > 0 {
 		apiObject.Padding = expandSpacing(v)
 	}
 
 	return apiObject
 }
 
-func expandHeaderFooterSectionConfigurations(tfList []interface{}) []awstypes.HeaderFooterSectionConfiguration {
+func expandHeaderFooterSectionConfigurations(tfList []any) []awstypes.HeaderFooterSectionConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1499,7 +1499,7 @@ func expandHeaderFooterSectionConfigurations(tfList []interface{}) []awstypes.He
 	var apiObjects []awstypes.HeaderFooterSectionConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1515,7 +1515,7 @@ func expandHeaderFooterSectionConfigurations(tfList []interface{}) []awstypes.He
 	return apiObjects
 }
 
-func expandHeaderFooterSectionConfiguration(tfMap map[string]interface{}) *awstypes.HeaderFooterSectionConfiguration {
+func expandHeaderFooterSectionConfiguration(tfMap map[string]any) *awstypes.HeaderFooterSectionConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -1525,17 +1525,17 @@ func expandHeaderFooterSectionConfiguration(tfMap map[string]interface{}) *awsty
 	if v, ok := tfMap["section_id"].(string); ok && v != "" {
 		apiObject.SectionId = aws.String(v)
 	}
-	if v, ok := tfMap["layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["layout"].([]any); ok && len(v) > 0 {
 		apiObject.Layout = expandSectionLayoutConfiguration(v)
 	}
-	if v, ok := tfMap["style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["style"].([]any); ok && len(v) > 0 {
 		apiObject.Style = expandSectionStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandParameterControls(tfList []interface{}) []awstypes.ParameterControl {
+func expandParameterControls(tfList []any) []awstypes.ParameterControl {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1543,7 +1543,7 @@ func expandParameterControls(tfList []interface{}) []awstypes.ParameterControl {
 	var apiObjects []awstypes.ParameterControl
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1559,7 +1559,7 @@ func expandParameterControls(tfList []interface{}) []awstypes.ParameterControl {
 	return apiObjects
 }
 
-func expandSheetControlLayouts(tfList []interface{}) []awstypes.SheetControlLayout {
+func expandSheetControlLayouts(tfList []any) []awstypes.SheetControlLayout {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1567,7 +1567,7 @@ func expandSheetControlLayouts(tfList []interface{}) []awstypes.SheetControlLayo
 	var apiObjects []awstypes.SheetControlLayout
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1583,40 +1583,40 @@ func expandSheetControlLayouts(tfList []interface{}) []awstypes.SheetControlLayo
 	return apiObjects
 }
 
-func expandSheetControlLayout(tfMap map[string]interface{}) *awstypes.SheetControlLayout {
+func expandSheetControlLayout(tfMap map[string]any) *awstypes.SheetControlLayout {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.SheetControlLayout{}
 
-	if v, ok := tfMap[names.AttrConfiguration].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrConfiguration].([]any); ok && len(v) > 0 {
 		apiObject.Configuration = expandSheetControlLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetControlLayoutConfiguration(tfList []interface{}) *awstypes.SheetControlLayoutConfiguration {
+func expandSheetControlLayoutConfiguration(tfList []any) *awstypes.SheetControlLayoutConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SheetControlLayoutConfiguration{}
 
-	if v, ok := tfMap["grid_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["grid_layout"].([]any); ok && len(v) > 0 {
 		apiObject.GridLayout = expandGridLayoutConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetTextBoxes(tfList []interface{}) []awstypes.SheetTextBox {
+func expandSheetTextBoxes(tfList []any) []awstypes.SheetTextBox {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1624,7 +1624,7 @@ func expandSheetTextBoxes(tfList []interface{}) []awstypes.SheetTextBox {
 	var apiObjects []awstypes.SheetTextBox
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1640,7 +1640,7 @@ func expandSheetTextBoxes(tfList []interface{}) []awstypes.SheetTextBox {
 	return apiObjects
 }
 
-func expandSheetTextBox(tfMap map[string]interface{}) *awstypes.SheetTextBox {
+func expandSheetTextBox(tfMap map[string]any) *awstypes.SheetTextBox {
 	if tfMap == nil {
 		return nil
 	}
@@ -1657,7 +1657,7 @@ func expandSheetTextBox(tfMap map[string]interface{}) *awstypes.SheetTextBox {
 	return apiObject
 }
 
-func expandVisuals(tfList []interface{}) []awstypes.Visual {
+func expandVisuals(tfList []any) []awstypes.Visual {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1665,7 +1665,7 @@ func expandVisuals(tfList []interface{}) []awstypes.Visual {
 	var apiObjects []awstypes.Visual
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1681,26 +1681,26 @@ func expandVisuals(tfList []interface{}) []awstypes.Visual {
 	return apiObjects
 }
 
-func flattenAnalysisDefaults(apiObject *awstypes.AnalysisDefaults) []interface{} {
+func flattenAnalysisDefaults(apiObject *awstypes.AnalysisDefaults) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DefaultNewSheetConfiguration != nil {
 		tfMap["default_new_sheet_configuration"] = flattenDefaultNewSheetConfiguration(apiObject.DefaultNewSheetConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultNewSheetConfiguration(apiObject *awstypes.DefaultNewSheetConfiguration) []interface{} {
+func flattenDefaultNewSheetConfiguration(apiObject *awstypes.DefaultNewSheetConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.InteractiveLayoutConfiguration != nil {
 		tfMap["interactive_layout_configuration"] = flattenDefaultInteractiveLayoutConfiguration(apiObject.InteractiveLayoutConfiguration)
@@ -1710,15 +1710,15 @@ func flattenDefaultNewSheetConfiguration(apiObject *awstypes.DefaultNewSheetConf
 	}
 	tfMap["sheet_content_type"] = apiObject.SheetContentType
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultInteractiveLayoutConfiguration(apiObject *awstypes.DefaultInteractiveLayoutConfiguration) []interface{} {
+func flattenDefaultInteractiveLayoutConfiguration(apiObject *awstypes.DefaultInteractiveLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FreeForm != nil {
 		tfMap["free_form"] = flattenDefaultFreeFormLayoutConfiguration(apiObject.FreeForm)
@@ -1727,142 +1727,142 @@ func flattenDefaultInteractiveLayoutConfiguration(apiObject *awstypes.DefaultInt
 		tfMap["grid"] = flattenDefaultGridLayoutConfiguration(apiObject.Grid)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultFreeFormLayoutConfiguration(apiObject *awstypes.DefaultFreeFormLayoutConfiguration) []interface{} {
+func flattenDefaultFreeFormLayoutConfiguration(apiObject *awstypes.DefaultFreeFormLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CanvasSizeOptions != nil {
 		tfMap["canvas_size_options"] = flattenFreeFormLayoutCanvasSizeOptions(apiObject.CanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormLayoutCanvasSizeOptions(apiObject *awstypes.FreeFormLayoutCanvasSizeOptions) []interface{} {
+func flattenFreeFormLayoutCanvasSizeOptions(apiObject *awstypes.FreeFormLayoutCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ScreenCanvasSizeOptions != nil {
 		tfMap["screen_canvas_size_options"] = flattenFreeFormLayoutScreenCanvasSizeOptions(apiObject.ScreenCanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormLayoutScreenCanvasSizeOptions(apiObject *awstypes.FreeFormLayoutScreenCanvasSizeOptions) []interface{} {
+func flattenFreeFormLayoutScreenCanvasSizeOptions(apiObject *awstypes.FreeFormLayoutScreenCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.OptimizedViewPortWidth != nil {
 		tfMap["optimized_view_port_width"] = aws.ToString(apiObject.OptimizedViewPortWidth)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultGridLayoutConfiguration(apiObject *awstypes.DefaultGridLayoutConfiguration) []interface{} {
+func flattenDefaultGridLayoutConfiguration(apiObject *awstypes.DefaultGridLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CanvasSizeOptions != nil {
 		tfMap["canvas_size_options"] = flattenGridLayoutCanvasSizeOptions(apiObject.CanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGridLayoutCanvasSizeOptions(apiObject *awstypes.GridLayoutCanvasSizeOptions) []interface{} {
+func flattenGridLayoutCanvasSizeOptions(apiObject *awstypes.GridLayoutCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ScreenCanvasSizeOptions != nil {
 		tfMap["screen_canvas_size_options"] = flattenGridLayoutScreenCanvasSizeOptions(apiObject.ScreenCanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGridLayoutScreenCanvasSizeOptions(apiObject *awstypes.GridLayoutScreenCanvasSizeOptions) []interface{} {
+func flattenGridLayoutScreenCanvasSizeOptions(apiObject *awstypes.GridLayoutScreenCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.OptimizedViewPortWidth != nil {
 		tfMap["optimized_view_port_width"] = aws.ToString(apiObject.OptimizedViewPortWidth)
 	}
 	tfMap["resize_option"] = apiObject.ResizeOption
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultPaginatedLayoutConfiguration(apiObject *awstypes.DefaultPaginatedLayoutConfiguration) []interface{} {
+func flattenDefaultPaginatedLayoutConfiguration(apiObject *awstypes.DefaultPaginatedLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SectionBased != nil {
 		tfMap["section_based"] = flattenDefaultSectionBasedLayoutConfiguration(apiObject.SectionBased)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDefaultSectionBasedLayoutConfiguration(apiObject *awstypes.DefaultSectionBasedLayoutConfiguration) []interface{} {
+func flattenDefaultSectionBasedLayoutConfiguration(apiObject *awstypes.DefaultSectionBasedLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CanvasSizeOptions != nil {
 		tfMap["canvas_size_options"] = flattenSectionBasedLayoutCanvasSizeOptions(apiObject.CanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionBasedLayoutCanvasSizeOptions(apiObject *awstypes.SectionBasedLayoutCanvasSizeOptions) []interface{} {
+func flattenSectionBasedLayoutCanvasSizeOptions(apiObject *awstypes.SectionBasedLayoutCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PaperCanvasSizeOptions != nil {
 		tfMap["paper_canvas_size_options"] = flattenSectionBasedLayoutPaperCanvasSizeOptions(apiObject.PaperCanvasSizeOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionBasedLayoutPaperCanvasSizeOptions(apiObject *awstypes.SectionBasedLayoutPaperCanvasSizeOptions) []interface{} {
+func flattenSectionBasedLayoutPaperCanvasSizeOptions(apiObject *awstypes.SectionBasedLayoutPaperCanvasSizeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PaperMargin != nil {
 		tfMap["paper_margin"] = flattenSpacing(apiObject.PaperMargin)
@@ -1870,15 +1870,15 @@ func flattenSectionBasedLayoutPaperCanvasSizeOptions(apiObject *awstypes.Section
 	tfMap["paper_orientation"] = apiObject.PaperOrientation
 	tfMap["paper_size"] = apiObject.PaperSize
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSpacing(apiObject *awstypes.Spacing) []interface{} {
+func flattenSpacing(apiObject *awstypes.Spacing) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Bottom != nil {
 		tfMap["bottom"] = aws.ToString(apiObject.Bottom)
@@ -1893,18 +1893,18 @@ func flattenSpacing(apiObject *awstypes.Spacing) []interface{} {
 		tfMap["top"] = aws.ToString(apiObject.Top)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLayouts(apiObjects []awstypes.Layout) []interface{} {
+func flattenLayouts(apiObjects []awstypes.Layout) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrConfiguration: flattenLayoutConfiguration(apiObject.Configuration),
 		}
 
@@ -1914,12 +1914,12 @@ func flattenLayouts(apiObjects []awstypes.Layout) []interface{} {
 	return tfList
 }
 
-func flattenLayoutConfiguration(apiObject *awstypes.LayoutConfiguration) []interface{} {
+func flattenLayoutConfiguration(apiObject *awstypes.LayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FreeFormLayout != nil {
 		tfMap["free_form_layout"] = flattenFreeFormLayoutConfiguration(apiObject.FreeFormLayout)
@@ -1931,15 +1931,15 @@ func flattenLayoutConfiguration(apiObject *awstypes.LayoutConfiguration) []inter
 		tfMap["section_based_layout"] = flattenSectionBasedLayoutConfiguration(apiObject.SectionBasedLayout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormLayoutConfiguration(apiObject *awstypes.FreeFormLayoutConfiguration) []interface{} {
+func flattenFreeFormLayoutConfiguration(apiObject *awstypes.FreeFormLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CanvasSizeOptions != nil {
 		tfMap["canvas_size_options"] = flattenFreeFormLayoutCanvasSizeOptions(apiObject.CanvasSizeOptions)
@@ -1948,18 +1948,18 @@ func flattenFreeFormLayoutConfiguration(apiObject *awstypes.FreeFormLayoutConfig
 		tfMap["elements"] = flattenFreeFormLayoutElement(apiObject.Elements)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormLayoutElement(apiObjects []awstypes.FreeFormLayoutElement) []interface{} {
+func flattenFreeFormLayoutElement(apiObjects []awstypes.FreeFormLayoutElement) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"element_id":      aws.ToString(apiObject.ElementId),
 			"element_type":    apiObject.ElementType,
 			"height":          aws.ToString(apiObject.Height),
@@ -1991,57 +1991,57 @@ func flattenFreeFormLayoutElement(apiObjects []awstypes.FreeFormLayoutElement) [
 	return tfList
 }
 
-func flattenFreeFormLayoutElementBackgroundStyle(apiObject *awstypes.FreeFormLayoutElementBackgroundStyle) []interface{} {
+func flattenFreeFormLayoutElementBackgroundStyle(apiObject *awstypes.FreeFormLayoutElementBackgroundStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormLayoutElementBorderStyle(apiObject *awstypes.FreeFormLayoutElementBorderStyle) []interface{} {
+func flattenFreeFormLayoutElementBorderStyle(apiObject *awstypes.FreeFormLayoutElementBorderStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLoadingAnimation(apiObject *awstypes.LoadingAnimation) []interface{} {
+func flattenLoadingAnimation(apiObject *awstypes.LoadingAnimation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSheetElementRenderingRule(apiObjects []awstypes.SheetElementRenderingRule) []interface{} {
+func flattenSheetElementRenderingRule(apiObjects []awstypes.SheetElementRenderingRule) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ConfigurationOverrides != nil {
 			tfMap["configuration_overrides"] = flattenSheetElementConfigurationOverrides(apiObject.ConfigurationOverrides)
@@ -2056,24 +2056,24 @@ func flattenSheetElementRenderingRule(apiObjects []awstypes.SheetElementRenderin
 	return tfList
 }
 
-func flattenSheetElementConfigurationOverrides(apiObject *awstypes.SheetElementConfigurationOverrides) []interface{} {
+func flattenSheetElementConfigurationOverrides(apiObject *awstypes.SheetElementConfigurationOverrides) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGridLayoutConfiguration(apiObject *awstypes.GridLayoutConfiguration) []interface{} {
+func flattenGridLayoutConfiguration(apiObject *awstypes.GridLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CanvasSizeOptions != nil {
 		tfMap["canvas_size_options"] = flattenGridLayoutCanvasSizeOptions(apiObject.CanvasSizeOptions)
@@ -2082,18 +2082,18 @@ func flattenGridLayoutConfiguration(apiObject *awstypes.GridLayoutConfiguration)
 		tfMap["elements"] = flattenGridLayoutElement(apiObject.Elements)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGridLayoutElement(apiObjects []awstypes.GridLayoutElement) []interface{} {
+func flattenGridLayoutElement(apiObjects []awstypes.GridLayoutElement) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"column_span":  aws.ToInt32(apiObject.ColumnSpan),
 			"element_id":   aws.ToString(apiObject.ElementId),
 			"element_type": apiObject.ElementType,
@@ -2113,12 +2113,12 @@ func flattenGridLayoutElement(apiObjects []awstypes.GridLayoutElement) []interfa
 	return tfList
 }
 
-func flattenSectionBasedLayoutConfiguration(apiObject *awstypes.SectionBasedLayoutConfiguration) []interface{} {
+func flattenSectionBasedLayoutConfiguration(apiObject *awstypes.SectionBasedLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BodySections != nil {
 		tfMap["body_sections"] = flattenBodySectionConfiguration(apiObject.BodySections)
@@ -2133,18 +2133,18 @@ func flattenSectionBasedLayoutConfiguration(apiObject *awstypes.SectionBasedLayo
 		tfMap["header_sections"] = flattenHeaderFooterSectionConfiguration(apiObject.HeaderSections)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBodySectionConfiguration(apiObjects []awstypes.BodySectionConfiguration) []interface{} {
+func flattenBodySectionConfiguration(apiObjects []awstypes.BodySectionConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrContent: flattenBodySectionContent(apiObject.Content),
 			"section_id":      aws.ToString(apiObject.SectionId),
 		}
@@ -2162,80 +2162,80 @@ func flattenBodySectionConfiguration(apiObjects []awstypes.BodySectionConfigurat
 	return tfList
 }
 
-func flattenBodySectionContent(apiObject *awstypes.BodySectionContent) []interface{} {
+func flattenBodySectionContent(apiObject *awstypes.BodySectionContent) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Layout != nil {
 		tfMap["layout"] = flattenSectionLayoutConfiguration(apiObject.Layout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionLayoutConfiguration(apiObject *awstypes.SectionLayoutConfiguration) []interface{} {
+func flattenSectionLayoutConfiguration(apiObject *awstypes.SectionLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FreeFormLayout != nil {
 		tfMap["free_form_layout"] = flattenFreeFormSectionLayoutConfiguration(apiObject.FreeFormLayout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFreeFormSectionLayoutConfiguration(apiObject *awstypes.FreeFormSectionLayoutConfiguration) []interface{} {
+func flattenFreeFormSectionLayoutConfiguration(apiObject *awstypes.FreeFormSectionLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Elements != nil {
 		tfMap["free_form_layout"] = flattenFreeFormLayoutElement(apiObject.Elements)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionPageBreakConfiguration(apiObject *awstypes.SectionPageBreakConfiguration) []interface{} {
+func flattenSectionPageBreakConfiguration(apiObject *awstypes.SectionPageBreakConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.After != nil {
 		tfMap["after"] = flattenSectionAfterPageBreak(apiObject.After)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionAfterPageBreak(apiObject *awstypes.SectionAfterPageBreak) []interface{} {
+func flattenSectionAfterPageBreak(apiObject *awstypes.SectionAfterPageBreak) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrStatus] = apiObject.Status
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSectionStyle(apiObject *awstypes.SectionStyle) []interface{} {
+func flattenSectionStyle(apiObject *awstypes.SectionStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Height != nil {
 		tfMap["height"] = aws.ToString(apiObject.Height)
@@ -2244,18 +2244,18 @@ func flattenSectionStyle(apiObject *awstypes.SectionStyle) []interface{} {
 		tfMap["padding"] = flattenSpacing(apiObject.Padding)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHeaderFooterSectionConfiguration(apiObjects []awstypes.HeaderFooterSectionConfiguration) []interface{} {
+func flattenHeaderFooterSectionConfiguration(apiObjects []awstypes.HeaderFooterSectionConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"section_id": aws.ToString(apiObject.SectionId),
 		}
 
@@ -2272,15 +2272,15 @@ func flattenHeaderFooterSectionConfiguration(apiObjects []awstypes.HeaderFooterS
 	return tfList
 }
 
-func flattenSheetControlLayouts(apiObjects []awstypes.SheetControlLayout) []interface{} {
+func flattenSheetControlLayouts(apiObjects []awstypes.SheetControlLayout) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrConfiguration: flattenSheetControlLayoutConfiguration(apiObject.Configuration),
 		}
 
@@ -2290,16 +2290,16 @@ func flattenSheetControlLayouts(apiObjects []awstypes.SheetControlLayout) []inte
 	return tfList
 }
 
-func flattenSheetControlLayoutConfiguration(apiObject *awstypes.SheetControlLayoutConfiguration) []interface{} {
+func flattenSheetControlLayoutConfiguration(apiObject *awstypes.SheetControlLayoutConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.GridLayout != nil {
 		tfMap["grid_layout"] = flattenGridLayoutConfiguration(apiObject.GridLayout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/theme.go
+++ b/internal/service/quicksight/schema/theme.go
@@ -164,106 +164,106 @@ func ThemeConfigurationDataSourceSchema() *schema.Schema {
 	return sdkv2.DataSourcePropertyFromResourceProperty(ThemeConfigurationSchema())
 }
 
-func ExpandThemeConfiguration(tfList []interface{}) *awstypes.ThemeConfiguration {
+func ExpandThemeConfiguration(tfList []any) *awstypes.ThemeConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ThemeConfiguration{}
 
-	if v, ok := tfMap["data_color_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_color_palette"].([]any); ok && len(v) > 0 {
 		apiObject.DataColorPalette = expandDataColorPalette(v)
 	}
-	if v, ok := tfMap["sheet"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sheet"].([]any); ok && len(v) > 0 {
 		apiObject.Sheet = expandSheetStyle(v)
 	}
-	if v, ok := tfMap["typography"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["typography"].([]any); ok && len(v) > 0 {
 		apiObject.Typography = expandTypography(v)
 	}
-	if v, ok := tfMap["ui_color_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["ui_color_palette"].([]any); ok && len(v) > 0 {
 		apiObject.UIColorPalette = expandUIColorPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandDataColorPalette(tfList []interface{}) *awstypes.DataColorPalette {
+func expandDataColorPalette(tfList []any) *awstypes.DataColorPalette {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DataColorPalette{}
 
-	if v, ok := tfMap["colors"].([]interface{}); ok {
+	if v, ok := tfMap["colors"].([]any); ok {
 		apiObject.Colors = flex.ExpandStringValueList(v)
 	}
 	if v, ok := tfMap["empty_fill_color"].(string); ok && v != "" {
 		apiObject.EmptyFillColor = aws.String(v)
 	}
-	if v, ok := tfMap["min_max_gradient"].([]interface{}); ok {
+	if v, ok := tfMap["min_max_gradient"].([]any); ok {
 		apiObject.MinMaxGradient = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandSheetStyle(tfList []interface{}) *awstypes.SheetStyle {
+func expandSheetStyle(tfList []any) *awstypes.SheetStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SheetStyle{}
 
-	if v, ok := tfMap["tile"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tile"].([]any); ok && len(v) > 0 {
 		apiObject.Tile = expandTileStyle(v)
 	}
-	if v, ok := tfMap["tile_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tile_layout"].([]any); ok && len(v) > 0 {
 		apiObject.TileLayout = expandTileLayoutStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandTileStyle(tfList []interface{}) *awstypes.TileStyle {
+func expandTileStyle(tfList []any) *awstypes.TileStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TileStyle{}
 
-	if v, ok := tfMap["border"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["border"].([]any); ok && len(v) > 0 {
 		apiObject.Border = expandBorderStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandBorderStyle(tfList []interface{}) *awstypes.BorderStyle {
+func expandBorderStyle(tfList []any) *awstypes.BorderStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -277,34 +277,34 @@ func expandBorderStyle(tfList []interface{}) *awstypes.BorderStyle {
 	return apiObject
 }
 
-func expandTileLayoutStyle(tfList []interface{}) *awstypes.TileLayoutStyle {
+func expandTileLayoutStyle(tfList []any) *awstypes.TileLayoutStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TileLayoutStyle{}
 
-	if v, ok := tfMap["gutter"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["gutter"].([]any); ok && len(v) > 0 {
 		apiObject.Gutter = expandGutterStyle(v)
 	}
-	if v, ok := tfMap["margin"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["margin"].([]any); ok && len(v) > 0 {
 		apiObject.Margin = expandMarginStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandGutterStyle(tfList []interface{}) *awstypes.GutterStyle {
+func expandGutterStyle(tfList []any) *awstypes.GutterStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -318,12 +318,12 @@ func expandGutterStyle(tfList []interface{}) *awstypes.GutterStyle {
 	return apiObject
 }
 
-func expandMarginStyle(tfList []interface{}) *awstypes.MarginStyle {
+func expandMarginStyle(tfList []any) *awstypes.MarginStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -337,26 +337,26 @@ func expandMarginStyle(tfList []interface{}) *awstypes.MarginStyle {
 	return apiObject
 }
 
-func expandTypography(tfList []interface{}) *awstypes.Typography {
+func expandTypography(tfList []any) *awstypes.Typography {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.Typography{}
 
-	if v, ok := tfMap["font_families"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_families"].([]any); ok && len(v) > 0 {
 		apiObject.FontFamilies = expandFonts(v)
 	}
 
 	return apiObject
 }
 
-func expandFonts(tfList []interface{}) []awstypes.Font {
+func expandFonts(tfList []any) []awstypes.Font {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -364,7 +364,7 @@ func expandFonts(tfList []interface{}) []awstypes.Font {
 	var apiObjects []awstypes.Font
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -380,7 +380,7 @@ func expandFonts(tfList []interface{}) []awstypes.Font {
 	return apiObjects
 }
 
-func expandFont(tfMap map[string]interface{}) *awstypes.Font {
+func expandFont(tfMap map[string]any) *awstypes.Font {
 	if tfMap == nil {
 		return nil
 	}
@@ -394,12 +394,12 @@ func expandFont(tfMap map[string]interface{}) *awstypes.Font {
 	return apiObject
 }
 
-func expandUIColorPalette(tfList []interface{}) *awstypes.UIColorPalette {
+func expandUIColorPalette(tfList []any) *awstypes.UIColorPalette {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -458,12 +458,12 @@ func expandUIColorPalette(tfList []interface{}) *awstypes.UIColorPalette {
 	return apiObject
 }
 
-func FlattenThemeConfiguration(apiObject *awstypes.ThemeConfiguration) []interface{} {
+func FlattenThemeConfiguration(apiObject *awstypes.ThemeConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataColorPalette != nil {
 		tfMap["data_color_palette"] = flattenDataColorPalette(apiObject.DataColorPalette)
@@ -478,15 +478,15 @@ func FlattenThemeConfiguration(apiObject *awstypes.ThemeConfiguration) []interfa
 		tfMap["ui_color_palette"] = flattenUIColorPalette(apiObject.UIColorPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataColorPalette(apiObject *awstypes.DataColorPalette) []interface{} {
+func flattenDataColorPalette(apiObject *awstypes.DataColorPalette) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Colors != nil {
 		tfMap["colors"] = apiObject.Colors
@@ -498,15 +498,15 @@ func flattenDataColorPalette(apiObject *awstypes.DataColorPalette) []interface{}
 		tfMap["min_max_gradient"] = apiObject.MinMaxGradient
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSheetStyle(apiObject *awstypes.SheetStyle) []interface{} {
+func flattenSheetStyle(apiObject *awstypes.SheetStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Tile != nil {
 		tfMap["tile"] = flattenTileStyle(apiObject.Tile)
@@ -515,43 +515,43 @@ func flattenSheetStyle(apiObject *awstypes.SheetStyle) []interface{} {
 		tfMap["tile_layout"] = flattenTileLayoutStyle(apiObject.TileLayout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTileStyle(apiObject *awstypes.TileStyle) []interface{} {
+func flattenTileStyle(apiObject *awstypes.TileStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Border != nil {
 		tfMap["border"] = flattenBorderStyle(apiObject.Border)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBorderStyle(apiObject *awstypes.BorderStyle) []interface{} {
+func flattenBorderStyle(apiObject *awstypes.BorderStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Show != nil {
 		tfMap["show"] = aws.ToBool(apiObject.Show)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTileLayoutStyle(apiObject *awstypes.TileLayoutStyle) []interface{} {
+func flattenTileLayoutStyle(apiObject *awstypes.TileLayoutStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Gutter != nil {
 		tfMap["gutter"] = flattenGutterStyle(apiObject.Gutter)
@@ -560,60 +560,60 @@ func flattenTileLayoutStyle(apiObject *awstypes.TileLayoutStyle) []interface{} {
 		tfMap["margin"] = flattenMarginStyle(apiObject.Margin)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGutterStyle(apiObject *awstypes.GutterStyle) []interface{} {
+func flattenGutterStyle(apiObject *awstypes.GutterStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Show != nil {
 		tfMap["show"] = aws.ToBool(apiObject.Show)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMarginStyle(apiObject *awstypes.MarginStyle) []interface{} {
+func flattenMarginStyle(apiObject *awstypes.MarginStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Show != nil {
 		tfMap["show"] = aws.ToBool(apiObject.Show)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTypography(apiObject *awstypes.Typography) []interface{} {
+func flattenTypography(apiObject *awstypes.Typography) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FontFamilies != nil {
 		tfMap["font_families"] = flattenFonts(apiObject.FontFamilies)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFonts(apiObject []awstypes.Font) []interface{} {
+func flattenFonts(apiObject []awstypes.Font) []any {
 	if len(apiObject) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObject {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FontFamily != nil {
 			tfMap["font_family"] = aws.ToString(apiObject.FontFamily)
@@ -625,12 +625,12 @@ func flattenFonts(apiObject []awstypes.Font) []interface{} {
 	return tfList
 }
 
-func flattenUIColorPalette(apiObject *awstypes.UIColorPalette) []interface{} {
+func flattenUIColorPalette(apiObject *awstypes.UIColorPalette) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Accent != nil {
 		tfMap["accent"] = aws.ToString(apiObject.Accent)
@@ -681,5 +681,5 @@ func flattenUIColorPalette(apiObject *awstypes.UIColorPalette) []interface{} {
 		tfMap["warning_foreground"] = aws.ToString(apiObject.WarningForeground)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual.go
+++ b/internal/service/quicksight/schema/visual.go
@@ -487,92 +487,92 @@ func hexColorSchema(handling attrHandling) *schema.Schema {
 	return stringMatchSchema(handling, `^#[0-9A-F]{6}$`, "")
 }
 
-func expandVisual(tfMap map[string]interface{}) *awstypes.Visual {
+func expandVisual(tfMap map[string]any) *awstypes.Visual {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.Visual{}
 
-	if v, ok := tfMap["bar_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bar_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.BarChartVisual = expandBarChartVisual(v)
 	}
-	if v, ok := tfMap["box_plot_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["box_plot_visual"].([]any); ok && len(v) > 0 {
 		apiObject.BoxPlotVisual = expandBoxPlotVisual(v)
 	}
-	if v, ok := tfMap["combo_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["combo_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.ComboChartVisual = expandComboChartVisual(v)
 	}
-	if v, ok := tfMap["custom_content_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_content_visual"].([]any); ok && len(v) > 0 {
 		apiObject.CustomContentVisual = expandCustomContentVisual(v)
 	}
-	if v, ok := tfMap["empty_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["empty_visual"].([]any); ok && len(v) > 0 {
 		apiObject.EmptyVisual = expandEmptyVisual(v)
 	}
-	if v, ok := tfMap["filled_map_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filled_map_visual"].([]any); ok && len(v) > 0 {
 		apiObject.FilledMapVisual = expandFilledMapVisual(v)
 	}
-	if v, ok := tfMap["funnel_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["funnel_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.FunnelChartVisual = expandFunnelChartVisual(v)
 	}
-	if v, ok := tfMap["gauge_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["gauge_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.GaugeChartVisual = expandGaugeChartVisual(v)
 	}
-	if v, ok := tfMap["geospatial_map_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["geospatial_map_visual"].([]any); ok && len(v) > 0 {
 		apiObject.GeospatialMapVisual = expandGeospatialMapVisual(v)
 	}
-	if v, ok := tfMap["heat_map_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_visual"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapVisual = expandHeatMapVisual(v)
 	}
-	if v, ok := tfMap["histogram_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["histogram_visual"].([]any); ok && len(v) > 0 {
 		apiObject.HistogramVisual = expandHistogramVisual(v)
 	}
-	if v, ok := tfMap["insight_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["insight_visual"].([]any); ok && len(v) > 0 {
 		apiObject.InsightVisual = expandInsightVisual(v)
 	}
-	if v, ok := tfMap["kpi_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["kpi_visual"].([]any); ok && len(v) > 0 {
 		apiObject.KPIVisual = expandKPIVisual(v)
 	}
-	if v, ok := tfMap["line_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.LineChartVisual = expandLineChartVisual(v)
 	}
-	if v, ok := tfMap["pie_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pie_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.PieChartVisual = expandPieChartVisual(v)
 	}
-	if v, ok := tfMap["pivot_table_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pivot_table_visual"].([]any); ok && len(v) > 0 {
 		apiObject.PivotTableVisual = expandPivotTableVisual(v)
 	}
-	if v, ok := tfMap["radar_chart_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["radar_chart_visual"].([]any); ok && len(v) > 0 {
 		apiObject.RadarChartVisual = expandRadarChartVisual(v)
 	}
-	if v, ok := tfMap["sankey_diagram_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sankey_diagram_visual"].([]any); ok && len(v) > 0 {
 		apiObject.SankeyDiagramVisual = expandSankeyDiagramVisual(v)
 	}
-	if v, ok := tfMap["scatter_plot_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scatter_plot_visual"].([]any); ok && len(v) > 0 {
 		apiObject.ScatterPlotVisual = expandScatterPlotVisual(v)
 	}
-	if v, ok := tfMap["table_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_visual"].([]any); ok && len(v) > 0 {
 		apiObject.TableVisual = expandTableVisual(v)
 	}
-	if v, ok := tfMap["tree_map_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tree_map_visual"].([]any); ok && len(v) > 0 {
 		apiObject.TreeMapVisual = expandTreeMapVisual(v)
 	}
-	if v, ok := tfMap["waterfall_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["waterfall_visual"].([]any); ok && len(v) > 0 {
 		apiObject.WaterfallVisual = expandWaterfallVisual(v)
 	}
-	if v, ok := tfMap["word_cloud_visual"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["word_cloud_visual"].([]any); ok && len(v) > 0 {
 		apiObject.WordCloudVisual = expandWordCloudVisual(v)
 	}
 
 	return apiObject
 }
 
-func expandDataLabelOptions(tfList []interface{}) *awstypes.DataLabelOptions {
+func expandDataLabelOptions(tfList []any) *awstypes.DataLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -600,17 +600,17 @@ func expandDataLabelOptions(tfList []interface{}) *awstypes.DataLabelOptions {
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["data_label_types"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_label_types"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabelTypes = expandDataLabelTypes(v)
 	}
-	if v, ok := tfMap["label_font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["label_font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LabelFontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDataLabelTypes(tfList []interface{}) []awstypes.DataLabelType {
+func expandDataLabelTypes(tfList []any) []awstypes.DataLabelType {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -618,7 +618,7 @@ func expandDataLabelTypes(tfList []interface{}) []awstypes.DataLabelType {
 	var apiObjects []awstypes.DataLabelType
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -634,38 +634,38 @@ func expandDataLabelTypes(tfList []interface{}) []awstypes.DataLabelType {
 	return apiObjects
 }
 
-func expandDataLabelType(tfMap map[string]interface{}) *awstypes.DataLabelType {
+func expandDataLabelType(tfMap map[string]any) *awstypes.DataLabelType {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DataLabelType{}
 
-	if v, ok := tfMap["data_path_label_type"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_path_label_type"].([]any); ok && len(v) > 0 {
 		apiObject.DataPathLabelType = expandDataPathLabelType(v)
 	}
-	if v, ok := tfMap["field_label_type"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_label_type"].([]any); ok && len(v) > 0 {
 		apiObject.FieldLabelType = expandFieldLabelType(v)
 	}
-	if v, ok := tfMap["maximum_label_type"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["maximum_label_type"].([]any); ok && len(v) > 0 {
 		apiObject.MaximumLabelType = expandMaximumLabelType(v)
 	}
-	if v, ok := tfMap["minimum_label_type"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["minimum_label_type"].([]any); ok && len(v) > 0 {
 		apiObject.MinimumLabelType = expandMinimumLabelType(v)
 	}
-	if v, ok := tfMap["range_ends_label_type"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range_ends_label_type"].([]any); ok && len(v) > 0 {
 		apiObject.RangeEndsLabelType = expandRangeEndsLabelType(v)
 	}
 
 	return apiObject
 }
 
-func expandDataPathLabelType(tfList []interface{}) *awstypes.DataPathLabelType {
+func expandDataPathLabelType(tfList []any) *awstypes.DataPathLabelType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -685,12 +685,12 @@ func expandDataPathLabelType(tfList []interface{}) *awstypes.DataPathLabelType {
 	return apiObject
 }
 
-func expandFieldLabelType(tfList []interface{}) *awstypes.FieldLabelType {
+func expandFieldLabelType(tfList []any) *awstypes.FieldLabelType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -707,12 +707,12 @@ func expandFieldLabelType(tfList []interface{}) *awstypes.FieldLabelType {
 	return apiObject
 }
 
-func expandMaximumLabelType(tfList []interface{}) *awstypes.MaximumLabelType {
+func expandMaximumLabelType(tfList []any) *awstypes.MaximumLabelType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -726,12 +726,12 @@ func expandMaximumLabelType(tfList []interface{}) *awstypes.MaximumLabelType {
 	return apiObject
 }
 
-func expandMinimumLabelType(tfList []interface{}) *awstypes.MinimumLabelType {
+func expandMinimumLabelType(tfList []any) *awstypes.MinimumLabelType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -745,12 +745,12 @@ func expandMinimumLabelType(tfList []interface{}) *awstypes.MinimumLabelType {
 	return apiObject
 }
 
-func expandRangeEndsLabelType(tfList []interface{}) *awstypes.RangeEndsLabelType {
+func expandRangeEndsLabelType(tfList []any) *awstypes.RangeEndsLabelType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -764,12 +764,12 @@ func expandRangeEndsLabelType(tfList []interface{}) *awstypes.RangeEndsLabelType
 	return apiObject
 }
 
-func expandLegendOptions(tfList []interface{}) *awstypes.LegendOptions {
+func expandLegendOptions(tfList []any) *awstypes.LegendOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -788,19 +788,19 @@ func expandLegendOptions(tfList []interface{}) *awstypes.LegendOptions {
 	if v, ok := tfMap["width"].(string); ok && v != "" {
 		apiObject.Width = aws.String(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTooltipOptions(tfList []interface{}) *awstypes.TooltipOptions {
+func expandTooltipOptions(tfList []any) *awstypes.TooltipOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -813,19 +813,19 @@ func expandTooltipOptions(tfList []interface{}) *awstypes.TooltipOptions {
 	if v, ok := tfMap["tooltip_visibility"].(string); ok && v != "" {
 		apiObject.TooltipVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["field_base_tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_base_tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.FieldBasedTooltip = expandFieldBasedTooltip(v)
 	}
 
 	return apiObject
 }
 
-func expandFieldBasedTooltip(tfList []interface{}) *awstypes.FieldBasedTooltip {
+func expandFieldBasedTooltip(tfList []any) *awstypes.FieldBasedTooltip {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -838,14 +838,14 @@ func expandFieldBasedTooltip(tfList []interface{}) *awstypes.FieldBasedTooltip {
 	if v, ok := tfMap["tooltip_title_type"].(string); ok && v != "" {
 		apiObject.TooltipTitleType = awstypes.TooltipTitleType(v)
 	}
-	if v, ok := tfMap["tooltip_fields"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip_fields"].([]any); ok && len(v) > 0 {
 		apiObject.TooltipFields = expandTooltipItems(v)
 	}
 
 	return apiObject
 }
 
-func expandTooltipItems(tfList []interface{}) []awstypes.TooltipItem {
+func expandTooltipItems(tfList []any) []awstypes.TooltipItem {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -853,7 +853,7 @@ func expandTooltipItems(tfList []interface{}) []awstypes.TooltipItem {
 	var apiObjects []awstypes.TooltipItem
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -869,29 +869,29 @@ func expandTooltipItems(tfList []interface{}) []awstypes.TooltipItem {
 	return apiObjects
 }
 
-func expandTooltipItem(tfMap map[string]interface{}) *awstypes.TooltipItem {
+func expandTooltipItem(tfMap map[string]any) *awstypes.TooltipItem {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.TooltipItem{}
 
-	if v, ok := tfMap["column_tooltip_item"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_tooltip_item"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnTooltipItem = expandColumnTooltipItem(v)
 	}
-	if v, ok := tfMap["field_tooltip_item"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_tooltip_item"].([]any); ok && len(v) > 0 {
 		apiObject.FieldTooltipItem = expandFieldTooltipItem(v)
 	}
 
 	return apiObject
 }
 
-func expandColumnTooltipItem(tfList []interface{}) *awstypes.ColumnTooltipItem {
+func expandColumnTooltipItem(tfList []any) *awstypes.ColumnTooltipItem {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -904,22 +904,22 @@ func expandColumnTooltipItem(tfList []interface{}) *awstypes.ColumnTooltipItem {
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["aggregation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation"].([]any); ok && len(v) > 0 {
 		apiObject.Aggregation = expandAggregationFunction(v)
 	}
 
 	return apiObject
 }
 
-func expandFieldTooltipItem(tfList []interface{}) *awstypes.FieldTooltipItem {
+func expandFieldTooltipItem(tfList []any) *awstypes.FieldTooltipItem {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -939,12 +939,12 @@ func expandFieldTooltipItem(tfList []interface{}) *awstypes.FieldTooltipItem {
 	return apiObject
 }
 
-func expandVisualPalette(tfList []interface{}) *awstypes.VisualPalette {
+func expandVisualPalette(tfList []any) *awstypes.VisualPalette {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -954,14 +954,14 @@ func expandVisualPalette(tfList []interface{}) *awstypes.VisualPalette {
 	if v, ok := tfMap["chart_color"].(string); ok && v != "" {
 		apiObject.ChartColor = aws.String(v)
 	}
-	if v, ok := tfMap["color_map"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_map"].([]any); ok && len(v) > 0 {
 		apiObject.ColorMap = expandDataPathColors(v)
 	}
 
 	return apiObject
 }
 
-func expandDataPathColors(tfList []interface{}) []awstypes.DataPathColor {
+func expandDataPathColors(tfList []any) []awstypes.DataPathColor {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -969,7 +969,7 @@ func expandDataPathColors(tfList []interface{}) []awstypes.DataPathColor {
 	var apiObjects []awstypes.DataPathColor
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -985,7 +985,7 @@ func expandDataPathColors(tfList []interface{}) []awstypes.DataPathColor {
 	return apiObjects
 }
 
-func expandDataPathColor(tfMap map[string]interface{}) *awstypes.DataPathColor {
+func expandDataPathColor(tfMap map[string]any) *awstypes.DataPathColor {
 	if tfMap == nil {
 		return nil
 	}
@@ -998,14 +998,14 @@ func expandDataPathColor(tfMap map[string]interface{}) *awstypes.DataPathColor {
 	if v, ok := tfMap["time_granularity"].(string); ok && v != "" {
 		apiObject.TimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["element"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["element"].([]any); ok && len(v) > 0 {
 		apiObject.Element = expandDataPathValue(v)
 	}
 
 	return apiObject
 }
 
-func expandDataPathValues(tfList []interface{}) []awstypes.DataPathValue {
+func expandDataPathValues(tfList []any) []awstypes.DataPathValue {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1013,7 +1013,7 @@ func expandDataPathValues(tfList []interface{}) []awstypes.DataPathValue {
 	var apiObjects []awstypes.DataPathValue
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1029,7 +1029,7 @@ func expandDataPathValues(tfList []interface{}) []awstypes.DataPathValue {
 	return apiObjects
 }
 
-func expandDataPathValueInternal(tfMap map[string]interface{}) *awstypes.DataPathValue {
+func expandDataPathValueInternal(tfMap map[string]any) *awstypes.DataPathValue {
 	if tfMap == nil {
 		return nil
 	}
@@ -1046,12 +1046,12 @@ func expandDataPathValueInternal(tfMap map[string]interface{}) *awstypes.DataPat
 	return apiObject
 }
 
-func expandDataPathValue(tfList []interface{}) *awstypes.DataPathValue {
+func expandDataPathValue(tfList []any) *awstypes.DataPathValue {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1059,7 +1059,7 @@ func expandDataPathValue(tfList []interface{}) *awstypes.DataPathValue {
 	return expandDataPathValueInternal(tfMap)
 }
 
-func expandColumnHierarchies(tfList []interface{}) []awstypes.ColumnHierarchy {
+func expandColumnHierarchies(tfList []any) []awstypes.ColumnHierarchy {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1067,7 +1067,7 @@ func expandColumnHierarchies(tfList []interface{}) []awstypes.ColumnHierarchy {
 	var apiObjects []awstypes.ColumnHierarchy
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1083,32 +1083,32 @@ func expandColumnHierarchies(tfList []interface{}) []awstypes.ColumnHierarchy {
 	return apiObjects
 }
 
-func expandColumnHierarchy(tfMap map[string]interface{}) *awstypes.ColumnHierarchy {
+func expandColumnHierarchy(tfMap map[string]any) *awstypes.ColumnHierarchy {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ColumnHierarchy{}
 
-	if v, ok := tfMap["date_time_hierarchy"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_time_hierarchy"].([]any); ok && len(v) > 0 {
 		apiObject.DateTimeHierarchy = expandDateTimeHierarchy(v)
 	}
-	if v, ok := tfMap["explicit_hierarchy"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["explicit_hierarchy"].([]any); ok && len(v) > 0 {
 		apiObject.ExplicitHierarchy = expandExplicitHierarchy(v)
 	}
-	if v, ok := tfMap["predefined_hierarchy"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["predefined_hierarchy"].([]any); ok && len(v) > 0 {
 		apiObject.PredefinedHierarchy = expandPredefinedHierarchy(v)
 	}
 
 	return apiObject
 }
 
-func expandDateTimeHierarchy(tfList []interface{}) *awstypes.DateTimeHierarchy {
+func expandDateTimeHierarchy(tfList []any) *awstypes.DateTimeHierarchy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1118,19 +1118,19 @@ func expandDateTimeHierarchy(tfList []interface{}) *awstypes.DateTimeHierarchy {
 	if v, ok := tfMap["hierarchy_id"].(string); ok && v != "" {
 		apiObject.HierarchyId = aws.String(v)
 	}
-	if v, ok := tfMap["drill_down_filters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["drill_down_filters"].([]any); ok && len(v) > 0 {
 		apiObject.DrillDownFilters = expandDrillDownFilters(v)
 	}
 
 	return apiObject
 }
 
-func expandExplicitHierarchy(tfList []interface{}) *awstypes.ExplicitHierarchy {
+func expandExplicitHierarchy(tfList []any) *awstypes.ExplicitHierarchy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1140,21 +1140,21 @@ func expandExplicitHierarchy(tfList []interface{}) *awstypes.ExplicitHierarchy {
 	if v, ok := tfMap["hierarchy_id"].(string); ok && v != "" {
 		apiObject.HierarchyId = aws.String(v)
 	}
-	if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["columns"].([]any); ok && len(v) > 0 {
 		apiObject.Columns = expandColumnIdentifiers(v)
 	}
-	if v, ok := tfMap["drill_down_filters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["drill_down_filters"].([]any); ok && len(v) > 0 {
 		apiObject.DrillDownFilters = expandDrillDownFilters(v)
 	}
 
 	return apiObject
 }
-func expandPredefinedHierarchy(tfList []interface{}) *awstypes.PredefinedHierarchy {
+func expandPredefinedHierarchy(tfList []any) *awstypes.PredefinedHierarchy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1164,22 +1164,22 @@ func expandPredefinedHierarchy(tfList []interface{}) *awstypes.PredefinedHierarc
 	if v, ok := tfMap["hierarchy_id"].(string); ok && v != "" {
 		apiObject.HierarchyId = aws.String(v)
 	}
-	if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["columns"].([]any); ok && len(v) > 0 {
 		apiObject.Columns = expandColumnIdentifiers(v)
 	}
-	if v, ok := tfMap["drill_down_filters"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["drill_down_filters"].([]any); ok && len(v) > 0 {
 		apiObject.DrillDownFilters = expandDrillDownFilters(v)
 	}
 
 	return apiObject
 }
 
-func expandVisualSubtitleLabelOptions(tfList []interface{}) *awstypes.VisualSubtitleLabelOptions {
+func expandVisualSubtitleLabelOptions(tfList []any) *awstypes.VisualSubtitleLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1189,19 +1189,19 @@ func expandVisualSubtitleLabelOptions(tfList []interface{}) *awstypes.VisualSubt
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["format_text"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_text"].([]any); ok && len(v) > 0 {
 		apiObject.FormatText = expandLongFormatText(v)
 	}
 
 	return apiObject
 }
 
-func expandLongFormatText(tfList []interface{}) *awstypes.LongFormatText {
+func expandLongFormatText(tfList []any) *awstypes.LongFormatText {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1218,12 +1218,12 @@ func expandLongFormatText(tfList []interface{}) *awstypes.LongFormatText {
 	return apiObject
 }
 
-func expandVisualTitleLabelOptions(tfList []interface{}) *awstypes.VisualTitleLabelOptions {
+func expandVisualTitleLabelOptions(tfList []any) *awstypes.VisualTitleLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1233,19 +1233,19 @@ func expandVisualTitleLabelOptions(tfList []interface{}) *awstypes.VisualTitleLa
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["format_text"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_text"].([]any); ok && len(v) > 0 {
 		apiObject.FormatText = expandShortFormatText(v)
 	}
 
 	return apiObject
 }
 
-func expandShortFormatText(tfList []interface{}) *awstypes.ShortFormatText {
+func expandShortFormatText(tfList []any) *awstypes.ShortFormatText {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1262,12 +1262,12 @@ func expandShortFormatText(tfList []interface{}) *awstypes.ShortFormatText {
 	return apiObject
 }
 
-func expandComparisonConfiguration(tfList []interface{}) *awstypes.ComparisonConfiguration {
+func expandComparisonConfiguration(tfList []any) *awstypes.ComparisonConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1277,19 +1277,19 @@ func expandComparisonConfiguration(tfList []interface{}) *awstypes.ComparisonCon
 	if v, ok := tfMap["comparison_method"].(string); ok && v != "" {
 		apiObject.ComparisonMethod = awstypes.ComparisonMethod(v)
 	}
-	if v, ok := tfMap["comparison_format"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["comparison_format"].([]any); ok && len(v) > 0 {
 		apiObject.ComparisonFormat = expandComparisonFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandColorScale(tfList []interface{}) *awstypes.ColorScale {
+func expandColorScale(tfList []any) *awstypes.ColorScale {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1299,22 +1299,22 @@ func expandColorScale(tfList []interface{}) *awstypes.ColorScale {
 	if v, ok := tfMap["color_fill_type"].(string); ok && v != "" {
 		apiObject.ColorFillType = awstypes.ColorFillType(v)
 	}
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandDataColors(v)
 	}
-	if v, ok := tfMap["null_value_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["null_value_color"].([]any); ok && len(v) > 0 {
 		apiObject.NullValueColor = expandDataColor(v)
 	}
 
 	return apiObject
 }
 
-func expandDataColor(tfList []interface{}) *awstypes.DataColor {
+func expandDataColor(tfList []any) *awstypes.DataColor {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1322,7 +1322,7 @@ func expandDataColor(tfList []interface{}) *awstypes.DataColor {
 	return expandDataColorInternal(tfMap)
 }
 
-func expandDataColorInternal(tfMap map[string]interface{}) *awstypes.DataColor {
+func expandDataColorInternal(tfMap map[string]any) *awstypes.DataColor {
 	apiObject := &awstypes.DataColor{}
 
 	if v, ok := tfMap["color"].(string); ok && v != "" {
@@ -1335,7 +1335,7 @@ func expandDataColorInternal(tfMap map[string]interface{}) *awstypes.DataColor {
 	return apiObject
 }
 
-func expandDataColors(tfList []interface{}) []awstypes.DataColor {
+func expandDataColors(tfList []any) []awstypes.DataColor {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1343,7 +1343,7 @@ func expandDataColors(tfList []interface{}) []awstypes.DataColor {
 	var apiObjects []awstypes.DataColor
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1359,15 +1359,15 @@ func expandDataColors(tfList []interface{}) []awstypes.DataColor {
 	return apiObjects
 }
 
-func flattenVisuals(apiObjects []awstypes.Visual) []interface{} {
+func flattenVisuals(apiObjects []awstypes.Visual) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.BarChartVisual != nil {
 			tfMap["bar_chart_visual"] = flattenBarChartVisual(apiObject.BarChartVisual)
@@ -1445,12 +1445,12 @@ func flattenVisuals(apiObjects []awstypes.Visual) []interface{} {
 	return tfList
 }
 
-func flattenDataLabelOptions(apiObject *awstypes.DataLabelOptions) []interface{} {
+func flattenDataLabelOptions(apiObject *awstypes.DataLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["category_label_visibility"] = apiObject.CategoryLabelVisibility
 	if apiObject.DataLabelTypes != nil {
@@ -1468,18 +1468,18 @@ func flattenDataLabelOptions(apiObject *awstypes.DataLabelOptions) []interface{}
 	tfMap["position"] = apiObject.Position
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataLabelType(apiObjects []awstypes.DataLabelType) []interface{} {
+func flattenDataLabelType(apiObjects []awstypes.DataLabelType) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataPathLabelType != nil {
 			tfMap["data_path_label_type"] = flattenDataPathLabelType(apiObject.DataPathLabelType)
@@ -1503,12 +1503,12 @@ func flattenDataLabelType(apiObjects []awstypes.DataLabelType) []interface{} {
 	return tfList
 }
 
-func flattenDataPathLabelType(apiObject *awstypes.DataPathLabelType) []interface{} {
+func flattenDataPathLabelType(apiObject *awstypes.DataPathLabelType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1518,66 +1518,66 @@ func flattenDataPathLabelType(apiObject *awstypes.DataPathLabelType) []interface
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldLabelType(apiObject *awstypes.FieldLabelType) []interface{} {
+func flattenFieldLabelType(apiObject *awstypes.FieldLabelType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMaximumLabelType(apiObject *awstypes.MaximumLabelType) []interface{} {
+func flattenMaximumLabelType(apiObject *awstypes.MaximumLabelType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMinimumLabelType(apiObject *awstypes.MinimumLabelType) []interface{} {
+func flattenMinimumLabelType(apiObject *awstypes.MinimumLabelType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRangeEndsLabelType(apiObject *awstypes.RangeEndsLabelType) []interface{} {
+func flattenRangeEndsLabelType(apiObject *awstypes.RangeEndsLabelType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLegendOptions(apiObject *awstypes.LegendOptions) []interface{} {
+func flattenLegendOptions(apiObject *awstypes.LegendOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Height != nil {
 		tfMap["height"] = aws.ToString(apiObject.Height)
@@ -1591,15 +1591,15 @@ func flattenLegendOptions(apiObject *awstypes.LegendOptions) []interface{} {
 		tfMap["width"] = aws.ToString(apiObject.Width)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTooltipOptions(apiObject *awstypes.TooltipOptions) []interface{} {
+func flattenTooltipOptions(apiObject *awstypes.TooltipOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldBasedTooltip != nil {
 		tfMap["field_base_tooltip"] = flattenFieldBasedTooltip(apiObject.FieldBasedTooltip)
@@ -1607,15 +1607,15 @@ func flattenTooltipOptions(apiObject *awstypes.TooltipOptions) []interface{} {
 	tfMap["selected_tooltip_type"] = apiObject.SelectedTooltipType
 	tfMap["tooltip_visibility"] = apiObject.TooltipVisibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldBasedTooltip(apiObject *awstypes.FieldBasedTooltip) []interface{} {
+func flattenFieldBasedTooltip(apiObject *awstypes.FieldBasedTooltip) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["aggregation_visibility"] = apiObject.AggregationVisibility
 	if apiObject.TooltipFields != nil {
@@ -1623,18 +1623,18 @@ func flattenFieldBasedTooltip(apiObject *awstypes.FieldBasedTooltip) []interface
 	}
 	tfMap["tooltip_title_type"] = apiObject.TooltipTitleType
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTooltipItem(apiObjects []awstypes.TooltipItem) []interface{} {
+func flattenTooltipItem(apiObjects []awstypes.TooltipItem) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnTooltipItem != nil {
 			tfMap["column_tooltip_item"] = flattenColumnTooltipItem(apiObject.ColumnTooltipItem)
@@ -1649,12 +1649,12 @@ func flattenTooltipItem(apiObjects []awstypes.TooltipItem) []interface{} {
 	return tfList
 }
 
-func flattenColumnTooltipItem(apiObject *awstypes.ColumnTooltipItem) []interface{} {
+func flattenColumnTooltipItem(apiObject *awstypes.ColumnTooltipItem) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1667,15 +1667,15 @@ func flattenColumnTooltipItem(apiObject *awstypes.ColumnTooltipItem) []interface
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldTooltipItem(apiObject *awstypes.FieldTooltipItem) []interface{} {
+func flattenFieldTooltipItem(apiObject *awstypes.FieldTooltipItem) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
 	}
@@ -1684,15 +1684,15 @@ func flattenFieldTooltipItem(apiObject *awstypes.FieldTooltipItem) []interface{}
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisualPalette(apiObject *awstypes.VisualPalette) []interface{} {
+func flattenVisualPalette(apiObject *awstypes.VisualPalette) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.ChartColor != nil {
 		tfMap["chart_color"] = aws.ToString(apiObject.ChartColor)
 	}
@@ -1700,18 +1700,18 @@ func flattenVisualPalette(apiObject *awstypes.VisualPalette) []interface{} {
 		tfMap["color_map"] = flattenDataPathColor(apiObject.ColorMap)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPathColor(apiObjects []awstypes.DataPathColor) []interface{} {
+func flattenDataPathColor(apiObjects []awstypes.DataPathColor) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Color != nil {
 			tfMap["color"] = aws.ToString(apiObject.Color)
@@ -1727,12 +1727,12 @@ func flattenDataPathColor(apiObjects []awstypes.DataPathColor) []interface{} {
 	return tfList
 }
 
-func flattenDataPathValue(apiObject *awstypes.DataPathValue) []interface{} {
+func flattenDataPathValue(apiObject *awstypes.DataPathValue) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1741,18 +1741,18 @@ func flattenDataPathValue(apiObject *awstypes.DataPathValue) []interface{} {
 		tfMap["field_value"] = aws.ToString(apiObject.FieldValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPathValues(apiObjects []awstypes.DataPathValue) []interface{} {
+func flattenDataPathValues(apiObjects []awstypes.DataPathValue) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FieldId != nil {
 			tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1767,15 +1767,15 @@ func flattenDataPathValues(apiObjects []awstypes.DataPathValue) []interface{} {
 	return tfList
 }
 
-func flattenColumnHierarchy(apiObjects []awstypes.ColumnHierarchy) []interface{} {
+func flattenColumnHierarchy(apiObjects []awstypes.ColumnHierarchy) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DateTimeHierarchy != nil {
 			tfMap["date_time_hierarchy"] = flattenDateTimeHierarchy(apiObject.DateTimeHierarchy)
@@ -1793,12 +1793,12 @@ func flattenColumnHierarchy(apiObjects []awstypes.ColumnHierarchy) []interface{}
 	return tfList
 }
 
-func flattenDateTimeHierarchy(apiObject *awstypes.DateTimeHierarchy) []interface{} {
+func flattenDateTimeHierarchy(apiObject *awstypes.DateTimeHierarchy) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.HierarchyId != nil {
 		tfMap["hierarchy_id"] = aws.ToString(apiObject.HierarchyId)
@@ -1807,18 +1807,18 @@ func flattenDateTimeHierarchy(apiObject *awstypes.DateTimeHierarchy) []interface
 		tfMap["drill_down_filters"] = flattenDrillDownFilter(apiObject.DrillDownFilters)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDrillDownFilter(apiObjects []awstypes.DrillDownFilter) []interface{} {
+func flattenDrillDownFilter(apiObjects []awstypes.DrillDownFilter) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.CategoryFilter != nil {
 			tfMap["category_filter"] = flattenCategoryDrillDownFilter(apiObject.CategoryFilter)
@@ -1836,12 +1836,12 @@ func flattenDrillDownFilter(apiObjects []awstypes.DrillDownFilter) []interface{}
 	return tfList
 }
 
-func flattenCategoryDrillDownFilter(apiObject *awstypes.CategoryDrillDownFilter) []interface{} {
+func flattenCategoryDrillDownFilter(apiObject *awstypes.CategoryDrillDownFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryValues != nil {
 		tfMap["category_values"] = apiObject.CategoryValues
@@ -1850,30 +1850,30 @@ func flattenCategoryDrillDownFilter(apiObject *awstypes.CategoryDrillDownFilter)
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericEqualityDrillDownFilter(apiObject *awstypes.NumericEqualityDrillDownFilter) []interface{} {
+func flattenNumericEqualityDrillDownFilter(apiObject *awstypes.NumericEqualityDrillDownFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
 	}
 	tfMap[names.AttrValue] = apiObject.Value
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTimeRangeDrillDownFilter(apiObject *awstypes.TimeRangeDrillDownFilter) []interface{} {
+func flattenTimeRangeDrillDownFilter(apiObject *awstypes.TimeRangeDrillDownFilter) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1886,15 +1886,15 @@ func flattenTimeRangeDrillDownFilter(apiObject *awstypes.TimeRangeDrillDownFilte
 	}
 	tfMap["time_granularity"] = apiObject.TimeGranularity
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenExplicitHierarchy(apiObject *awstypes.ExplicitHierarchy) []interface{} {
+func flattenExplicitHierarchy(apiObject *awstypes.ExplicitHierarchy) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenColumnIdentifiers(apiObject.Columns)
@@ -1906,15 +1906,15 @@ func flattenExplicitHierarchy(apiObject *awstypes.ExplicitHierarchy) []interface
 		tfMap["drill_down_filters"] = flattenDrillDownFilter(apiObject.DrillDownFilters)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredefinedHierarchy(apiObject *awstypes.PredefinedHierarchy) []interface{} {
+func flattenPredefinedHierarchy(apiObject *awstypes.PredefinedHierarchy) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenColumnIdentifiers(apiObject.Columns)
@@ -1926,30 +1926,30 @@ func flattenPredefinedHierarchy(apiObject *awstypes.PredefinedHierarchy) []inter
 		tfMap["drill_down_filters"] = flattenDrillDownFilter(apiObject.DrillDownFilters)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisualSubtitleLabelOptions(apiObject *awstypes.VisualSubtitleLabelOptions) []interface{} {
+func flattenVisualSubtitleLabelOptions(apiObject *awstypes.VisualSubtitleLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FormatText != nil {
 		tfMap["format_text"] = flattenLongFormatText(apiObject.FormatText)
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLongFormatText(apiObject *awstypes.LongFormatText) []interface{} {
+func flattenLongFormatText(apiObject *awstypes.LongFormatText) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PlainText != nil {
 		tfMap["plain_text"] = aws.ToString(apiObject.PlainText)
@@ -1958,30 +1958,30 @@ func flattenLongFormatText(apiObject *awstypes.LongFormatText) []interface{} {
 		tfMap["rich_text"] = aws.ToString(apiObject.RichText)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisualTitleLabelOptions(apiObject *awstypes.VisualTitleLabelOptions) []interface{} {
+func flattenVisualTitleLabelOptions(apiObject *awstypes.VisualTitleLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FormatText != nil {
 		tfMap["format_text"] = flattenShortFormatText(apiObject.FormatText)
 	}
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenShortFormatText(apiObject *awstypes.ShortFormatText) []interface{} {
+func flattenShortFormatText(apiObject *awstypes.ShortFormatText) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PlainText != nil {
 		tfMap["plain_text"] = aws.ToString(apiObject.PlainText)
@@ -1990,15 +1990,15 @@ func flattenShortFormatText(apiObject *awstypes.ShortFormatText) []interface{} {
 		tfMap["rich_text"] = aws.ToString(apiObject.RichText)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenColorScale(apiObject *awstypes.ColorScale) []interface{} {
+func flattenColorScale(apiObject *awstypes.ColorScale) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["color_fill_type"] = apiObject.ColorFillType
 	if apiObject.Colors != nil {
@@ -2008,15 +2008,15 @@ func flattenColorScale(apiObject *awstypes.ColorScale) []interface{} {
 		tfMap["null_value_color"] = flattenDataColor(apiObject.NullValueColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataColor(apiObject *awstypes.DataColor) []interface{} {
+func flattenDataColor(apiObject *awstypes.DataColor) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
@@ -2025,18 +2025,18 @@ func flattenDataColor(apiObject *awstypes.DataColor) []interface{} {
 		tfMap["data_value"] = aws.ToFloat64(apiObject.DataValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataColors(apiObject []awstypes.DataColor) []interface{} {
+func flattenDataColors(apiObject []awstypes.DataColor) []any {
 	if len(apiObject) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObject {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Color != nil {
 			tfMap["color"] = aws.ToString(apiObject.Color)

--- a/internal/service/quicksight/schema/visual_actions.go
+++ b/internal/service/quicksight/schema/visual_actions.go
@@ -232,7 +232,7 @@ func visualCustomActionsSchema(maxItems int) *schema.Schema {
 	}
 }
 
-func expandVisualCustomActions(tfList []interface{}) []awstypes.VisualCustomAction {
+func expandVisualCustomActions(tfList []any) []awstypes.VisualCustomAction {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -240,7 +240,7 @@ func expandVisualCustomActions(tfList []interface{}) []awstypes.VisualCustomActi
 	var apiObjects []awstypes.VisualCustomAction
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -256,7 +256,7 @@ func expandVisualCustomActions(tfList []interface{}) []awstypes.VisualCustomActi
 	return apiObjects
 }
 
-func expandVisualCustomAction(tfMap map[string]interface{}) *awstypes.VisualCustomAction {
+func expandVisualCustomAction(tfMap map[string]any) *awstypes.VisualCustomAction {
 	if tfMap == nil {
 		return nil
 	}
@@ -275,14 +275,14 @@ func expandVisualCustomAction(tfMap map[string]interface{}) *awstypes.VisualCust
 	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
 		apiObject.Status = awstypes.WidgetStatus(v)
 	}
-	if v, ok := tfMap["action_operations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["action_operations"].([]any); ok && len(v) > 0 {
 		apiObject.ActionOperations = expandVisualCustomActionOperations(v)
 	}
 
 	return apiObject
 }
 
-func expandVisualCustomActionOperations(tfList []interface{}) []awstypes.VisualCustomActionOperation {
+func expandVisualCustomActionOperations(tfList []any) []awstypes.VisualCustomActionOperation {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -290,7 +290,7 @@ func expandVisualCustomActionOperations(tfList []interface{}) []awstypes.VisualC
 	var apiObjects []awstypes.VisualCustomActionOperation
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -306,57 +306,57 @@ func expandVisualCustomActionOperations(tfList []interface{}) []awstypes.VisualC
 	return apiObjects
 }
 
-func expandVisualCustomActionOperation(tfMap map[string]interface{}) *awstypes.VisualCustomActionOperation {
+func expandVisualCustomActionOperation(tfMap map[string]any) *awstypes.VisualCustomActionOperation {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.VisualCustomActionOperation{}
 
-	if v, ok := tfMap["filter_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filter_operation"].([]any); ok && len(v) > 0 {
 		apiObject.FilterOperation = expandCustomActionFilterOperation(v)
 	}
-	if v, ok := tfMap["navigation_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["navigation_operation"].([]any); ok && len(v) > 0 {
 		apiObject.NavigationOperation = expandCustomActionNavigationOperation(v)
 	}
-	if v, ok := tfMap["set_parameters_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["set_parameters_operation"].([]any); ok && len(v) > 0 {
 		apiObject.SetParametersOperation = expandCustomActionSetParametersOperation(v)
 	}
-	if v, ok := tfMap["url_operation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["url_operation"].([]any); ok && len(v) > 0 {
 		apiObject.URLOperation = expandCustomActionURLOperation(v)
 	}
 
 	return apiObject
 }
 
-func expandCustomActionFilterOperation(tfList []interface{}) *awstypes.CustomActionFilterOperation {
+func expandCustomActionFilterOperation(tfList []any) *awstypes.CustomActionFilterOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomActionFilterOperation{}
 
-	if v, ok := tfMap["selected_fields_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selected_fields_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SelectedFieldsConfiguration = expandFilterOperationSelectedFieldsConfiguration(v)
 	}
-	if v, ok := tfMap["target_visuals_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["target_visuals_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.TargetVisualsConfiguration = expandFilterOperationTargetVisualsConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterOperationSelectedFieldsConfiguration(tfList []interface{}) *awstypes.FilterOperationSelectedFieldsConfiguration {
+func expandFilterOperationSelectedFieldsConfiguration(tfList []any) *awstypes.FilterOperationSelectedFieldsConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -366,38 +366,38 @@ func expandFilterOperationSelectedFieldsConfiguration(tfList []interface{}) *aws
 	if v, ok := tfMap["selected_field_option"].(string); ok && v != "" {
 		apiObject.SelectedFieldOptions = awstypes.SelectedFieldOptions(v)
 	}
-	if v, ok := tfMap["selected_fields"].([]interface{}); ok {
+	if v, ok := tfMap["selected_fields"].([]any); ok {
 		apiObject.SelectedFields = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandFilterOperationTargetVisualsConfiguration(tfList []interface{}) *awstypes.FilterOperationTargetVisualsConfiguration {
+func expandFilterOperationTargetVisualsConfiguration(tfList []any) *awstypes.FilterOperationTargetVisualsConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilterOperationTargetVisualsConfiguration{}
 
-	if v, ok := tfMap["same_sheet_target_visual_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["same_sheet_target_visual_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SameSheetTargetVisualConfiguration = expandSameSheetTargetVisualConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSameSheetTargetVisualConfiguration(tfList []interface{}) *awstypes.SameSheetTargetVisualConfiguration {
+func expandSameSheetTargetVisualConfiguration(tfList []any) *awstypes.SameSheetTargetVisualConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -414,31 +414,31 @@ func expandSameSheetTargetVisualConfiguration(tfList []interface{}) *awstypes.Sa
 	return apiObject
 }
 
-func expandCustomActionNavigationOperation(tfList []interface{}) *awstypes.CustomActionNavigationOperation {
+func expandCustomActionNavigationOperation(tfList []any) *awstypes.CustomActionNavigationOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomActionNavigationOperation{}
 
-	if v, ok := tfMap["local_navigation_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["local_navigation_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LocalNavigationConfiguration = expandLocalNavigationConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandLocalNavigationConfiguration(tfList []interface{}) *awstypes.LocalNavigationConfiguration {
+func expandLocalNavigationConfiguration(tfList []any) *awstypes.LocalNavigationConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -451,26 +451,26 @@ func expandLocalNavigationConfiguration(tfList []interface{}) *awstypes.LocalNav
 	return apiObject
 }
 
-func expandCustomActionSetParametersOperation(tfList []interface{}) *awstypes.CustomActionSetParametersOperation {
+func expandCustomActionSetParametersOperation(tfList []any) *awstypes.CustomActionSetParametersOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomActionSetParametersOperation{}
 
-	if v, ok := tfMap["parameter_value_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["parameter_value_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.ParameterValueConfigurations = expandSetParameterValueConfigurations(v)
 	}
 
 	return apiObject
 }
 
-func expandSetParameterValueConfigurations(tfList []interface{}) []awstypes.SetParameterValueConfiguration {
+func expandSetParameterValueConfigurations(tfList []any) []awstypes.SetParameterValueConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -478,7 +478,7 @@ func expandSetParameterValueConfigurations(tfList []interface{}) []awstypes.SetP
 	var apiObjects []awstypes.SetParameterValueConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -494,7 +494,7 @@ func expandSetParameterValueConfigurations(tfList []interface{}) []awstypes.SetP
 	return apiObjects
 }
 
-func expandSetParameterValueConfiguration(tfMap map[string]interface{}) *awstypes.SetParameterValueConfiguration {
+func expandSetParameterValueConfiguration(tfMap map[string]any) *awstypes.SetParameterValueConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -504,26 +504,26 @@ func expandSetParameterValueConfiguration(tfMap map[string]interface{}) *awstype
 	if v, ok := tfMap["destination_parameter_name"].(string); ok && v != "" {
 		apiObject.DestinationParameterName = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandDestinationParameterValueConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDestinationParameterValueConfiguration(tfList []interface{}) *awstypes.DestinationParameterValueConfiguration {
+func expandDestinationParameterValueConfiguration(tfList []any) *awstypes.DestinationParameterValueConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DestinationParameterValueConfiguration{}
 
-	if v, ok := tfMap["custom_values_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_values_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CustomValuesConfiguration = expandCustomValuesConfiguration(v)
 	}
 	if v, ok := tfMap["select_all_value_options"].(string); ok && v != "" {
@@ -539,19 +539,19 @@ func expandDestinationParameterValueConfiguration(tfList []interface{}) *awstype
 	return apiObject
 }
 
-func expandCustomValuesConfiguration(tfList []interface{}) *awstypes.CustomValuesConfiguration {
+func expandCustomValuesConfiguration(tfList []any) *awstypes.CustomValuesConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomValuesConfiguration{}
 
-	if v, ok := tfMap["custom_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_values"].([]any); ok && len(v) > 0 {
 		apiObject.CustomValues = expandCustomParameterValues(v)
 	}
 	if v, ok := tfMap["include_null_value"].(bool); ok {
@@ -561,40 +561,40 @@ func expandCustomValuesConfiguration(tfList []interface{}) *awstypes.CustomValue
 	return apiObject
 }
 
-func expandCustomParameterValues(tfList []interface{}) *awstypes.CustomParameterValues {
+func expandCustomParameterValues(tfList []any) *awstypes.CustomParameterValues {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.CustomParameterValues{}
 
-	if v, ok := tfMap["date_time_values"].([]interface{}); ok {
+	if v, ok := tfMap["date_time_values"].([]any); ok {
 		apiObject.DateTimeValues = flex.ExpandStringTimeValueList(v, time.RFC3339)
 	}
-	if v, ok := tfMap["decimal_values"].([]interface{}); ok {
+	if v, ok := tfMap["decimal_values"].([]any); ok {
 		apiObject.DecimalValues = flex.ExpandFloat64ValueList(v)
 	}
-	if v, ok := tfMap["integer_values"].([]interface{}); ok {
+	if v, ok := tfMap["integer_values"].([]any); ok {
 		apiObject.IntegerValues = flex.ExpandInt64ValueList(v)
 	}
-	if v, ok := tfMap["string_values"].([]interface{}); ok {
+	if v, ok := tfMap["string_values"].([]any); ok {
 		apiObject.StringValues = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandCustomActionURLOperation(tfList []interface{}) *awstypes.CustomActionURLOperation {
+func expandCustomActionURLOperation(tfList []any) *awstypes.CustomActionURLOperation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -611,15 +611,15 @@ func expandCustomActionURLOperation(tfList []interface{}) *awstypes.CustomAction
 	return apiObject
 }
 
-func flattenVisualCustomAction(apiObjects []awstypes.VisualCustomAction) []interface{} {
+func flattenVisualCustomAction(apiObjects []awstypes.VisualCustomAction) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"custom_action_id": aws.ToString(apiObject.CustomActionId),
 			names.AttrName:     aws.ToString(apiObject.Name),
 			names.AttrStatus:   apiObject.Status,
@@ -636,15 +636,15 @@ func flattenVisualCustomAction(apiObjects []awstypes.VisualCustomAction) []inter
 	return tfList
 }
 
-func flattenVisualCustomActionOperation(apiObjects []awstypes.VisualCustomActionOperation) []interface{} {
+func flattenVisualCustomActionOperation(apiObjects []awstypes.VisualCustomActionOperation) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FilterOperation != nil {
 			tfMap["filter_operation"] = flattenCustomActionFilterOperation(apiObject.FilterOperation)
@@ -665,12 +665,12 @@ func flattenVisualCustomActionOperation(apiObjects []awstypes.VisualCustomAction
 	return tfList
 }
 
-func flattenCustomActionFilterOperation(apiObject *awstypes.CustomActionFilterOperation) []interface{} {
+func flattenCustomActionFilterOperation(apiObject *awstypes.CustomActionFilterOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.SelectedFieldsConfiguration != nil {
 		tfMap["selected_fields_configuration"] = flattenFilterOperationSelectedFieldsConfiguration(apiObject.SelectedFieldsConfiguration)
 	}
@@ -678,98 +678,98 @@ func flattenCustomActionFilterOperation(apiObject *awstypes.CustomActionFilterOp
 		tfMap["target_visuals_configuration"] = flattenFilterOperationTargetVisualsConfiguration(apiObject.TargetVisualsConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterOperationSelectedFieldsConfiguration(apiObject *awstypes.FilterOperationSelectedFieldsConfiguration) []interface{} {
+func flattenFilterOperationSelectedFieldsConfiguration(apiObject *awstypes.FilterOperationSelectedFieldsConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SelectedFields != nil {
 		tfMap["selected_fields"] = apiObject.SelectedFields
 	}
 	tfMap["selected_field_option"] = apiObject.SelectedFieldOptions
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilterOperationTargetVisualsConfiguration(apiObject *awstypes.FilterOperationTargetVisualsConfiguration) []interface{} {
+func flattenFilterOperationTargetVisualsConfiguration(apiObject *awstypes.FilterOperationTargetVisualsConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SameSheetTargetVisualConfiguration != nil {
 		tfMap["same_sheet_target_visual_configuration"] = flattenSameSheetTargetVisualConfiguration(apiObject.SameSheetTargetVisualConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSameSheetTargetVisualConfiguration(apiObject *awstypes.SameSheetTargetVisualConfiguration) []interface{} {
+func flattenSameSheetTargetVisualConfiguration(apiObject *awstypes.SameSheetTargetVisualConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"target_visual_option": apiObject.TargetVisualOptions,
 		"target_visuals":       apiObject.TargetVisuals,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomActionNavigationOperation(apiObject *awstypes.CustomActionNavigationOperation) []interface{} {
+func flattenCustomActionNavigationOperation(apiObject *awstypes.CustomActionNavigationOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LocalNavigationConfiguration != nil {
 		tfMap["local_navigation_configuration"] = flattenLocalNavigationConfiguration(apiObject.LocalNavigationConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLocalNavigationConfiguration(apiObject *awstypes.LocalNavigationConfiguration) []interface{} {
+func flattenLocalNavigationConfiguration(apiObject *awstypes.LocalNavigationConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"target_sheet_id": aws.ToString(apiObject.TargetSheetId),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomActionSetParametersOperation(apiObject *awstypes.CustomActionSetParametersOperation) []interface{} {
+func flattenCustomActionSetParametersOperation(apiObject *awstypes.CustomActionSetParametersOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"parameter_value_configurations": flattenSetParameterValueConfiguration(apiObject.ParameterValueConfigurations),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSetParameterValueConfiguration(apiObjects []awstypes.SetParameterValueConfiguration) []interface{} {
+func flattenSetParameterValueConfiguration(apiObjects []awstypes.SetParameterValueConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"destination_parameter_name": aws.ToString(apiObject.DestinationParameterName),
 		}
 
@@ -783,12 +783,12 @@ func flattenSetParameterValueConfiguration(apiObjects []awstypes.SetParameterVal
 	return tfList
 }
 
-func flattenDestinationParameterValueConfiguration(apiObject *awstypes.DestinationParameterValueConfiguration) []interface{} {
+func flattenDestinationParameterValueConfiguration(apiObject *awstypes.DestinationParameterValueConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValuesConfiguration != nil {
 		tfMap["custom_values_configuration"] = flattenCustomValuesConfiguration(apiObject.CustomValuesConfiguration)
@@ -801,15 +801,15 @@ func flattenDestinationParameterValueConfiguration(apiObject *awstypes.Destinati
 		tfMap["source_parameter_name"] = aws.ToString(apiObject.SourceParameterName)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomValuesConfiguration(apiObject *awstypes.CustomValuesConfiguration) []interface{} {
+func flattenCustomValuesConfiguration(apiObject *awstypes.CustomValuesConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomValues != nil {
 		tfMap["custom_values"] = flattenCustomParameterValues(apiObject.CustomValues)
@@ -818,15 +818,15 @@ func flattenCustomValuesConfiguration(apiObject *awstypes.CustomValuesConfigurat
 		tfMap["include_null_value"] = aws.ToBool(apiObject.IncludeNullValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomParameterValues(apiObject *awstypes.CustomParameterValues) []interface{} {
+func flattenCustomParameterValues(apiObject *awstypes.CustomParameterValues) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateTimeValues != nil {
 		tfMap["date_time_values"] = flex.FlattenTimeStringValueList(apiObject.DateTimeValues, time.RFC3339)
@@ -841,18 +841,18 @@ func flattenCustomParameterValues(apiObject *awstypes.CustomParameterValues) []i
 		tfMap["string_values"] = apiObject.StringValues
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomActionURLOperation(apiObject *awstypes.CustomActionURLOperation) []interface{} {
+func flattenCustomActionURLOperation(apiObject *awstypes.CustomActionURLOperation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"url_target":   apiObject.URLTarget,
 		"url_template": aws.ToString(apiObject.URLTemplate),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_bar_chart.go
+++ b/internal/service/quicksight/schema/visual_bar_chart.go
@@ -94,12 +94,12 @@ func barCharVisualSchema() *schema.Schema {
 	}
 }
 
-func expandBarChartVisual(tfList []interface{}) *awstypes.BarChartVisual {
+func expandBarChartVisual(tfList []any) *awstypes.BarChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -109,31 +109,31 @@ func expandBarChartVisual(tfList []interface{}) *awstypes.BarChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandBarChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandBarChartConfiguration(tfList []interface{}) *awstypes.BarChartConfiguration {
+func expandBarChartConfiguration(tfList []any) *awstypes.BarChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -146,139 +146,139 @@ func expandBarChartConfiguration(tfList []interface{}) *awstypes.BarChartConfigu
 	if v, ok := tfMap["orientation"].(string); ok && v != "" {
 		apiObject.Orientation = awstypes.BarChartOrientation(v)
 	}
-	if v, ok := tfMap["category_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["color_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColorLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["contribution_analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["contribution_analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.ContributionAnalysisDefaults = expandContributionAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandBarChartFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["reference_lines"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["reference_lines"].([]any); ok && len(v) > 0 {
 		apiObject.ReferenceLines = expandReferenceLines(v)
 	}
-	if v, ok := tfMap["small_multiples_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_options"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesOptions = expandSmallMultiplesOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandBarChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["value_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_axis"].([]any); ok && len(v) > 0 {
 		apiObject.ValueAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["value_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ValueLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandBarChartFieldWells(tfList []interface{}) *awstypes.BarChartFieldWells {
+func expandBarChartFieldWells(tfList []any) *awstypes.BarChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BarChartFieldWells{}
 
-	if v, ok := tfMap["bar_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bar_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.BarChartAggregatedFieldWells = expandBarChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandBarChartAggregatedFieldWells(tfList []interface{}) *awstypes.BarChartAggregatedFieldWells {
+func expandBarChartAggregatedFieldWells(tfList []any) *awstypes.BarChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BarChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["small_multiples"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiples = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandBarChartSortConfiguration(tfList []interface{}) *awstypes.BarChartSortConfiguration {
+func expandBarChartSortConfiguration(tfList []any) *awstypes.BarChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BarChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["color_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.ColorItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["color_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_sort"].([]any); ok && len(v) > 0 {
 		apiObject.ColorSort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["small_multiples_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["small_multiples_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_sort"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func flattenBarChartVisual(apiObject *awstypes.BarChartVisual) []interface{} {
+func flattenBarChartVisual(apiObject *awstypes.BarChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 	if apiObject.Actions != nil {
@@ -297,15 +297,15 @@ func flattenBarChartVisual(apiObject *awstypes.BarChartVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBarChartConfiguration(apiObject *awstypes.BarChartConfiguration) []interface{} {
+func flattenBarChartConfiguration(apiObject *awstypes.BarChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["bars_arrangement"] = apiObject.BarsArrangement
 	if apiObject.CategoryAxis != nil {
@@ -352,29 +352,29 @@ func flattenBarChartConfiguration(apiObject *awstypes.BarChartConfiguration) []i
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBarChartFieldWells(apiObject *awstypes.BarChartFieldWells) []interface{} {
+func flattenBarChartFieldWells(apiObject *awstypes.BarChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BarChartAggregatedFieldWells != nil {
 		tfMap["bar_chart_aggregated_field_wells"] = flattenBarChartAggregatedFieldWells(apiObject.BarChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBarChartAggregatedFieldWells(apiObject *awstypes.BarChartAggregatedFieldWells) []interface{} {
+func flattenBarChartAggregatedFieldWells(apiObject *awstypes.BarChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -389,15 +389,15 @@ func flattenBarChartAggregatedFieldWells(apiObject *awstypes.BarChartAggregatedF
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBarChartSortConfiguration(apiObject *awstypes.BarChartSortConfiguration) []interface{} {
+func flattenBarChartSortConfiguration(apiObject *awstypes.BarChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -418,33 +418,33 @@ func flattenBarChartSortConfiguration(apiObject *awstypes.BarChartSortConfigurat
 		tfMap["small_multiples_sort"] = flattenFieldSortOptions(apiObject.SmallMultiplesSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenItemsLimitConfiguration(apiObject *awstypes.ItemsLimitConfiguration) []interface{} {
+func flattenItemsLimitConfiguration(apiObject *awstypes.ItemsLimitConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ItemsLimit != nil {
 		tfMap["items_limit"] = aws.ToInt64(apiObject.ItemsLimit)
 	}
 	tfMap["other_categories"] = apiObject.OtherCategories
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldSortOptions(apiObjects []awstypes.FieldSortOptions) []interface{} {
+func flattenFieldSortOptions(apiObjects []awstypes.FieldSortOptions) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ColumnSort != nil {
 			tfMap["column_sort"] = flattenColumnSort(apiObject.ColumnSort)
@@ -459,12 +459,12 @@ func flattenFieldSortOptions(apiObjects []awstypes.FieldSortOptions) []interface
 	return tfList
 }
 
-func flattenColumnSort(apiObject *awstypes.ColumnSort) []interface{} {
+func flattenColumnSort(apiObject *awstypes.ColumnSort) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["direction"] = apiObject.Direction
 	if apiObject.SortBy != nil {
@@ -474,20 +474,20 @@ func flattenColumnSort(apiObject *awstypes.ColumnSort) []interface{} {
 		tfMap["aggregation_function"] = flattenAggregationFunction(apiObject.AggregationFunction)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldSort(apiObject *awstypes.FieldSort) []interface{} {
+func flattenFieldSort(apiObject *awstypes.FieldSort) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["direction"] = apiObject.Direction
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_box_plot.go
+++ b/internal/service/quicksight/schema/visual_box_plot.go
@@ -128,12 +128,12 @@ func paginationConfigurationSchema() *schema.Schema {
 	}
 }
 
-func expandBoxPlotVisual(tfList []interface{}) *awstypes.BoxPlotVisual {
+func expandBoxPlotVisual(tfList []any) *awstypes.BoxPlotVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -143,80 +143,80 @@ func expandBoxPlotVisual(tfList []interface{}) *awstypes.BoxPlotVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandBoxPlotChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandBoxPlotChartConfiguration(tfList []interface{}) *awstypes.BoxPlotChartConfiguration {
+func expandBoxPlotChartConfiguration(tfList []any) *awstypes.BoxPlotChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BoxPlotChartConfiguration{}
 
-	if v, ok := tfMap["box_plot_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["box_plot_options"].([]any); ok && len(v) > 0 {
 		apiObject.BoxPlotOptions = expandBoxPlotOptions(v)
 	}
-	if v, ok := tfMap["category_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandBoxPlotFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["reference_lines"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["reference_lines"].([]any); ok && len(v) > 0 {
 		apiObject.ReferenceLines = expandReferenceLines(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandBoxPlotSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandBoxPlotOptions(tfList []interface{}) *awstypes.BoxPlotOptions {
+func expandBoxPlotOptions(tfList []any) *awstypes.BoxPlotOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -229,19 +229,19 @@ func expandBoxPlotOptions(tfList []interface{}) *awstypes.BoxPlotOptions {
 	if v, ok := tfMap["outlier_visibility"].(string); ok && v != "" {
 		apiObject.OutlierVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["style_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["style_options"].([]any); ok && len(v) > 0 {
 		apiObject.StyleOptions = expandBoxPlotStyleOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandBoxPlotStyleOptions(tfList []interface{}) *awstypes.BoxPlotStyleOptions {
+func expandBoxPlotStyleOptions(tfList []any) *awstypes.BoxPlotStyleOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -255,75 +255,75 @@ func expandBoxPlotStyleOptions(tfList []interface{}) *awstypes.BoxPlotStyleOptio
 	return apiObject
 }
 
-func expandBoxPlotFieldWells(tfList []interface{}) *awstypes.BoxPlotFieldWells {
+func expandBoxPlotFieldWells(tfList []any) *awstypes.BoxPlotFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BoxPlotFieldWells{}
 
-	if v, ok := tfMap["box_plot_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["box_plot_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.BoxPlotAggregatedFieldWells = expandBoxPlotAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandBoxPlotAggregatedFieldWells(tfList []interface{}) *awstypes.BoxPlotAggregatedFieldWells {
+func expandBoxPlotAggregatedFieldWells(tfList []any) *awstypes.BoxPlotAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BoxPlotAggregatedFieldWells{}
 
-	if v, ok := tfMap["group_by"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["group_by"].([]any); ok && len(v) > 0 {
 		apiObject.GroupBy = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandBoxPlotSortConfiguration(tfList []interface{}) *awstypes.BoxPlotSortConfiguration {
+func expandBoxPlotSortConfiguration(tfList []any) *awstypes.BoxPlotSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.BoxPlotSortConfiguration{}
 
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["pagination_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pagination_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PaginationConfiguration = expandPaginationConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandPaginationConfiguration(tfList []interface{}) *awstypes.PaginationConfiguration {
+func expandPaginationConfiguration(tfList []any) *awstypes.PaginationConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -340,12 +340,12 @@ func expandPaginationConfiguration(tfList []interface{}) *awstypes.PaginationCon
 	return apiObject
 }
 
-func flattenBoxPlotVisual(apiObject *awstypes.BoxPlotVisual) []interface{} {
+func flattenBoxPlotVisual(apiObject *awstypes.BoxPlotVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 	if apiObject.Actions != nil {
@@ -364,15 +364,15 @@ func flattenBoxPlotVisual(apiObject *awstypes.BoxPlotVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotChartConfiguration(apiObject *awstypes.BoxPlotChartConfiguration) []interface{} {
+func flattenBoxPlotChartConfiguration(apiObject *awstypes.BoxPlotChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BoxPlotOptions != nil {
 		tfMap["box_plot_options"] = flattenBoxPlotOptions(apiObject.BoxPlotOptions)
@@ -408,15 +408,15 @@ func flattenBoxPlotChartConfiguration(apiObject *awstypes.BoxPlotChartConfigurat
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotOptions(apiObject *awstypes.BoxPlotOptions) []interface{} {
+func flattenBoxPlotOptions(apiObject *awstypes.BoxPlotOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["all_data_points_visibility"] = apiObject.AllDataPointsVisibility
 	tfMap["outlier_visibility"] = apiObject.OutlierVisibility
@@ -424,41 +424,41 @@ func flattenBoxPlotOptions(apiObject *awstypes.BoxPlotOptions) []interface{} {
 		tfMap["style_options"] = flattenBoxPlotStyleOptions(apiObject.StyleOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotStyleOptions(apiObject *awstypes.BoxPlotStyleOptions) []interface{} {
+func flattenBoxPlotStyleOptions(apiObject *awstypes.BoxPlotStyleOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"fill_style": apiObject.FillStyle,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotFieldWells(apiObject *awstypes.BoxPlotFieldWells) []interface{} {
+func flattenBoxPlotFieldWells(apiObject *awstypes.BoxPlotFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BoxPlotAggregatedFieldWells != nil {
 		tfMap["box_plot_aggregated_field_wells"] = flattenBoxPlotAggregatedFieldWells(apiObject.BoxPlotAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotAggregatedFieldWells(apiObject *awstypes.BoxPlotAggregatedFieldWells) []interface{} {
+func flattenBoxPlotAggregatedFieldWells(apiObject *awstypes.BoxPlotAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.GroupBy != nil {
 		tfMap["group_by"] = flattenDimensionFields(apiObject.GroupBy)
@@ -467,15 +467,15 @@ func flattenBoxPlotAggregatedFieldWells(apiObject *awstypes.BoxPlotAggregatedFie
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBoxPlotSortConfiguration(apiObject *awstypes.BoxPlotSortConfiguration) []interface{} {
+func flattenBoxPlotSortConfiguration(apiObject *awstypes.BoxPlotSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategorySort != nil {
 		tfMap["category_sort"] = flattenFieldSortOptions(apiObject.CategorySort)
@@ -484,15 +484,15 @@ func flattenBoxPlotSortConfiguration(apiObject *awstypes.BoxPlotSortConfiguratio
 		tfMap["pagination_configuration"] = flattenPaginationConfiguration(apiObject.PaginationConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPaginationConfiguration(apiObject *awstypes.PaginationConfiguration) []interface{} {
+func flattenPaginationConfiguration(apiObject *awstypes.PaginationConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PageNumber != nil {
 		tfMap["page_number"] = aws.ToInt64(apiObject.PageNumber)
@@ -501,5 +501,5 @@ func flattenPaginationConfiguration(apiObject *awstypes.PaginationConfiguration)
 		tfMap["page_size"] = aws.ToInt64(apiObject.PageSize)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_chart_configuration.go
+++ b/internal/service/quicksight/schema/visual_chart_configuration.go
@@ -428,12 +428,12 @@ var smallMultiplesOptionsSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandAxisDisplayOptions(tfList []interface{}) *awstypes.AxisDisplayOptions {
+func expandAxisDisplayOptions(tfList []any) *awstypes.AxisDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -449,47 +449,47 @@ func expandAxisDisplayOptions(tfList []interface{}) *awstypes.AxisDisplayOptions
 	if v, ok := tfMap["grid_line_visibility"].(string); ok && v != "" {
 		apiObject.GridLineVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["data_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_options"].([]any); ok && len(v) > 0 {
 		apiObject.DataOptions = expandAxisDataOptions(v)
 	}
-	if v, ok := tfMap["scrollbar_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scrollbar_options"].([]any); ok && len(v) > 0 {
 		apiObject.ScrollbarOptions = expandScrollBarOptions(v)
 	}
-	if v, ok := tfMap["tick_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tick_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.TickLabelOptions = expandAxisTickLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisDataOptions(tfList []interface{}) *awstypes.AxisDataOptions {
+func expandAxisDataOptions(tfList []any) *awstypes.AxisDataOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AxisDataOptions{}
 
-	if v, ok := tfMap["date_axis_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_axis_options"].([]any); ok && len(v) > 0 {
 		apiObject.DateAxisOptions = expandDateAxisOptions(v)
 	}
-	if v, ok := tfMap["numeric_axis_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numeric_axis_options"].([]any); ok && len(v) > 0 {
 		apiObject.NumericAxisOptions = expandNumericAxisOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandDateAxisOptions(tfList []interface{}) *awstypes.DateAxisOptions {
+func expandDateAxisOptions(tfList []any) *awstypes.DateAxisOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -503,51 +503,51 @@ func expandDateAxisOptions(tfList []interface{}) *awstypes.DateAxisOptions {
 	return apiObject
 }
 
-func expandNumericAxisOptions(tfList []interface{}) *awstypes.NumericAxisOptions {
+func expandNumericAxisOptions(tfList []any) *awstypes.NumericAxisOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.NumericAxisOptions{}
 
-	if v, ok := tfMap["range"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range"].([]any); ok && len(v) > 0 {
 		apiObject.Range = expandAxisDisplayRange(v)
 	}
-	if v, ok := tfMap["scale"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scale"].([]any); ok && len(v) > 0 {
 		apiObject.Scale = expandAxisScale(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisDisplayRange(tfList []interface{}) *awstypes.AxisDisplayRange {
+func expandAxisDisplayRange(tfList []any) *awstypes.AxisDisplayRange {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AxisDisplayRange{}
 
-	if v, ok := tfMap["data_driven"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_driven"].([]any); ok && len(v) > 0 {
 		apiObject.DataDriven = expandAxisDisplayDataDrivenRange(v)
 	}
-	if v, ok := tfMap["min_max"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["min_max"].([]any); ok && len(v) > 0 {
 		apiObject.MinMax = expandAxisDisplayMinMaxRange(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisDisplayDataDrivenRange(tfList []interface{}) *awstypes.AxisDisplayDataDrivenRange {
+func expandAxisDisplayDataDrivenRange(tfList []any) *awstypes.AxisDisplayDataDrivenRange {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -562,12 +562,12 @@ func expandAxisDisplayDataDrivenRange(tfList []interface{}) *awstypes.AxisDispla
 	return apiObject
 }
 
-func expandAxisDisplayMinMaxRange(tfList []interface{}) *awstypes.AxisDisplayMinMaxRange {
+func expandAxisDisplayMinMaxRange(tfList []any) *awstypes.AxisDisplayMinMaxRange {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -584,34 +584,34 @@ func expandAxisDisplayMinMaxRange(tfList []interface{}) *awstypes.AxisDisplayMin
 	return apiObject
 }
 
-func expandAxisScale(tfList []interface{}) *awstypes.AxisScale {
+func expandAxisScale(tfList []any) *awstypes.AxisScale {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.AxisScale{}
 
-	if v, ok := tfMap["linear"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["linear"].([]any); ok && len(v) > 0 {
 		apiObject.Linear = expandAxisLinearScale(v)
 	}
-	if v, ok := tfMap["logarithmic"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["logarithmic"].([]any); ok && len(v) > 0 {
 		apiObject.Logarithmic = expandAxisLogarithmicScale(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisLinearScale(tfList []interface{}) *awstypes.AxisLinearScale {
+func expandAxisLinearScale(tfList []any) *awstypes.AxisLinearScale {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -628,12 +628,12 @@ func expandAxisLinearScale(tfList []interface{}) *awstypes.AxisLinearScale {
 	return apiObject
 }
 
-func expandAxisLogarithmicScale(tfList []interface{}) *awstypes.AxisLogarithmicScale {
+func expandAxisLogarithmicScale(tfList []any) *awstypes.AxisLogarithmicScale {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -647,12 +647,12 @@ func expandAxisLogarithmicScale(tfList []interface{}) *awstypes.AxisLogarithmicS
 	return apiObject
 }
 
-func expandScrollBarOptions(tfList []interface{}) *awstypes.ScrollBarOptions {
+func expandScrollBarOptions(tfList []any) *awstypes.ScrollBarOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -662,38 +662,38 @@ func expandScrollBarOptions(tfList []interface{}) *awstypes.ScrollBarOptions {
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["visible_range"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visible_range"].([]any); ok && len(v) > 0 {
 		apiObject.VisibleRange = expandVisibleRangeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandVisibleRangeOptions(tfList []interface{}) *awstypes.VisibleRangeOptions {
+func expandVisibleRangeOptions(tfList []any) *awstypes.VisibleRangeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.VisibleRangeOptions{}
 
-	if v, ok := tfMap["percent_range"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["percent_range"].([]any); ok && len(v) > 0 {
 		apiObject.PercentRange = expandPercentVisibleRange(v)
 	}
 
 	return apiObject
 }
 
-func expandPercentVisibleRange(tfList []interface{}) *awstypes.PercentVisibleRange {
+func expandPercentVisibleRange(tfList []any) *awstypes.PercentVisibleRange {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -710,12 +710,12 @@ func expandPercentVisibleRange(tfList []interface{}) *awstypes.PercentVisibleRan
 	return apiObject
 }
 
-func expandAxisTickLabelOptions(tfList []interface{}) *awstypes.AxisTickLabelOptions {
+func expandAxisTickLabelOptions(tfList []any) *awstypes.AxisTickLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -725,19 +725,19 @@ func expandAxisTickLabelOptions(tfList []interface{}) *awstypes.AxisTickLabelOpt
 	if v, ok := tfMap["rotation_angle"].(float64); ok {
 		apiObject.RotationAngle = aws.Float64(v)
 	}
-	if v, ok := tfMap["label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["label_options"].([]any); ok && len(v) > 0 {
 		apiObject.LabelOptions = expandLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandChartAxisLabelOptions(tfList []interface{}) *awstypes.ChartAxisLabelOptions {
+func expandChartAxisLabelOptions(tfList []any) *awstypes.ChartAxisLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -750,14 +750,14 @@ func expandChartAxisLabelOptions(tfList []interface{}) *awstypes.ChartAxisLabelO
 	if v, ok := tfMap["sort_icon_visibility"].(string); ok && v != "" {
 		apiObject.SortIconVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.AxisLabelOptions = expandAxisLabelOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisLabelOptionsList(tfList []interface{}) []awstypes.AxisLabelOptions {
+func expandAxisLabelOptionsList(tfList []any) []awstypes.AxisLabelOptions {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -765,7 +765,7 @@ func expandAxisLabelOptionsList(tfList []interface{}) []awstypes.AxisLabelOption
 	var apiObjects []awstypes.AxisLabelOptions
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -781,7 +781,7 @@ func expandAxisLabelOptionsList(tfList []interface{}) []awstypes.AxisLabelOption
 	return apiObjects
 }
 
-func expandAxisLabelOptions(tfMap map[string]interface{}) *awstypes.AxisLabelOptions {
+func expandAxisLabelOptions(tfMap map[string]any) *awstypes.AxisLabelOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -791,22 +791,22 @@ func expandAxisLabelOptions(tfMap map[string]interface{}) *awstypes.AxisLabelOpt
 	if v, ok := tfMap["custom_label"].(string); ok && v != "" {
 		apiObject.CustomLabel = aws.String(v)
 	}
-	if v, ok := tfMap["apply_to"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["apply_to"].([]any); ok && len(v) > 0 {
 		apiObject.ApplyTo = expandAxisLabelReferenceOptions(v)
 	}
-	if v, ok := tfMap["font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandAxisLabelReferenceOptions(tfList []interface{}) *awstypes.AxisLabelReferenceOptions {
+func expandAxisLabelReferenceOptions(tfList []any) *awstypes.AxisLabelReferenceOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -816,14 +816,14 @@ func expandAxisLabelReferenceOptions(tfList []interface{}) *awstypes.AxisLabelRe
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
 
 	return apiObject
 }
 
-func expandContributionAnalysisDefaults(tfList []interface{}) []awstypes.ContributionAnalysisDefault {
+func expandContributionAnalysisDefaults(tfList []any) []awstypes.ContributionAnalysisDefault {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -831,7 +831,7 @@ func expandContributionAnalysisDefaults(tfList []interface{}) []awstypes.Contrib
 	var apiObjects []awstypes.ContributionAnalysisDefault
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -847,7 +847,7 @@ func expandContributionAnalysisDefaults(tfList []interface{}) []awstypes.Contrib
 	return apiObjects
 }
 
-func expandContributionAnalysisDefault(tfMap map[string]interface{}) *awstypes.ContributionAnalysisDefault {
+func expandContributionAnalysisDefault(tfMap map[string]any) *awstypes.ContributionAnalysisDefault {
 	if tfMap == nil {
 		return nil
 	}
@@ -857,14 +857,14 @@ func expandContributionAnalysisDefault(tfMap map[string]interface{}) *awstypes.C
 	if v, ok := tfMap["measure_field_id"].(string); ok && v != "" {
 		apiObject.MeasureFieldId = aws.String(v)
 	}
-	if v, ok := tfMap["contributor_dimensions"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["contributor_dimensions"].([]any); ok && len(v) > 0 {
 		apiObject.ContributorDimensions = expandColumnIdentifiers(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLines(tfList []interface{}) []awstypes.ReferenceLine {
+func expandReferenceLines(tfList []any) []awstypes.ReferenceLine {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -872,7 +872,7 @@ func expandReferenceLines(tfList []interface{}) []awstypes.ReferenceLine {
 	var apiObjects []awstypes.ReferenceLine
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -888,7 +888,7 @@ func expandReferenceLines(tfList []interface{}) []awstypes.ReferenceLine {
 	return apiObjects
 }
 
-func expandReferenceLine(tfMap map[string]interface{}) *awstypes.ReferenceLine {
+func expandReferenceLine(tfMap map[string]any) *awstypes.ReferenceLine {
 	if tfMap == nil {
 		return nil
 	}
@@ -898,25 +898,25 @@ func expandReferenceLine(tfMap map[string]interface{}) *awstypes.ReferenceLine {
 	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
 		apiObject.Status = awstypes.WidgetStatus(v)
 	}
-	if v, ok := tfMap["data_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DataConfiguration = expandReferenceLineDataConfiguration(v)
 	}
-	if v, ok := tfMap["label_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["label_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LabelConfiguration = expandReferenceLineLabelConfiguration(v)
 	}
-	if v, ok := tfMap["style_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["style_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.StyleConfiguration = expandReferenceLineStyleConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLineDataConfiguration(tfList []interface{}) *awstypes.ReferenceLineDataConfiguration {
+func expandReferenceLineDataConfiguration(tfList []any) *awstypes.ReferenceLineDataConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -926,47 +926,47 @@ func expandReferenceLineDataConfiguration(tfList []interface{}) *awstypes.Refere
 	if v, ok := tfMap["axis_binding"].(string); ok && v != "" {
 		apiObject.AxisBinding = awstypes.AxisBinding(v)
 	}
-	if v, ok := tfMap["dynamic_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["dynamic_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DynamicConfiguration = expandReferenceLineDynamicDataConfiguration(v)
 	}
-	if v, ok := tfMap["static_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["static_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.StaticConfiguration = expandReferenceLineStaticDataConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLineDynamicDataConfiguration(tfList []interface{}) *awstypes.ReferenceLineDynamicDataConfiguration {
+func expandReferenceLineDynamicDataConfiguration(tfList []any) *awstypes.ReferenceLineDynamicDataConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ReferenceLineDynamicDataConfiguration{}
 
-	if v, ok := tfMap["calculation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["calculation"].([]any); ok && len(v) > 0 {
 		apiObject.Calculation = expandNumericalAggregationFunction(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["measure_aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["measure_aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.MeasureAggregationFunction = expandAggregationFunction(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLineStaticDataConfiguration(tfList []interface{}) *awstypes.ReferenceLineStaticDataConfiguration {
+func expandReferenceLineStaticDataConfiguration(tfList []any) *awstypes.ReferenceLineStaticDataConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -980,12 +980,12 @@ func expandReferenceLineStaticDataConfiguration(tfList []interface{}) *awstypes.
 	return apiObject
 }
 
-func expandReferenceLineLabelConfiguration(tfList []interface{}) *awstypes.ReferenceLineLabelConfiguration {
+func expandReferenceLineLabelConfiguration(tfList []any) *awstypes.ReferenceLineLabelConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1001,25 +1001,25 @@ func expandReferenceLineLabelConfiguration(tfList []interface{}) *awstypes.Refer
 	if v, ok := tfMap["vertical_position"].(string); ok && v != "" {
 		apiObject.VerticalPosition = awstypes.ReferenceLineLabelVerticalPosition(v)
 	}
-	if v, ok := tfMap["custom_label_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_label_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.CustomLabelConfiguration = expandReferenceLineCustomLabelConfiguration(v)
 	}
-	if v, ok := tfMap["font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
-	if v, ok := tfMap["value_label_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_label_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ValueLabelConfiguration = expandReferenceLineValueLabelConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLineCustomLabelConfiguration(tfList []interface{}) *awstypes.ReferenceLineCustomLabelConfiguration {
+func expandReferenceLineCustomLabelConfiguration(tfList []any) *awstypes.ReferenceLineCustomLabelConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1033,12 +1033,12 @@ func expandReferenceLineCustomLabelConfiguration(tfList []interface{}) *awstypes
 	return apiObject
 }
 
-func expandReferenceLineValueLabelConfiguration(tfList []interface{}) *awstypes.ReferenceLineValueLabelConfiguration {
+func expandReferenceLineValueLabelConfiguration(tfList []any) *awstypes.ReferenceLineValueLabelConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1048,19 +1048,19 @@ func expandReferenceLineValueLabelConfiguration(tfList []interface{}) *awstypes.
 	if v, ok := tfMap["relative_position"].(string); ok && v != "" {
 		apiObject.RelativePosition = awstypes.ReferenceLineValueLabelRelativePosition(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandNumericFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandReferenceLineStyleConfiguration(tfList []interface{}) *awstypes.ReferenceLineStyleConfiguration {
+func expandReferenceLineStyleConfiguration(tfList []any) *awstypes.ReferenceLineStyleConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1077,12 +1077,12 @@ func expandReferenceLineStyleConfiguration(tfList []interface{}) *awstypes.Refer
 	return apiObject
 }
 
-func expandSmallMultiplesOptions(tfList []interface{}) *awstypes.SmallMultiplesOptions {
+func expandSmallMultiplesOptions(tfList []any) *awstypes.SmallMultiplesOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1095,19 +1095,19 @@ func expandSmallMultiplesOptions(tfList []interface{}) *awstypes.SmallMultiplesO
 	if v, ok := tfMap["max_visible_rows"].(int); ok {
 		apiObject.MaxVisibleRows = aws.Int64(int64(v))
 	}
-	if v, ok := tfMap["panel_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["panel_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PanelConfiguration = expandPanelConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandPanelConfiguration(tfList []interface{}) *awstypes.PanelConfiguration {
+func expandPanelConfiguration(tfList []any) *awstypes.PanelConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1138,19 +1138,19 @@ func expandPanelConfiguration(tfList []interface{}) *awstypes.PanelConfiguration
 	if v, ok := tfMap["gutter_visibility"].(string); ok && v != "" {
 		apiObject.GutterVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandPanelTitleOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandPanelTitleOptions(tfList []interface{}) *awstypes.PanelTitleOptions {
+func expandPanelTitleOptions(tfList []any) *awstypes.PanelTitleOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1163,19 +1163,19 @@ func expandPanelTitleOptions(tfList []interface{}) *awstypes.PanelTitleOptions {
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandItemsLimitConfiguration(tfList []interface{}) *awstypes.ItemsLimitConfiguration {
+func expandItemsLimitConfiguration(tfList []any) *awstypes.ItemsLimitConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1192,12 +1192,12 @@ func expandItemsLimitConfiguration(tfList []interface{}) *awstypes.ItemsLimitCon
 	return apiObject
 }
 
-func flattenAxisDisplayOptions(apiObject *awstypes.AxisDisplayOptions) []interface{} {
+func flattenAxisDisplayOptions(apiObject *awstypes.AxisDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["axis_line_visibility"] = apiObject.AxisLineVisibility
 	if apiObject.AxisOffset != nil {
@@ -1214,15 +1214,15 @@ func flattenAxisDisplayOptions(apiObject *awstypes.AxisDisplayOptions) []interfa
 		tfMap["tick_label_options"] = flattenAxisTickLabelOptions(apiObject.TickLabelOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisDataOptions(apiObject *awstypes.AxisDataOptions) []interface{} {
+func flattenAxisDataOptions(apiObject *awstypes.AxisDataOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DateAxisOptions != nil {
 		tfMap["date_axis_options"] = flattenDateAxisOptions(apiObject.DateAxisOptions)
@@ -1231,27 +1231,27 @@ func flattenAxisDataOptions(apiObject *awstypes.AxisDataOptions) []interface{} {
 		tfMap["numeric_axis_options"] = flattenNumericAxisOptions(apiObject.NumericAxisOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateAxisOptions(apiObject *awstypes.DateAxisOptions) []interface{} {
+func flattenDateAxisOptions(apiObject *awstypes.DateAxisOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"missing_date_visibility": apiObject.MissingDateVisibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericAxisOptions(apiObject *awstypes.NumericAxisOptions) []interface{} {
+func flattenNumericAxisOptions(apiObject *awstypes.NumericAxisOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Range != nil {
 		tfMap["range"] = flattenAxisDisplayRange(apiObject.Range)
@@ -1260,15 +1260,15 @@ func flattenNumericAxisOptions(apiObject *awstypes.NumericAxisOptions) []interfa
 		tfMap["scale"] = flattenAxisScale(apiObject.Scale)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisDisplayRange(apiObject *awstypes.AxisDisplayRange) []interface{} {
+func flattenAxisDisplayRange(apiObject *awstypes.AxisDisplayRange) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataDriven != nil {
 		tfMap["data_driven"] = flattenAxisDisplayDataDrivenRange(apiObject.DataDriven)
@@ -1277,26 +1277,26 @@ func flattenAxisDisplayRange(apiObject *awstypes.AxisDisplayRange) []interface{}
 		tfMap["min_max"] = flattenAxisDisplayMinMaxRange(apiObject.MinMax)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisDisplayDataDrivenRange(apiObject *awstypes.AxisDisplayDataDrivenRange) []interface{} {
+func flattenAxisDisplayDataDrivenRange(apiObject *awstypes.AxisDisplayDataDrivenRange) []any {
 	if apiObject == nil {
 		return nil
 	}
 
 	// For future extensions
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisDisplayMinMaxRange(apiObject *awstypes.AxisDisplayMinMaxRange) []interface{} {
+func flattenAxisDisplayMinMaxRange(apiObject *awstypes.AxisDisplayMinMaxRange) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Maximum != nil {
 		tfMap["maximum"] = aws.ToFloat64(apiObject.Maximum)
@@ -1305,15 +1305,15 @@ func flattenAxisDisplayMinMaxRange(apiObject *awstypes.AxisDisplayMinMaxRange) [
 		tfMap["minimum"] = aws.ToFloat64(apiObject.Minimum)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisScale(apiObject *awstypes.AxisScale) []interface{} {
+func flattenAxisScale(apiObject *awstypes.AxisScale) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Linear != nil {
 		tfMap["linear"] = flattenAxisLinearScale(apiObject.Linear)
@@ -1322,15 +1322,15 @@ func flattenAxisScale(apiObject *awstypes.AxisScale) []interface{} {
 		tfMap["logarithmic"] = flattenAxisLogarithmicScale(apiObject.Logarithmic)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisLinearScale(apiObject *awstypes.AxisLinearScale) []interface{} {
+func flattenAxisLinearScale(apiObject *awstypes.AxisLinearScale) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.StepCount != nil {
 		tfMap["step_count"] = aws.ToInt32(apiObject.StepCount)
@@ -1339,58 +1339,58 @@ func flattenAxisLinearScale(apiObject *awstypes.AxisLinearScale) []interface{} {
 		tfMap["step_size"] = aws.ToFloat64(apiObject.StepSize)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisLogarithmicScale(apiObject *awstypes.AxisLogarithmicScale) []interface{} {
+func flattenAxisLogarithmicScale(apiObject *awstypes.AxisLogarithmicScale) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Base != nil {
 		tfMap["base"] = aws.ToFloat64(apiObject.Base)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenScrollBarOptions(apiObject *awstypes.ScrollBarOptions) []interface{} {
+func flattenScrollBarOptions(apiObject *awstypes.ScrollBarOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["visibility"] = apiObject.Visibility
 	if apiObject.VisibleRange != nil {
 		tfMap["visible_range"] = flattenVisibleRangeOptions(apiObject.VisibleRange)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenVisibleRangeOptions(apiObject *awstypes.VisibleRangeOptions) []interface{} {
+func flattenVisibleRangeOptions(apiObject *awstypes.VisibleRangeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PercentRange != nil {
 		tfMap["percent_range"] = flattenPercentVisibleRange(apiObject.PercentRange)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPercentVisibleRange(apiObject *awstypes.PercentVisibleRange) []interface{} {
+func flattenPercentVisibleRange(apiObject *awstypes.PercentVisibleRange) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.From != nil {
 		tfMap["from"] = aws.ToFloat64(apiObject.From)
@@ -1399,15 +1399,15 @@ func flattenPercentVisibleRange(apiObject *awstypes.PercentVisibleRange) []inter
 		tfMap["to"] = aws.ToFloat64(apiObject.To)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisTickLabelOptions(apiObject *awstypes.AxisTickLabelOptions) []interface{} {
+func flattenAxisTickLabelOptions(apiObject *awstypes.AxisTickLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LabelOptions != nil {
 		tfMap["label_options"] = flattenLabelOptions(apiObject.LabelOptions)
@@ -1416,15 +1416,15 @@ func flattenAxisTickLabelOptions(apiObject *awstypes.AxisTickLabelOptions) []int
 		tfMap["rotation_angle"] = aws.ToFloat64(apiObject.RotationAngle)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenChartAxisLabelOptions(apiObject *awstypes.ChartAxisLabelOptions) []interface{} {
+func flattenChartAxisLabelOptions(apiObject *awstypes.ChartAxisLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AxisLabelOptions != nil {
 		tfMap["axis_label_options"] = flattenAxisLabelOptions(apiObject.AxisLabelOptions)
@@ -1432,18 +1432,18 @@ func flattenChartAxisLabelOptions(apiObject *awstypes.ChartAxisLabelOptions) []i
 	tfMap["sort_icon_visibility"] = apiObject.SortIconVisibility
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAxisLabelOptions(apiObjects []awstypes.AxisLabelOptions) []interface{} {
+func flattenAxisLabelOptions(apiObjects []awstypes.AxisLabelOptions) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ApplyTo != nil {
 			tfMap["apply_to"] = flattenAxisLabelReferenceOptions(apiObject.ApplyTo)
@@ -1461,12 +1461,12 @@ func flattenAxisLabelOptions(apiObjects []awstypes.AxisLabelOptions) []interface
 	return tfList
 }
 
-func flattenAxisLabelReferenceOptions(apiObject *awstypes.AxisLabelReferenceOptions) []interface{} {
+func flattenAxisLabelReferenceOptions(apiObject *awstypes.AxisLabelReferenceOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1475,18 +1475,18 @@ func flattenAxisLabelReferenceOptions(apiObject *awstypes.AxisLabelReferenceOpti
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenContributionAnalysisDefault(apiObjects []awstypes.ContributionAnalysisDefault) []interface{} {
+func flattenContributionAnalysisDefault(apiObjects []awstypes.ContributionAnalysisDefault) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"measure_field_id": aws.ToString(apiObject.MeasureFieldId),
 		}
 
@@ -1500,15 +1500,15 @@ func flattenContributionAnalysisDefault(apiObjects []awstypes.ContributionAnalys
 	return tfList
 }
 
-func flattenColumnIdentifiers(apiObjects []awstypes.ColumnIdentifier) []interface{} {
+func flattenColumnIdentifiers(apiObjects []awstypes.ColumnIdentifier) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"column_name":         aws.ToString(apiObject.ColumnName),
 			"data_set_identifier": aws.ToString(apiObject.DataSetIdentifier),
 		}
@@ -1519,15 +1519,15 @@ func flattenColumnIdentifiers(apiObjects []awstypes.ColumnIdentifier) []interfac
 	return tfList
 }
 
-func flattenReferenceLine(apiObjects []awstypes.ReferenceLine) []interface{} {
+func flattenReferenceLine(apiObjects []awstypes.ReferenceLine) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataConfiguration != nil {
 			tfMap["data_configuration"] = flattenReferenceLineDataConfiguration(apiObject.DataConfiguration)
@@ -1546,12 +1546,12 @@ func flattenReferenceLine(apiObjects []awstypes.ReferenceLine) []interface{} {
 	return tfList
 }
 
-func flattenReferenceLineDataConfiguration(apiObject *awstypes.ReferenceLineDataConfiguration) []interface{} {
+func flattenReferenceLineDataConfiguration(apiObject *awstypes.ReferenceLineDataConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["axis_binding"] = apiObject.AxisBinding
 	if apiObject.DynamicConfiguration != nil {
@@ -1561,15 +1561,15 @@ func flattenReferenceLineDataConfiguration(apiObject *awstypes.ReferenceLineData
 		tfMap["static_configuration"] = flattenReferenceLineStaticDataConfiguration(apiObject.StaticConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReferenceLineDynamicDataConfiguration(apiObject *awstypes.ReferenceLineDynamicDataConfiguration) []interface{} {
+func flattenReferenceLineDynamicDataConfiguration(apiObject *awstypes.ReferenceLineDynamicDataConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Calculation != nil {
 		tfMap["calculation"] = flattenNumericalAggregationFunction(apiObject.Calculation)
@@ -1581,27 +1581,27 @@ func flattenReferenceLineDynamicDataConfiguration(apiObject *awstypes.ReferenceL
 		tfMap["measure_aggregation_function"] = flattenAggregationFunction(apiObject.MeasureAggregationFunction)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReferenceLineStaticDataConfiguration(apiObject *awstypes.ReferenceLineStaticDataConfiguration) []interface{} {
+func flattenReferenceLineStaticDataConfiguration(apiObject *awstypes.ReferenceLineStaticDataConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrValue: apiObject.Value,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReferenceLineLabelConfiguration(apiObject *awstypes.ReferenceLineLabelConfiguration) []interface{} {
+func flattenReferenceLineLabelConfiguration(apiObject *awstypes.ReferenceLineLabelConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomLabelConfiguration != nil {
 		tfMap["custom_label_configuration"] = flattenReferenceLineCustomLabelConfiguration(apiObject.CustomLabelConfiguration)
@@ -1618,56 +1618,56 @@ func flattenReferenceLineLabelConfiguration(apiObject *awstypes.ReferenceLineLab
 	}
 	tfMap["vertical_position"] = apiObject.VerticalPosition
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
-func flattenReferenceLineCustomLabelConfiguration(apiObject *awstypes.ReferenceLineCustomLabelConfiguration) []interface{} {
+func flattenReferenceLineCustomLabelConfiguration(apiObject *awstypes.ReferenceLineCustomLabelConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"custom_label": aws.ToString(apiObject.CustomLabel),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReferenceLineValueLabelConfiguration(apiObject *awstypes.ReferenceLineValueLabelConfiguration) []interface{} {
+func flattenReferenceLineValueLabelConfiguration(apiObject *awstypes.ReferenceLineValueLabelConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FormatConfiguration != nil {
 		tfMap["format_configuration"] = flattenNumericFormatConfiguration(apiObject.FormatConfiguration)
 	}
 	tfMap["relative_position"] = apiObject.RelativePosition
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReferenceLineStyleConfiguration(apiObject *awstypes.ReferenceLineStyleConfiguration) []interface{} {
+func flattenReferenceLineStyleConfiguration(apiObject *awstypes.ReferenceLineStyleConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
 	}
 	tfMap["pattern"] = apiObject.Pattern
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSmallMultiplesOptions(apiObject *awstypes.SmallMultiplesOptions) []interface{} {
+func flattenSmallMultiplesOptions(apiObject *awstypes.SmallMultiplesOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.MaxVisibleColumns != nil {
 		tfMap["max_visible_columns"] = aws.ToInt64(apiObject.MaxVisibleColumns)
@@ -1679,15 +1679,15 @@ func flattenSmallMultiplesOptions(apiObject *awstypes.SmallMultiplesOptions) []i
 		tfMap["panel_configuration"] = flattenPanelConfiguration(apiObject.PanelConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPanelConfiguration(apiObject *awstypes.PanelConfiguration) []interface{} {
+func flattenPanelConfiguration(apiObject *awstypes.PanelConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BackgroundColor != nil {
 		tfMap["background_color"] = aws.ToString(apiObject.BackgroundColor)
@@ -1708,15 +1708,15 @@ func flattenPanelConfiguration(apiObject *awstypes.PanelConfiguration) []interfa
 		tfMap["title"] = flattenPanelTitleOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPanelTitleOptions(apiObject *awstypes.PanelTitleOptions) []interface{} {
+func flattenPanelTitleOptions(apiObject *awstypes.PanelTitleOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FontConfiguration != nil {
 		tfMap["font_configuration"] = flattenFontConfiguration(apiObject.FontConfiguration)
@@ -1724,5 +1724,5 @@ func flattenPanelTitleOptions(apiObject *awstypes.PanelTitleOptions) []interface
 	tfMap["horizontal_text_alignment"] = apiObject.HorizontalTextAlignment
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_combo_chart.go
+++ b/internal/service/quicksight/schema/visual_combo_chart.go
@@ -92,12 +92,12 @@ func comboChartVisualSchema() *schema.Schema {
 	}
 }
 
-func expandComboChartVisual(tfList []interface{}) *awstypes.ComboChartVisual {
+func expandComboChartVisual(tfList []any) *awstypes.ComboChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -107,31 +107,31 @@ func expandComboChartVisual(tfList []interface{}) *awstypes.ComboChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandComboChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandComboChartConfiguration(tfList []interface{}) *awstypes.ComboChartConfiguration {
+func expandComboChartConfiguration(tfList []any) *awstypes.ComboChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -141,136 +141,136 @@ func expandComboChartConfiguration(tfList []interface{}) *awstypes.ComboChartCon
 	if v, ok := tfMap["bars_arrangement"].(string); ok && v != "" {
 		apiObject.BarsArrangement = awstypes.BarsArrangement(v)
 	}
-	if v, ok := tfMap["bar_data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bar_data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.BarDataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["category_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["color_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColorLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandComboChartFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["line_data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.LineDataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["reference_lines"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["reference_lines"].([]any); ok && len(v) > 0 {
 		apiObject.ReferenceLines = expandReferenceLines(v)
 	}
-	if v, ok := tfMap["secondary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryYAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["secondary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandComboChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandComboChartFieldWells(tfList []interface{}) *awstypes.ComboChartFieldWells {
+func expandComboChartFieldWells(tfList []any) *awstypes.ComboChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ComboChartFieldWells{}
 
-	if v, ok := tfMap["combo_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["combo_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.ComboChartAggregatedFieldWells = expandComboChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandComboChartAggregatedFieldWells(tfList []interface{}) *awstypes.ComboChartAggregatedFieldWells {
+func expandComboChartAggregatedFieldWells(tfList []any) *awstypes.ComboChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ComboChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["bar_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bar_values"].([]any); ok && len(v) > 0 {
 		apiObject.BarValues = expandMeasureFields(v)
 	}
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["line_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_values"].([]any); ok && len(v) > 0 {
 		apiObject.LineValues = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandComboChartSortConfiguration(tfList []interface{}) *awstypes.ComboChartSortConfiguration {
+func expandComboChartSortConfiguration(tfList []any) *awstypes.ComboChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ComboChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["color_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.ColorItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["color_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_sort"].([]any); ok && len(v) > 0 {
 		apiObject.ColorSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func flattenComboChartVisual(apiObject *awstypes.ComboChartVisual) []interface{} {
+func flattenComboChartVisual(apiObject *awstypes.ComboChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -290,15 +290,15 @@ func flattenComboChartVisual(apiObject *awstypes.ComboChartVisual) []interface{}
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComboChartConfiguration(apiObject *awstypes.ComboChartConfiguration) []interface{} {
+func flattenComboChartConfiguration(apiObject *awstypes.ComboChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BarDataLabels != nil {
 		tfMap["bar_data_labels"] = flattenDataLabelOptions(apiObject.BarDataLabels)
@@ -347,29 +347,29 @@ func flattenComboChartConfiguration(apiObject *awstypes.ComboChartConfiguration)
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComboChartFieldWells(apiObject *awstypes.ComboChartFieldWells) []interface{} {
+func flattenComboChartFieldWells(apiObject *awstypes.ComboChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComboChartAggregatedFieldWells != nil {
 		tfMap["combo_chart_aggregated_field_wells"] = flattenComboChartAggregatedFieldWells(apiObject.ComboChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComboChartAggregatedFieldWells(apiObject *awstypes.ComboChartAggregatedFieldWells) []interface{} {
+func flattenComboChartAggregatedFieldWells(apiObject *awstypes.ComboChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BarValues != nil {
 		tfMap["bar_values"] = flattenMeasureFields(apiObject.BarValues)
@@ -384,15 +384,15 @@ func flattenComboChartAggregatedFieldWells(apiObject *awstypes.ComboChartAggrega
 		tfMap["line_values"] = flattenMeasureFields(apiObject.LineValues)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComboChartSortConfiguration(apiObject *awstypes.ComboChartSortConfiguration) []interface{} {
+func flattenComboChartSortConfiguration(apiObject *awstypes.ComboChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -407,5 +407,5 @@ func flattenComboChartSortConfiguration(apiObject *awstypes.ComboChartSortConfig
 		tfMap["color_sort"] = flattenFieldSortOptions(apiObject.ColorSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_conditional_formatting.go
+++ b/internal/service/quicksight/schema/visual_conditional_formatting.go
@@ -136,34 +136,34 @@ var conditionalFormattingIconSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandConditionalFormattingColor(tfList []interface{}) *awstypes.ConditionalFormattingColor {
+func expandConditionalFormattingColor(tfList []any) *awstypes.ConditionalFormattingColor {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ConditionalFormattingColor{}
 
-	if v, ok := tfMap["gradient"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["gradient"].([]any); ok && len(v) > 0 {
 		apiObject.Gradient = expandConditionalFormattingGradientColor(v)
 	}
-	if v, ok := tfMap["solid"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["solid"].([]any); ok && len(v) > 0 {
 		apiObject.Solid = expandConditionalFormattingSolidColor(v)
 	}
 
 	return apiObject
 }
 
-func expandConditionalFormattingGradientColor(tfList []interface{}) *awstypes.ConditionalFormattingGradientColor {
+func expandConditionalFormattingGradientColor(tfList []any) *awstypes.ConditionalFormattingGradientColor {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -173,33 +173,33 @@ func expandConditionalFormattingGradientColor(tfList []interface{}) *awstypes.Co
 	if v, ok := tfMap[names.AttrExpression].(string); ok && v != "" {
 		apiObject.Expression = aws.String(v)
 	}
-	if v, ok := tfMap["color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color"].([]any); ok && len(v) > 0 {
 		apiObject.Color = expandGradientColor(v)
 	}
 
 	return apiObject
 }
 
-func expandGradientColor(tfList []interface{}) *awstypes.GradientColor {
+func expandGradientColor(tfList []any) *awstypes.GradientColor {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GradientColor{}
 
-	if v, ok := tfMap["stops"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["stops"].([]any); ok && len(v) > 0 {
 		apiObject.Stops = expandGradientStops(v)
 	}
 
 	return apiObject
 }
 
-func expandGradientStops(tfList []interface{}) []awstypes.GradientStop {
+func expandGradientStops(tfList []any) []awstypes.GradientStop {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -207,7 +207,7 @@ func expandGradientStops(tfList []interface{}) []awstypes.GradientStop {
 	var apiObjects []awstypes.GradientStop
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -223,7 +223,7 @@ func expandGradientStops(tfList []interface{}) []awstypes.GradientStop {
 	return apiObjects
 }
 
-func expandGradientStop(tfMap map[string]interface{}) *awstypes.GradientStop {
+func expandGradientStop(tfMap map[string]any) *awstypes.GradientStop {
 	if tfMap == nil {
 		return nil
 	}
@@ -243,12 +243,12 @@ func expandGradientStop(tfMap map[string]interface{}) *awstypes.GradientStop {
 	return apiObject
 }
 
-func expandConditionalFormattingSolidColor(tfList []interface{}) *awstypes.ConditionalFormattingSolidColor {
+func expandConditionalFormattingSolidColor(tfList []any) *awstypes.ConditionalFormattingSolidColor {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -265,34 +265,34 @@ func expandConditionalFormattingSolidColor(tfList []interface{}) *awstypes.Condi
 	return apiObject
 }
 
-func expandConditionalFormattingIcon(tfList []interface{}) *awstypes.ConditionalFormattingIcon {
+func expandConditionalFormattingIcon(tfList []any) *awstypes.ConditionalFormattingIcon {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ConditionalFormattingIcon{}
 
-	if v, ok := tfMap["custom_condition"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_condition"].([]any); ok && len(v) > 0 {
 		apiObject.CustomCondition = expandConditionalFormattingCustomIconCondition(v)
 	}
-	if v, ok := tfMap["icon_set"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon_set"].([]any); ok && len(v) > 0 {
 		apiObject.IconSet = expandConditionalFormattingIconSet(v)
 	}
 
 	return apiObject
 }
 
-func expandConditionalFormattingCustomIconCondition(tfList []interface{}) *awstypes.ConditionalFormattingCustomIconCondition {
+func expandConditionalFormattingCustomIconCondition(tfList []any) *awstypes.ConditionalFormattingCustomIconCondition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -305,22 +305,22 @@ func expandConditionalFormattingCustomIconCondition(tfList []interface{}) *awsty
 	if v, ok := tfMap[names.AttrExpression].(string); ok && v != "" {
 		apiObject.Expression = aws.String(v)
 	}
-	if v, ok := tfMap["icon_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon_options"].([]any); ok && len(v) > 0 {
 		apiObject.IconOptions = expandConditionalFormattingCustomIconOptions(v)
 	}
-	if v, ok := tfMap["display_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["display_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.DisplayConfiguration = expandConditionalFormattingIconDisplayConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandConditionalFormattingCustomIconOptions(tfList []interface{}) *awstypes.ConditionalFormattingCustomIconOptions {
+func expandConditionalFormattingCustomIconOptions(tfList []any) *awstypes.ConditionalFormattingCustomIconOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -337,12 +337,12 @@ func expandConditionalFormattingCustomIconOptions(tfList []interface{}) *awstype
 	return apiObject
 }
 
-func expandConditionalFormattingIconDisplayConfiguration(tfList []interface{}) *awstypes.ConditionalFormattingIconDisplayConfiguration {
+func expandConditionalFormattingIconDisplayConfiguration(tfList []any) *awstypes.ConditionalFormattingIconDisplayConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -356,12 +356,12 @@ func expandConditionalFormattingIconDisplayConfiguration(tfList []interface{}) *
 	return apiObject
 }
 
-func expandConditionalFormattingIconSet(tfList []interface{}) *awstypes.ConditionalFormattingIconSet {
+func expandConditionalFormattingIconSet(tfList []any) *awstypes.ConditionalFormattingIconSet {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -378,37 +378,37 @@ func expandConditionalFormattingIconSet(tfList []interface{}) *awstypes.Conditio
 	return apiObject
 }
 
-func expandTextConditionalFormat(tfList []interface{}) *awstypes.TextConditionalFormat {
+func expandTextConditionalFormat(tfList []any) *awstypes.TextConditionalFormat {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TextConditionalFormat{}
 
-	if v, ok := tfMap["background_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["background_color"].([]any); ok && len(v) > 0 {
 		apiObject.BackgroundColor = expandConditionalFormattingColor(v)
 	}
-	if v, ok := tfMap["icon"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon"].([]any); ok && len(v) > 0 {
 		apiObject.Icon = expandConditionalFormattingIcon(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func flattenConditionalFormattingColor(apiObject *awstypes.ConditionalFormattingColor) []interface{} {
+func flattenConditionalFormattingColor(apiObject *awstypes.ConditionalFormattingColor) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Gradient != nil {
 		tfMap["gradient"] = flattenConditionalFormattingGradientColor(apiObject.Gradient)
@@ -417,15 +417,15 @@ func flattenConditionalFormattingColor(apiObject *awstypes.ConditionalFormatting
 		tfMap["solid"] = flattenConditionalFormattingSolidColor(apiObject.Solid)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingGradientColor(apiObject *awstypes.ConditionalFormattingGradientColor) []interface{} {
+func flattenConditionalFormattingGradientColor(apiObject *awstypes.ConditionalFormattingGradientColor) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = flattenGradientColor(apiObject.Color)
@@ -434,32 +434,32 @@ func flattenConditionalFormattingGradientColor(apiObject *awstypes.ConditionalFo
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGradientColor(apiObject *awstypes.GradientColor) []interface{} {
+func flattenGradientColor(apiObject *awstypes.GradientColor) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Stops != nil {
 		tfMap["stops"] = flattenGradientStop(apiObject.Stops)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGradientStop(apiObjects []awstypes.GradientStop) []interface{} {
+func flattenGradientStop(apiObjects []awstypes.GradientStop) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		tfMap["gradient_offset"] = apiObject.GradientOffset
 		if apiObject.Color != nil {
@@ -475,12 +475,12 @@ func flattenGradientStop(apiObjects []awstypes.GradientStop) []interface{} {
 	return tfList
 }
 
-func flattenConditionalFormattingSolidColor(apiObject *awstypes.ConditionalFormattingSolidColor) []interface{} {
+func flattenConditionalFormattingSolidColor(apiObject *awstypes.ConditionalFormattingSolidColor) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
@@ -489,15 +489,15 @@ func flattenConditionalFormattingSolidColor(apiObject *awstypes.ConditionalForma
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingIcon(apiObject *awstypes.ConditionalFormattingIcon) []interface{} {
+func flattenConditionalFormattingIcon(apiObject *awstypes.ConditionalFormattingIcon) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomCondition != nil {
 		tfMap["custom_condition"] = flattenConditionalFormattingCustomIconCondition(apiObject.CustomCondition)
@@ -506,15 +506,15 @@ func flattenConditionalFormattingIcon(apiObject *awstypes.ConditionalFormattingI
 		tfMap["icon_set"] = flattenConditionalFormattingIconSet(apiObject.IconSet)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingCustomIconCondition(apiObject *awstypes.ConditionalFormattingCustomIconCondition) []interface{} {
+func flattenConditionalFormattingCustomIconCondition(apiObject *awstypes.ConditionalFormattingCustomIconCondition) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
@@ -529,47 +529,47 @@ func flattenConditionalFormattingCustomIconCondition(apiObject *awstypes.Conditi
 		tfMap["display_configuration"] = flattenConditionalFormattingIconDisplayConfiguration(apiObject.DisplayConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingCustomIconOptions(apiObject *awstypes.ConditionalFormattingCustomIconOptions) []interface{} {
+func flattenConditionalFormattingCustomIconOptions(apiObject *awstypes.ConditionalFormattingCustomIconOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["icon"] = apiObject.Icon
 	if apiObject.UnicodeIcon != nil {
 		tfMap["unicode_icon"] = aws.ToString(apiObject.UnicodeIcon)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingIconDisplayConfiguration(apiObject *awstypes.ConditionalFormattingIconDisplayConfiguration) []interface{} {
+func flattenConditionalFormattingIconDisplayConfiguration(apiObject *awstypes.ConditionalFormattingIconDisplayConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"icon_display_option": apiObject.IconDisplayOption,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionalFormattingIconSet(apiObject *awstypes.ConditionalFormattingIconSet) []interface{} {
+func flattenConditionalFormattingIconSet(apiObject *awstypes.ConditionalFormattingIconSet) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Expression != nil {
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 	}
 	tfMap["icon_set_type"] = apiObject.IconSetType
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_custom_content.go
+++ b/internal/service/quicksight/schema/visual_custom_content.go
@@ -43,12 +43,12 @@ func customContentVisualSchema() *schema.Schema {
 	}
 }
 
-func expandCustomContentVisual(tfList []interface{}) *awstypes.CustomContentVisual {
+func expandCustomContentVisual(tfList []any) *awstypes.CustomContentVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -61,28 +61,28 @@ func expandCustomContentVisual(tfList []interface{}) *awstypes.CustomContentVisu
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandCustomContentConfiguration(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandCustomContentConfiguration(tfList []interface{}) *awstypes.CustomContentConfiguration {
+func expandCustomContentConfiguration(tfList []any) *awstypes.CustomContentConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -102,12 +102,12 @@ func expandCustomContentConfiguration(tfList []interface{}) *awstypes.CustomCont
 	return apiObject
 }
 
-func flattenCustomContentVisual(apiObject *awstypes.CustomContentVisual) []interface{} {
+func flattenCustomContentVisual(apiObject *awstypes.CustomContentVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"data_set_identifier": aws.ToString(apiObject.DataSetIdentifier),
 		"visual_id":           aws.ToString(apiObject.VisualId),
 	}
@@ -125,15 +125,15 @@ func flattenCustomContentVisual(apiObject *awstypes.CustomContentVisual) []inter
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomContentConfiguration(apiObject *awstypes.CustomContentConfiguration) []interface{} {
+func flattenCustomContentConfiguration(apiObject *awstypes.CustomContentConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrContentType] = apiObject.ContentType
 	if apiObject.ContentUrl != nil {
@@ -141,5 +141,5 @@ func flattenCustomContentConfiguration(apiObject *awstypes.CustomContentConfigur
 	}
 	tfMap["image_scaling"] = apiObject.ImageScaling
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_empty.go
+++ b/internal/service/quicksight/schema/visual_empty.go
@@ -26,12 +26,12 @@ func emptyVisualSchema() *schema.Schema {
 	}
 }
 
-func expandEmptyVisual(tfList []interface{}) *awstypes.EmptyVisual {
+func expandEmptyVisual(tfList []any) *awstypes.EmptyVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -44,19 +44,19 @@ func expandEmptyVisual(tfList []interface{}) *awstypes.EmptyVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
 
 	return apiObject
 }
 
-func flattenEmptyVisual(apiObject *awstypes.EmptyVisual) []interface{} {
+func flattenEmptyVisual(apiObject *awstypes.EmptyVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"data_set_identifier": aws.ToString(apiObject.DataSetIdentifier),
 		"visual_id":           aws.ToString(apiObject.VisualId),
 	}
@@ -65,5 +65,5 @@ func flattenEmptyVisual(apiObject *awstypes.EmptyVisual) []interface{} {
 		tfMap[names.AttrActions] = flattenVisualCustomAction(apiObject.Actions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_fields.go
+++ b/internal/service/quicksight/schema/visual_fields.go
@@ -184,7 +184,7 @@ func measureFieldSchema(maxItems measureFieldsSize) *schema.Schema {
 	return s
 }
 
-func expandDimensionFields(tfList []interface{}) []awstypes.DimensionField {
+func expandDimensionFields(tfList []any) []awstypes.DimensionField {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -192,7 +192,7 @@ func expandDimensionFields(tfList []interface{}) []awstypes.DimensionField {
 	var apiObjects []awstypes.DimensionField
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -208,32 +208,32 @@ func expandDimensionFields(tfList []interface{}) []awstypes.DimensionField {
 	return apiObjects
 }
 
-func expandDimensionInternal(tfMap map[string]interface{}) *awstypes.DimensionField {
+func expandDimensionInternal(tfMap map[string]any) *awstypes.DimensionField {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DimensionField{}
 
-	if v, ok := tfMap["categorical_dimension_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["categorical_dimension_field"].([]any); ok && len(v) > 0 {
 		apiObject.CategoricalDimensionField = expandCategoricalDimensionField(v)
 	}
-	if v, ok := tfMap["date_dimension_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_dimension_field"].([]any); ok && len(v) > 0 {
 		apiObject.DateDimensionField = expandDateDimensionField(v)
 	}
-	if v, ok := tfMap["numerical_dimension_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numerical_dimension_field"].([]any); ok && len(v) > 0 {
 		apiObject.NumericalDimensionField = expandNumericalDimensionField(v)
 	}
 
 	return apiObject
 }
 
-func expandDimensionField(tfList []interface{}) *awstypes.DimensionField {
+func expandDimensionField(tfList []any) *awstypes.DimensionField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -245,12 +245,12 @@ func expandDimensionField(tfList []interface{}) *awstypes.DimensionField {
 	return expandDimensionInternal(tfMap)
 }
 
-func expandCategoricalDimensionField(tfList []interface{}) *awstypes.CategoricalDimensionField {
+func expandCategoricalDimensionField(tfList []any) *awstypes.CategoricalDimensionField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -263,22 +263,22 @@ func expandCategoricalDimensionField(tfList []interface{}) *awstypes.Categorical
 	if v, ok := tfMap["hierarchy_id"].(string); ok && v != "" {
 		apiObject.HierarchyId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandStringFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDateDimensionField(tfList []interface{}) *awstypes.DateDimensionField {
+func expandDateDimensionField(tfList []any) *awstypes.DateDimensionField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -294,22 +294,22 @@ func expandDateDimensionField(tfList []interface{}) *awstypes.DateDimensionField
 	if v, ok := tfMap["date_granularity"].(string); ok && v != "" {
 		apiObject.DateGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandDateTimeFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandNumericalDimensionField(tfList []interface{}) *awstypes.NumericalDimensionField {
+func expandNumericalDimensionField(tfList []any) *awstypes.NumericalDimensionField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -322,17 +322,17 @@ func expandNumericalDimensionField(tfList []interface{}) *awstypes.NumericalDime
 	if v, ok := tfMap["hierarchy_id"].(string); ok && v != "" {
 		apiObject.HierarchyId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandNumberFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandMeasureFields(tfList []interface{}) []awstypes.MeasureField {
+func expandMeasureFields(tfList []any) []awstypes.MeasureField {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -340,7 +340,7 @@ func expandMeasureFields(tfList []interface{}) []awstypes.MeasureField {
 	var apiObjects []awstypes.MeasureField
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -356,35 +356,35 @@ func expandMeasureFields(tfList []interface{}) []awstypes.MeasureField {
 	return apiObjects
 }
 
-func expandMeasureFieldInternal(tfMap map[string]interface{}) *awstypes.MeasureField {
+func expandMeasureFieldInternal(tfMap map[string]any) *awstypes.MeasureField {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.MeasureField{}
 
-	if v, ok := tfMap["calculated_measure_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["calculated_measure_field"].([]any); ok && len(v) > 0 {
 		apiObject.CalculatedMeasureField = expandCalculatedMeasureField(v)
 	}
-	if v, ok := tfMap["categorical_measure_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["categorical_measure_field"].([]any); ok && len(v) > 0 {
 		apiObject.CategoricalMeasureField = expandCategoricalMeasureField(v)
 	}
-	if v, ok := tfMap["date_measure_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["date_measure_field"].([]any); ok && len(v) > 0 {
 		apiObject.DateMeasureField = expandDateMeasureField(v)
 	}
-	if v, ok := tfMap["numerical_measure_field"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["numerical_measure_field"].([]any); ok && len(v) > 0 {
 		apiObject.NumericalMeasureField = expandNumericalMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandMeasureField(tfList []interface{}) *awstypes.MeasureField {
+func expandMeasureField(tfList []any) *awstypes.MeasureField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -392,12 +392,12 @@ func expandMeasureField(tfList []interface{}) *awstypes.MeasureField {
 	return expandMeasureFieldInternal(tfMap)
 }
 
-func expandCalculatedMeasureField(tfList []interface{}) *awstypes.CalculatedMeasureField {
+func expandCalculatedMeasureField(tfList []any) *awstypes.CalculatedMeasureField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -414,12 +414,12 @@ func expandCalculatedMeasureField(tfList []interface{}) *awstypes.CalculatedMeas
 	return apiObject
 }
 
-func expandCategoricalMeasureField(tfList []interface{}) *awstypes.CategoricalMeasureField {
+func expandCategoricalMeasureField(tfList []any) *awstypes.CategoricalMeasureField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -432,22 +432,22 @@ func expandCategoricalMeasureField(tfList []interface{}) *awstypes.CategoricalMe
 	if v, ok := tfMap["aggregation_function"].(string); ok && v != "" {
 		apiObject.AggregationFunction = awstypes.CategoricalAggregationFunction(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandStringFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandDateMeasureField(tfList []interface{}) *awstypes.DateMeasureField {
+func expandDateMeasureField(tfList []any) *awstypes.DateMeasureField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -460,22 +460,22 @@ func expandDateMeasureField(tfList []interface{}) *awstypes.DateMeasureField {
 	if v, ok := tfMap["aggregation_function"].(string); ok && v != "" {
 		apiObject.AggregationFunction = awstypes.DateAggregationFunction(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandDateTimeFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandNumericalMeasureField(tfList []interface{}) *awstypes.NumericalMeasureField {
+func expandNumericalMeasureField(tfList []any) *awstypes.NumericalMeasureField {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -485,25 +485,25 @@ func expandNumericalMeasureField(tfList []interface{}) *awstypes.NumericalMeasur
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationFunction = expandNumericalAggregationFunction(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandNumberFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func flattenDimensionField(apiObject *awstypes.DimensionField) []interface{} {
+func flattenDimensionField(apiObject *awstypes.DimensionField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoricalDimensionField != nil {
 		tfMap["categorical_dimension_field"] = flattenCategoricalDimensionField(apiObject.CategoricalDimensionField)
@@ -515,18 +515,18 @@ func flattenDimensionField(apiObject *awstypes.DimensionField) []interface{} {
 		tfMap["numerical_dimension_field"] = flattenNumericalDimensionField(apiObject.NumericalDimensionField)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDimensionFields(apiObjects []awstypes.DimensionField) []interface{} {
+func flattenDimensionFields(apiObjects []awstypes.DimensionField) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.CategoricalDimensionField != nil {
 			tfMap["categorical_dimension_field"] = flattenCategoricalDimensionField(apiObject.CategoricalDimensionField)
@@ -544,12 +544,12 @@ func flattenDimensionFields(apiObjects []awstypes.DimensionField) []interface{} 
 	return tfList
 }
 
-func flattenCategoricalDimensionField(apiObject *awstypes.CategoricalDimensionField) []interface{} {
+func flattenCategoricalDimensionField(apiObject *awstypes.CategoricalDimensionField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -564,15 +564,15 @@ func flattenCategoricalDimensionField(apiObject *awstypes.CategoricalDimensionFi
 		tfMap["hierarchy_id"] = aws.ToString(apiObject.HierarchyId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateDimensionField(apiObject *awstypes.DateDimensionField) []interface{} {
+func flattenDateDimensionField(apiObject *awstypes.DateDimensionField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -588,15 +588,15 @@ func flattenDateDimensionField(apiObject *awstypes.DateDimensionField) []interfa
 		tfMap["hierarchy_id"] = aws.ToString(apiObject.HierarchyId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericalDimensionField(apiObject *awstypes.NumericalDimensionField) []interface{} {
+func flattenNumericalDimensionField(apiObject *awstypes.NumericalDimensionField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -611,15 +611,15 @@ func flattenNumericalDimensionField(apiObject *awstypes.NumericalDimensionField)
 		tfMap["hierarchy_id"] = aws.ToString(apiObject.HierarchyId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMeasureField(apiObject *awstypes.MeasureField) []interface{} {
+func flattenMeasureField(apiObject *awstypes.MeasureField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CalculatedMeasureField != nil {
 		tfMap["calculated_measure_field"] = flattenCalculatedMeasureField(apiObject.CalculatedMeasureField)
@@ -634,18 +634,18 @@ func flattenMeasureField(apiObject *awstypes.MeasureField) []interface{} {
 		tfMap["numerical_measure_field"] = flattenNumericalMeasureField(apiObject.NumericalMeasureField)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMeasureFields(apiObjects []awstypes.MeasureField) []interface{} {
+func flattenMeasureFields(apiObjects []awstypes.MeasureField) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.CalculatedMeasureField != nil {
 			tfMap["calculated_measure_field"] = flattenCalculatedMeasureField(apiObject.CalculatedMeasureField)
@@ -666,12 +666,12 @@ func flattenMeasureFields(apiObjects []awstypes.MeasureField) []interface{} {
 	return tfList
 }
 
-func flattenCalculatedMeasureField(apiObject *awstypes.CalculatedMeasureField) []interface{} {
+func flattenCalculatedMeasureField(apiObject *awstypes.CalculatedMeasureField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -680,15 +680,15 @@ func flattenCalculatedMeasureField(apiObject *awstypes.CalculatedMeasureField) [
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCategoricalMeasureField(apiObject *awstypes.CategoricalMeasureField) []interface{} {
+func flattenCategoricalMeasureField(apiObject *awstypes.CategoricalMeasureField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["aggregation_function"] = apiObject.AggregationFunction
 	if apiObject.Column != nil {
@@ -701,15 +701,15 @@ func flattenCategoricalMeasureField(apiObject *awstypes.CategoricalMeasureField)
 		tfMap["format_configuration"] = flattenStringFormatConfiguration(apiObject.FormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDateMeasureField(apiObject *awstypes.DateMeasureField) []interface{} {
+func flattenDateMeasureField(apiObject *awstypes.DateMeasureField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["aggregation_function"] = apiObject.AggregationFunction
 	if apiObject.Column != nil {
@@ -722,15 +722,15 @@ func flattenDateMeasureField(apiObject *awstypes.DateMeasureField) []interface{}
 		tfMap["format_configuration"] = flattenDateTimeFormatConfiguration(apiObject.FormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenNumericalMeasureField(apiObject *awstypes.NumericalMeasureField) []interface{} {
+func flattenNumericalMeasureField(apiObject *awstypes.NumericalMeasureField) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AggregationFunction != nil {
 		tfMap["aggregation_function"] = flattenNumericalAggregationFunction(apiObject.AggregationFunction)
@@ -745,5 +745,5 @@ func flattenNumericalMeasureField(apiObject *awstypes.NumericalMeasureField) []i
 		tfMap["format_configuration"] = flattenNumberFormatConfiguration(apiObject.FormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_filled_map.go
+++ b/internal/service/quicksight/schema/visual_filled_map.go
@@ -119,12 +119,12 @@ func filledMapVisualSchema() *schema.Schema {
 	}
 }
 
-func expandFilledMapVisual(tfList []interface{}) *awstypes.FilledMapVisual {
+func expandFilledMapVisual(tfList []any) *awstypes.FilledMapVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -134,142 +134,142 @@ func expandFilledMapVisual(tfList []interface{}) *awstypes.FilledMapVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandFilledMapConfiguration(v)
 	}
-	if v, ok := tfMap["conditional_formatting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormatting = expandFilledMapConditionalFormatting(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapConfiguration(tfList []interface{}) *awstypes.FilledMapConfiguration {
+func expandFilledMapConfiguration(tfList []any) *awstypes.FilledMapConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapConfiguration{}
 
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandFilledMapFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["map_style_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["map_style_options"].([]any); ok && len(v) > 0 {
 		apiObject.MapStyleOptions = expandGeospatialMapStyleOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandFilledMapSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["value_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_axis"].([]any); ok && len(v) > 0 {
 		apiObject.WindowOptions = expandGeospatialWindowOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapFieldWells(tfList []interface{}) *awstypes.FilledMapFieldWells {
+func expandFilledMapFieldWells(tfList []any) *awstypes.FilledMapFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapFieldWells{}
 
-	if v, ok := tfMap["filled_map_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["filled_map_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FilledMapAggregatedFieldWells = expandFilledMapAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapAggregatedFieldWells(tfList []interface{}) *awstypes.FilledMapAggregatedFieldWells {
+func expandFilledMapAggregatedFieldWells(tfList []any) *awstypes.FilledMapAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapAggregatedFieldWells{}
 
-	if v, ok := tfMap["geospatial"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["geospatial"].([]any); ok && len(v) > 0 {
 		apiObject.Geospatial = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapSortConfiguration(tfList []interface{}) *awstypes.FilledMapSortConfiguration {
+func expandFilledMapSortConfiguration(tfList []any) *awstypes.FilledMapSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapSortConfiguration{}
 
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapConditionalFormatting(tfList []interface{}) *awstypes.FilledMapConditionalFormatting {
+func expandFilledMapConditionalFormatting(tfList []any) *awstypes.FilledMapConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapConditionalFormatting{}
 
-	if v, ok := tfMap["conditional_formatting_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting_options"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormattingOptions = expandFilledMapConditionalFormattingOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapConditionalFormattingOptions(tfList []interface{}) []awstypes.FilledMapConditionalFormattingOption {
+func expandFilledMapConditionalFormattingOptions(tfList []any) []awstypes.FilledMapConditionalFormattingOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -277,7 +277,7 @@ func expandFilledMapConditionalFormattingOptions(tfList []interface{}) []awstype
 	var apiObjects []awstypes.FilledMapConditionalFormattingOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -293,26 +293,26 @@ func expandFilledMapConditionalFormattingOptions(tfList []interface{}) []awstype
 	return apiObjects
 }
 
-func expandFilledMapConditionalFormattingOption(tfMap map[string]interface{}) *awstypes.FilledMapConditionalFormattingOption {
+func expandFilledMapConditionalFormattingOption(tfMap map[string]any) *awstypes.FilledMapConditionalFormattingOption {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.FilledMapConditionalFormattingOption{}
 
-	if v, ok := tfMap["shape"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["shape"].([]any); ok && len(v) > 0 {
 		apiObject.Shape = expandFilledMapShapeConditionalFormatting(v)
 	}
 
 	return apiObject
 }
 
-func expandFilledMapShapeConditionalFormatting(tfList []interface{}) *awstypes.FilledMapShapeConditionalFormatting {
+func expandFilledMapShapeConditionalFormatting(tfList []any) *awstypes.FilledMapShapeConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -322,38 +322,38 @@ func expandFilledMapShapeConditionalFormatting(tfList []interface{}) *awstypes.F
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrFormat].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrFormat].([]any); ok && len(v) > 0 {
 		apiObject.Format = expandShapeConditionalFormat(v)
 	}
 
 	return apiObject
 }
 
-func expandShapeConditionalFormat(tfList []interface{}) *awstypes.ShapeConditionalFormat {
+func expandShapeConditionalFormat(tfList []any) *awstypes.ShapeConditionalFormat {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ShapeConditionalFormat{}
 
-	if v, ok := tfMap["background_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["background_color"].([]any); ok && len(v) > 0 {
 		apiObject.BackgroundColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func flattenFilledMapVisual(apiObject *awstypes.FilledMapVisual) []interface{} {
+func flattenFilledMapVisual(apiObject *awstypes.FilledMapVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -376,15 +376,15 @@ func flattenFilledMapVisual(apiObject *awstypes.FilledMapVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapConfiguration(apiObject *awstypes.FilledMapConfiguration) []interface{} {
+func flattenFilledMapConfiguration(apiObject *awstypes.FilledMapConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldWells != nil {
 		tfMap["field_wells"] = flattenFilledMapFieldWells(apiObject.FieldWells)
@@ -405,29 +405,29 @@ func flattenFilledMapConfiguration(apiObject *awstypes.FilledMapConfiguration) [
 		tfMap["window_options"] = flattenGeospatialWindowOptions(apiObject.WindowOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapFieldWells(apiObject *awstypes.FilledMapFieldWells) []interface{} {
+func flattenFilledMapFieldWells(apiObject *awstypes.FilledMapFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FilledMapAggregatedFieldWells != nil {
 		tfMap["filled_map_aggregated_field_wells"] = flattenFilledMapAggregatedFieldWells(apiObject.FilledMapAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapAggregatedFieldWells(apiObject *awstypes.FilledMapAggregatedFieldWells) []interface{} {
+func flattenFilledMapAggregatedFieldWells(apiObject *awstypes.FilledMapAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Geospatial != nil {
 		tfMap["geospatial"] = flattenDimensionFields(apiObject.Geospatial)
@@ -436,46 +436,46 @@ func flattenFilledMapAggregatedFieldWells(apiObject *awstypes.FilledMapAggregate
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapSortConfiguration(apiObject *awstypes.FilledMapSortConfiguration) []interface{} {
+func flattenFilledMapSortConfiguration(apiObject *awstypes.FilledMapSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategorySort != nil {
 		tfMap["category_sort"] = flattenFieldSortOptions(apiObject.CategorySort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapConditionalFormatting(apiObject *awstypes.FilledMapConditionalFormatting) []interface{} {
+func flattenFilledMapConditionalFormatting(apiObject *awstypes.FilledMapConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionalFormattingOptions != nil {
 		tfMap["conditional_formatting_options"] = flattenFilledMapConditionalFormattingOption(apiObject.ConditionalFormattingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFilledMapConditionalFormattingOption(apiObjects []awstypes.FilledMapConditionalFormattingOption) []interface{} {
+func flattenFilledMapConditionalFormattingOption(apiObjects []awstypes.FilledMapConditionalFormattingOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Shape != nil {
 			tfMap["shape"] = flattenFilledMapShapeConditionalFormatting(apiObject.Shape)
@@ -487,12 +487,12 @@ func flattenFilledMapConditionalFormattingOption(apiObjects []awstypes.FilledMap
 	return tfList
 }
 
-func flattenFilledMapShapeConditionalFormatting(apiObject *awstypes.FilledMapShapeConditionalFormatting) []interface{} {
+func flattenFilledMapShapeConditionalFormatting(apiObject *awstypes.FilledMapShapeConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -501,19 +501,19 @@ func flattenFilledMapShapeConditionalFormatting(apiObject *awstypes.FilledMapSha
 		tfMap[names.AttrFormat] = flattenShapeConditionalFormat(apiObject.Format)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenShapeConditionalFormat(apiObject *awstypes.ShapeConditionalFormat) []interface{} {
+func flattenShapeConditionalFormat(apiObject *awstypes.ShapeConditionalFormat) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BackgroundColor != nil {
 		tfMap["background_color"] = flattenConditionalFormattingColor(apiObject.BackgroundColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_funnel_chart.go
+++ b/internal/service/quicksight/schema/visual_funnel_chart.go
@@ -95,12 +95,12 @@ func funnelChartVisualSchema() *schema.Schema {
 	}
 }
 
-func expandFunnelChartVisual(tfList []interface{}) *awstypes.FunnelChartVisual {
+func expandFunnelChartVisual(tfList []any) *awstypes.FunnelChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -110,131 +110,131 @@ func expandFunnelChartVisual(tfList []interface{}) *awstypes.FunnelChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandFunnelChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandFunnelChartConfiguration(tfList []interface{}) *awstypes.FunnelChartConfiguration {
+func expandFunnelChartConfiguration(tfList []any) *awstypes.FunnelChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FunnelChartConfiguration{}
 
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["data_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabelOptions = expandFunnelChartDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandFunnelChartFieldWells(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandFunnelChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["value_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ValueLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandFunnelChartFieldWells(tfList []interface{}) *awstypes.FunnelChartFieldWells {
+func expandFunnelChartFieldWells(tfList []any) *awstypes.FunnelChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FunnelChartFieldWells{}
 
-	if v, ok := tfMap["funnel_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["funnel_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FunnelChartAggregatedFieldWells = expandFunnelChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandFunnelChartAggregatedFieldWells(tfList []interface{}) *awstypes.FunnelChartAggregatedFieldWells {
+func expandFunnelChartAggregatedFieldWells(tfList []any) *awstypes.FunnelChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FunnelChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandFunnelChartSortConfiguration(tfList []interface{}) *awstypes.FunnelChartSortConfiguration {
+func expandFunnelChartSortConfiguration(tfList []any) *awstypes.FunnelChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.FunnelChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandFunnelChartDataLabelOptions(tfList []interface{}) *awstypes.FunnelChartDataLabelOptions {
+func expandFunnelChartDataLabelOptions(tfList []any) *awstypes.FunnelChartDataLabelOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -259,19 +259,19 @@ func expandFunnelChartDataLabelOptions(tfList []interface{}) *awstypes.FunnelCha
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["label_font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["label_font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LabelFontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func flattenFunnelChartVisual(apiObject *awstypes.FunnelChartVisual) []interface{} {
+func flattenFunnelChartVisual(apiObject *awstypes.FunnelChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -291,15 +291,15 @@ func flattenFunnelChartVisual(apiObject *awstypes.FunnelChartVisual) []interface
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunnelChartConfiguration(apiObject *awstypes.FunnelChartConfiguration) []interface{} {
+func flattenFunnelChartConfiguration(apiObject *awstypes.FunnelChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryLabelOptions != nil {
 		tfMap["category_label_options"] = flattenChartAxisLabelOptions(apiObject.CategoryLabelOptions)
@@ -323,15 +323,15 @@ func flattenFunnelChartConfiguration(apiObject *awstypes.FunnelChartConfiguratio
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunnelChartDataLabelOptions(apiObject *awstypes.FunnelChartDataLabelOptions) []interface{} {
+func flattenFunnelChartDataLabelOptions(apiObject *awstypes.FunnelChartDataLabelOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["category_label_visibility"] = apiObject.CategoryLabelVisibility
 	if apiObject.LabelColor != nil {
@@ -345,29 +345,29 @@ func flattenFunnelChartDataLabelOptions(apiObject *awstypes.FunnelChartDataLabel
 	tfMap["position"] = apiObject.Position
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunnelChartFieldWells(apiObject *awstypes.FunnelChartFieldWells) []interface{} {
+func flattenFunnelChartFieldWells(apiObject *awstypes.FunnelChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FunnelChartAggregatedFieldWells != nil {
 		tfMap["funnel_chart_aggregated_field_wells"] = flattenFunnelChartAggregatedFieldWells(apiObject.FunnelChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunnelChartAggregatedFieldWells(apiObject *awstypes.FunnelChartAggregatedFieldWells) []interface{} {
+func flattenFunnelChartAggregatedFieldWells(apiObject *awstypes.FunnelChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -376,15 +376,15 @@ func flattenFunnelChartAggregatedFieldWells(apiObject *awstypes.FunnelChartAggre
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunnelChartSortConfiguration(apiObject *awstypes.FunnelChartSortConfiguration) []interface{} {
+func flattenFunnelChartSortConfiguration(apiObject *awstypes.FunnelChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -393,5 +393,5 @@ func flattenFunnelChartSortConfiguration(apiObject *awstypes.FunnelChartSortConf
 		tfMap["category_sort"] = flattenFieldSortOptions(apiObject.CategorySort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_gauge_chart.go
+++ b/internal/service/quicksight/schema/visual_gauge_chart.go
@@ -155,12 +155,12 @@ func gaugeChartVisualSchema() *schema.Schema {
 	}
 }
 
-func expandGaugeChartVisual(tfList []interface{}) *awstypes.GaugeChartVisual {
+func expandGaugeChartVisual(tfList []any) *awstypes.GaugeChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -170,84 +170,84 @@ func expandGaugeChartVisual(tfList []interface{}) *awstypes.GaugeChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandGaugeChartConfiguration(v)
 	}
-	if v, ok := tfMap["conditional_formatting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormatting = expandGaugeChartConditionalFormatting(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartConfiguration(tfList []interface{}) *awstypes.GaugeChartConfiguration {
+func expandGaugeChartConfiguration(tfList []any) *awstypes.GaugeChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartConfiguration{}
 
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandGaugeChartFieldWells(v)
 	}
-	if v, ok := tfMap["gauge_chart_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["gauge_chart_options"].([]any); ok && len(v) > 0 {
 		apiObject.GaugeChartOptions = expandGaugeChartOptions(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.TooltipOptions = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartFieldWells(tfList []interface{}) *awstypes.GaugeChartFieldWells {
+func expandGaugeChartFieldWells(tfList []any) *awstypes.GaugeChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartFieldWells{}
 
-	if v, ok := tfMap["target_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["target_values"].([]any); ok && len(v) > 0 {
 		apiObject.TargetValues = expandMeasureFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartOptions(tfList []interface{}) *awstypes.GaugeChartOptions {
+func expandGaugeChartOptions(tfList []any) *awstypes.GaugeChartOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -257,42 +257,42 @@ func expandGaugeChartOptions(tfList []interface{}) *awstypes.GaugeChartOptions {
 	if v, ok := tfMap["primary_value_display_type"].(string); ok && v != "" {
 		apiObject.PrimaryValueDisplayType = awstypes.PrimaryValueDisplayType(v)
 	}
-	if v, ok := tfMap["primary_value_font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_value_font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryValueFontConfiguration = expandFontConfiguration(v)
 	}
-	if v, ok := tfMap["arc"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["arc"].([]any); ok && len(v) > 0 {
 		apiObject.Arc = expandArcConfiguration(v)
 	}
-	if v, ok := tfMap["arc_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["arc_axis"].([]any); ok && len(v) > 0 {
 		apiObject.ArcAxis = expandArcAxisConfiguration(v)
 	}
-	if v, ok := tfMap["comparison"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["comparison"].([]any); ok && len(v) > 0 {
 		apiObject.Comparison = expandComparisonConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartConditionalFormatting(tfList []interface{}) *awstypes.GaugeChartConditionalFormatting {
+func expandGaugeChartConditionalFormatting(tfList []any) *awstypes.GaugeChartConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartConditionalFormatting{}
 
-	if v, ok := tfMap["conditional_formatting_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting_options"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormattingOptions = expandGaugeChartConditionalFormattingOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartConditionalFormattingOptions(tfList []interface{}) []awstypes.GaugeChartConditionalFormattingOption {
+func expandGaugeChartConditionalFormattingOptions(tfList []any) []awstypes.GaugeChartConditionalFormattingOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -300,7 +300,7 @@ func expandGaugeChartConditionalFormattingOptions(tfList []interface{}) []awstyp
 	var apiObjects []awstypes.GaugeChartConditionalFormattingOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -316,70 +316,70 @@ func expandGaugeChartConditionalFormattingOptions(tfList []interface{}) []awstyp
 	return apiObjects
 }
 
-func expandGaugeChartConditionalFormattingOption(tfMap map[string]interface{}) *awstypes.GaugeChartConditionalFormattingOption {
+func expandGaugeChartConditionalFormattingOption(tfMap map[string]any) *awstypes.GaugeChartConditionalFormattingOption {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartConditionalFormattingOption{}
 
-	if v, ok := tfMap["arc"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["arc"].([]any); ok && len(v) > 0 {
 		apiObject.Arc = expandGaugeChartArcConditionalFormatting(v)
 	}
-	if v, ok := tfMap["primary_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_value"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryValue = expandGaugeChartPrimaryValueConditionalFormatting(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartArcConditionalFormatting(tfList []interface{}) *awstypes.GaugeChartArcConditionalFormatting {
+func expandGaugeChartArcConditionalFormatting(tfList []any) *awstypes.GaugeChartArcConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartArcConditionalFormatting{}
 
-	if v, ok := tfMap["foreground_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["foreground_color"].([]any); ok && len(v) > 0 {
 		apiObject.ForegroundColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandGaugeChartPrimaryValueConditionalFormatting(tfList []interface{}) *awstypes.GaugeChartPrimaryValueConditionalFormatting {
+func expandGaugeChartPrimaryValueConditionalFormatting(tfList []any) *awstypes.GaugeChartPrimaryValueConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GaugeChartPrimaryValueConditionalFormatting{}
 
-	if v, ok := tfMap["icon"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon"].([]any); ok && len(v) > 0 {
 		apiObject.Icon = expandConditionalFormattingIcon(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandArcConfiguration(tfList []interface{}) *awstypes.ArcConfiguration {
+func expandArcConfiguration(tfList []any) *awstypes.ArcConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -396,19 +396,19 @@ func expandArcConfiguration(tfList []interface{}) *awstypes.ArcConfiguration {
 	return apiObject
 }
 
-func expandArcAxisConfiguration(tfList []interface{}) *awstypes.ArcAxisConfiguration {
+func expandArcAxisConfiguration(tfList []any) *awstypes.ArcAxisConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ArcAxisConfiguration{}
 
-	if v, ok := tfMap["range"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["range"].([]any); ok && len(v) > 0 {
 		apiObject.Range = expandArcAxisDisplayRange(v)
 	}
 	if v, ok := tfMap["reserve_range"].(int); ok {
@@ -418,12 +418,12 @@ func expandArcAxisConfiguration(tfList []interface{}) *awstypes.ArcAxisConfigura
 	return apiObject
 }
 
-func expandArcAxisDisplayRange(tfList []interface{}) *awstypes.ArcAxisDisplayRange {
+func expandArcAxisDisplayRange(tfList []any) *awstypes.ArcAxisDisplayRange {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -440,12 +440,12 @@ func expandArcAxisDisplayRange(tfList []interface{}) *awstypes.ArcAxisDisplayRan
 	return apiObject
 }
 
-func flattenGaugeChartVisual(apiObject *awstypes.GaugeChartVisual) []interface{} {
+func flattenGaugeChartVisual(apiObject *awstypes.GaugeChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -465,15 +465,15 @@ func flattenGaugeChartVisual(apiObject *awstypes.GaugeChartVisual) []interface{}
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartConfiguration(apiObject *awstypes.GaugeChartConfiguration) []interface{} {
+func flattenGaugeChartConfiguration(apiObject *awstypes.GaugeChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataLabels != nil {
 		tfMap["data_labels"] = flattenDataLabelOptions(apiObject.DataLabels)
@@ -491,15 +491,15 @@ func flattenGaugeChartConfiguration(apiObject *awstypes.GaugeChartConfiguration)
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartFieldWells(apiObject *awstypes.GaugeChartFieldWells) []interface{} {
+func flattenGaugeChartFieldWells(apiObject *awstypes.GaugeChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TargetValues != nil {
 		tfMap["target_values"] = flattenMeasureFields(apiObject.TargetValues)
@@ -508,15 +508,15 @@ func flattenGaugeChartFieldWells(apiObject *awstypes.GaugeChartFieldWells) []int
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartOptions(apiObject *awstypes.GaugeChartOptions) []interface{} {
+func flattenGaugeChartOptions(apiObject *awstypes.GaugeChartOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Arc != nil {
 		tfMap["arc"] = flattenArcConfiguration(apiObject.Arc)
@@ -532,45 +532,45 @@ func flattenGaugeChartOptions(apiObject *awstypes.GaugeChartOptions) []interface
 		tfMap["primary_value_font_configuration"] = flattenFontConfiguration(apiObject.PrimaryValueFontConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenArcConfiguration(apiObject *awstypes.ArcConfiguration) []interface{} {
+func flattenArcConfiguration(apiObject *awstypes.ArcConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ArcAngle != nil {
 		tfMap["arc_angle"] = aws.ToFloat64(apiObject.ArcAngle)
 	}
 	tfMap["arc_thickness"] = apiObject.ArcThickness
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenArcAxisConfiguration(apiObject *awstypes.ArcAxisConfiguration) []interface{} {
+func flattenArcAxisConfiguration(apiObject *awstypes.ArcAxisConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Range != nil {
 		tfMap["range"] = flattenArcAxisDisplayRange(apiObject.Range)
 	}
 	tfMap["reserve_range"] = apiObject.ReserveRange
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenArcAxisDisplayRange(apiObject *awstypes.ArcAxisDisplayRange) []interface{} {
+func flattenArcAxisDisplayRange(apiObject *awstypes.ArcAxisDisplayRange) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Max != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(apiObject.Max)
@@ -579,30 +579,30 @@ func flattenArcAxisDisplayRange(apiObject *awstypes.ArcAxisDisplayRange) []inter
 		tfMap[names.AttrMin] = aws.ToFloat64(apiObject.Min)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComparisonConfiguration(apiObject *awstypes.ComparisonConfiguration) []interface{} {
+func flattenComparisonConfiguration(apiObject *awstypes.ComparisonConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComparisonFormat != nil {
 		tfMap["comparison_format"] = flattenComparisonFormatConfiguration(apiObject.ComparisonFormat)
 	}
 	tfMap["comparison_method"] = apiObject.ComparisonMethod
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComparisonFormatConfiguration(apiObject *awstypes.ComparisonFormatConfiguration) []interface{} {
+func flattenComparisonFormatConfiguration(apiObject *awstypes.ComparisonFormatConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.NumberDisplayFormatConfiguration != nil {
 		tfMap["number_display_format_configuration"] = flattenNumberDisplayFormatConfiguration(apiObject.NumberDisplayFormatConfiguration)
@@ -611,32 +611,32 @@ func flattenComparisonFormatConfiguration(apiObject *awstypes.ComparisonFormatCo
 		tfMap["percentage_display_format_configuration"] = flattenPercentageDisplayFormatConfiguration(apiObject.PercentageDisplayFormatConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartConditionalFormatting(apiObject *awstypes.GaugeChartConditionalFormatting) []interface{} {
+func flattenGaugeChartConditionalFormatting(apiObject *awstypes.GaugeChartConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionalFormattingOptions != nil {
 		tfMap["conditional_formatting_options"] = flattenGaugeChartConditionalFormattingOption(apiObject.ConditionalFormattingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartConditionalFormattingOption(apiObjects []awstypes.GaugeChartConditionalFormattingOption) []interface{} {
+func flattenGaugeChartConditionalFormattingOption(apiObjects []awstypes.GaugeChartConditionalFormattingOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Arc != nil {
 			tfMap["arc"] = flattenGaugeChartArcConditionalFormatting(apiObject.Arc)
@@ -651,26 +651,26 @@ func flattenGaugeChartConditionalFormattingOption(apiObjects []awstypes.GaugeCha
 	return tfList
 }
 
-func flattenGaugeChartArcConditionalFormatting(apiObject *awstypes.GaugeChartArcConditionalFormatting) []interface{} {
+func flattenGaugeChartArcConditionalFormatting(apiObject *awstypes.GaugeChartArcConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ForegroundColor != nil {
 		tfMap["foreground_color"] = flattenConditionalFormattingColor(apiObject.ForegroundColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGaugeChartPrimaryValueConditionalFormatting(apiObject *awstypes.GaugeChartPrimaryValueConditionalFormatting) []interface{} {
+func flattenGaugeChartPrimaryValueConditionalFormatting(apiObject *awstypes.GaugeChartPrimaryValueConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Icon != nil {
 		tfMap["icon"] = flattenConditionalFormattingIcon(apiObject.Icon)
@@ -679,5 +679,5 @@ func flattenGaugeChartPrimaryValueConditionalFormatting(apiObject *awstypes.Gaug
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_geospatial_map.go
+++ b/internal/service/quicksight/schema/visual_geospatial_map.go
@@ -108,12 +108,12 @@ func geospatialMapVisualSchema() *schema.Schema {
 	}
 }
 
-func expandGeospatialMapVisual(tfList []interface{}) *awstypes.GeospatialMapVisual {
+func expandGeospatialMapVisual(tfList []any) *awstypes.GeospatialMapVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -123,112 +123,112 @@ func expandGeospatialMapVisual(tfList []interface{}) *awstypes.GeospatialMapVisu
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandGeospatialMapConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGeospatialMapConfiguration(tfList []interface{}) *awstypes.GeospatialMapConfiguration {
+func expandGeospatialMapConfiguration(tfList []any) *awstypes.GeospatialMapConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GeospatialMapConfiguration{}
 
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandGeospatialMapFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["map_style_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["map_style_options"].([]any); ok && len(v) > 0 {
 		apiObject.MapStyleOptions = expandGeospatialMapStyleOptions(v)
 	}
-	if v, ok := tfMap["point_style_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["point_style_options"].([]any); ok && len(v) > 0 {
 		apiObject.PointStyleOptions = expandGeospatialPointStyleOptions(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palatte"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palatte"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
-	if v, ok := tfMap["window_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["window_options"].([]any); ok && len(v) > 0 {
 		apiObject.WindowOptions = expandGeospatialWindowOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandGeospatialMapFieldWells(tfList []interface{}) *awstypes.GeospatialMapFieldWells {
+func expandGeospatialMapFieldWells(tfList []any) *awstypes.GeospatialMapFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GeospatialMapFieldWells{}
 
-	if v, ok := tfMap["geospatial_map_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["geospatial_map_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.GeospatialMapAggregatedFieldWells = expandGeospatialMapAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandGeospatialMapAggregatedFieldWells(tfList []interface{}) *awstypes.GeospatialMapAggregatedFieldWells {
+func expandGeospatialMapAggregatedFieldWells(tfList []any) *awstypes.GeospatialMapAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GeospatialMapAggregatedFieldWells{}
 
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["geospatial"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["geospatial"].([]any); ok && len(v) > 0 {
 		apiObject.Geospatial = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandGeospatialPointStyleOptions(tfList []interface{}) *awstypes.GeospatialPointStyleOptions {
+func expandGeospatialPointStyleOptions(tfList []any) *awstypes.GeospatialPointStyleOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -238,57 +238,57 @@ func expandGeospatialPointStyleOptions(tfList []interface{}) *awstypes.Geospatia
 	if v, ok := tfMap["selected_point_style"].(string); ok && v != "" {
 		apiObject.SelectedPointStyle = awstypes.GeospatialSelectedPointStyle(v)
 	}
-	if v, ok := tfMap["cluster_marker_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cluster_marker_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ClusterMarkerConfiguration = expandClusterMarkerConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandClusterMarkerConfiguration(tfList []interface{}) *awstypes.ClusterMarkerConfiguration {
+func expandClusterMarkerConfiguration(tfList []any) *awstypes.ClusterMarkerConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ClusterMarkerConfiguration{}
 
-	if v, ok := tfMap["cluster_marker"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cluster_marker"].([]any); ok && len(v) > 0 {
 		apiObject.ClusterMarker = expandClusterMarker(v)
 	}
 
 	return apiObject
 }
 
-func expandClusterMarker(tfList []interface{}) *awstypes.ClusterMarker {
+func expandClusterMarker(tfList []any) *awstypes.ClusterMarker {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ClusterMarker{}
 
-	if v, ok := tfMap["simple_cluster_marker"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["simple_cluster_marker"].([]any); ok && len(v) > 0 {
 		apiObject.SimpleClusterMarker = expandSimpleClusterMarker(v)
 	}
 
 	return apiObject
 }
 
-func expandSimpleClusterMarker(tfList []interface{}) *awstypes.SimpleClusterMarker {
+func expandSimpleClusterMarker(tfList []any) *awstypes.SimpleClusterMarker {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -302,12 +302,12 @@ func expandSimpleClusterMarker(tfList []interface{}) *awstypes.SimpleClusterMark
 	return apiObject
 }
 
-func flattenGeospatialMapVisual(apiObject *awstypes.GeospatialMapVisual) []interface{} {
+func flattenGeospatialMapVisual(apiObject *awstypes.GeospatialMapVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -327,15 +327,15 @@ func flattenGeospatialMapVisual(apiObject *awstypes.GeospatialMapVisual) []inter
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialMapConfiguration(apiObject *awstypes.GeospatialMapConfiguration) []interface{} {
+func flattenGeospatialMapConfiguration(apiObject *awstypes.GeospatialMapConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldWells != nil {
 		tfMap["field_wells"] = flattenGeospatialMapFieldWells(apiObject.FieldWells)
@@ -359,29 +359,29 @@ func flattenGeospatialMapConfiguration(apiObject *awstypes.GeospatialMapConfigur
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialMapFieldWells(apiObject *awstypes.GeospatialMapFieldWells) []interface{} {
+func flattenGeospatialMapFieldWells(apiObject *awstypes.GeospatialMapFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.GeospatialMapAggregatedFieldWells != nil {
 		tfMap["geospatial_map_aggregated_field_wells"] = flattenGeospatialMapAggregatedFieldWells(apiObject.GeospatialMapAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialMapAggregatedFieldWells(apiObject *awstypes.GeospatialMapAggregatedFieldWells) []interface{} {
+func flattenGeospatialMapAggregatedFieldWells(apiObject *awstypes.GeospatialMapAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Colors != nil {
 		tfMap["colors"] = flattenDimensionFields(apiObject.Colors)
@@ -393,61 +393,61 @@ func flattenGeospatialMapAggregatedFieldWells(apiObject *awstypes.GeospatialMapA
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialPointStyleOptions(apiObject *awstypes.GeospatialPointStyleOptions) []interface{} {
+func flattenGeospatialPointStyleOptions(apiObject *awstypes.GeospatialPointStyleOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ClusterMarkerConfiguration != nil {
 		tfMap["cluster_marker_configuration"] = flattenClusterMarkerConfiguration(apiObject.ClusterMarkerConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenClusterMarkerConfiguration(apiObject *awstypes.ClusterMarkerConfiguration) []interface{} {
+func flattenClusterMarkerConfiguration(apiObject *awstypes.ClusterMarkerConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ClusterMarker != nil {
 		tfMap["cluster_marker"] = flattenClusterMarker(apiObject.ClusterMarker)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenClusterMarker(apiObject *awstypes.ClusterMarker) []interface{} {
+func flattenClusterMarker(apiObject *awstypes.ClusterMarker) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SimpleClusterMarker != nil {
 		tfMap["simple_cluster_marker"] = flattenSimpleClusterMarker(apiObject.SimpleClusterMarker)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSimpleClusterMarker(apiObject *awstypes.SimpleClusterMarker) []interface{} {
+func flattenSimpleClusterMarker(apiObject *awstypes.SimpleClusterMarker) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_heat_map.go
+++ b/internal/service/quicksight/schema/visual_heat_map.go
@@ -83,12 +83,12 @@ func heatMapVisualSchema() *schema.Schema {
 	}
 }
 
-func expandHeatMapVisual(tfList []interface{}) *awstypes.HeatMapVisual {
+func expandHeatMapVisual(tfList []any) *awstypes.HeatMapVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -98,143 +98,143 @@ func expandHeatMapVisual(tfList []interface{}) *awstypes.HeatMapVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandHeatMapConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandHeatMapConfiguration(tfList []interface{}) *awstypes.HeatMapConfiguration {
+func expandHeatMapConfiguration(tfList []any) *awstypes.HeatMapConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HeatMapConfiguration{}
 
-	if v, ok := tfMap["color_scale"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_scale"].([]any); ok && len(v) > 0 {
 		apiObject.ColorScale = expandColorScale(v)
 	}
-	if v, ok := tfMap["column_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandHeatMapFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["row_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.RowLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandHeatMapSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandHeatMapFieldWells(tfList []interface{}) *awstypes.HeatMapFieldWells {
+func expandHeatMapFieldWells(tfList []any) *awstypes.HeatMapFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HeatMapFieldWells{}
 
-	if v, ok := tfMap["heat_map_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapAggregatedFieldWells = expandHeatMapAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandHeatMapAggregatedFieldWells(tfList []interface{}) *awstypes.HeatMapAggregatedFieldWells {
+func expandHeatMapAggregatedFieldWells(tfList []any) *awstypes.HeatMapAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HeatMapAggregatedFieldWells{}
 
-	if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["columns"].([]any); ok && len(v) > 0 {
 		apiObject.Columns = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["rows"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rows"].([]any); ok && len(v) > 0 {
 		apiObject.Rows = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandHeatMapSortConfiguration(tfList []interface{}) *awstypes.HeatMapSortConfiguration {
+func expandHeatMapSortConfiguration(tfList []any) *awstypes.HeatMapSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HeatMapSortConfiguration{}
 
-	if v, ok := tfMap["heat_map_column_items_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_column_items_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapColumnItemsLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["heat_map_column_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_column_sort"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapColumnSort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["heat_map_row_items_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_row_items_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapRowItemsLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["heat_map_row_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["heat_map_row_sort"].([]any); ok && len(v) > 0 {
 		apiObject.HeatMapRowSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func flattenHeatMapVisual(apiObject *awstypes.HeatMapVisual) []interface{} {
+func flattenHeatMapVisual(apiObject *awstypes.HeatMapVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -254,15 +254,15 @@ func flattenHeatMapVisual(apiObject *awstypes.HeatMapVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHeatMapConfiguration(apiObject *awstypes.HeatMapConfiguration) []interface{} {
+func flattenHeatMapConfiguration(apiObject *awstypes.HeatMapConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColorScale != nil {
 		tfMap["color_scale"] = flattenColorScale(apiObject.ColorScale)
@@ -289,29 +289,29 @@ func flattenHeatMapConfiguration(apiObject *awstypes.HeatMapConfiguration) []int
 		tfMap["tooltip"] = flattenTooltipOptions(apiObject.Tooltip)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHeatMapFieldWells(apiObject *awstypes.HeatMapFieldWells) []interface{} {
+func flattenHeatMapFieldWells(apiObject *awstypes.HeatMapFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.HeatMapAggregatedFieldWells != nil {
 		tfMap["heat_map_aggregated_field_wells"] = flattenHeatMapAggregatedFieldWells(apiObject.HeatMapAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHeatMapAggregatedFieldWells(apiObject *awstypes.HeatMapAggregatedFieldWells) []interface{} {
+func flattenHeatMapAggregatedFieldWells(apiObject *awstypes.HeatMapAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenDimensionFields(apiObject.Columns)
@@ -323,15 +323,15 @@ func flattenHeatMapAggregatedFieldWells(apiObject *awstypes.HeatMapAggregatedFie
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHeatMapSortConfiguration(apiObject *awstypes.HeatMapSortConfiguration) []interface{} {
+func flattenHeatMapSortConfiguration(apiObject *awstypes.HeatMapSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.HeatMapColumnItemsLimitConfiguration != nil {
 		tfMap["heat_map_column_items_limit_configuration"] = flattenItemsLimitConfiguration(apiObject.HeatMapColumnItemsLimitConfiguration)
@@ -346,5 +346,5 @@ func flattenHeatMapSortConfiguration(apiObject *awstypes.HeatMapSortConfiguratio
 		tfMap["heat_map_row_sort"] = flattenFieldSortOptions(apiObject.HeatMapRowSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_histogram.go
+++ b/internal/service/quicksight/schema/visual_histogram.go
@@ -111,12 +111,12 @@ func histogramVisualSchema() *schema.Schema {
 	}
 }
 
-func expandHistogramVisual(tfList []interface{}) *awstypes.HistogramVisual {
+func expandHistogramVisual(tfList []any) *awstypes.HistogramVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -126,106 +126,106 @@ func expandHistogramVisual(tfList []interface{}) *awstypes.HistogramVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandHistogramConfiguration(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandHistogramConfiguration(tfList []interface{}) *awstypes.HistogramConfiguration {
+func expandHistogramConfiguration(tfList []any) *awstypes.HistogramConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HistogramConfiguration{}
 
-	if v, ok := tfMap["bin_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bin_options"].([]any); ok && len(v) > 0 {
 		apiObject.BinOptions = expandHistogramBinOptions(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandHistogramFieldWells(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
-	if v, ok := tfMap["x_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["x_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.YAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandHistogramFieldWells(tfList []interface{}) *awstypes.HistogramFieldWells {
+func expandHistogramFieldWells(tfList []any) *awstypes.HistogramFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HistogramFieldWells{}
 
-	if v, ok := tfMap["histogram_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["histogram_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.HistogramAggregatedFieldWells = expandHistogramAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandHistogramAggregatedFieldWells(tfList []interface{}) *awstypes.HistogramAggregatedFieldWells {
+func expandHistogramAggregatedFieldWells(tfList []any) *awstypes.HistogramAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.HistogramAggregatedFieldWells{}
 
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandHistogramBinOptions(tfList []interface{}) *awstypes.HistogramBinOptions {
+func expandHistogramBinOptions(tfList []any) *awstypes.HistogramBinOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -238,22 +238,22 @@ func expandHistogramBinOptions(tfList []interface{}) *awstypes.HistogramBinOptio
 	if v, ok := tfMap["start_value"].(float64); ok {
 		apiObject.StartValue = aws.Float64(v)
 	}
-	if v, ok := tfMap["bin_count"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bin_count"].([]any); ok && len(v) > 0 {
 		apiObject.BinCount = expandBinCountOptions(v)
 	}
-	if v, ok := tfMap["bin_width"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bin_width"].([]any); ok && len(v) > 0 {
 		apiObject.BinWidth = expandBinWidthOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandBinCountOptions(tfList []interface{}) *awstypes.BinCountOptions {
+func expandBinCountOptions(tfList []any) *awstypes.BinCountOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -267,12 +267,12 @@ func expandBinCountOptions(tfList []interface{}) *awstypes.BinCountOptions {
 	return apiObject
 }
 
-func expandBinWidthOptions(tfList []interface{}) *awstypes.BinWidthOptions {
+func expandBinWidthOptions(tfList []any) *awstypes.BinWidthOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -289,12 +289,12 @@ func expandBinWidthOptions(tfList []interface{}) *awstypes.BinWidthOptions {
 	return apiObject
 }
 
-func flattenHistogramVisual(apiObject *awstypes.HistogramVisual) []interface{} {
+func flattenHistogramVisual(apiObject *awstypes.HistogramVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -311,15 +311,15 @@ func flattenHistogramVisual(apiObject *awstypes.HistogramVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHistogramConfiguration(apiObject *awstypes.HistogramConfiguration) []interface{} {
+func flattenHistogramConfiguration(apiObject *awstypes.HistogramConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BinOptions != nil {
 		tfMap["bin_options"] = flattenHistogramBinOptions(apiObject.BinOptions)
@@ -346,15 +346,15 @@ func flattenHistogramConfiguration(apiObject *awstypes.HistogramConfiguration) [
 		tfMap["y_axis_display_options"] = flattenAxisDisplayOptions(apiObject.YAxisDisplayOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHistogramBinOptions(apiObject *awstypes.HistogramBinOptions) []interface{} {
+func flattenHistogramBinOptions(apiObject *awstypes.HistogramBinOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BinCount != nil {
 		tfMap["bin_count"] = flattenBinCountOptions(apiObject.BinCount)
@@ -367,29 +367,29 @@ func flattenHistogramBinOptions(apiObject *awstypes.HistogramBinOptions) []inter
 		tfMap["start_value"] = aws.ToFloat64(apiObject.StartValue)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBinCountOptions(apiObject *awstypes.BinCountOptions) []interface{} {
+func flattenBinCountOptions(apiObject *awstypes.BinCountOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Value != nil {
 		tfMap[names.AttrValue] = aws.ToInt32(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBinWidthOptions(apiObject *awstypes.BinWidthOptions) []interface{} {
+func flattenBinWidthOptions(apiObject *awstypes.BinWidthOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BinCountLimit != nil {
 		tfMap["bin_count_limit"] = aws.ToInt64(apiObject.BinCountLimit)
@@ -398,33 +398,33 @@ func flattenBinWidthOptions(apiObject *awstypes.BinWidthOptions) []interface{} {
 		tfMap[names.AttrValue] = aws.ToFloat64(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHistogramFieldWells(apiObject *awstypes.HistogramFieldWells) []interface{} {
+func flattenHistogramFieldWells(apiObject *awstypes.HistogramFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.HistogramAggregatedFieldWells != nil {
 		tfMap["histogram_aggregated_field_wells"] = flattenHistogramAggregatedFieldWells(apiObject.HistogramAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenHistogramAggregatedFieldWells(apiObject *awstypes.HistogramAggregatedFieldWells) []interface{} {
+func flattenHistogramAggregatedFieldWells(apiObject *awstypes.HistogramAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Values != nil {
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_insight.go
+++ b/internal/service/quicksight/schema/visual_insight.go
@@ -250,12 +250,12 @@ func insightVisualSchema() *schema.Schema {
 	}
 }
 
-func expandInsightVisual(tfList []interface{}) *awstypes.InsightVisual {
+func expandInsightVisual(tfList []any) *awstypes.InsightVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -268,45 +268,45 @@ func expandInsightVisual(tfList []interface{}) *awstypes.InsightVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["insight_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["insight_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.InsightConfiguration = expandInsightConfiguration(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandInsightConfiguration(tfList []interface{}) *awstypes.InsightConfiguration {
+func expandInsightConfiguration(tfList []any) *awstypes.InsightConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.InsightConfiguration{}
 
-	if v, ok := tfMap["computation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["computation"].([]any); ok && len(v) > 0 {
 		apiObject.Computations = expandComputations(v)
 	}
-	if v, ok := tfMap["custom_narrative"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_narrative"].([]any); ok && len(v) > 0 {
 		apiObject.CustomNarrative = expandCustomNarrativeOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandComputations(tfList []interface{}) []awstypes.Computation {
+func expandComputations(tfList []any) []awstypes.Computation {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -314,7 +314,7 @@ func expandComputations(tfList []interface{}) []awstypes.Computation {
 	var apiObjects []awstypes.Computation
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -330,53 +330,53 @@ func expandComputations(tfList []interface{}) []awstypes.Computation {
 	return apiObjects
 }
 
-func expandComputation(tfMap map[string]interface{}) *awstypes.Computation {
+func expandComputation(tfMap map[string]any) *awstypes.Computation {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.Computation{}
 
-	if v, ok := tfMap["forecast"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["forecast"].([]any); ok && len(v) > 0 {
 		apiObject.Forecast = expandForecastComputation(v)
 	}
-	if v, ok := tfMap["growth_rate"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["growth_rate"].([]any); ok && len(v) > 0 {
 		apiObject.GrowthRate = expandGrowthRateComputation(v)
 	}
-	if v, ok := tfMap["maximum_minimum"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["maximum_minimum"].([]any); ok && len(v) > 0 {
 		apiObject.MaximumMinimum = expandMaximumMinimumComputation(v)
 	}
-	if v, ok := tfMap["metric_comparison"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["metric_comparison"].([]any); ok && len(v) > 0 {
 		apiObject.MetricComparison = expandMetricComparisonComputation(v)
 	}
-	if v, ok := tfMap["period_over_period"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["period_over_period"].([]any); ok && len(v) > 0 {
 		apiObject.PeriodOverPeriod = expandPeriodOverPeriodComputation(v)
 	}
-	if v, ok := tfMap["period_to_date"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["period_to_date"].([]any); ok && len(v) > 0 {
 		apiObject.PeriodToDate = expandPeriodToDateComputation(v)
 	}
-	if v, ok := tfMap["top_bottom_movers"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["top_bottom_movers"].([]any); ok && len(v) > 0 {
 		apiObject.TopBottomMovers = expandTopBottomMoversComputation(v)
 	}
-	if v, ok := tfMap["top_bottom_ranked"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["top_bottom_ranked"].([]any); ok && len(v) > 0 {
 		apiObject.TopBottomRanked = expandTopBottomRankedComputation(v)
 	}
-	if v, ok := tfMap["total_aggregation"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_aggregation"].([]any); ok && len(v) > 0 {
 		apiObject.TotalAggregation = expandTotalAggregationComputation(v)
 	}
-	if v, ok := tfMap["unique_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["unique_values"].([]any); ok && len(v) > 0 {
 		apiObject.UniqueValues = expandUniqueValuesComputation(v)
 	}
 
 	return apiObject
 }
 
-func expandForecastComputation(tfList []interface{}) *awstypes.ForecastComputation {
+func expandForecastComputation(tfList []any) *awstypes.ForecastComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -410,22 +410,22 @@ func expandForecastComputation(tfList []interface{}) *awstypes.ForecastComputati
 	if v, ok := tfMap["upper_boundary"].(float64); ok {
 		apiObject.UpperBoundary = aws.Float64(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandGrowthRateComputation(tfList []interface{}) *awstypes.GrowthRateComputation {
+func expandGrowthRateComputation(tfList []any) *awstypes.GrowthRateComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -441,22 +441,22 @@ func expandGrowthRateComputation(tfList []interface{}) *awstypes.GrowthRateCompu
 	if v, ok := tfMap["period_size"].(int); ok {
 		apiObject.PeriodSize = aws.Int32(int32(v))
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandMaximumMinimumComputation(tfList []interface{}) *awstypes.MaximumMinimumComputation {
+func expandMaximumMinimumComputation(tfList []any) *awstypes.MaximumMinimumComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -472,22 +472,22 @@ func expandMaximumMinimumComputation(tfList []interface{}) *awstypes.MaximumMini
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.MaximumMinimumComputationType(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandMetricComparisonComputation(tfList []interface{}) *awstypes.MetricComparisonComputation {
+func expandMetricComparisonComputation(tfList []any) *awstypes.MetricComparisonComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -500,25 +500,25 @@ func expandMetricComparisonComputation(tfList []interface{}) *awstypes.MetricCom
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap["from_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["from_value"].([]any); ok && len(v) > 0 {
 		apiObject.FromValue = expandMeasureField(v)
 	}
-	if v, ok := tfMap["target_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["target_value"].([]any); ok && len(v) > 0 {
 		apiObject.TargetValue = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandPeriodOverPeriodComputation(tfList []interface{}) *awstypes.PeriodOverPeriodComputation {
+func expandPeriodOverPeriodComputation(tfList []any) *awstypes.PeriodOverPeriodComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -531,22 +531,22 @@ func expandPeriodOverPeriodComputation(tfList []interface{}) *awstypes.PeriodOve
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandPeriodToDateComputation(tfList []interface{}) *awstypes.PeriodToDateComputation {
+func expandPeriodToDateComputation(tfList []any) *awstypes.PeriodToDateComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -562,22 +562,22 @@ func expandPeriodToDateComputation(tfList []interface{}) *awstypes.PeriodToDateC
 	if v, ok := tfMap["period_time_granularity"].(string); ok && v != "" {
 		apiObject.PeriodTimeGranularity = awstypes.TimeGranularity(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandTopBottomMoversComputation(tfList []interface{}) *awstypes.TopBottomMoversComputation {
+func expandTopBottomMoversComputation(tfList []any) *awstypes.TopBottomMoversComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -599,25 +599,25 @@ func expandTopBottomMoversComputation(tfList []interface{}) *awstypes.TopBottomM
 	if v, ok := tfMap["mover_size"].(int); ok {
 		apiObject.MoverSize = aws.Int32(int32(v))
 	}
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionField(v)
 	}
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 {
 		apiObject.Time = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandTopBottomRankedComputation(tfList []interface{}) *awstypes.TopBottomRankedComputation {
+func expandTopBottomRankedComputation(tfList []any) *awstypes.TopBottomRankedComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -636,22 +636,22 @@ func expandTopBottomRankedComputation(tfList []interface{}) *awstypes.TopBottomR
 	if v, ok := tfMap["result_size"].(int); ok {
 		apiObject.ResultSize = aws.Int32(int32(v))
 	}
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionField(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandTotalAggregationComputation(tfList []interface{}) *awstypes.TotalAggregationComputation {
+func expandTotalAggregationComputation(tfList []any) *awstypes.TotalAggregationComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -664,19 +664,19 @@ func expandTotalAggregationComputation(tfList []interface{}) *awstypes.TotalAggr
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrValue].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValue].([]any); ok && len(v) > 0 {
 		apiObject.Value = expandMeasureField(v)
 	}
 
 	return apiObject
 }
 
-func expandUniqueValuesComputation(tfList []interface{}) *awstypes.UniqueValuesComputation {
+func expandUniqueValuesComputation(tfList []any) *awstypes.UniqueValuesComputation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -689,19 +689,19 @@ func expandUniqueValuesComputation(tfList []interface{}) *awstypes.UniqueValuesC
 	if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 		apiObject.Name = aws.String(v)
 	}
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionField(v)
 	}
 
 	return apiObject
 }
 
-func expandCustomNarrativeOptions(tfList []interface{}) *awstypes.CustomNarrativeOptions {
+func expandCustomNarrativeOptions(tfList []any) *awstypes.CustomNarrativeOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -715,12 +715,12 @@ func expandCustomNarrativeOptions(tfList []interface{}) *awstypes.CustomNarrativ
 	return apiObject
 }
 
-func flattenInsightVisual(apiObject *awstypes.InsightVisual) []interface{} {
+func flattenInsightVisual(apiObject *awstypes.InsightVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id":           aws.ToString(apiObject.VisualId),
 		"data_set_identifier": aws.ToString(apiObject.DataSetIdentifier),
 	}
@@ -738,15 +738,15 @@ func flattenInsightVisual(apiObject *awstypes.InsightVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenInsightConfiguration(apiObject *awstypes.InsightConfiguration) []interface{} {
+func flattenInsightConfiguration(apiObject *awstypes.InsightConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Computations != nil {
 		tfMap["computation"] = flattenComputation(apiObject.Computations)
@@ -755,18 +755,18 @@ func flattenInsightConfiguration(apiObject *awstypes.InsightConfiguration) []int
 		tfMap["custom_narrative"] = flattenCustomNarrativeOptions(apiObject.CustomNarrative)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenComputation(apiObjects []awstypes.Computation) []interface{} {
+func flattenComputation(apiObjects []awstypes.Computation) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Forecast != nil {
 			tfMap["forecast"] = flattenForecastComputation(apiObject.Forecast)
@@ -805,12 +805,12 @@ func flattenComputation(apiObjects []awstypes.Computation) []interface{} {
 	return tfList
 }
 
-func flattenForecastComputation(apiObject *awstypes.ForecastComputation) []interface{} {
+func flattenForecastComputation(apiObject *awstypes.ForecastComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -844,15 +844,15 @@ func flattenForecastComputation(apiObject *awstypes.ForecastComputation) []inter
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGrowthRateComputation(apiObject *awstypes.GrowthRateComputation) []interface{} {
+func flattenGrowthRateComputation(apiObject *awstypes.GrowthRateComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -870,15 +870,15 @@ func flattenGrowthRateComputation(apiObject *awstypes.GrowthRateComputation) []i
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMaximumMinimumComputation(apiObject *awstypes.MaximumMinimumComputation) []interface{} {
+func flattenMaximumMinimumComputation(apiObject *awstypes.MaximumMinimumComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -894,15 +894,15 @@ func flattenMaximumMinimumComputation(apiObject *awstypes.MaximumMinimumComputat
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMetricComparisonComputation(apiObject *awstypes.MetricComparisonComputation) []interface{} {
+func flattenMetricComparisonComputation(apiObject *awstypes.MetricComparisonComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -920,15 +920,15 @@ func flattenMetricComparisonComputation(apiObject *awstypes.MetricComparisonComp
 		tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPeriodOverPeriodComputation(apiObject *awstypes.PeriodOverPeriodComputation) []interface{} {
+func flattenPeriodOverPeriodComputation(apiObject *awstypes.PeriodOverPeriodComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -943,15 +943,15 @@ func flattenPeriodOverPeriodComputation(apiObject *awstypes.PeriodOverPeriodComp
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPeriodToDateComputation(apiObject *awstypes.PeriodToDateComputation) []interface{} {
+func flattenPeriodToDateComputation(apiObject *awstypes.PeriodToDateComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -967,15 +967,15 @@ func flattenPeriodToDateComputation(apiObject *awstypes.PeriodToDateComputation)
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTopBottomMoversComputation(apiObject *awstypes.TopBottomMoversComputation) []interface{} {
+func flattenTopBottomMoversComputation(apiObject *awstypes.TopBottomMoversComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -998,15 +998,15 @@ func flattenTopBottomMoversComputation(apiObject *awstypes.TopBottomMoversComput
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTopBottomRankedComputation(apiObject *awstypes.TopBottomRankedComputation) []interface{} {
+func flattenTopBottomRankedComputation(apiObject *awstypes.TopBottomRankedComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -1025,15 +1025,15 @@ func flattenTopBottomRankedComputation(apiObject *awstypes.TopBottomRankedComput
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTotalAggregationComputation(apiObject *awstypes.TotalAggregationComputation) []interface{} {
+func flattenTotalAggregationComputation(apiObject *awstypes.TotalAggregationComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -1045,15 +1045,15 @@ func flattenTotalAggregationComputation(apiObject *awstypes.TotalAggregationComp
 		tfMap[names.AttrValue] = flattenMeasureField(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenUniqueValuesComputation(apiObject *awstypes.UniqueValuesComputation) []interface{} {
+func flattenUniqueValuesComputation(apiObject *awstypes.UniqueValuesComputation) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ComputationId != nil {
 		tfMap["computation_id"] = aws.ToString(apiObject.ComputationId)
@@ -1065,19 +1065,19 @@ func flattenUniqueValuesComputation(apiObject *awstypes.UniqueValuesComputation)
 		tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenCustomNarrativeOptions(apiObject *awstypes.CustomNarrativeOptions) []interface{} {
+func flattenCustomNarrativeOptions(apiObject *awstypes.CustomNarrativeOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Narrative != nil {
 		tfMap["narrative"] = aws.ToString(apiObject.Narrative)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_kpi.go
+++ b/internal/service/quicksight/schema/visual_kpi.go
@@ -213,12 +213,12 @@ func kpiVisualSchema() *schema.Schema {
 	}
 }
 
-func expandKPIVisual(tfList []interface{}) *awstypes.KPIVisual {
+func expandKPIVisual(tfList []any) *awstypes.KPIVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -228,83 +228,83 @@ func expandKPIVisual(tfList []interface{}) *awstypes.KPIVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandKPIConfiguration(v)
 	}
-	if v, ok := tfMap["conditional_formatting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormatting = expandKPIConditionalFormatting(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIConfiguration(tfList []interface{}) *awstypes.KPIConfiguration {
+func expandKPIConfiguration(tfList []any) *awstypes.KPIConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIConfiguration{}
 
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandKPIFieldWells(v)
 	}
-	if v, ok := tfMap["kpi_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["kpi_options"].([]any); ok && len(v) > 0 {
 		apiObject.KPIOptions = expandKPIOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandKPISortConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIFieldWells(tfList []interface{}) *awstypes.KPIFieldWells {
+func expandKPIFieldWells(tfList []any) *awstypes.KPIFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIFieldWells{}
 
-	if v, ok := tfMap["trend_groups"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["trend_groups"].([]any); ok && len(v) > 0 {
 		apiObject.TrendGroups = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["target_values"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["target_values"].([]any); ok && len(v) > 0 {
 		apiObject.TargetValues = expandMeasureFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 	return apiObject
 }
 
-func expandKPIOptions(tfList []interface{}) *awstypes.KPIOptions {
+func expandKPIOptions(tfList []any) *awstypes.KPIOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -314,40 +314,40 @@ func expandKPIOptions(tfList []interface{}) *awstypes.KPIOptions {
 	if v, ok := tfMap["primary_value_display_type"].(string); ok && v != "" {
 		apiObject.PrimaryValueDisplayType = awstypes.PrimaryValueDisplayType(v)
 	}
-	if v, ok := tfMap["comparison"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["comparison"].([]any); ok && len(v) > 0 {
 		apiObject.Comparison = expandComparisonConfiguration(v)
 	}
-	if v, ok := tfMap["primary_value_font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_value_font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryValueFontConfiguration = expandFontConfiguration(v)
 	}
-	if v, ok := tfMap["progress_bar"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["progress_bar"].([]any); ok && len(v) > 0 {
 		apiObject.ProgressBar = expandProgressBarOptions(v)
 	}
-	if v, ok := tfMap["secondary_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_value"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryValue = expandSecondaryValueOptions(v)
 	}
-	if v, ok := tfMap["secondary_value_font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_value_font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryValueFontConfiguration = expandFontConfiguration(v)
 	}
-	if v, ok := tfMap["sparkline"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sparkline"].([]any); ok && len(v) > 0 {
 		apiObject.Sparkline = expandKPISparklineOptions(v)
 	}
-	if v, ok := tfMap["trend_arrows"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["trend_arrows"].([]any); ok && len(v) > 0 {
 		apiObject.TrendArrows = expandTrendArrowOptions(v)
 	}
-	if v, ok := tfMap["visual_layout_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_layout_options"].([]any); ok && len(v) > 0 {
 		apiObject.VisualLayoutOptions = expandKPIVisualLayoutOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandProgressBarOptions(tfList []interface{}) *awstypes.ProgressBarOptions {
+func expandProgressBarOptions(tfList []any) *awstypes.ProgressBarOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -361,12 +361,12 @@ func expandProgressBarOptions(tfList []interface{}) *awstypes.ProgressBarOptions
 	return apiObject
 }
 
-func expandSecondaryValueOptions(tfList []interface{}) *awstypes.SecondaryValueOptions {
+func expandSecondaryValueOptions(tfList []any) *awstypes.SecondaryValueOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -380,12 +380,12 @@ func expandSecondaryValueOptions(tfList []interface{}) *awstypes.SecondaryValueO
 	return apiObject
 }
 
-func expandKPISparklineOptions(tfList []interface{}) *awstypes.KPISparklineOptions {
+func expandKPISparklineOptions(tfList []any) *awstypes.KPISparklineOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -408,12 +408,12 @@ func expandKPISparklineOptions(tfList []interface{}) *awstypes.KPISparklineOptio
 	return apiObject
 }
 
-func expandTrendArrowOptions(tfList []interface{}) *awstypes.TrendArrowOptions {
+func expandTrendArrowOptions(tfList []any) *awstypes.TrendArrowOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -427,31 +427,31 @@ func expandTrendArrowOptions(tfList []interface{}) *awstypes.TrendArrowOptions {
 	return apiObject
 }
 
-func expandKPIVisualLayoutOptions(tfList []interface{}) *awstypes.KPIVisualLayoutOptions {
+func expandKPIVisualLayoutOptions(tfList []any) *awstypes.KPIVisualLayoutOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIVisualLayoutOptions{}
 
-	if v, ok := tfMap["standard_layout"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["standard_layout"].([]any); ok && len(v) > 0 {
 		apiObject.StandardLayout = expandKPIVisualStandardLayout(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIVisualStandardLayout(tfList []interface{}) *awstypes.KPIVisualStandardLayout {
+func expandKPIVisualStandardLayout(tfList []any) *awstypes.KPIVisualStandardLayout {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -465,45 +465,45 @@ func expandKPIVisualStandardLayout(tfList []interface{}) *awstypes.KPIVisualStan
 	return apiObject
 }
 
-func expandKPISortConfiguration(tfList []interface{}) *awstypes.KPISortConfiguration {
+func expandKPISortConfiguration(tfList []any) *awstypes.KPISortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPISortConfiguration{}
 
-	if v, ok := tfMap["trend_group_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["trend_group_sort"].([]any); ok && len(v) > 0 {
 		apiObject.TrendGroupSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIConditionalFormatting(tfList []interface{}) *awstypes.KPIConditionalFormatting {
+func expandKPIConditionalFormatting(tfList []any) *awstypes.KPIConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIConditionalFormatting{}
 
-	if v, ok := tfMap["conditional_formatting_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting_options"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormattingOptions = expandKPIConditionalFormattingOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIConditionalFormattingOptions(tfList []interface{}) []awstypes.KPIConditionalFormattingOption {
+func expandKPIConditionalFormattingOptions(tfList []any) []awstypes.KPIConditionalFormattingOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -511,7 +511,7 @@ func expandKPIConditionalFormattingOptions(tfList []interface{}) []awstypes.KPIC
 	var apiObjects []awstypes.KPIConditionalFormattingOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -527,120 +527,120 @@ func expandKPIConditionalFormattingOptions(tfList []interface{}) []awstypes.KPIC
 	return apiObjects
 }
 
-func expandKPIConditionalFormattingOption(tfMap map[string]interface{}) *awstypes.KPIConditionalFormattingOption {
+func expandKPIConditionalFormattingOption(tfMap map[string]any) *awstypes.KPIConditionalFormattingOption {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIConditionalFormattingOption{}
 
-	if v, ok := tfMap["actual_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["actual_value"].([]any); ok && len(v) > 0 {
 		apiObject.ActualValue = expandKPIActualValueConditionalFormatting(v)
 	}
-	if v, ok := tfMap["comparison_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["comparison_value"].([]any); ok && len(v) > 0 {
 		apiObject.ComparisonValue = expandKPIComparisonValueConditionalFormatting(v)
 	}
-	if v, ok := tfMap["primary_value"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_value"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryValue = expandKPIPrimaryValueConditionalFormatting(v)
 	}
-	if v, ok := tfMap["progress_bar"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["progress_bar"].([]any); ok && len(v) > 0 {
 		apiObject.ProgressBar = expandKPIProgressBarConditionalFormatting(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIActualValueConditionalFormatting(tfList []interface{}) *awstypes.KPIActualValueConditionalFormatting {
+func expandKPIActualValueConditionalFormatting(tfList []any) *awstypes.KPIActualValueConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIActualValueConditionalFormatting{}
 
-	if v, ok := tfMap["icon"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon"].([]any); ok && len(v) > 0 {
 		apiObject.Icon = expandConditionalFormattingIcon(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIComparisonValueConditionalFormatting(tfList []interface{}) *awstypes.KPIComparisonValueConditionalFormatting {
+func expandKPIComparisonValueConditionalFormatting(tfList []any) *awstypes.KPIComparisonValueConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIComparisonValueConditionalFormatting{}
 
-	if v, ok := tfMap["icon"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon"].([]any); ok && len(v) > 0 {
 		apiObject.Icon = expandConditionalFormattingIcon(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIPrimaryValueConditionalFormatting(tfList []interface{}) *awstypes.KPIPrimaryValueConditionalFormatting {
+func expandKPIPrimaryValueConditionalFormatting(tfList []any) *awstypes.KPIPrimaryValueConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIPrimaryValueConditionalFormatting{}
 
-	if v, ok := tfMap["icon"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["icon"].([]any); ok && len(v) > 0 {
 		apiObject.Icon = expandConditionalFormattingIcon(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandKPIProgressBarConditionalFormatting(tfList []interface{}) *awstypes.KPIProgressBarConditionalFormatting {
+func expandKPIProgressBarConditionalFormatting(tfList []any) *awstypes.KPIProgressBarConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.KPIProgressBarConditionalFormatting{}
 
-	if v, ok := tfMap["foreground_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["foreground_color"].([]any); ok && len(v) > 0 {
 		apiObject.ForegroundColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func flattenKPIVisual(apiObject *awstypes.KPIVisual) []interface{} {
+func flattenKPIVisual(apiObject *awstypes.KPIVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -663,15 +663,15 @@ func flattenKPIVisual(apiObject *awstypes.KPIVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIConfiguration(apiObject *awstypes.KPIConfiguration) []interface{} {
+func flattenKPIConfiguration(apiObject *awstypes.KPIConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldWells != nil {
 		tfMap["field_wells"] = flattenKPIFieldWells(apiObject.FieldWells)
@@ -683,15 +683,15 @@ func flattenKPIConfiguration(apiObject *awstypes.KPIConfiguration) []interface{}
 		tfMap["sort_configuration"] = flattenKPISortConfiguration(apiObject.SortConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIFieldWells(apiObject *awstypes.KPIFieldWells) []interface{} {
+func flattenKPIFieldWells(apiObject *awstypes.KPIFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TargetValues != nil {
 		tfMap["target_values"] = flattenMeasureFields(apiObject.TargetValues)
@@ -703,15 +703,15 @@ func flattenKPIFieldWells(apiObject *awstypes.KPIFieldWells) []interface{} {
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIOptions(apiObject *awstypes.KPIOptions) []interface{} {
+func flattenKPIOptions(apiObject *awstypes.KPIOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Comparison != nil {
 		tfMap["comparison"] = flattenComparisonConfiguration(apiObject.Comparison)
@@ -739,39 +739,39 @@ func flattenKPIOptions(apiObject *awstypes.KPIOptions) []interface{} {
 		tfMap["visual_layout_options"] = flattenKPIVisualLayoutOptions(apiObject.VisualLayoutOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenProgressBarOptions(apiObject *awstypes.ProgressBarOptions) []interface{} {
+func flattenProgressBarOptions(apiObject *awstypes.ProgressBarOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSecondaryValueOptions(apiObject *awstypes.SecondaryValueOptions) []interface{} {
+func flattenSecondaryValueOptions(apiObject *awstypes.SecondaryValueOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPISparklineOptions(apiObject *awstypes.KPISparklineOptions) []interface{} {
+func flattenKPISparklineOptions(apiObject *awstypes.KPISparklineOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Color != nil {
 		tfMap["color"] = aws.ToString(apiObject.Color)
@@ -780,84 +780,84 @@ func flattenKPISparklineOptions(apiObject *awstypes.KPISparklineOptions) []inter
 	tfMap[names.AttrType] = apiObject.Type
 	tfMap["visibility"] = apiObject.Visibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTrendArrowOptions(apiObject *awstypes.TrendArrowOptions) []interface{} {
+func flattenTrendArrowOptions(apiObject *awstypes.TrendArrowOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIVisualLayoutOptions(apiObject *awstypes.KPIVisualLayoutOptions) []interface{} {
+func flattenKPIVisualLayoutOptions(apiObject *awstypes.KPIVisualLayoutOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.StandardLayout != nil {
 		tfMap["standard_layout"] = flattenKPIVisualStandardLayout(apiObject.StandardLayout)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIVisualStandardLayout(apiObject *awstypes.KPIVisualStandardLayout) []interface{} {
+func flattenKPIVisualStandardLayout(apiObject *awstypes.KPIVisualStandardLayout) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrType: apiObject.Type,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPISortConfiguration(apiObject *awstypes.KPISortConfiguration) []interface{} {
+func flattenKPISortConfiguration(apiObject *awstypes.KPISortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TrendGroupSort != nil {
 		tfMap["trend_group_sort"] = flattenFieldSortOptions(apiObject.TrendGroupSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIConditionalFormatting(apiObject *awstypes.KPIConditionalFormatting) []interface{} {
+func flattenKPIConditionalFormatting(apiObject *awstypes.KPIConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionalFormattingOptions != nil {
 		tfMap["conditional_formatting_options"] = flattenKPIConditionalFormattingOption(apiObject.ConditionalFormattingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIConditionalFormattingOption(apiObjects []awstypes.KPIConditionalFormattingOption) []interface{} {
+func flattenKPIConditionalFormattingOption(apiObjects []awstypes.KPIConditionalFormattingOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ActualValue != nil {
 			tfMap["actual_value"] = flattenKPIActualValueConditionalFormatting(apiObject.ActualValue)
@@ -878,12 +878,12 @@ func flattenKPIConditionalFormattingOption(apiObjects []awstypes.KPIConditionalF
 	return tfList
 }
 
-func flattenKPIActualValueConditionalFormatting(apiObject *awstypes.KPIActualValueConditionalFormatting) []interface{} {
+func flattenKPIActualValueConditionalFormatting(apiObject *awstypes.KPIActualValueConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Icon != nil {
 		tfMap["icon"] = flattenConditionalFormattingIcon(apiObject.Icon)
@@ -892,15 +892,15 @@ func flattenKPIActualValueConditionalFormatting(apiObject *awstypes.KPIActualVal
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIComparisonValueConditionalFormatting(apiObject *awstypes.KPIComparisonValueConditionalFormatting) []interface{} {
+func flattenKPIComparisonValueConditionalFormatting(apiObject *awstypes.KPIComparisonValueConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Icon != nil {
 		tfMap["icon"] = flattenConditionalFormattingIcon(apiObject.Icon)
@@ -909,15 +909,15 @@ func flattenKPIComparisonValueConditionalFormatting(apiObject *awstypes.KPICompa
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIPrimaryValueConditionalFormatting(apiObject *awstypes.KPIPrimaryValueConditionalFormatting) []interface{} {
+func flattenKPIPrimaryValueConditionalFormatting(apiObject *awstypes.KPIPrimaryValueConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Icon != nil {
 		tfMap["icon"] = flattenConditionalFormattingIcon(apiObject.Icon)
@@ -926,19 +926,19 @@ func flattenKPIPrimaryValueConditionalFormatting(apiObject *awstypes.KPIPrimaryV
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKPIProgressBarConditionalFormatting(apiObject *awstypes.KPIProgressBarConditionalFormatting) []interface{} {
+func flattenKPIProgressBarConditionalFormatting(apiObject *awstypes.KPIProgressBarConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ForegroundColor != nil {
 		tfMap["foreground_color"] = flattenConditionalFormattingColor(apiObject.ForegroundColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_line_chart.go
+++ b/internal/service/quicksight/schema/visual_line_chart.go
@@ -326,12 +326,12 @@ var lineChartMarkerStyleSettingsSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandLineChartVisual(tfList []interface{}) *awstypes.LineChartVisual {
+func expandLineChartVisual(tfList []any) *awstypes.LineChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -341,31 +341,31 @@ func expandLineChartVisual(tfList []interface{}) *awstypes.LineChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandLineChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartConfiguration(tfList []interface{}) *awstypes.LineChartConfiguration {
+func expandLineChartConfiguration(tfList []any) *awstypes.LineChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -375,148 +375,148 @@ func expandLineChartConfiguration(tfList []interface{}) *awstypes.LineChartConfi
 	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
 		apiObject.Type = awstypes.LineChartType(v)
 	}
-	if v, ok := tfMap["contribution_analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["contribution_analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.ContributionAnalysisDefaults = expandContributionAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["default_series_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_series_settings"].([]any); ok && len(v) > 0 {
 		apiObject.DefaultSeriesSettings = expandLineChartDefaultSeriesSettings(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandLineChartFieldWells(v)
 	}
-	if v, ok := tfMap["forecast_configurations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["forecast_configurations"].([]any); ok && len(v) > 0 {
 		apiObject.ForecastConfigurations = expandForecastConfigurations(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisDisplayOptions = expandLineSeriesAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["reference_lines"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["reference_lines"].([]any); ok && len(v) > 0 {
 		apiObject.ReferenceLines = expandReferenceLines(v)
 	}
-	if v, ok := tfMap["secondary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryYAxisDisplayOptions = expandLineSeriesAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["secondary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["secondary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.SecondaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["series"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["series"].([]any); ok && len(v) > 0 {
 		apiObject.Series = expandSeriesItems(v)
 	}
-	if v, ok := tfMap["small_multiples_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_options"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesOptions = expandSmallMultiplesOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandLineChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
-	if v, ok := tfMap["x_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["x_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartFieldWells(tfList []interface{}) *awstypes.LineChartFieldWells {
+func expandLineChartFieldWells(tfList []any) *awstypes.LineChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LineChartFieldWells{}
 
-	if v, ok := tfMap["line_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.LineChartAggregatedFieldWells = expandLineChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartAggregatedFieldWells(tfList []interface{}) *awstypes.LineChartAggregatedFieldWells {
+func expandLineChartAggregatedFieldWells(tfList []any) *awstypes.LineChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LineChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["small_multiples"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiples = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartSortConfiguration(tfList []interface{}) *awstypes.LineChartSortConfiguration {
+func expandLineChartSortConfiguration(tfList []any) *awstypes.LineChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LineChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["color_items_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_items_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ColorItemsLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["small_multiples_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["small_multiples_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_sort"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartDefaultSeriesSettings(tfList []interface{}) *awstypes.LineChartDefaultSeriesSettings {
+func expandLineChartDefaultSeriesSettings(tfList []any) *awstypes.LineChartDefaultSeriesSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -526,22 +526,22 @@ func expandLineChartDefaultSeriesSettings(tfList []interface{}) *awstypes.LineCh
 	if v, ok := tfMap["axis_binding"].(string); ok && v != "" {
 		apiObject.AxisBinding = awstypes.AxisBinding(v)
 	}
-	if v, ok := tfMap["line_style_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_style_settings"].([]any); ok && len(v) > 0 {
 		apiObject.LineStyleSettings = expandLineChartLineStyleSettings(v)
 	}
-	if v, ok := tfMap["marker_style_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["marker_style_settings"].([]any); ok && len(v) > 0 {
 		apiObject.MarkerStyleSettings = expandLineChartMarkerStyleSettings(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartLineStyleSettings(tfList []interface{}) *awstypes.LineChartLineStyleSettings {
+func expandLineChartLineStyleSettings(tfList []any) *awstypes.LineChartLineStyleSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -564,12 +564,12 @@ func expandLineChartLineStyleSettings(tfList []interface{}) *awstypes.LineChartL
 	return apiObject
 }
 
-func expandLineChartMarkerStyleSettings(tfList []interface{}) *awstypes.LineChartMarkerStyleSettings {
+func expandLineChartMarkerStyleSettings(tfList []any) *awstypes.LineChartMarkerStyleSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -592,7 +592,7 @@ func expandLineChartMarkerStyleSettings(tfList []interface{}) *awstypes.LineChar
 	return apiObject
 }
 
-func expandForecastConfigurations(tfList []interface{}) []awstypes.ForecastConfiguration {
+func expandForecastConfigurations(tfList []any) []awstypes.ForecastConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -600,7 +600,7 @@ func expandForecastConfigurations(tfList []interface{}) []awstypes.ForecastConfi
 	var apiObjects []awstypes.ForecastConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -616,29 +616,29 @@ func expandForecastConfigurations(tfList []interface{}) []awstypes.ForecastConfi
 	return apiObjects
 }
 
-func expandForecastConfiguration(tfMap map[string]interface{}) *awstypes.ForecastConfiguration {
+func expandForecastConfiguration(tfMap map[string]any) *awstypes.ForecastConfiguration {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ForecastConfiguration{}
 
-	if v, ok := tfMap["forecast_properties"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["forecast_properties"].([]any); ok && len(v) > 0 {
 		apiObject.ForecastProperties = expandTimeBasedForecastProperties(v)
 	}
-	if v, ok := tfMap["scenario"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scenario"].([]any); ok && len(v) > 0 {
 		apiObject.Scenario = expandForecastScenario(v)
 	}
 
 	return apiObject
 }
 
-func expandTimeBasedForecastProperties(tfList []interface{}) *awstypes.TimeBasedForecastProperties {
+func expandTimeBasedForecastProperties(tfList []any) *awstypes.TimeBasedForecastProperties {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -667,34 +667,34 @@ func expandTimeBasedForecastProperties(tfList []interface{}) *awstypes.TimeBased
 	return apiObject
 }
 
-func expandForecastScenario(tfList []interface{}) *awstypes.ForecastScenario {
+func expandForecastScenario(tfList []any) *awstypes.ForecastScenario {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ForecastScenario{}
 
-	if v, ok := tfMap["what_if_point_scenario"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["what_if_point_scenario"].([]any); ok && len(v) > 0 {
 		apiObject.WhatIfPointScenario = expandWhatIfPointScenario(v)
 	}
-	if v, ok := tfMap["what_if_range_scenario"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["what_if_range_scenario"].([]any); ok && len(v) > 0 {
 		apiObject.WhatIfRangeScenario = expandWhatIfRangeScenario(v)
 	}
 
 	return apiObject
 }
 
-func expandWhatIfPointScenario(tfList []interface{}) *awstypes.WhatIfPointScenario {
+func expandWhatIfPointScenario(tfList []any) *awstypes.WhatIfPointScenario {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -713,12 +713,12 @@ func expandWhatIfPointScenario(tfList []interface{}) *awstypes.WhatIfPointScenar
 	return apiObject
 }
 
-func expandWhatIfRangeScenario(tfList []interface{}) *awstypes.WhatIfRangeScenario {
+func expandWhatIfRangeScenario(tfList []any) *awstypes.WhatIfRangeScenario {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -740,29 +740,29 @@ func expandWhatIfRangeScenario(tfList []interface{}) *awstypes.WhatIfRangeScenar
 	return apiObject
 }
 
-func expandLineSeriesAxisDisplayOptions(tfList []interface{}) *awstypes.LineSeriesAxisDisplayOptions {
+func expandLineSeriesAxisDisplayOptions(tfList []any) *awstypes.LineSeriesAxisDisplayOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LineSeriesAxisDisplayOptions{}
 
-	if v, ok := tfMap["axis_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["axis_options"].([]any); ok && len(v) > 0 {
 		apiObject.AxisOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["missing_data_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["missing_data_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.MissingDataConfigurations = expandMissingDataConfigurations(v)
 	}
 
 	return apiObject
 }
 
-func expandMissingDataConfigurations(tfList []interface{}) []awstypes.MissingDataConfiguration {
+func expandMissingDataConfigurations(tfList []any) []awstypes.MissingDataConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -770,7 +770,7 @@ func expandMissingDataConfigurations(tfList []interface{}) []awstypes.MissingDat
 	var apiObjects []awstypes.MissingDataConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -786,7 +786,7 @@ func expandMissingDataConfigurations(tfList []interface{}) []awstypes.MissingDat
 	return apiObjects
 }
 
-func expandMissingDataConfiguration(tfMap map[string]interface{}) *awstypes.MissingDataConfiguration {
+func expandMissingDataConfiguration(tfMap map[string]any) *awstypes.MissingDataConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -800,7 +800,7 @@ func expandMissingDataConfiguration(tfMap map[string]interface{}) *awstypes.Miss
 	return apiObject
 }
 
-func expandSeriesItems(tfList []interface{}) []awstypes.SeriesItem {
+func expandSeriesItems(tfList []any) []awstypes.SeriesItem {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -808,7 +808,7 @@ func expandSeriesItems(tfList []interface{}) []awstypes.SeriesItem {
 	var apiObjects []awstypes.SeriesItem
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -824,29 +824,29 @@ func expandSeriesItems(tfList []interface{}) []awstypes.SeriesItem {
 	return apiObjects
 }
 
-func expandSeriesItem(tfMap map[string]interface{}) *awstypes.SeriesItem {
+func expandSeriesItem(tfMap map[string]any) *awstypes.SeriesItem {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.SeriesItem{}
 
-	if v, ok := tfMap["data_field_series_item"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_field_series_item"].([]any); ok && len(v) > 0 {
 		apiObject.DataFieldSeriesItem = expandDataFieldSeriesItem(v)
 	}
-	if v, ok := tfMap["field_series_item"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_series_item"].([]any); ok && len(v) > 0 {
 		apiObject.FieldSeriesItem = expandFieldSeriesItem(v)
 	}
 
 	return apiObject
 }
 
-func expandDataFieldSeriesItem(tfList []interface{}) *awstypes.DataFieldSeriesItem {
+func expandDataFieldSeriesItem(tfList []any) *awstypes.DataFieldSeriesItem {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -862,19 +862,19 @@ func expandDataFieldSeriesItem(tfList []interface{}) *awstypes.DataFieldSeriesIt
 	if v, ok := tfMap["field_value"].(string); ok && v != "" {
 		apiObject.FieldValue = aws.String(v)
 	}
-	if v, ok := tfMap["settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["settings"].([]any); ok && len(v) > 0 {
 		apiObject.Settings = expandLineChartSeriesSettings(v)
 	}
 
 	return apiObject
 }
 
-func expandFieldSeriesItem(tfList []interface{}) *awstypes.FieldSeriesItem {
+func expandFieldSeriesItem(tfList []any) *awstypes.FieldSeriesItem {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -887,41 +887,41 @@ func expandFieldSeriesItem(tfList []interface{}) *awstypes.FieldSeriesItem {
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["settings"].([]any); ok && len(v) > 0 {
 		apiObject.Settings = expandLineChartSeriesSettings(v)
 	}
 
 	return apiObject
 }
 
-func expandLineChartSeriesSettings(tfList []interface{}) *awstypes.LineChartSeriesSettings {
+func expandLineChartSeriesSettings(tfList []any) *awstypes.LineChartSeriesSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.LineChartSeriesSettings{}
 
-	if v, ok := tfMap["line_style_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["line_style_settings"].([]any); ok && len(v) > 0 {
 		apiObject.LineStyleSettings = expandLineChartLineStyleSettings(v)
 	}
-	if v, ok := tfMap["marker_style_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["marker_style_settings"].([]any); ok && len(v) > 0 {
 		apiObject.MarkerStyleSettings = expandLineChartMarkerStyleSettings(v)
 	}
 
 	return apiObject
 }
 
-func flattenLineChartVisual(apiObject *awstypes.LineChartVisual) []interface{} {
+func flattenLineChartVisual(apiObject *awstypes.LineChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -941,15 +941,15 @@ func flattenLineChartVisual(apiObject *awstypes.LineChartVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartConfiguration(apiObject *awstypes.LineChartConfiguration) []interface{} {
+func flattenLineChartConfiguration(apiObject *awstypes.LineChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ContributionAnalysisDefaults != nil {
 		tfMap["contribution_analysis_defaults"] = flattenContributionAnalysisDefault(apiObject.ContributionAnalysisDefaults)
@@ -1007,15 +1007,15 @@ func flattenLineChartConfiguration(apiObject *awstypes.LineChartConfiguration) [
 		tfMap["x_axis_label_options"] = flattenChartAxisLabelOptions(apiObject.XAxisLabelOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartDefaultSeriesSettings(apiObject *awstypes.LineChartDefaultSeriesSettings) []interface{} {
+func flattenLineChartDefaultSeriesSettings(apiObject *awstypes.LineChartDefaultSeriesSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["axis_binding"] = apiObject.AxisBinding
 	if apiObject.LineStyleSettings != nil {
@@ -1025,15 +1025,15 @@ func flattenLineChartDefaultSeriesSettings(apiObject *awstypes.LineChartDefaultS
 		tfMap["marker_style_settings"] = flattenLineChartMarkerStyleSettings(apiObject.MarkerStyleSettings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartLineStyleSettings(apiObject *awstypes.LineChartLineStyleSettings) []interface{} {
+func flattenLineChartLineStyleSettings(apiObject *awstypes.LineChartLineStyleSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"line_interpolation": apiObject.LineInterpolation,
 		"line_style":         apiObject.LineStyle,
 		"line_visibility":    apiObject.LineVisibility,
@@ -1043,15 +1043,15 @@ func flattenLineChartLineStyleSettings(apiObject *awstypes.LineChartLineStyleSet
 		tfMap["line_width"] = aws.ToString(apiObject.LineWidth)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartMarkerStyleSettings(apiObject *awstypes.LineChartMarkerStyleSettings) []interface{} {
+func flattenLineChartMarkerStyleSettings(apiObject *awstypes.LineChartMarkerStyleSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"marker_shape":      apiObject.MarkerShape,
 		"marker_visibility": apiObject.MarkerVisibility,
 	}
@@ -1063,29 +1063,29 @@ func flattenLineChartMarkerStyleSettings(apiObject *awstypes.LineChartMarkerStyl
 		tfMap["marker_size"] = aws.ToString(apiObject.MarkerSize)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartFieldWells(apiObject *awstypes.LineChartFieldWells) []interface{} {
+func flattenLineChartFieldWells(apiObject *awstypes.LineChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LineChartAggregatedFieldWells != nil {
 		tfMap["line_chart_aggregated_field_wells"] = flattenLineChartAggregatedFieldWells(apiObject.LineChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartAggregatedFieldWells(apiObject *awstypes.LineChartAggregatedFieldWells) []interface{} {
+func flattenLineChartAggregatedFieldWells(apiObject *awstypes.LineChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -1100,18 +1100,18 @@ func flattenLineChartAggregatedFieldWells(apiObject *awstypes.LineChartAggregate
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenForecastConfiguration(apiObjects []awstypes.ForecastConfiguration) []interface{} {
+func flattenForecastConfiguration(apiObjects []awstypes.ForecastConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.ForecastProperties != nil {
 			tfMap["forecast_properties"] = flattenTimeBasedForecastProperties(apiObject.ForecastProperties)
@@ -1126,12 +1126,12 @@ func flattenForecastConfiguration(apiObjects []awstypes.ForecastConfiguration) [
 	return tfList
 }
 
-func flattenTimeBasedForecastProperties(apiObject *awstypes.TimeBasedForecastProperties) []interface{} {
+func flattenTimeBasedForecastProperties(apiObject *awstypes.TimeBasedForecastProperties) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LowerBoundary != nil {
 		tfMap["lower_boundary"] = aws.ToFloat64(apiObject.LowerBoundary)
@@ -1152,15 +1152,15 @@ func flattenTimeBasedForecastProperties(apiObject *awstypes.TimeBasedForecastPro
 		tfMap["upper_boundary"] = aws.ToFloat64(apiObject.UpperBoundary)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenForecastScenario(apiObject *awstypes.ForecastScenario) []interface{} {
+func flattenForecastScenario(apiObject *awstypes.ForecastScenario) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.WhatIfPointScenario != nil {
 		tfMap["what_if_point_scenario"] = flattenWhatIfPointScenario(apiObject.WhatIfPointScenario)
@@ -1169,30 +1169,30 @@ func flattenForecastScenario(apiObject *awstypes.ForecastScenario) []interface{}
 		tfMap["what_if_range_scenario"] = flattenWhatIfRangeScenario(apiObject.WhatIfRangeScenario)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWhatIfPointScenario(apiObject *awstypes.WhatIfPointScenario) []interface{} {
+func flattenWhatIfPointScenario(apiObject *awstypes.WhatIfPointScenario) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Date != nil {
 		tfMap["date"] = aws.ToTime(apiObject.Date).Format(time.RFC3339)
 	}
 	tfMap[names.AttrValue] = apiObject.Value
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWhatIfRangeScenario(apiObject *awstypes.WhatIfRangeScenario) []interface{} {
+func flattenWhatIfRangeScenario(apiObject *awstypes.WhatIfRangeScenario) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.EndDate != nil {
 		tfMap["end_date"] = aws.ToTime(apiObject.EndDate).Format(time.RFC3339)
@@ -1202,15 +1202,15 @@ func flattenWhatIfRangeScenario(apiObject *awstypes.WhatIfRangeScenario) []inter
 	}
 	tfMap[names.AttrValue] = apiObject.Value
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineSeriesAxisDisplayOptions(apiObject *awstypes.LineSeriesAxisDisplayOptions) []interface{} {
+func flattenLineSeriesAxisDisplayOptions(apiObject *awstypes.LineSeriesAxisDisplayOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AxisOptions != nil {
 		tfMap["axis_options"] = flattenAxisDisplayOptions(apiObject.AxisOptions)
@@ -1219,18 +1219,18 @@ func flattenLineSeriesAxisDisplayOptions(apiObject *awstypes.LineSeriesAxisDispl
 		tfMap["missing_data_configurations"] = flattenMissingDataConfiguration(apiObject.MissingDataConfigurations)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMissingDataConfiguration(apiObjects []awstypes.MissingDataConfiguration) []interface{} {
+func flattenMissingDataConfiguration(apiObjects []awstypes.MissingDataConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"treatment_option": apiObject.TreatmentOption,
 		}
 
@@ -1240,15 +1240,15 @@ func flattenMissingDataConfiguration(apiObjects []awstypes.MissingDataConfigurat
 	return tfList
 }
 
-func flattenSeriesItem(apiObjects []awstypes.SeriesItem) []interface{} {
+func flattenSeriesItem(apiObjects []awstypes.SeriesItem) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataFieldSeriesItem != nil {
 			tfMap["data_field_series_item"] = flattenDataFieldSeriesItem(apiObject.DataFieldSeriesItem)
@@ -1263,12 +1263,12 @@ func flattenSeriesItem(apiObjects []awstypes.SeriesItem) []interface{} {
 	return tfList
 }
 
-func flattenDataFieldSeriesItem(apiObject *awstypes.DataFieldSeriesItem) []interface{} {
+func flattenDataFieldSeriesItem(apiObject *awstypes.DataFieldSeriesItem) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"axis_binding": apiObject.AxisBinding,
 	}
 
@@ -1282,15 +1282,15 @@ func flattenDataFieldSeriesItem(apiObject *awstypes.DataFieldSeriesItem) []inter
 		tfMap["settings"] = flattenLineChartSeriesSettings(apiObject.Settings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartSeriesSettings(apiObject *awstypes.LineChartSeriesSettings) []interface{} {
+func flattenLineChartSeriesSettings(apiObject *awstypes.LineChartSeriesSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.LineStyleSettings != nil {
 		tfMap["line_style_settings"] = flattenLineChartLineStyleSettings(apiObject.LineStyleSettings)
@@ -1299,15 +1299,15 @@ func flattenLineChartSeriesSettings(apiObject *awstypes.LineChartSeriesSettings)
 		tfMap["marker_style_settings"] = flattenLineChartMarkerStyleSettings(apiObject.MarkerStyleSettings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFieldSeriesItem(apiObject *awstypes.FieldSeriesItem) []interface{} {
+func flattenFieldSeriesItem(apiObject *awstypes.FieldSeriesItem) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"axis_binding": apiObject.AxisBinding,
 	}
 
@@ -1318,15 +1318,15 @@ func flattenFieldSeriesItem(apiObject *awstypes.FieldSeriesItem) []interface{} {
 		tfMap["settings"] = flattenLineChartSeriesSettings(apiObject.Settings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenLineChartSortConfiguration(apiObject *awstypes.LineChartSortConfiguration) []interface{} {
+func flattenLineChartSortConfiguration(apiObject *awstypes.LineChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimitConfiguration != nil {
 		tfMap["category_items_limit_configuration"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimitConfiguration)
@@ -1344,5 +1344,5 @@ func flattenLineChartSortConfiguration(apiObject *awstypes.LineChartSortConfigur
 		tfMap["small_multiples_sort"] = flattenFieldSortOptions(apiObject.SmallMultiplesSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_map.go
+++ b/internal/service/quicksight/schema/visual_map.go
@@ -53,12 +53,12 @@ var geospatialWindowOptionsSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandGeospatialMapStyleOptions(tfList []interface{}) *awstypes.GeospatialMapStyleOptions {
+func expandGeospatialMapStyleOptions(tfList []any) *awstypes.GeospatialMapStyleOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -72,12 +72,12 @@ func expandGeospatialMapStyleOptions(tfList []interface{}) *awstypes.GeospatialM
 	return apiObject
 }
 
-func expandGeospatialWindowOptions(tfList []interface{}) *awstypes.GeospatialWindowOptions {
+func expandGeospatialWindowOptions(tfList []any) *awstypes.GeospatialWindowOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -87,19 +87,19 @@ func expandGeospatialWindowOptions(tfList []interface{}) *awstypes.GeospatialWin
 	if v, ok := tfMap["map_zoom_mode"].(string); ok && v != "" {
 		apiObject.MapZoomMode = awstypes.MapZoomMode(v)
 	}
-	if v, ok := tfMap["bounds"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bounds"].([]any); ok && len(v) > 0 {
 		apiObject.Bounds = expandGeospatialCoordinateBounds(v)
 	}
 
 	return apiObject
 }
 
-func expandGeospatialCoordinateBounds(tfList []interface{}) *awstypes.GeospatialCoordinateBounds {
+func expandGeospatialCoordinateBounds(tfList []any) *awstypes.GeospatialCoordinateBounds {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -122,39 +122,39 @@ func expandGeospatialCoordinateBounds(tfList []interface{}) *awstypes.Geospatial
 	return apiObject
 }
 
-func flattenGeospatialMapStyleOptions(apiObject *awstypes.GeospatialMapStyleOptions) []interface{} {
+func flattenGeospatialMapStyleOptions(apiObject *awstypes.GeospatialMapStyleOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"base_map_style": apiObject.BaseMapStyle,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialWindowOptions(apiObject *awstypes.GeospatialWindowOptions) []interface{} {
+func flattenGeospatialWindowOptions(apiObject *awstypes.GeospatialWindowOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Bounds != nil {
 		tfMap["bounds"] = flattenGeospatialCoordinateBounds(apiObject.Bounds)
 	}
 	tfMap["map_zoom_mode"] = apiObject.MapZoomMode
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGeospatialCoordinateBounds(apiObject *awstypes.GeospatialCoordinateBounds) []interface{} {
+func flattenGeospatialCoordinateBounds(apiObject *awstypes.GeospatialCoordinateBounds) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.East != nil {
 		tfMap["east"] = aws.ToFloat64(apiObject.East)
@@ -169,5 +169,5 @@ func flattenGeospatialCoordinateBounds(apiObject *awstypes.GeospatialCoordinateB
 		tfMap["west"] = aws.ToFloat64(apiObject.West)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_pie_chart.go
+++ b/internal/service/quicksight/schema/visual_pie_chart.go
@@ -117,12 +117,12 @@ func pieChartVisualSchema() *schema.Schema {
 	}
 }
 
-func expandPieChartVisual(tfList []interface{}) *awstypes.PieChartVisual {
+func expandPieChartVisual(tfList []any) *awstypes.PieChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -132,174 +132,174 @@ func expandPieChartVisual(tfList []interface{}) *awstypes.PieChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandPieChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandPieChartConfiguration(tfList []interface{}) *awstypes.PieChartConfiguration {
+func expandPieChartConfiguration(tfList []any) *awstypes.PieChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PieChartConfiguration{}
 
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["contribution_analysis_defaults"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["contribution_analysis_defaults"].([]any); ok && len(v) > 0 {
 		apiObject.ContributionAnalysisDefaults = expandContributionAnalysisDefaults(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["donut_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["donut_options"].([]any); ok && len(v) > 0 {
 		apiObject.DonutOptions = expandDonutOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandPieChartFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["small_multiples_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_options"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesOptions = expandSmallMultiplesOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandPieChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["value_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ValueLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandPieChartFieldWells(tfList []interface{}) *awstypes.PieChartFieldWells {
+func expandPieChartFieldWells(tfList []any) *awstypes.PieChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PieChartFieldWells{}
 
-	if v, ok := tfMap["pie_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pie_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.PieChartAggregatedFieldWells = expandPieChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandPieChartAggregatedFieldWells(tfList []interface{}) *awstypes.PieChartAggregatedFieldWells {
+func expandPieChartAggregatedFieldWells(tfList []any) *awstypes.PieChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PieChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["small_multiples"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiples = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandPieChartSortConfiguration(tfList []interface{}) *awstypes.PieChartSortConfiguration {
+func expandPieChartSortConfiguration(tfList []any) *awstypes.PieChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PieChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["small_multiples_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["small_multiples_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["small_multiples_sort"].([]any); ok && len(v) > 0 {
 		apiObject.SmallMultiplesSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandDonutOptions(tfList []interface{}) *awstypes.DonutOptions {
+func expandDonutOptions(tfList []any) *awstypes.DonutOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.DonutOptions{}
 
-	if v, ok := tfMap["arc_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["arc_options"].([]any); ok && len(v) > 0 {
 		apiObject.ArcOptions = expandArcOptions(v)
 	}
-	if v, ok := tfMap["donut_center_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["donut_center_options"].([]any); ok && len(v) > 0 {
 		apiObject.DonutCenterOptions = expandDonutCenterOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandArcOptions(tfList []interface{}) *awstypes.ArcOptions {
+func expandArcOptions(tfList []any) *awstypes.ArcOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -313,12 +313,12 @@ func expandArcOptions(tfList []interface{}) *awstypes.ArcOptions {
 	return apiObject
 }
 
-func expandDonutCenterOptions(tfList []interface{}) *awstypes.DonutCenterOptions {
+func expandDonutCenterOptions(tfList []any) *awstypes.DonutCenterOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -332,12 +332,12 @@ func expandDonutCenterOptions(tfList []interface{}) *awstypes.DonutCenterOptions
 	return apiObject
 }
 
-func flattenPieChartVisual(apiObject *awstypes.PieChartVisual) []interface{} {
+func flattenPieChartVisual(apiObject *awstypes.PieChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -357,15 +357,15 @@ func flattenPieChartVisual(apiObject *awstypes.PieChartVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPieChartConfiguration(apiObject *awstypes.PieChartConfiguration) []interface{} {
+func flattenPieChartConfiguration(apiObject *awstypes.PieChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryLabelOptions != nil {
 		tfMap["category_label_options"] = flattenChartAxisLabelOptions(apiObject.CategoryLabelOptions)
@@ -401,15 +401,15 @@ func flattenPieChartConfiguration(apiObject *awstypes.PieChartConfiguration) []i
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDonutOptions(apiObject *awstypes.DonutOptions) []interface{} {
+func flattenDonutOptions(apiObject *awstypes.DonutOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ArcOptions != nil {
 		tfMap["arc_options"] = flattenArcOptions(apiObject.ArcOptions)
@@ -418,53 +418,53 @@ func flattenDonutOptions(apiObject *awstypes.DonutOptions) []interface{} {
 		tfMap["donut_center_options"] = flattenDonutCenterOptions(apiObject.DonutCenterOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenArcOptions(apiObject *awstypes.ArcOptions) []interface{} {
+func flattenArcOptions(apiObject *awstypes.ArcOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"arc_thickness": apiObject.ArcThickness,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDonutCenterOptions(apiObject *awstypes.DonutCenterOptions) []interface{} {
+func flattenDonutCenterOptions(apiObject *awstypes.DonutCenterOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"label_visibility": apiObject.LabelVisibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPieChartFieldWells(apiObject *awstypes.PieChartFieldWells) []interface{} {
+func flattenPieChartFieldWells(apiObject *awstypes.PieChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PieChartAggregatedFieldWells != nil {
 		tfMap["pie_chart_aggregated_field_wells"] = flattenPieChartAggregatedFieldWells(apiObject.PieChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPieChartAggregatedFieldWells(apiObject *awstypes.PieChartAggregatedFieldWells) []interface{} {
+func flattenPieChartAggregatedFieldWells(apiObject *awstypes.PieChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -476,15 +476,15 @@ func flattenPieChartAggregatedFieldWells(apiObject *awstypes.PieChartAggregatedF
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPieChartSortConfiguration(apiObject *awstypes.PieChartSortConfiguration) []interface{} {
+func flattenPieChartSortConfiguration(apiObject *awstypes.PieChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -499,5 +499,5 @@ func flattenPieChartSortConfiguration(apiObject *awstypes.PieChartSortConfigurat
 		tfMap["small_multiples_sort"] = flattenFieldSortOptions(apiObject.SmallMultiplesSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_pivot_table.go
+++ b/internal/service/quicksight/schema/visual_pivot_table.go
@@ -406,12 +406,12 @@ var textConditionalFormatSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandPivotTableVisual(tfList []interface{}) *awstypes.PivotTableVisual {
+func expandPivotTableVisual(tfList []any) *awstypes.PivotTableVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -421,123 +421,123 @@ func expandPivotTableVisual(tfList []interface{}) *awstypes.PivotTableVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandPivotTableConfiguration(v)
 	}
-	if v, ok := tfMap["conditional_formatting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormatting = expandPivotTableConditionalFormatting(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableConfiguration(tfList []interface{}) *awstypes.PivotTableConfiguration {
+func expandPivotTableConfiguration(tfList []any) *awstypes.PivotTableConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableConfiguration{}
 
-	if v, ok := tfMap["field_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_options"].([]any); ok && len(v) > 0 {
 		apiObject.FieldOptions = expandPivotTableFieldOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandPivotTableFieldWells(v)
 	}
-	if v, ok := tfMap["paginated_report_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["paginated_report_options"].([]any); ok && len(v) > 0 {
 		apiObject.PaginatedReportOptions = expandPivotTablePaginatedReportOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandPivotTableSortConfiguration(v)
 	}
-	if v, ok := tfMap["table_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_options"].([]any); ok && len(v) > 0 {
 		apiObject.TableOptions = expandPivotTableOptions(v)
 	}
-	if v, ok := tfMap["total_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_options"].([]any); ok && len(v) > 0 {
 		apiObject.TotalOptions = expandPivotTableTotalOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableFieldWells(tfList []interface{}) *awstypes.PivotTableFieldWells {
+func expandPivotTableFieldWells(tfList []any) *awstypes.PivotTableFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableFieldWells{}
 
-	if v, ok := tfMap["pivot_table_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pivot_table_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.PivotTableAggregatedFieldWells = expandPivotTableAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableAggregatedFieldWells(tfList []interface{}) *awstypes.PivotTableAggregatedFieldWells {
+func expandPivotTableAggregatedFieldWells(tfList []any) *awstypes.PivotTableAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableAggregatedFieldWells{}
 
-	if v, ok := tfMap["columns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["columns"].([]any); ok && len(v) > 0 {
 		apiObject.Columns = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["rows"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["rows"].([]any); ok && len(v) > 0 {
 		apiObject.Rows = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableSortConfiguration(tfList []interface{}) *awstypes.PivotTableSortConfiguration {
+func expandPivotTableSortConfiguration(tfList []any) *awstypes.PivotTableSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableSortConfiguration{}
 
-	if v, ok := tfMap["field_sort_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_sort_options"].([]any); ok && len(v) > 0 {
 		apiObject.FieldSortOptions = expandPivotFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotFieldSortOptionsList(tfList []interface{}) []awstypes.PivotFieldSortOptions {
+func expandPivotFieldSortOptionsList(tfList []any) []awstypes.PivotFieldSortOptions {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -545,7 +545,7 @@ func expandPivotFieldSortOptionsList(tfList []interface{}) []awstypes.PivotField
 	var apiObjects []awstypes.PivotFieldSortOptions
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -561,7 +561,7 @@ func expandPivotFieldSortOptionsList(tfList []interface{}) []awstypes.PivotField
 	return apiObjects
 }
 
-func expandPivotFieldSortOptions(tfMap map[string]interface{}) *awstypes.PivotFieldSortOptions {
+func expandPivotFieldSortOptions(tfMap map[string]any) *awstypes.PivotFieldSortOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -571,44 +571,44 @@ func expandPivotFieldSortOptions(tfMap map[string]interface{}) *awstypes.PivotFi
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["sort_by"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_by"].([]any); ok && len(v) > 0 {
 		apiObject.SortBy = expandPivotTableSortBy(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableSortBy(tfList []interface{}) *awstypes.PivotTableSortBy {
+func expandPivotTableSortBy(tfList []any) *awstypes.PivotTableSortBy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableSortBy{}
 
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnSort(v)
 	}
-	if v, ok := tfMap["data_path"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_path"].([]any); ok && len(v) > 0 {
 		apiObject.DataPath = expandDataPathSort(v)
 	}
-	if v, ok := tfMap[names.AttrField].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrField].([]any); ok && len(v) > 0 {
 		apiObject.Field = expandFieldSort(v)
 	}
 
 	return apiObject
 }
 
-func expandDataPathSort(tfList []interface{}) *awstypes.DataPathSort {
+func expandDataPathSort(tfList []any) *awstypes.DataPathSort {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -618,36 +618,36 @@ func expandDataPathSort(tfList []interface{}) *awstypes.DataPathSort {
 	if v, ok := tfMap["direction"].(string); ok && v != "" {
 		apiObject.Direction = awstypes.SortDirection(v)
 	}
-	if v, ok := tfMap["sort_paths"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_paths"].([]any); ok && len(v) > 0 {
 		apiObject.SortPaths = expandDataPathValues(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableFieldOptions(tfList []interface{}) *awstypes.PivotTableFieldOptions {
+func expandPivotTableFieldOptions(tfList []any) *awstypes.PivotTableFieldOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableFieldOptions{}
 
-	if v, ok := tfMap["data_path_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_path_options"].([]any); ok && len(v) > 0 {
 		apiObject.DataPathOptions = expandPivotTableDataPathOptions(v)
 	}
-	if v, ok := tfMap["selected_field_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selected_field_options"].([]any); ok && len(v) > 0 {
 		apiObject.SelectedFieldOptions = expandPivotTableFieldOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableDataPathOptions(tfList []interface{}) []awstypes.PivotTableDataPathOption {
+func expandPivotTableDataPathOptions(tfList []any) []awstypes.PivotTableDataPathOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -655,7 +655,7 @@ func expandPivotTableDataPathOptions(tfList []interface{}) []awstypes.PivotTable
 	var apiObjects []awstypes.PivotTableDataPathOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -671,7 +671,7 @@ func expandPivotTableDataPathOptions(tfList []interface{}) []awstypes.PivotTable
 	return apiObjects
 }
 
-func expandPivotTableDataPathOption(tfMap map[string]interface{}) *awstypes.PivotTableDataPathOption {
+func expandPivotTableDataPathOption(tfMap map[string]any) *awstypes.PivotTableDataPathOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -681,14 +681,14 @@ func expandPivotTableDataPathOption(tfMap map[string]interface{}) *awstypes.Pivo
 	if v, ok := tfMap["width"].(string); ok && v != "" {
 		apiObject.Width = aws.String(v)
 	}
-	if v, ok := tfMap["data_path_list"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_path_list"].([]any); ok && len(v) > 0 {
 		apiObject.DataPathList = expandDataPathValues(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableFieldOptionsList(tfList []interface{}) []awstypes.PivotTableFieldOption {
+func expandPivotTableFieldOptionsList(tfList []any) []awstypes.PivotTableFieldOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -696,7 +696,7 @@ func expandPivotTableFieldOptionsList(tfList []interface{}) []awstypes.PivotTabl
 	var apiObjects []awstypes.PivotTableFieldOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -712,7 +712,7 @@ func expandPivotTableFieldOptionsList(tfList []interface{}) []awstypes.PivotTabl
 	return apiObjects
 }
 
-func expandPivotTableFieldOption(tfMap map[string]interface{}) *awstypes.PivotTableFieldOption {
+func expandPivotTableFieldOption(tfMap map[string]any) *awstypes.PivotTableFieldOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -732,12 +732,12 @@ func expandPivotTableFieldOption(tfMap map[string]interface{}) *awstypes.PivotTa
 	return apiObject
 }
 
-func expandPivotTablePaginatedReportOptions(tfList []interface{}) *awstypes.PivotTablePaginatedReportOptions {
+func expandPivotTablePaginatedReportOptions(tfList []any) *awstypes.PivotTablePaginatedReportOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -754,12 +754,12 @@ func expandPivotTablePaginatedReportOptions(tfList []interface{}) *awstypes.Pivo
 	return apiObject
 }
 
-func expandPivotTableOptions(tfList []interface{}) *awstypes.PivotTableOptions {
+func expandPivotTableOptions(tfList []any) *awstypes.PivotTableOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -781,31 +781,31 @@ func expandPivotTableOptions(tfList []interface{}) *awstypes.PivotTableOptions {
 	if v, ok := tfMap["toggle_buttons_visibility"].(string); ok && v != "" {
 		apiObject.ToggleButtonsVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.CellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["column_header_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_header_style"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHeaderStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["row_alternate_color_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_alternate_color_options"].([]any); ok && len(v) > 0 {
 		apiObject.RowAlternateColorOptions = expandRowAlternateColorOptions(v)
 	}
-	if v, ok := tfMap["row_field_names_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_field_names_style"].([]any); ok && len(v) > 0 {
 		apiObject.RowFieldNamesStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["row_header_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_header_style"].([]any); ok && len(v) > 0 {
 		apiObject.RowHeaderStyle = expandTableCellStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandTableCellStyle(tfList []interface{}) *awstypes.TableCellStyle {
+func expandTableCellStyle(tfList []any) *awstypes.TableCellStyle {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -830,78 +830,78 @@ func expandTableCellStyle(tfList []interface{}) *awstypes.TableCellStyle {
 	if v, ok := tfMap["visibility"].(string); ok && v != "" {
 		apiObject.Visibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["border"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["border"].([]any); ok && len(v) > 0 {
 		apiObject.Border = expandGlobalTableBorderOptions(v)
 	}
-	if v, ok := tfMap["font_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["font_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandGlobalTableBorderOptions(tfList []interface{}) *awstypes.GlobalTableBorderOptions {
+func expandGlobalTableBorderOptions(tfList []any) *awstypes.GlobalTableBorderOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.GlobalTableBorderOptions{}
 
-	if v, ok := tfMap["side_specific_border"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["side_specific_border"].([]any); ok && len(v) > 0 {
 		apiObject.SideSpecificBorder = expandTableSideBorderOptions(v)
 	}
-	if v, ok := tfMap["uniform_border"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["uniform_border"].([]any); ok && len(v) > 0 {
 		apiObject.UniformBorder = expandTableBorderOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableSideBorderOptions(tfList []interface{}) *awstypes.TableSideBorderOptions {
+func expandTableSideBorderOptions(tfList []any) *awstypes.TableSideBorderOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableSideBorderOptions{}
 
-	if v, ok := tfMap["bottom"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["bottom"].([]any); ok && len(v) > 0 {
 		apiObject.Bottom = expandTableBorderOptions(v)
 	}
-	if v, ok := tfMap["inner_horizontal"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["inner_horizontal"].([]any); ok && len(v) > 0 {
 		apiObject.InnerHorizontal = expandTableBorderOptions(v)
 	}
-	if v, ok := tfMap["inner_vertical"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["inner_vertical"].([]any); ok && len(v) > 0 {
 		apiObject.InnerVertical = expandTableBorderOptions(v)
 	}
-	if v, ok := tfMap["left"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["left"].([]any); ok && len(v) > 0 {
 		apiObject.Left = expandTableBorderOptions(v)
 	}
-	if v, ok := tfMap["right"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["right"].([]any); ok && len(v) > 0 {
 		apiObject.Right = expandTableBorderOptions(v)
 	}
-	if v, ok := tfMap["top"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["top"].([]any); ok && len(v) > 0 {
 		apiObject.Top = expandTableBorderOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableBorderOptions(tfList []interface{}) *awstypes.TableBorderOptions {
+func expandTableBorderOptions(tfList []any) *awstypes.TableBorderOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -921,40 +921,40 @@ func expandTableBorderOptions(tfList []interface{}) *awstypes.TableBorderOptions
 	return apiObject
 }
 
-func expandPivotTableTotalOptions(tfList []interface{}) *awstypes.PivotTableTotalOptions {
+func expandPivotTableTotalOptions(tfList []any) *awstypes.PivotTableTotalOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableTotalOptions{}
 
-	if v, ok := tfMap["column_subtotal_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_subtotal_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnSubtotalOptions = expandSubtotalOptions(v)
 	}
-	if v, ok := tfMap["column_total_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_total_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnTotalOptions = expandPivotTotalOptions(v)
 	}
-	if v, ok := tfMap["row_subtotal_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_subtotal_options"].([]any); ok && len(v) > 0 {
 		apiObject.RowSubtotalOptions = expandSubtotalOptions(v)
 	}
-	if v, ok := tfMap["row_total_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_total_options"].([]any); ok && len(v) > 0 {
 		apiObject.RowTotalOptions = expandPivotTotalOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandSubtotalOptions(tfList []interface{}) *awstypes.SubtotalOptions {
+func expandSubtotalOptions(tfList []any) *awstypes.SubtotalOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -970,23 +970,23 @@ func expandSubtotalOptions(tfList []interface{}) *awstypes.SubtotalOptions {
 	if v, ok := tfMap["totals_visibility"].(string); ok && v != "" {
 		apiObject.TotalsVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["field_level_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_level_options"].([]any); ok && len(v) > 0 {
 		apiObject.FieldLevelOptions = expandPivotTableFieldSubtotalOptionsList(v)
 	}
-	if v, ok := tfMap["metric_header_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["metric_header_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.MetricHeaderCellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["total_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.TotalCellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["value_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.ValueCellStyle = expandTableCellStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableFieldSubtotalOptionsList(tfList []interface{}) []awstypes.PivotTableFieldSubtotalOptions {
+func expandPivotTableFieldSubtotalOptionsList(tfList []any) []awstypes.PivotTableFieldSubtotalOptions {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -994,7 +994,7 @@ func expandPivotTableFieldSubtotalOptionsList(tfList []interface{}) []awstypes.P
 	var apiObjects []awstypes.PivotTableFieldSubtotalOptions
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1010,7 +1010,7 @@ func expandPivotTableFieldSubtotalOptionsList(tfList []interface{}) []awstypes.P
 	return apiObjects
 }
 
-func expandPivotTableFieldSubtotalOptions(tfMap map[string]interface{}) *awstypes.PivotTableFieldSubtotalOptions {
+func expandPivotTableFieldSubtotalOptions(tfMap map[string]any) *awstypes.PivotTableFieldSubtotalOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -1024,12 +1024,12 @@ func expandPivotTableFieldSubtotalOptions(tfMap map[string]interface{}) *awstype
 	return apiObject
 }
 
-func expandPivotTotalOptions(tfList []interface{}) *awstypes.PivotTotalOptions {
+func expandPivotTotalOptions(tfList []any) *awstypes.PivotTotalOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1048,25 +1048,25 @@ func expandPivotTotalOptions(tfList []interface{}) *awstypes.PivotTotalOptions {
 	if v, ok := tfMap["totals_visibility"].(string); ok && v != "" {
 		apiObject.TotalsVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["metric_header_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["metric_header_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.MetricHeaderCellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["total_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.TotalCellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["value_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["value_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.ValueCellStyle = expandTableCellStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandRowAlternateColorOptions(tfList []interface{}) *awstypes.RowAlternateColorOptions {
+func expandRowAlternateColorOptions(tfList []any) *awstypes.RowAlternateColorOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1076,33 +1076,33 @@ func expandRowAlternateColorOptions(tfList []interface{}) *awstypes.RowAlternate
 	if v, ok := tfMap[names.AttrStatus].(string); ok && v != "" {
 		apiObject.Status = awstypes.WidgetStatus(v)
 	}
-	if v, ok := tfMap["row_alternate_colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_alternate_colors"].([]any); ok && len(v) > 0 {
 		apiObject.RowAlternateColors = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableConditionalFormatting(tfList []interface{}) *awstypes.PivotTableConditionalFormatting {
+func expandPivotTableConditionalFormatting(tfList []any) *awstypes.PivotTableConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableConditionalFormatting{}
 
-	if v, ok := tfMap["conditional_formatting_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting_options"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormattingOptions = expandPivotTableConditionalFormattingOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableConditionalFormattingOptions(tfList []interface{}) []awstypes.PivotTableConditionalFormattingOption {
+func expandPivotTableConditionalFormattingOptions(tfList []any) []awstypes.PivotTableConditionalFormattingOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1110,7 +1110,7 @@ func expandPivotTableConditionalFormattingOptions(tfList []interface{}) []awstyp
 	var apiObjects []awstypes.PivotTableConditionalFormattingOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1126,26 +1126,26 @@ func expandPivotTableConditionalFormattingOptions(tfList []interface{}) []awstyp
 	return apiObjects
 }
 
-func expandPivotTableConditionalFormattingOption(tfMap map[string]interface{}) *awstypes.PivotTableConditionalFormattingOption {
+func expandPivotTableConditionalFormattingOption(tfMap map[string]any) *awstypes.PivotTableConditionalFormattingOption {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.PivotTableConditionalFormattingOption{}
 
-	if v, ok := tfMap["cell"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cell"].([]any); ok && len(v) > 0 {
 		apiObject.Cell = expandPivotTableCellConditionalFormatting(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableCellConditionalFormatting(tfList []interface{}) *awstypes.PivotTableCellConditionalFormatting {
+func expandPivotTableCellConditionalFormatting(tfList []any) *awstypes.PivotTableCellConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1155,22 +1155,22 @@ func expandPivotTableCellConditionalFormatting(tfList []interface{}) *awstypes.P
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrScope].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrScope].([]any); ok && len(v) > 0 {
 		apiObject.Scope = expandPivotTableConditionalFormattingScope(v)
 	}
-	if v, ok := tfMap["text_format"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_format"].([]any); ok && len(v) > 0 {
 		apiObject.TextFormat = expandTextConditionalFormat(v)
 	}
 
 	return apiObject
 }
 
-func expandPivotTableConditionalFormattingScope(tfList []interface{}) *awstypes.PivotTableConditionalFormattingScope {
+func expandPivotTableConditionalFormattingScope(tfList []any) *awstypes.PivotTableConditionalFormattingScope {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1184,12 +1184,12 @@ func expandPivotTableConditionalFormattingScope(tfList []interface{}) *awstypes.
 	return apiObject
 }
 
-func flattenPivotTableVisual(apiObject *awstypes.PivotTableVisual) []interface{} {
+func flattenPivotTableVisual(apiObject *awstypes.PivotTableVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -1209,15 +1209,15 @@ func flattenPivotTableVisual(apiObject *awstypes.PivotTableVisual) []interface{}
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableConfiguration(apiObject *awstypes.PivotTableConfiguration) []interface{} {
+func flattenPivotTableConfiguration(apiObject *awstypes.PivotTableConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldOptions != nil {
 		tfMap["field_options"] = flattenPivotTableFieldOptions(apiObject.FieldOptions)
@@ -1238,15 +1238,15 @@ func flattenPivotTableConfiguration(apiObject *awstypes.PivotTableConfiguration)
 		tfMap["total_options"] = flattenPivotTableTotalOptions(apiObject.TotalOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableFieldOptions(apiObject *awstypes.PivotTableFieldOptions) []interface{} {
+func flattenPivotTableFieldOptions(apiObject *awstypes.PivotTableFieldOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataPathOptions != nil {
 		tfMap["data_path_options"] = flattenPivotTableDataPathOption(apiObject.DataPathOptions)
@@ -1255,18 +1255,18 @@ func flattenPivotTableFieldOptions(apiObject *awstypes.PivotTableFieldOptions) [
 		tfMap["selected_field_options"] = flattenPivotTableFieldOption(apiObject.SelectedFieldOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableDataPathOption(apiObjects []awstypes.PivotTableDataPathOption) []interface{} {
+func flattenPivotTableDataPathOption(apiObjects []awstypes.PivotTableDataPathOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataPathList != nil {
 			tfMap["data_path_list"] = flattenDataPathValues(apiObject.DataPathList)
@@ -1281,26 +1281,26 @@ func flattenPivotTableDataPathOption(apiObjects []awstypes.PivotTableDataPathOpt
 	return tfList
 }
 
-func flattenPivotTableFieldWells(apiObject *awstypes.PivotTableFieldWells) []interface{} {
+func flattenPivotTableFieldWells(apiObject *awstypes.PivotTableFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PivotTableAggregatedFieldWells != nil {
 		tfMap["pivot_table_aggregated_field_wells"] = flattenPivotTableAggregatedFieldWells(apiObject.PivotTableAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableAggregatedFieldWells(apiObject *awstypes.PivotTableAggregatedFieldWells) []interface{} {
+func flattenPivotTableAggregatedFieldWells(apiObject *awstypes.PivotTableAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Columns != nil {
 		tfMap["columns"] = flattenDimensionFields(apiObject.Columns)
@@ -1312,45 +1312,45 @@ func flattenPivotTableAggregatedFieldWells(apiObject *awstypes.PivotTableAggrega
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTablePaginatedReportOptions(apiObject *awstypes.PivotTablePaginatedReportOptions) []interface{} {
+func flattenPivotTablePaginatedReportOptions(apiObject *awstypes.PivotTablePaginatedReportOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"overflow_column_header_visibility": apiObject.OverflowColumnHeaderVisibility,
 		"vertical_overflow_visibility":      apiObject.VerticalOverflowVisibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableSortConfiguration(apiObject *awstypes.PivotTableSortConfiguration) []interface{} {
+func flattenPivotTableSortConfiguration(apiObject *awstypes.PivotTableSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldSortOptions != nil {
 		tfMap["field_sort_options"] = flattenPivotFieldSortOptions(apiObject.FieldSortOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotFieldSortOptions(apiObjects []awstypes.PivotFieldSortOptions) []interface{} {
+func flattenPivotFieldSortOptions(apiObjects []awstypes.PivotFieldSortOptions) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FieldId != nil {
 			tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1365,12 +1365,12 @@ func flattenPivotFieldSortOptions(apiObjects []awstypes.PivotFieldSortOptions) [
 	return tfList
 }
 
-func flattenPivotTableSortBy(apiObject *awstypes.PivotTableSortBy) []interface{} {
+func flattenPivotTableSortBy(apiObject *awstypes.PivotTableSortBy) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Column != nil {
 		tfMap["column"] = flattenColumnSort(apiObject.Column)
@@ -1382,15 +1382,15 @@ func flattenPivotTableSortBy(apiObject *awstypes.PivotTableSortBy) []interface{}
 		tfMap[names.AttrField] = flattenFieldSort(apiObject.Field)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDataPathSort(apiObject *awstypes.DataPathSort) []interface{} {
+func flattenDataPathSort(apiObject *awstypes.DataPathSort) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"direction": apiObject.Direction,
 	}
 
@@ -1398,15 +1398,15 @@ func flattenDataPathSort(apiObject *awstypes.DataPathSort) []interface{} {
 		tfMap["sort_paths"] = flattenDataPathValues(apiObject.SortPaths)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableOptions(apiObject *awstypes.PivotTableOptions) []interface{} {
+func flattenPivotTableOptions(apiObject *awstypes.PivotTableOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"collapsed_row_dimensions_visibility": apiObject.CollapsedRowDimensionsVisibility,
 		"column_names_visibility":             apiObject.ColumnNamesVisibility,
 		"metric_placement":                    apiObject.MetricPlacement,
@@ -1430,15 +1430,15 @@ func flattenPivotTableOptions(apiObject *awstypes.PivotTableOptions) []interface
 		tfMap["row_header_style"] = flattenTableCellStyle(apiObject.RowHeaderStyle)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableCellStyle(apiObject *awstypes.TableCellStyle) []interface{} {
+func flattenTableCellStyle(apiObject *awstypes.TableCellStyle) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"horizontal_text_alignment": apiObject.HorizontalTextAlignment,
 		"text_wrap":                 apiObject.TextWrap,
 		"vertical_text_alignment":   apiObject.VerticalTextAlignment,
@@ -1458,15 +1458,15 @@ func flattenTableCellStyle(apiObject *awstypes.TableCellStyle) []interface{} {
 		tfMap["height"] = aws.ToInt32(apiObject.Height)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenGlobalTableBorderOptions(apiObject *awstypes.GlobalTableBorderOptions) []interface{} {
+func flattenGlobalTableBorderOptions(apiObject *awstypes.GlobalTableBorderOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SideSpecificBorder != nil {
 		tfMap["side_specific_border"] = flattenTableSideBorderOptions(apiObject.SideSpecificBorder)
@@ -1475,15 +1475,15 @@ func flattenGlobalTableBorderOptions(apiObject *awstypes.GlobalTableBorderOption
 		tfMap["uniform_border"] = flattenTableBorderOptions(apiObject.UniformBorder)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableSideBorderOptions(apiObject *awstypes.TableSideBorderOptions) []interface{} {
+func flattenTableSideBorderOptions(apiObject *awstypes.TableSideBorderOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Bottom != nil {
 		tfMap["bottom"] = flattenTableBorderOptions(apiObject.Bottom)
@@ -1504,15 +1504,15 @@ func flattenTableSideBorderOptions(apiObject *awstypes.TableSideBorderOptions) [
 		tfMap["top"] = flattenTableBorderOptions(apiObject.Top)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableBorderOptions(apiObject *awstypes.TableBorderOptions) []interface{} {
+func flattenTableBorderOptions(apiObject *awstypes.TableBorderOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"style": apiObject.Style,
 	}
 
@@ -1523,15 +1523,15 @@ func flattenTableBorderOptions(apiObject *awstypes.TableBorderOptions) []interfa
 		tfMap["thickness"] = aws.ToInt32(apiObject.Thickness)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRowAlternateColorOptions(apiObject *awstypes.RowAlternateColorOptions) []interface{} {
+func flattenRowAlternateColorOptions(apiObject *awstypes.RowAlternateColorOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
@@ -1539,15 +1539,15 @@ func flattenRowAlternateColorOptions(apiObject *awstypes.RowAlternateColorOption
 		tfMap["row_alternate_colors"] = apiObject.RowAlternateColors
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableTotalOptions(apiObject *awstypes.PivotTableTotalOptions) []interface{} {
+func flattenPivotTableTotalOptions(apiObject *awstypes.PivotTableTotalOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColumnSubtotalOptions != nil {
 		tfMap["column_subtotal_options"] = flattenSubtotalOptions(apiObject.ColumnSubtotalOptions)
@@ -1562,15 +1562,15 @@ func flattenPivotTableTotalOptions(apiObject *awstypes.PivotTableTotalOptions) [
 		tfMap["row_total_options"] = flattenPivotTotalOptions(apiObject.RowTotalOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSubtotalOptions(apiObject *awstypes.SubtotalOptions) []interface{} {
+func flattenSubtotalOptions(apiObject *awstypes.SubtotalOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"field_level":       apiObject.FieldLevel,
 		"totals_visibility": apiObject.TotalsVisibility,
 	}
@@ -1591,18 +1591,18 @@ func flattenSubtotalOptions(apiObject *awstypes.SubtotalOptions) []interface{} {
 		tfMap["value_cell_style"] = flattenTableCellStyle(apiObject.ValueCellStyle)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableFieldSubtotalOptions(apiObjects []awstypes.PivotTableFieldSubtotalOptions) []interface{} {
+func flattenPivotTableFieldSubtotalOptions(apiObjects []awstypes.PivotTableFieldSubtotalOptions) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FieldId != nil {
 			tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1614,12 +1614,12 @@ func flattenPivotTableFieldSubtotalOptions(apiObjects []awstypes.PivotTableField
 	return tfList
 }
 
-func flattenPivotTotalOptions(apiObject *awstypes.PivotTotalOptions) []interface{} {
+func flattenPivotTotalOptions(apiObject *awstypes.PivotTotalOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"placement":         apiObject.Placement,
 		"scroll_status":     apiObject.ScrollStatus,
 		"totals_visibility": apiObject.TotalsVisibility,
@@ -1638,18 +1638,18 @@ func flattenPivotTotalOptions(apiObject *awstypes.PivotTotalOptions) []interface
 		tfMap["value_cell_style"] = flattenTableCellStyle(apiObject.ValueCellStyle)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableFieldOption(apiObjects []awstypes.PivotTableFieldOption) []interface{} {
+func flattenPivotTableFieldOption(apiObjects []awstypes.PivotTableFieldOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"visibility": apiObject.Visibility,
 		}
 
@@ -1666,29 +1666,29 @@ func flattenPivotTableFieldOption(apiObjects []awstypes.PivotTableFieldOption) [
 	return tfList
 }
 
-func flattenPivotTableConditionalFormatting(apiObject *awstypes.PivotTableConditionalFormatting) []interface{} {
+func flattenPivotTableConditionalFormatting(apiObject *awstypes.PivotTableConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionalFormattingOptions != nil {
 		tfMap["conditional_formatting_options"] = flattenPivotTableConditionalFormattingOption(apiObject.ConditionalFormattingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableConditionalFormattingOption(apiObjects []awstypes.PivotTableConditionalFormattingOption) []interface{} {
+func flattenPivotTableConditionalFormattingOption(apiObjects []awstypes.PivotTableConditionalFormattingOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Cell != nil {
 			tfMap["cell"] = flattenPivotTableCellConditionalFormatting(apiObject.Cell)
@@ -1700,12 +1700,12 @@ func flattenPivotTableConditionalFormattingOption(apiObjects []awstypes.PivotTab
 	return tfList
 }
 
-func flattenPivotTableCellConditionalFormatting(apiObject *awstypes.PivotTableCellConditionalFormatting) []interface{} {
+func flattenPivotTableCellConditionalFormatting(apiObject *awstypes.PivotTableCellConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"field_id": aws.ToString(apiObject.FieldId),
 	}
 
@@ -1716,27 +1716,27 @@ func flattenPivotTableCellConditionalFormatting(apiObject *awstypes.PivotTableCe
 		tfMap["text_format"] = flattenTextConditionalFormat(apiObject.TextFormat)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPivotTableConditionalFormattingScope(apiObject *awstypes.PivotTableConditionalFormattingScope) []interface{} {
+func flattenPivotTableConditionalFormattingScope(apiObject *awstypes.PivotTableConditionalFormattingScope) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrRole: apiObject.Role,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTextConditionalFormat(apiObject *awstypes.TextConditionalFormat) []interface{} {
+func flattenTextConditionalFormat(apiObject *awstypes.TextConditionalFormat) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BackgroundColor != nil {
 		tfMap["background_color"] = flattenConditionalFormattingColor(apiObject.BackgroundColor)
@@ -1748,5 +1748,5 @@ func flattenTextConditionalFormat(apiObject *awstypes.TextConditionalFormat) []i
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_radar_chart.go
+++ b/internal/service/quicksight/schema/visual_radar_chart.go
@@ -109,12 +109,12 @@ func radarChartVisualSchema() *schema.Schema {
 	}
 }
 
-func expandRadarChartVisual(tfList []interface{}) *awstypes.RadarChartVisual {
+func expandRadarChartVisual(tfList []any) *awstypes.RadarChartVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -124,31 +124,31 @@ func expandRadarChartVisual(tfList []interface{}) *awstypes.RadarChartVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandRadarChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartConfiguration(tfList []interface{}) *awstypes.RadarChartConfiguration {
+func expandRadarChartConfiguration(tfList []any) *awstypes.RadarChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -170,134 +170,134 @@ func expandRadarChartConfiguration(tfList []interface{}) *awstypes.RadarChartCon
 	if v, ok := tfMap["start_angle"].(float64); ok {
 		apiObject.StartAngle = aws.Float64(v)
 	}
-	if v, ok := tfMap["base_series_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["base_series_settings"].([]any); ok && len(v) > 0 {
 		apiObject.BaseSeriesSettings = expandRadarChartSeriesSettings(v)
 	}
-	if v, ok := tfMap["category_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["color_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_axis"].([]any); ok && len(v) > 0 {
 		apiObject.ColorAxis = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["color_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColorLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandRadarChartFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandRadarChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartFieldWells(tfList []interface{}) *awstypes.RadarChartFieldWells {
+func expandRadarChartFieldWells(tfList []any) *awstypes.RadarChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RadarChartFieldWells{}
 
-	if v, ok := tfMap["radar_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["radar_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.RadarChartAggregatedFieldWells = expandRadarChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartAggregatedFieldWells(tfList []interface{}) *awstypes.RadarChartAggregatedFieldWells {
+func expandRadarChartAggregatedFieldWells(tfList []any) *awstypes.RadarChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RadarChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Color = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartSortConfiguration(tfList []interface{}) *awstypes.RadarChartSortConfiguration {
+func expandRadarChartSortConfiguration(tfList []any) *awstypes.RadarChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RadarChartSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
-	if v, ok := tfMap["color_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.ColorItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["color_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_sort"].([]any); ok && len(v) > 0 {
 		apiObject.ColorSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartSeriesSettings(tfList []interface{}) *awstypes.RadarChartSeriesSettings {
+func expandRadarChartSeriesSettings(tfList []any) *awstypes.RadarChartSeriesSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.RadarChartSeriesSettings{}
 
-	if v, ok := tfMap["area_style_settings"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["area_style_settings"].([]any); ok && len(v) > 0 {
 		apiObject.AreaStyleSettings = expandRadarChartAreaStyleSettings(v)
 	}
 
 	return apiObject
 }
 
-func expandRadarChartAreaStyleSettings(tfList []interface{}) *awstypes.RadarChartAreaStyleSettings {
+func expandRadarChartAreaStyleSettings(tfList []any) *awstypes.RadarChartAreaStyleSettings {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -311,12 +311,12 @@ func expandRadarChartAreaStyleSettings(tfList []interface{}) *awstypes.RadarChar
 	return apiObject
 }
 
-func flattenRadarChartVisual(apiObject *awstypes.RadarChartVisual) []interface{} {
+func flattenRadarChartVisual(apiObject *awstypes.RadarChartVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 	if apiObject.Actions != nil {
@@ -335,15 +335,15 @@ func flattenRadarChartVisual(apiObject *awstypes.RadarChartVisual) []interface{}
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartConfiguration(apiObject *awstypes.RadarChartConfiguration) []interface{} {
+func flattenRadarChartConfiguration(apiObject *awstypes.RadarChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"alternate_band_colors_visibility": apiObject.AlternateBandColorsVisibility,
 	}
 
@@ -385,55 +385,55 @@ func flattenRadarChartConfiguration(apiObject *awstypes.RadarChartConfiguration)
 		tfMap["visual_palette"] = flattenVisualPalette(apiObject.VisualPalette)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartSeriesSettings(apiObject *awstypes.RadarChartSeriesSettings) []interface{} {
+func flattenRadarChartSeriesSettings(apiObject *awstypes.RadarChartSeriesSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.AreaStyleSettings != nil {
 		tfMap["area_style_settings"] = flattenRadarChartAreaStyleSettings(apiObject.AreaStyleSettings)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartAreaStyleSettings(apiObject *awstypes.RadarChartAreaStyleSettings) []interface{} {
+func flattenRadarChartAreaStyleSettings(apiObject *awstypes.RadarChartAreaStyleSettings) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visibility": apiObject.Visibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartFieldWells(apiObject *awstypes.RadarChartFieldWells) []interface{} {
+func flattenRadarChartFieldWells(apiObject *awstypes.RadarChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.RadarChartAggregatedFieldWells != nil {
 		tfMap["radar_chart_aggregated_field_wells"] = flattenRadarChartAggregatedFieldWells(apiObject.RadarChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartAggregatedFieldWells(apiObject *awstypes.RadarChartAggregatedFieldWells) []interface{} {
+func flattenRadarChartAggregatedFieldWells(apiObject *awstypes.RadarChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -445,15 +445,15 @@ func flattenRadarChartAggregatedFieldWells(apiObject *awstypes.RadarChartAggrega
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenRadarChartSortConfiguration(apiObject *awstypes.RadarChartSortConfiguration) []interface{} {
+func flattenRadarChartSortConfiguration(apiObject *awstypes.RadarChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -468,5 +468,5 @@ func flattenRadarChartSortConfiguration(apiObject *awstypes.RadarChartSortConfig
 		tfMap["color_sort"] = flattenFieldSortOptions(apiObject.ColorSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_sankey_diagram.go
+++ b/internal/service/quicksight/schema/visual_sankey_diagram.go
@@ -76,12 +76,12 @@ func sankeyDiagramVisualSchema() *schema.Schema {
 	}
 }
 
-func expandSankeyDiagramVisual(tfList []interface{}) *awstypes.SankeyDiagramVisual {
+func expandSankeyDiagramVisual(tfList []any) *awstypes.SankeyDiagramVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -91,122 +91,122 @@ func expandSankeyDiagramVisual(tfList []interface{}) *awstypes.SankeyDiagramVisu
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandSankeyDiagramConfiguration(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandSankeyDiagramConfiguration(tfList []interface{}) *awstypes.SankeyDiagramChartConfiguration {
+func expandSankeyDiagramConfiguration(tfList []any) *awstypes.SankeyDiagramChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SankeyDiagramChartConfiguration{}
 
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandSankeyDiagramFieldWells(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandSankeyDiagramSortConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandSankeyDiagramFieldWells(tfList []interface{}) *awstypes.SankeyDiagramFieldWells {
+func expandSankeyDiagramFieldWells(tfList []any) *awstypes.SankeyDiagramFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SankeyDiagramFieldWells{}
 
-	if v, ok := tfMap["sankey_diagram_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sankey_diagram_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.SankeyDiagramAggregatedFieldWells = expandSankeyDiagramAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandSankeyDiagramAggregatedFieldWells(tfList []interface{}) *awstypes.SankeyDiagramAggregatedFieldWells {
+func expandSankeyDiagramAggregatedFieldWells(tfList []any) *awstypes.SankeyDiagramAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SankeyDiagramAggregatedFieldWells{}
 
-	if v, ok := tfMap[names.AttrDestination].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrDestination].([]any); ok && len(v) > 0 {
 		apiObject.Destination = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrSource].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrSource].([]any); ok && len(v) > 0 {
 		apiObject.Source = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrWeight].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrWeight].([]any); ok && len(v) > 0 {
 		apiObject.Weight = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandSankeyDiagramSortConfiguration(tfList []interface{}) *awstypes.SankeyDiagramSortConfiguration {
+func expandSankeyDiagramSortConfiguration(tfList []any) *awstypes.SankeyDiagramSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.SankeyDiagramSortConfiguration{}
 
-	if v, ok := tfMap["destination_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["destination_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.DestinationItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["source_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["source_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.SourceItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["weight_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["weight_sort"].([]any); ok && len(v) > 0 {
 		apiObject.WeightSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func flattenSankeyDiagramVisual(apiObject *awstypes.SankeyDiagramVisual) []interface{} {
+func flattenSankeyDiagramVisual(apiObject *awstypes.SankeyDiagramVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -223,15 +223,15 @@ func flattenSankeyDiagramVisual(apiObject *awstypes.SankeyDiagramVisual) []inter
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSankeyDiagramChartConfiguration(apiObject *awstypes.SankeyDiagramChartConfiguration) []interface{} {
+func flattenSankeyDiagramChartConfiguration(apiObject *awstypes.SankeyDiagramChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataLabels != nil {
 		tfMap["data_labels"] = flattenDataLabelOptions(apiObject.DataLabels)
@@ -243,29 +243,29 @@ func flattenSankeyDiagramChartConfiguration(apiObject *awstypes.SankeyDiagramCha
 		tfMap["sort_configuration"] = flattenSankeyDiagramSortConfiguration(apiObject.SortConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSankeyDiagramFieldWells(apiObject *awstypes.SankeyDiagramFieldWells) []interface{} {
+func flattenSankeyDiagramFieldWells(apiObject *awstypes.SankeyDiagramFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SankeyDiagramAggregatedFieldWells != nil {
 		tfMap["sankey_diagram_aggregated_field_wells"] = flattenSankeyDiagramAggregatedFieldWells(apiObject.SankeyDiagramAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSankeyDiagramAggregatedFieldWells(apiObject *awstypes.SankeyDiagramAggregatedFieldWells) []interface{} {
+func flattenSankeyDiagramAggregatedFieldWells(apiObject *awstypes.SankeyDiagramAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Destination != nil {
 		tfMap[names.AttrDestination] = flattenDimensionFields(apiObject.Destination)
@@ -277,15 +277,15 @@ func flattenSankeyDiagramAggregatedFieldWells(apiObject *awstypes.SankeyDiagramA
 		tfMap[names.AttrWeight] = flattenMeasureFields(apiObject.Weight)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSankeyDiagramSortConfiguration(apiObject *awstypes.SankeyDiagramSortConfiguration) []interface{} {
+func flattenSankeyDiagramSortConfiguration(apiObject *awstypes.SankeyDiagramSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DestinationItemsLimit != nil {
 		tfMap["destination_items_limit"] = flattenItemsLimitConfiguration(apiObject.DestinationItemsLimit)
@@ -297,5 +297,5 @@ func flattenSankeyDiagramSortConfiguration(apiObject *awstypes.SankeyDiagramSort
 		tfMap["weight_sort"] = flattenFieldSortOptions(apiObject.WeightSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_scatter_plot.go
+++ b/internal/service/quicksight/schema/visual_scatter_plot.go
@@ -83,12 +83,12 @@ func scatterPlotVisualSchema() *schema.Schema {
 	}
 }
 
-func expandScatterPlotVisual(tfList []interface{}) *awstypes.ScatterPlotVisual {
+func expandScatterPlotVisual(tfList []any) *awstypes.ScatterPlotVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -98,149 +98,149 @@ func expandScatterPlotVisual(tfList []interface{}) *awstypes.ScatterPlotVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandScatterPlotConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandScatterPlotConfiguration(tfList []interface{}) *awstypes.ScatterPlotConfiguration {
+func expandScatterPlotConfiguration(tfList []any) *awstypes.ScatterPlotConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ScatterPlotConfiguration{}
 
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandScatterPlotFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
-	if v, ok := tfMap["x_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["x_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.XAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.YAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.YAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandScatterPlotFieldWells(tfList []interface{}) *awstypes.ScatterPlotFieldWells {
+func expandScatterPlotFieldWells(tfList []any) *awstypes.ScatterPlotFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ScatterPlotFieldWells{}
 
-	if v, ok := tfMap["scatter_plot_categorically_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scatter_plot_categorically_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.ScatterPlotCategoricallyAggregatedFieldWells = expandScatterPlotCategoricallyAggregatedFieldWells(v)
 	}
-	if v, ok := tfMap["scatter_plot_unaggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["scatter_plot_unaggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.ScatterPlotUnaggregatedFieldWells = expandScatterPlotUnaggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandScatterPlotCategoricallyAggregatedFieldWells(tfList []interface{}) *awstypes.ScatterPlotCategoricallyAggregatedFieldWells {
+func expandScatterPlotCategoricallyAggregatedFieldWells(tfList []any) *awstypes.ScatterPlotCategoricallyAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ScatterPlotCategoricallyAggregatedFieldWells{}
 
-	if v, ok := tfMap["category"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category"].([]any); ok && len(v) > 0 {
 		apiObject.Category = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrSize].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrSize].([]any); ok && len(v) > 0 {
 		apiObject.Size = expandMeasureFields(v)
 	}
-	if v, ok := tfMap["x_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis"].([]any); ok && len(v) > 0 {
 		apiObject.XAxis = expandMeasureFields(v)
 	}
-	if v, ok := tfMap["y_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["y_axis"].([]any); ok && len(v) > 0 {
 		apiObject.YAxis = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandScatterPlotUnaggregatedFieldWells(tfList []interface{}) *awstypes.ScatterPlotUnaggregatedFieldWells {
+func expandScatterPlotUnaggregatedFieldWells(tfList []any) *awstypes.ScatterPlotUnaggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.ScatterPlotUnaggregatedFieldWells{}
 
-	if v, ok := tfMap[names.AttrSize].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrSize].([]any); ok && len(v) > 0 {
 		apiObject.Size = expandMeasureFields(v)
 	}
-	if v, ok := tfMap["x_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["x_axis"].([]any); ok && len(v) > 0 {
 		apiObject.XAxis = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["y_axis"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["y_axis"].([]any); ok && len(v) > 0 {
 		apiObject.YAxis = expandDimensionFields(v)
 	}
 
 	return apiObject
 }
 
-func flattenScatterPlotVisual(apiObject *awstypes.ScatterPlotVisual) []interface{} {
+func flattenScatterPlotVisual(apiObject *awstypes.ScatterPlotVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -260,15 +260,15 @@ func flattenScatterPlotVisual(apiObject *awstypes.ScatterPlotVisual) []interface
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenScatterPlotConfiguration(apiObject *awstypes.ScatterPlotConfiguration) []interface{} {
+func flattenScatterPlotConfiguration(apiObject *awstypes.ScatterPlotConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.DataLabels != nil {
 		tfMap["data_labels"] = flattenDataLabelOptions(apiObject.DataLabels)
@@ -298,15 +298,15 @@ func flattenScatterPlotConfiguration(apiObject *awstypes.ScatterPlotConfiguratio
 		tfMap["y_axis_label_options"] = flattenChartAxisLabelOptions(apiObject.YAxisLabelOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenScatterPlotFieldWells(apiObject *awstypes.ScatterPlotFieldWells) []interface{} {
+func flattenScatterPlotFieldWells(apiObject *awstypes.ScatterPlotFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.ScatterPlotCategoricallyAggregatedFieldWells != nil {
 		tfMap["scatter_plot_categorically_aggregated_field_wells"] = flattenScatterPlotCategoricallyAggregatedFieldWells(apiObject.ScatterPlotCategoricallyAggregatedFieldWells)
 	}
@@ -314,15 +314,15 @@ func flattenScatterPlotFieldWells(apiObject *awstypes.ScatterPlotFieldWells) []i
 		tfMap["scatter_plot_unaggregated_field_wells"] = flattenScatterPlotUnaggregatedFieldWells(apiObject.ScatterPlotUnaggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenScatterPlotCategoricallyAggregatedFieldWells(apiObject *awstypes.ScatterPlotCategoricallyAggregatedFieldWells) []interface{} {
+func flattenScatterPlotCategoricallyAggregatedFieldWells(apiObject *awstypes.ScatterPlotCategoricallyAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Category != nil {
 		tfMap["category"] = flattenDimensionFields(apiObject.Category)
@@ -337,15 +337,15 @@ func flattenScatterPlotCategoricallyAggregatedFieldWells(apiObject *awstypes.Sca
 		tfMap["y_axis"] = flattenMeasureFields(apiObject.YAxis)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenScatterPlotUnaggregatedFieldWells(apiObject *awstypes.ScatterPlotUnaggregatedFieldWells) []interface{} {
+func flattenScatterPlotUnaggregatedFieldWells(apiObject *awstypes.ScatterPlotUnaggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Size != nil {
 		tfMap[names.AttrSize] = flattenMeasureFields(apiObject.Size)
@@ -357,5 +357,5 @@ func flattenScatterPlotUnaggregatedFieldWells(apiObject *awstypes.ScatterPlotUna
 		tfMap["y_axis"] = flattenDimensionFields(apiObject.YAxis)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_sort.go
+++ b/internal/service/quicksight/schema/visual_sort.go
@@ -59,7 +59,7 @@ var fieldSortSchema = sync.OnceValue(func() *schema.Schema {
 	}
 })
 
-func expandFieldSortOptionsList(tfList []interface{}) []awstypes.FieldSortOptions {
+func expandFieldSortOptionsList(tfList []any) []awstypes.FieldSortOptions {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -67,7 +67,7 @@ func expandFieldSortOptionsList(tfList []interface{}) []awstypes.FieldSortOption
 	var apiObjects []awstypes.FieldSortOptions
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -83,29 +83,29 @@ func expandFieldSortOptionsList(tfList []interface{}) []awstypes.FieldSortOption
 	return apiObjects
 }
 
-func expandFieldSortOptions(tfMap map[string]interface{}) *awstypes.FieldSortOptions {
+func expandFieldSortOptions(tfMap map[string]any) *awstypes.FieldSortOptions {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.FieldSortOptions{}
 
-	if v, ok := tfMap["column_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_sort"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnSort = expandColumnSort(v)
 	}
-	if v, ok := tfMap["field_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_sort"].([]any); ok && len(v) > 0 {
 		apiObject.FieldSort = expandFieldSort(v)
 	}
 
 	return apiObject
 }
 
-func expandColumnSort(tfList []interface{}) *awstypes.ColumnSort {
+func expandColumnSort(tfList []any) *awstypes.ColumnSort {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -115,22 +115,22 @@ func expandColumnSort(tfList []interface{}) *awstypes.ColumnSort {
 	if v, ok := tfMap["direction"].(string); ok && v != "" {
 		apiObject.Direction = awstypes.SortDirection(v)
 	}
-	if v, ok := tfMap["sort_by"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_by"].([]any); ok && len(v) > 0 {
 		apiObject.SortBy = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["aggregation_function"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["aggregation_function"].([]any); ok && len(v) > 0 {
 		apiObject.AggregationFunction = expandAggregationFunction(v)
 	}
 
 	return apiObject
 }
 
-func expandFieldSort(tfList []interface{}) *awstypes.FieldSort {
+func expandFieldSort(tfList []any) *awstypes.FieldSort {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}

--- a/internal/service/quicksight/schema/visual_table.go
+++ b/internal/service/quicksight/schema/visual_table.go
@@ -335,12 +335,12 @@ func tableVisualSchema() *schema.Schema {
 	}
 }
 
-func expandTableVisual(tfList []interface{}) *awstypes.TableVisual {
+func expandTableVisual(tfList []any) *awstypes.TableVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -350,126 +350,126 @@ func expandTableVisual(tfList []interface{}) *awstypes.TableVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandTableConfiguration(v)
 	}
-	if v, ok := tfMap["conditional_formatting"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormatting = expandTableConditionalFormatting(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableConfiguration(tfList []interface{}) *awstypes.TableConfiguration {
+func expandTableConfiguration(tfList []any) *awstypes.TableConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableConfiguration{}
 
-	if v, ok := tfMap["field_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_options"].([]any); ok && len(v) > 0 {
 		apiObject.FieldOptions = expandTableFieldOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandTableFieldWells(v)
 	}
-	if v, ok := tfMap["paginated_report_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["paginated_report_options"].([]any); ok && len(v) > 0 {
 		apiObject.PaginatedReportOptions = expandTablePaginatedReportOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandTableSortConfiguration(v)
 	}
-	if v, ok := tfMap["table_inline_visualizations"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_inline_visualizations"].([]any); ok && len(v) > 0 {
 		apiObject.TableInlineVisualizations = expandTableInlineVisualizations(v)
 	}
-	if v, ok := tfMap["table_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_options"].([]any); ok && len(v) > 0 {
 		apiObject.TableOptions = expandTableOptions(v)
 	}
-	if v, ok := tfMap["total_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_options"].([]any); ok && len(v) > 0 {
 		apiObject.TotalOptions = expandTableTotalOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldWells(tfList []interface{}) *awstypes.TableFieldWells {
+func expandTableFieldWells(tfList []any) *awstypes.TableFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableFieldWells{}
 
-	if v, ok := tfMap["table_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.TableAggregatedFieldWells = expandTableAggregatedFieldWells(v)
 	}
-	if v, ok := tfMap["table_unaggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["table_unaggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.TableUnaggregatedFieldWells = expandTableUnaggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandTableAggregatedFieldWells(tfList []interface{}) *awstypes.TableAggregatedFieldWells {
+func expandTableAggregatedFieldWells(tfList []any) *awstypes.TableAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableAggregatedFieldWells{}
 
-	if v, ok := tfMap["group_by"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["group_by"].([]any); ok && len(v) > 0 {
 		apiObject.GroupBy = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandTableUnaggregatedFieldWells(tfList []interface{}) *awstypes.TableUnaggregatedFieldWells {
+func expandTableUnaggregatedFieldWells(tfList []any) *awstypes.TableUnaggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableUnaggregatedFieldWells{}
 
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandUnaggregatedFields(v)
 	}
 
 	return apiObject
 }
 
-func expandUnaggregatedFields(tfList []interface{}) []awstypes.UnaggregatedField {
+func expandUnaggregatedFields(tfList []any) []awstypes.UnaggregatedField {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -477,7 +477,7 @@ func expandUnaggregatedFields(tfList []interface{}) []awstypes.UnaggregatedField
 	var apiObjects []awstypes.UnaggregatedField
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -493,7 +493,7 @@ func expandUnaggregatedFields(tfList []interface{}) []awstypes.UnaggregatedField
 	return apiObjects
 }
 
-func expandUnaggregatedField(tfMap map[string]interface{}) *awstypes.UnaggregatedField {
+func expandUnaggregatedField(tfMap map[string]any) *awstypes.UnaggregatedField {
 	if tfMap == nil {
 		return nil
 	}
@@ -503,61 +503,61 @@ func expandUnaggregatedField(tfMap map[string]interface{}) *awstypes.Unaggregate
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["column"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column"].([]any); ok && len(v) > 0 {
 		apiObject.Column = expandColumnIdentifier(v)
 	}
-	if v, ok := tfMap["format_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["format_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.FormatConfiguration = expandFormatConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTableSortConfiguration(tfList []interface{}) *awstypes.TableSortConfiguration {
+func expandTableSortConfiguration(tfList []any) *awstypes.TableSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableSortConfiguration{}
 
-	if v, ok := tfMap["pagination_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["pagination_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.PaginationConfiguration = expandPaginationConfiguration(v)
 	}
-	if v, ok := tfMap["row_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_sort"].([]any); ok && len(v) > 0 {
 		apiObject.RowSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldOptions(tfList []interface{}) *awstypes.TableFieldOptions {
+func expandTableFieldOptions(tfList []any) *awstypes.TableFieldOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableFieldOptions{}
 
-	if v, ok := tfMap["order"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["order"].([]any); ok && len(v) > 0 {
 		apiObject.Order = flex.ExpandStringValueList(v)
 	}
-	if v, ok := tfMap["selected_field_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["selected_field_options"].([]any); ok && len(v) > 0 {
 		apiObject.SelectedFieldOptions = expandTableFieldOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldOptionsList(tfList []interface{}) []awstypes.TableFieldOption {
+func expandTableFieldOptionsList(tfList []any) []awstypes.TableFieldOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -565,7 +565,7 @@ func expandTableFieldOptionsList(tfList []interface{}) []awstypes.TableFieldOpti
 	var apiObjects []awstypes.TableFieldOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -581,7 +581,7 @@ func expandTableFieldOptionsList(tfList []interface{}) []awstypes.TableFieldOpti
 	return apiObjects
 }
 
-func expandTableFieldOption(tfMap map[string]interface{}) *awstypes.TableFieldOption {
+func expandTableFieldOption(tfMap map[string]any) *awstypes.TableFieldOption {
 	if tfMap == nil {
 		return nil
 	}
@@ -600,60 +600,60 @@ func expandTableFieldOption(tfMap map[string]interface{}) *awstypes.TableFieldOp
 	if v, ok := tfMap["width"].(string); ok && v != "" {
 		apiObject.Width = aws.String(v)
 	}
-	if v, ok := tfMap["url_styling"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["url_styling"].([]any); ok && len(v) > 0 {
 		apiObject.URLStyling = expandTableFieldURLConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldURLConfiguration(tfList []interface{}) *awstypes.TableFieldURLConfiguration {
+func expandTableFieldURLConfiguration(tfList []any) *awstypes.TableFieldURLConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableFieldURLConfiguration{}
 
-	if v, ok := tfMap["image_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["image_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ImageConfiguration = expandTableFieldImageConfiguration(v)
 	}
-	if v, ok := tfMap["link_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["link_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LinkConfiguration = expandTableFieldLinkConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldImageConfiguration(tfList []interface{}) *awstypes.TableFieldImageConfiguration {
+func expandTableFieldImageConfiguration(tfList []any) *awstypes.TableFieldImageConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableFieldImageConfiguration{}
 
-	if v, ok := tfMap["sizing_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sizing_options"].([]any); ok && len(v) > 0 {
 		apiObject.SizingOptions = expandTableCellImageSizingConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTableCellImageSizingConfiguration(tfList []interface{}) *awstypes.TableCellImageSizingConfiguration {
+func expandTableCellImageSizingConfiguration(tfList []any) *awstypes.TableCellImageSizingConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -667,12 +667,12 @@ func expandTableCellImageSizingConfiguration(tfList []interface{}) *awstypes.Tab
 	return apiObject
 }
 
-func expandTableFieldLinkConfiguration(tfList []interface{}) *awstypes.TableFieldLinkConfiguration {
+func expandTableFieldLinkConfiguration(tfList []any) *awstypes.TableFieldLinkConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -682,41 +682,41 @@ func expandTableFieldLinkConfiguration(tfList []interface{}) *awstypes.TableFiel
 	if v, ok := tfMap[names.AttrTarget].(string); ok && v != "" {
 		apiObject.Target = awstypes.URLTargetConfiguration(v)
 	}
-	if v, ok := tfMap[names.AttrContent].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrContent].([]any); ok && len(v) > 0 {
 		apiObject.Content = expandTableFieldLinkContentConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldLinkContentConfiguration(tfList []interface{}) *awstypes.TableFieldLinkContentConfiguration {
+func expandTableFieldLinkContentConfiguration(tfList []any) *awstypes.TableFieldLinkContentConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableFieldLinkContentConfiguration{}
 
-	if v, ok := tfMap["custom_icon_content"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_icon_content"].([]any); ok && len(v) > 0 {
 		apiObject.CustomIconContent = expandTableFieldCustomIconContent(v)
 	}
-	if v, ok := tfMap["custom_text_content"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_text_content"].([]any); ok && len(v) > 0 {
 		apiObject.CustomTextContent = expandTableFieldCustomTextContent(v)
 	}
 
 	return apiObject
 }
 
-func expandTableFieldCustomIconContent(tfList []interface{}) *awstypes.TableFieldCustomIconContent {
+func expandTableFieldCustomIconContent(tfList []any) *awstypes.TableFieldCustomIconContent {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -730,12 +730,12 @@ func expandTableFieldCustomIconContent(tfList []interface{}) *awstypes.TableFiel
 	return apiObject
 }
 
-func expandTableFieldCustomTextContent(tfList []interface{}) *awstypes.TableFieldCustomTextContent {
+func expandTableFieldCustomTextContent(tfList []any) *awstypes.TableFieldCustomTextContent {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -745,19 +745,19 @@ func expandTableFieldCustomTextContent(tfList []interface{}) *awstypes.TableFiel
 	if v, ok := tfMap[names.AttrValue].(string); ok && v != "" {
 		apiObject.Value = aws.String(v)
 	}
-	if v, ok := tfMap["custom_text_content"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["custom_text_content"].([]any); ok && len(v) > 0 {
 		apiObject.FontConfiguration = expandFontConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandTablePaginatedReportOptions(tfList []interface{}) *awstypes.TablePaginatedReportOptions {
+func expandTablePaginatedReportOptions(tfList []any) *awstypes.TablePaginatedReportOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -774,12 +774,12 @@ func expandTablePaginatedReportOptions(tfList []interface{}) *awstypes.TablePagi
 	return apiObject
 }
 
-func expandTableOptions(tfList []interface{}) *awstypes.TableOptions {
+func expandTableOptions(tfList []any) *awstypes.TableOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -789,25 +789,25 @@ func expandTableOptions(tfList []interface{}) *awstypes.TableOptions {
 	if v, ok := tfMap["orientation"].(string); ok && v != "" {
 		apiObject.Orientation = awstypes.TableOrientation(v)
 	}
-	if v, ok := tfMap["cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.CellStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["header_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["header_style"].([]any); ok && len(v) > 0 {
 		apiObject.HeaderStyle = expandTableCellStyle(v)
 	}
-	if v, ok := tfMap["row_alternate_color_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row_alternate_color_options"].([]any); ok && len(v) > 0 {
 		apiObject.RowAlternateColorOptions = expandRowAlternateColorOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableTotalOptions(tfList []interface{}) *awstypes.TotalOptions {
+func expandTableTotalOptions(tfList []any) *awstypes.TotalOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -826,33 +826,33 @@ func expandTableTotalOptions(tfList []interface{}) *awstypes.TotalOptions {
 	if v, ok := tfMap["totals_visibility"].(string); ok && v != "" {
 		apiObject.TotalsVisibility = awstypes.Visibility(v)
 	}
-	if v, ok := tfMap["total_cell_style"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["total_cell_style"].([]any); ok && len(v) > 0 {
 		apiObject.TotalCellStyle = expandTableCellStyle(v)
 	}
 
 	return apiObject
 }
 
-func expandTableConditionalFormatting(tfList []interface{}) *awstypes.TableConditionalFormatting {
+func expandTableConditionalFormatting(tfList []any) *awstypes.TableConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableConditionalFormatting{}
 
-	if v, ok := tfMap["conditional_formatting_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["conditional_formatting_options"].([]any); ok && len(v) > 0 {
 		apiObject.ConditionalFormattingOptions = expandTableConditionalFormattingOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTableConditionalFormattingOptions(tfList []interface{}) []awstypes.TableConditionalFormattingOption {
+func expandTableConditionalFormattingOptions(tfList []any) []awstypes.TableConditionalFormattingOption {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -860,7 +860,7 @@ func expandTableConditionalFormattingOptions(tfList []interface{}) []awstypes.Ta
 	var apiObjects []awstypes.TableConditionalFormattingOption
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -876,29 +876,29 @@ func expandTableConditionalFormattingOptions(tfList []interface{}) []awstypes.Ta
 	return apiObjects
 }
 
-func expandTableConditionalFormattingOption(tfMap map[string]interface{}) *awstypes.TableConditionalFormattingOption {
+func expandTableConditionalFormattingOption(tfMap map[string]any) *awstypes.TableConditionalFormattingOption {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.TableConditionalFormattingOption{}
 
-	if v, ok := tfMap["cell"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["cell"].([]any); ok && len(v) > 0 {
 		apiObject.Cell = expandTableCellConditionalFormatting(v)
 	}
-	if v, ok := tfMap["row"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["row"].([]any); ok && len(v) > 0 {
 		apiObject.Row = expandTableRowConditionalFormatting(v)
 	}
 
 	return apiObject
 }
 
-func expandTableCellConditionalFormatting(tfList []interface{}) *awstypes.TableCellConditionalFormatting {
+func expandTableCellConditionalFormatting(tfList []any) *awstypes.TableCellConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -908,36 +908,36 @@ func expandTableCellConditionalFormatting(tfList []interface{}) *awstypes.TableC
 	if v, ok := tfMap["field_id"].(string); ok && v != "" {
 		apiObject.FieldId = aws.String(v)
 	}
-	if v, ok := tfMap["text_format"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_format"].([]any); ok && len(v) > 0 {
 		apiObject.TextFormat = expandTextConditionalFormat(v)
 	}
 
 	return apiObject
 }
 
-func expandTableRowConditionalFormatting(tfList []interface{}) *awstypes.TableRowConditionalFormatting {
+func expandTableRowConditionalFormatting(tfList []any) *awstypes.TableRowConditionalFormatting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TableRowConditionalFormatting{}
 
-	if v, ok := tfMap["background_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["background_color"].([]any); ok && len(v) > 0 {
 		apiObject.BackgroundColor = expandConditionalFormattingColor(v)
 	}
-	if v, ok := tfMap["text_color"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["text_color"].([]any); ok && len(v) > 0 {
 		apiObject.TextColor = expandConditionalFormattingColor(v)
 	}
 
 	return apiObject
 }
 
-func expandTableInlineVisualizations(tfList []interface{}) []awstypes.TableInlineVisualization {
+func expandTableInlineVisualizations(tfList []any) []awstypes.TableInlineVisualization {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -945,7 +945,7 @@ func expandTableInlineVisualizations(tfList []interface{}) []awstypes.TableInlin
 	var apiObjects []awstypes.TableInlineVisualization
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -961,26 +961,26 @@ func expandTableInlineVisualizations(tfList []interface{}) []awstypes.TableInlin
 	return apiObjects
 }
 
-func expandTableInlineVisualization(tfMap map[string]interface{}) *awstypes.TableInlineVisualization {
+func expandTableInlineVisualization(tfMap map[string]any) *awstypes.TableInlineVisualization {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.TableInlineVisualization{}
 
-	if v, ok := tfMap["data_bars"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_bars"].([]any); ok && len(v) > 0 {
 		apiObject.DataBars = expandDataBarsOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandDataBarsOptions(tfList []interface{}) *awstypes.DataBarsOptions {
+func expandDataBarsOptions(tfList []any) *awstypes.DataBarsOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1000,12 +1000,12 @@ func expandDataBarsOptions(tfList []interface{}) *awstypes.DataBarsOptions {
 	return apiObject
 }
 
-func flattenTableVisual(apiObject *awstypes.TableVisual) []interface{} {
+func flattenTableVisual(apiObject *awstypes.TableVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -1025,15 +1025,15 @@ func flattenTableVisual(apiObject *awstypes.TableVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableConfiguration(apiObject *awstypes.TableConfiguration) []interface{} {
+func flattenTableConfiguration(apiObject *awstypes.TableConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldOptions != nil {
 		tfMap["field_options"] = flattenTableFieldOptions(apiObject.FieldOptions)
@@ -1057,15 +1057,15 @@ func flattenTableConfiguration(apiObject *awstypes.TableConfiguration) []interfa
 		tfMap["total_options"] = flattenTotalOptions(apiObject.TotalOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldOptions(apiObject *awstypes.TableFieldOptions) []interface{} {
+func flattenTableFieldOptions(apiObject *awstypes.TableFieldOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Order != nil {
 		tfMap["order"] = apiObject.Order
@@ -1074,18 +1074,18 @@ func flattenTableFieldOptions(apiObject *awstypes.TableFieldOptions) []interface
 		tfMap["selected_field_options"] = flattenTableFieldOption(apiObject.SelectedFieldOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldOption(apiObjects []awstypes.TableFieldOption) []interface{} {
+func flattenTableFieldOption(apiObjects []awstypes.TableFieldOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.FieldId != nil {
 			tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1107,12 +1107,12 @@ func flattenTableFieldOption(apiObjects []awstypes.TableFieldOption) []interface
 	return tfList
 }
 
-func flattenTableFieldURLConfiguration(apiObject *awstypes.TableFieldURLConfiguration) []interface{} {
+func flattenTableFieldURLConfiguration(apiObject *awstypes.TableFieldURLConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ImageConfiguration != nil {
 		tfMap["image_configuration"] = flattenTableFieldImageConfiguration(apiObject.ImageConfiguration)
@@ -1121,56 +1121,56 @@ func flattenTableFieldURLConfiguration(apiObject *awstypes.TableFieldURLConfigur
 		tfMap["link_configuration"] = flattenTableFieldLinkConfiguration(apiObject.LinkConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldImageConfiguration(apiObject *awstypes.TableFieldImageConfiguration) []interface{} {
+func flattenTableFieldImageConfiguration(apiObject *awstypes.TableFieldImageConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.SizingOptions != nil {
 		tfMap["sizing_options"] = flattenTableCellImageSizingConfiguration(apiObject.SizingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableCellImageSizingConfiguration(apiObject *awstypes.TableCellImageSizingConfiguration) []interface{} {
+func flattenTableCellImageSizingConfiguration(apiObject *awstypes.TableCellImageSizingConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"table_cell_image_scaling_configuration": apiObject.TableCellImageScalingConfiguration,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldLinkConfiguration(apiObject *awstypes.TableFieldLinkConfiguration) []interface{} {
+func flattenTableFieldLinkConfiguration(apiObject *awstypes.TableFieldLinkConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Content != nil {
 		tfMap[names.AttrContent] = flattenTableFieldLinkContentConfiguration(apiObject.Content)
 	}
 	tfMap[names.AttrTarget] = apiObject.Target
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldLinkContentConfiguration(apiObject *awstypes.TableFieldLinkContentConfiguration) []interface{} {
+func flattenTableFieldLinkContentConfiguration(apiObject *awstypes.TableFieldLinkContentConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CustomIconContent != nil {
 		tfMap["custom_icon_content"] = flattenTableFieldCustomIconContent(apiObject.CustomIconContent)
@@ -1179,27 +1179,27 @@ func flattenTableFieldLinkContentConfiguration(apiObject *awstypes.TableFieldLin
 		tfMap["custom_text_content"] = flattenTableFieldCustomTextContent(apiObject.CustomTextContent)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldCustomIconContent(apiObject *awstypes.TableFieldCustomIconContent) []interface{} {
+func flattenTableFieldCustomIconContent(apiObject *awstypes.TableFieldCustomIconContent) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"icon": apiObject.Icon,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldCustomTextContent(apiObject *awstypes.TableFieldCustomTextContent) []interface{} {
+func flattenTableFieldCustomTextContent(apiObject *awstypes.TableFieldCustomTextContent) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FontConfiguration != nil {
 		tfMap["font_configuration"] = flattenFontConfiguration(apiObject.FontConfiguration)
@@ -1208,15 +1208,15 @@ func flattenTableFieldCustomTextContent(apiObject *awstypes.TableFieldCustomText
 		tfMap[names.AttrValue] = aws.ToString(apiObject.Value)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableFieldWells(apiObject *awstypes.TableFieldWells) []interface{} {
+func flattenTableFieldWells(apiObject *awstypes.TableFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TableAggregatedFieldWells != nil {
 		tfMap["table_aggregated_field_wells"] = flattenTableAggregatedFieldWells(apiObject.TableAggregatedFieldWells)
@@ -1225,15 +1225,15 @@ func flattenTableFieldWells(apiObject *awstypes.TableFieldWells) []interface{} {
 		tfMap["table_unaggregated_field_wells"] = flattenTableUnaggregatedFieldWells(apiObject.TableUnaggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableAggregatedFieldWells(apiObject *awstypes.TableAggregatedFieldWells) []interface{} {
+func flattenTableAggregatedFieldWells(apiObject *awstypes.TableAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.GroupBy != nil {
 		tfMap["group_by"] = flattenDimensionFields(apiObject.GroupBy)
@@ -1242,32 +1242,32 @@ func flattenTableAggregatedFieldWells(apiObject *awstypes.TableAggregatedFieldWe
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableUnaggregatedFieldWells(apiObject *awstypes.TableUnaggregatedFieldWells) []interface{} {
+func flattenTableUnaggregatedFieldWells(apiObject *awstypes.TableUnaggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Values != nil {
 		tfMap[names.AttrValues] = flattenUnaggregatedField(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenUnaggregatedField(apiObjects []awstypes.UnaggregatedField) []interface{} {
+func flattenUnaggregatedField(apiObjects []awstypes.UnaggregatedField) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Column != nil {
 			tfMap["column"] = flattenColumnIdentifier(apiObject.Column)
@@ -1285,25 +1285,25 @@ func flattenUnaggregatedField(apiObjects []awstypes.UnaggregatedField) []interfa
 	return tfList
 }
 
-func flattenTablePaginatedReportOptions(apiObject *awstypes.TablePaginatedReportOptions) []interface{} {
+func flattenTablePaginatedReportOptions(apiObject *awstypes.TablePaginatedReportOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"overflow_column_header_visibility": apiObject.OverflowColumnHeaderVisibility,
 		"vertical_overflow_visibility":      apiObject.VerticalOverflowVisibility,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableSortConfiguration(apiObject *awstypes.TableSortConfiguration) []interface{} {
+func flattenTableSortConfiguration(apiObject *awstypes.TableSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.PaginationConfiguration != nil {
 		tfMap["pagination_configuration"] = flattenPaginationConfiguration(apiObject.PaginationConfiguration)
@@ -1312,18 +1312,18 @@ func flattenTableSortConfiguration(apiObject *awstypes.TableSortConfiguration) [
 		tfMap["row_sort"] = flattenFieldSortOptions(apiObject.RowSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableInlineVisualization(apiObjects []awstypes.TableInlineVisualization) []interface{} {
+func flattenTableInlineVisualization(apiObjects []awstypes.TableInlineVisualization) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.DataBars != nil {
 			tfMap["data_bars"] = flattenDataBarsOptions(apiObject.DataBars)
@@ -1335,12 +1335,12 @@ func flattenTableInlineVisualization(apiObjects []awstypes.TableInlineVisualizat
 	return tfList
 }
 
-func flattenDataBarsOptions(apiObject *awstypes.DataBarsOptions) []interface{} {
+func flattenDataBarsOptions(apiObject *awstypes.DataBarsOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1352,15 +1352,15 @@ func flattenDataBarsOptions(apiObject *awstypes.DataBarsOptions) []interface{} {
 		tfMap["positive_color"] = aws.ToString(apiObject.PositiveColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableOptions(apiObject *awstypes.TableOptions) []interface{} {
+func flattenTableOptions(apiObject *awstypes.TableOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CellStyle != nil {
 		tfMap["cell_style"] = flattenTableCellStyle(apiObject.CellStyle)
@@ -1373,15 +1373,15 @@ func flattenTableOptions(apiObject *awstypes.TableOptions) []interface{} {
 		tfMap["row_alternate_color_options"] = flattenRowAlternateColorOptions(apiObject.RowAlternateColorOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTotalOptions(apiObject *awstypes.TotalOptions) []interface{} {
+func flattenTotalOptions(apiObject *awstypes.TotalOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.CustomLabel != nil {
 		tfMap["custom_label"] = aws.ToString(apiObject.CustomLabel)
 	}
@@ -1392,32 +1392,32 @@ func flattenTotalOptions(apiObject *awstypes.TotalOptions) []interface{} {
 	}
 	tfMap["totals_visibility"] = apiObject.TotalsVisibility
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableConditionalFormatting(apiObject *awstypes.TableConditionalFormatting) []interface{} {
+func flattenTableConditionalFormatting(apiObject *awstypes.TableConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ConditionalFormattingOptions != nil {
 		tfMap["conditional_formatting_options"] = flattenTableConditionalFormattingOption(apiObject.ConditionalFormattingOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableConditionalFormattingOption(apiObjects []awstypes.TableConditionalFormattingOption) []interface{} {
+func flattenTableConditionalFormattingOption(apiObjects []awstypes.TableConditionalFormattingOption) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if apiObject.Cell != nil {
 			tfMap["cell"] = flattenTableCellConditionalFormatting(apiObject.Cell)
@@ -1432,12 +1432,12 @@ func flattenTableConditionalFormattingOption(apiObjects []awstypes.TableConditio
 	return tfList
 }
 
-func flattenTableCellConditionalFormatting(apiObject *awstypes.TableCellConditionalFormatting) []interface{} {
+func flattenTableCellConditionalFormatting(apiObject *awstypes.TableCellConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FieldId != nil {
 		tfMap["field_id"] = aws.ToString(apiObject.FieldId)
@@ -1446,15 +1446,15 @@ func flattenTableCellConditionalFormatting(apiObject *awstypes.TableCellConditio
 		tfMap["text_format"] = flattenTextConditionalFormat(apiObject.TextFormat)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTableRowConditionalFormatting(apiObject *awstypes.TableRowConditionalFormatting) []interface{} {
+func flattenTableRowConditionalFormatting(apiObject *awstypes.TableRowConditionalFormatting) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BackgroundColor != nil {
 		tfMap["background_color"] = flattenConditionalFormattingColor(apiObject.BackgroundColor)
@@ -1463,5 +1463,5 @@ func flattenTableRowConditionalFormatting(apiObject *awstypes.TableRowConditiona
 		tfMap["text_color"] = flattenConditionalFormattingColor(apiObject.TextColor)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_tree_map.go
+++ b/internal/service/quicksight/schema/visual_tree_map.go
@@ -82,12 +82,12 @@ func treeMapVisualSchema() *schema.Schema {
 	}
 }
 
-func expandTreeMapVisual(tfList []interface{}) *awstypes.TreeMapVisual {
+func expandTreeMapVisual(tfList []any) *awstypes.TreeMapVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -97,140 +97,140 @@ func expandTreeMapVisual(tfList []interface{}) *awstypes.TreeMapVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandTreeMapConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTreeMapConfiguration(tfList []interface{}) *awstypes.TreeMapConfiguration {
+func expandTreeMapConfiguration(tfList []any) *awstypes.TreeMapConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TreeMapConfiguration{}
 
-	if v, ok := tfMap["color_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.ColorLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["color_scale"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["color_scale"].([]any); ok && len(v) > 0 {
 		apiObject.ColorScale = expandColorScale(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandTreeMapFieldWells(v)
 	}
-	if v, ok := tfMap["group_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["group_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.GroupLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["size_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["size_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.SizeLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandTreeMapSortConfiguration(v)
 	}
-	if v, ok := tfMap["tooltip"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tooltip"].([]any); ok && len(v) > 0 {
 		apiObject.Tooltip = expandTooltipOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandTreeMapFieldWells(tfList []interface{}) *awstypes.TreeMapFieldWells {
+func expandTreeMapFieldWells(tfList []any) *awstypes.TreeMapFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TreeMapFieldWells{}
 
-	if v, ok := tfMap["tree_map_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tree_map_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.TreeMapAggregatedFieldWells = expandTreeMapAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandTreeMapAggregatedFieldWells(tfList []interface{}) *awstypes.TreeMapAggregatedFieldWells {
+func expandTreeMapAggregatedFieldWells(tfList []any) *awstypes.TreeMapAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TreeMapAggregatedFieldWells{}
 
-	if v, ok := tfMap["colors"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["colors"].([]any); ok && len(v) > 0 {
 		apiObject.Colors = expandMeasureFields(v)
 	}
-	if v, ok := tfMap["groups"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["groups"].([]any); ok && len(v) > 0 {
 		apiObject.Groups = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["sizes"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sizes"].([]any); ok && len(v) > 0 {
 		apiObject.Sizes = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandTreeMapSortConfiguration(tfList []interface{}) *awstypes.TreeMapSortConfiguration {
+func expandTreeMapSortConfiguration(tfList []any) *awstypes.TreeMapSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.TreeMapSortConfiguration{}
 
-	if v, ok := tfMap["tree_map_group_items_limit_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tree_map_group_items_limit_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.TreeMapGroupItemsLimitConfiguration = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["tree_map_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["tree_map_sort"].([]any); ok && len(v) > 0 {
 		apiObject.TreeMapSort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func flattenTreeMapVisual(apiObject *awstypes.TreeMapVisual) []interface{} {
+func flattenTreeMapVisual(apiObject *awstypes.TreeMapVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -250,15 +250,15 @@ func flattenTreeMapVisual(apiObject *awstypes.TreeMapVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTreeMapConfiguration(apiObject *awstypes.TreeMapConfiguration) []interface{} {
+func flattenTreeMapConfiguration(apiObject *awstypes.TreeMapConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ColorLabelOptions != nil {
 		tfMap["color_label_options"] = flattenChartAxisLabelOptions(apiObject.ColorLabelOptions)
@@ -288,29 +288,29 @@ func flattenTreeMapConfiguration(apiObject *awstypes.TreeMapConfiguration) []int
 		tfMap["tooltip"] = flattenTooltipOptions(apiObject.Tooltip)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTreeMapFieldWells(apiObject *awstypes.TreeMapFieldWells) []interface{} {
+func flattenTreeMapFieldWells(apiObject *awstypes.TreeMapFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TreeMapAggregatedFieldWells != nil {
 		tfMap["tree_map_aggregated_field_wells"] = flattenTreeMapAggregatedFieldWells(apiObject.TreeMapAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTreeMapAggregatedFieldWells(apiObject *awstypes.TreeMapAggregatedFieldWells) []interface{} {
+func flattenTreeMapAggregatedFieldWells(apiObject *awstypes.TreeMapAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Colors != nil {
 		tfMap["colors"] = flattenMeasureFields(apiObject.Colors)
@@ -322,15 +322,15 @@ func flattenTreeMapAggregatedFieldWells(apiObject *awstypes.TreeMapAggregatedFie
 		tfMap["sizes"] = flattenMeasureFields(apiObject.Sizes)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTreeMapSortConfiguration(apiObject *awstypes.TreeMapSortConfiguration) []interface{} {
+func flattenTreeMapSortConfiguration(apiObject *awstypes.TreeMapSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TreeMapGroupItemsLimitConfiguration != nil {
 		tfMap["tree_map_group_items_limit_configuration"] = flattenItemsLimitConfiguration(apiObject.TreeMapGroupItemsLimitConfiguration)
@@ -339,5 +339,5 @@ func flattenTreeMapSortConfiguration(apiObject *awstypes.TreeMapSortConfiguratio
 		tfMap["tree_map_sort"] = flattenFieldSortOptions(apiObject.TreeMapSort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_waterfall.go
+++ b/internal/service/quicksight/schema/visual_waterfall.go
@@ -96,12 +96,12 @@ func waterfallVisualSchema() *schema.Schema {
 	}
 }
 
-func expandWaterfallVisual(tfList []interface{}) *awstypes.WaterfallVisual {
+func expandWaterfallVisual(tfList []any) *awstypes.WaterfallVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -111,143 +111,143 @@ func expandWaterfallVisual(tfList []interface{}) *awstypes.WaterfallVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandWaterfallChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandWaterfallChartConfiguration(tfList []interface{}) *awstypes.WaterfallChartConfiguration {
+func expandWaterfallChartConfiguration(tfList []any) *awstypes.WaterfallChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WaterfallChartConfiguration{}
 
-	if v, ok := tfMap["category_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["category_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["data_labels"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["data_labels"].([]any); ok && len(v) > 0 {
 		apiObject.DataLabels = expandDataLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandWaterfallChartFieldWells(v)
 	}
-	if v, ok := tfMap["legend"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["legend"].([]any); ok && len(v) > 0 {
 		apiObject.Legend = expandLegendOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_display_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_display_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisDisplayOptions = expandAxisDisplayOptions(v)
 	}
-	if v, ok := tfMap["primary_y_axis_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["primary_y_axis_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.PrimaryYAxisLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandWaterfallChartSortConfiguration(v)
 	}
-	if v, ok := tfMap["visual_palette"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["visual_palette"].([]any); ok && len(v) > 0 {
 		apiObject.VisualPalette = expandVisualPalette(v)
 	}
-	if v, ok := tfMap["waterfall_chart_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["waterfall_chart_options"].([]any); ok && len(v) > 0 {
 		apiObject.WaterfallChartOptions = expandWaterfallChartOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandWaterfallChartFieldWells(tfList []interface{}) *awstypes.WaterfallChartFieldWells {
+func expandWaterfallChartFieldWells(tfList []any) *awstypes.WaterfallChartFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WaterfallChartFieldWells{}
 
-	if v, ok := tfMap["waterfall_chart_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["waterfall_chart_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.WaterfallChartAggregatedFieldWells = expandWaterfallChartAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandWaterfallChartAggregatedFieldWells(tfList []interface{}) *awstypes.WaterfallChartAggregatedFieldWells {
+func expandWaterfallChartAggregatedFieldWells(tfList []any) *awstypes.WaterfallChartAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WaterfallChartAggregatedFieldWells{}
 
-	if v, ok := tfMap["breakdowns"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["breakdowns"].([]any); ok && len(v) > 0 {
 		apiObject.Breakdowns = expandDimensionFields(v)
 	}
-	if v, ok := tfMap["categories"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["categories"].([]any); ok && len(v) > 0 {
 		apiObject.Categories = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrValues].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrValues].([]any); ok && len(v) > 0 {
 		apiObject.Values = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandWaterfallChartSortConfiguration(tfList []interface{}) *awstypes.WaterfallChartSortConfiguration {
+func expandWaterfallChartSortConfiguration(tfList []any) *awstypes.WaterfallChartSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WaterfallChartSortConfiguration{}
 
-	if v, ok := tfMap["breakdown_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["breakdown_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.BreakdownItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandWaterfallChartOptions(tfList []interface{}) *awstypes.WaterfallChartOptions {
+func expandWaterfallChartOptions(tfList []any) *awstypes.WaterfallChartOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -261,12 +261,12 @@ func expandWaterfallChartOptions(tfList []interface{}) *awstypes.WaterfallChartO
 	return apiObject
 }
 
-func flattenWaterfallVisual(apiObject *awstypes.WaterfallVisual) []interface{} {
+func flattenWaterfallVisual(apiObject *awstypes.WaterfallVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -286,15 +286,15 @@ func flattenWaterfallVisual(apiObject *awstypes.WaterfallVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWaterfallChartConfiguration(apiObject *awstypes.WaterfallChartConfiguration) []interface{} {
+func flattenWaterfallChartConfiguration(apiObject *awstypes.WaterfallChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryAxisDisplayOptions != nil {
 		tfMap["category_axis_display_options"] = flattenAxisDisplayOptions(apiObject.CategoryAxisDisplayOptions)
@@ -327,29 +327,29 @@ func flattenWaterfallChartConfiguration(apiObject *awstypes.WaterfallChartConfig
 		tfMap["waterfall_chart_options"] = flattenWaterfallChartOptions(apiObject.WaterfallChartOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWaterfallChartFieldWells(apiObject *awstypes.WaterfallChartFieldWells) []interface{} {
+func flattenWaterfallChartFieldWells(apiObject *awstypes.WaterfallChartFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.WaterfallChartAggregatedFieldWells != nil {
 		tfMap["waterfall_chart_aggregated_field_wells"] = flattenWaterfallChartAggregatedFieldWells(apiObject.WaterfallChartAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWaterfallChartAggregatedFieldWells(apiObject *awstypes.WaterfallChartAggregatedFieldWells) []interface{} {
+func flattenWaterfallChartAggregatedFieldWells(apiObject *awstypes.WaterfallChartAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.Breakdowns != nil {
 		tfMap["breakdowns"] = flattenDimensionFields(apiObject.Breakdowns)
@@ -361,15 +361,15 @@ func flattenWaterfallChartAggregatedFieldWells(apiObject *awstypes.WaterfallChar
 		tfMap[names.AttrValues] = flattenMeasureFields(apiObject.Values)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWaterfallChartSortConfiguration(apiObject *awstypes.WaterfallChartSortConfiguration) []interface{} {
+func flattenWaterfallChartSortConfiguration(apiObject *awstypes.WaterfallChartSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.BreakdownItemsLimit != nil {
 		tfMap["breakdown_items_limit"] = flattenItemsLimitConfiguration(apiObject.BreakdownItemsLimit)
@@ -378,19 +378,19 @@ func flattenWaterfallChartSortConfiguration(apiObject *awstypes.WaterfallChartSo
 		tfMap["category_sort"] = flattenFieldSortOptions(apiObject.CategorySort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWaterfallChartOptions(apiObject *awstypes.WaterfallChartOptions) []interface{} {
+func flattenWaterfallChartOptions(apiObject *awstypes.WaterfallChartOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.TotalBarLabel != nil {
 		tfMap["total_bar_label"] = aws.ToString(apiObject.TotalBarLabel)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/schema/visual_word_cloud.go
+++ b/internal/service/quicksight/schema/visual_word_cloud.go
@@ -91,12 +91,12 @@ func wordCloudVisualSchema() *schema.Schema {
 	}
 }
 
-func expandWordCloudVisual(tfList []interface{}) *awstypes.WordCloudVisual {
+func expandWordCloudVisual(tfList []any) *awstypes.WordCloudVisual {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -106,122 +106,122 @@ func expandWordCloudVisual(tfList []interface{}) *awstypes.WordCloudVisual {
 	if v, ok := tfMap["visual_id"].(string); ok && v != "" {
 		apiObject.VisualId = aws.String(v)
 	}
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandVisualCustomActions(v)
 	}
-	if v, ok := tfMap["chart_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["chart_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ChartConfiguration = expandWordCloudChartConfiguration(v)
 	}
-	if v, ok := tfMap["column_hierarchies"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["column_hierarchies"].([]any); ok && len(v) > 0 {
 		apiObject.ColumnHierarchies = expandColumnHierarchies(v)
 	}
-	if v, ok := tfMap["subtitle"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["subtitle"].([]any); ok && len(v) > 0 {
 		apiObject.Subtitle = expandVisualSubtitleLabelOptions(v)
 	}
-	if v, ok := tfMap["title"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["title"].([]any); ok && len(v) > 0 {
 		apiObject.Title = expandVisualTitleLabelOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandWordCloudChartConfiguration(tfList []interface{}) *awstypes.WordCloudChartConfiguration {
+func expandWordCloudChartConfiguration(tfList []any) *awstypes.WordCloudChartConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WordCloudChartConfiguration{}
 
-	if v, ok := tfMap["category_label_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_label_options"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryLabelOptions = expandChartAxisLabelOptions(v)
 	}
-	if v, ok := tfMap["field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.FieldWells = expandWordCloudFieldWells(v)
 	}
-	if v, ok := tfMap["sort_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["sort_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.SortConfiguration = expandWordCloudSortConfiguration(v)
 	}
-	if v, ok := tfMap["word_cloud_options"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["word_cloud_options"].([]any); ok && len(v) > 0 {
 		apiObject.WordCloudOptions = expandWordCloudOptions(v)
 	}
 
 	return apiObject
 }
 
-func expandWordCloudFieldWells(tfList []interface{}) *awstypes.WordCloudFieldWells {
+func expandWordCloudFieldWells(tfList []any) *awstypes.WordCloudFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WordCloudFieldWells{}
 
-	if v, ok := tfMap["word_cloud_aggregated_field_wells"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["word_cloud_aggregated_field_wells"].([]any); ok && len(v) > 0 {
 		apiObject.WordCloudAggregatedFieldWells = expandWordCloudAggregatedFieldWells(v)
 	}
 
 	return apiObject
 }
 
-func expandWordCloudAggregatedFieldWells(tfList []interface{}) *awstypes.WordCloudAggregatedFieldWells {
+func expandWordCloudAggregatedFieldWells(tfList []any) *awstypes.WordCloudAggregatedFieldWells {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WordCloudAggregatedFieldWells{}
 
-	if v, ok := tfMap["group_by"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["group_by"].([]any); ok && len(v) > 0 {
 		apiObject.GroupBy = expandDimensionFields(v)
 	}
-	if v, ok := tfMap[names.AttrSize].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrSize].([]any); ok && len(v) > 0 {
 		apiObject.Size = expandMeasureFields(v)
 	}
 
 	return apiObject
 }
 
-func expandWordCloudSortConfiguration(tfList []interface{}) *awstypes.WordCloudSortConfiguration {
+func expandWordCloudSortConfiguration(tfList []any) *awstypes.WordCloudSortConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &awstypes.WordCloudSortConfiguration{}
 
-	if v, ok := tfMap["category_items_limit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_items_limit"].([]any); ok && len(v) > 0 {
 		apiObject.CategoryItemsLimit = expandItemsLimitConfiguration(v)
 	}
-	if v, ok := tfMap["category_sort"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["category_sort"].([]any); ok && len(v) > 0 {
 		apiObject.CategorySort = expandFieldSortOptionsList(v)
 	}
 
 	return apiObject
 }
 
-func expandWordCloudOptions(tfList []interface{}) *awstypes.WordCloudOptions {
+func expandWordCloudOptions(tfList []any) *awstypes.WordCloudOptions {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -250,12 +250,12 @@ func expandWordCloudOptions(tfList []interface{}) *awstypes.WordCloudOptions {
 	return apiObject
 }
 
-func flattenWordCloudVisual(apiObject *awstypes.WordCloudVisual) []interface{} {
+func flattenWordCloudVisual(apiObject *awstypes.WordCloudVisual) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"visual_id": aws.ToString(apiObject.VisualId),
 	}
 
@@ -275,15 +275,15 @@ func flattenWordCloudVisual(apiObject *awstypes.WordCloudVisual) []interface{} {
 		tfMap["title"] = flattenVisualTitleLabelOptions(apiObject.Title)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWordCloudChartConfiguration(apiObject *awstypes.WordCloudChartConfiguration) []interface{} {
+func flattenWordCloudChartConfiguration(apiObject *awstypes.WordCloudChartConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryLabelOptions != nil {
 		tfMap["category_label_options"] = flattenChartAxisLabelOptions(apiObject.CategoryLabelOptions)
@@ -298,28 +298,28 @@ func flattenWordCloudChartConfiguration(apiObject *awstypes.WordCloudChartConfig
 		tfMap["word_cloud_options"] = flattenWordCloudOptions(apiObject.WordCloudOptions)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWordCloudFieldWells(apiObject *awstypes.WordCloudFieldWells) []interface{} {
+func flattenWordCloudFieldWells(apiObject *awstypes.WordCloudFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject.WordCloudAggregatedFieldWells != nil {
 		tfMap["word_cloud_aggregated_field_wells"] = flattenWordCloudAggregatedFieldWells(apiObject.WordCloudAggregatedFieldWells)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWordCloudAggregatedFieldWells(apiObject *awstypes.WordCloudAggregatedFieldWells) []interface{} {
+func flattenWordCloudAggregatedFieldWells(apiObject *awstypes.WordCloudAggregatedFieldWells) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.GroupBy != nil {
 		tfMap["group_by"] = flattenDimensionFields(apiObject.GroupBy)
@@ -328,15 +328,15 @@ func flattenWordCloudAggregatedFieldWells(apiObject *awstypes.WordCloudAggregate
 		tfMap[names.AttrSize] = flattenMeasureFields(apiObject.Size)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWordCloudSortConfiguration(apiObject *awstypes.WordCloudSortConfiguration) []interface{} {
+func flattenWordCloudSortConfiguration(apiObject *awstypes.WordCloudSortConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CategoryItemsLimit != nil {
 		tfMap["category_items_limit"] = flattenItemsLimitConfiguration(apiObject.CategoryItemsLimit)
@@ -345,15 +345,15 @@ func flattenWordCloudSortConfiguration(apiObject *awstypes.WordCloudSortConfigur
 		tfMap["category_sort"] = flattenFieldSortOptions(apiObject.CategorySort)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWordCloudOptions(apiObject *awstypes.WordCloudOptions) []interface{} {
+func flattenWordCloudOptions(apiObject *awstypes.WordCloudOptions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["cloud_layout"] = apiObject.CloudLayout
 	if apiObject.MaximumStringLength != nil {
@@ -364,5 +364,5 @@ func flattenWordCloudOptions(apiObject *awstypes.WordCloudOptions) []interface{}
 	tfMap["word_padding"] = apiObject.WordPadding
 	tfMap["word_scaling"] = apiObject.WordScaling
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/quicksight/template.go
+++ b/internal/service/quicksight/template.go
@@ -109,7 +109,7 @@ func resourceTemplate() *schema.Resource {
 	}
 }
 
-func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -126,16 +126,16 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta in
 		TemplateId:   aws.String(templateID),
 	}
 
-	if v, ok := d.GetOk("definition"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Definition = quicksightschema.ExpandTemplateDefinition(d.Get("definition").([]interface{}))
+	if v, ok := d.GetOk("definition"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Definition = quicksightschema.ExpandTemplateDefinition(d.Get("definition").([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrPermissions); ok && v.(*schema.Set).Len() != 0 {
 		input.Permissions = quicksightschema.ExpandResourcePermissions(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("source_entity"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SourceEntity = quicksightschema.ExpandTemplateSourceEntity(v.([]interface{}))
+	if v, ok := d.GetOk("source_entity"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SourceEntity = quicksightschema.ExpandTemplateSourceEntity(v.([]any))
 	}
 
 	if v, ok := d.GetOk("version_description"); ok {
@@ -157,7 +157,7 @@ func resourceTemplateCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceTemplateRead(ctx, d, meta)...)
 }
 
-func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -213,7 +213,7 @@ func resourceTemplateRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -232,9 +232,9 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 		// One of source_entity or definition is required for update
 		if v, ok := d.GetOk("source_entity"); ok {
-			input.SourceEntity = quicksightschema.ExpandTemplateSourceEntity(v.([]interface{}))
+			input.SourceEntity = quicksightschema.ExpandTemplateSourceEntity(v.([]any))
 		} else {
-			input.Definition = quicksightschema.ExpandTemplateDefinition(d.Get("definition").([]interface{}))
+			input.Definition = quicksightschema.ExpandTemplateDefinition(d.Get("definition").([]any))
 		}
 
 		_, err := conn.UpdateTemplate(ctx, input)
@@ -276,7 +276,7 @@ func resourceTemplateUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceTemplateRead(ctx, d, meta)...)
 }
 
-func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTemplateDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -413,7 +413,7 @@ func findTemplatePermissions(ctx context.Context, conn *quicksight.Client, input
 }
 
 func statusTemplate(ctx context.Context, conn *quicksight.Client, awsAccountID, templateID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTemplateByTwoPartKey(ctx, conn, awsAccountID, templateID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/theme.go
+++ b/internal/service/quicksight/theme.go
@@ -108,7 +108,7 @@ func resourceTheme() *schema.Resource {
 	}
 }
 
-func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -126,8 +126,8 @@ func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		ThemeId:      aws.String(themeID),
 	}
 
-	if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Configuration = quicksightschema.ExpandThemeConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Configuration = quicksightschema.ExpandThemeConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrPermissions); ok && v.(*schema.Set).Len() != 0 {
@@ -153,7 +153,7 @@ func resourceThemeCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceThemeRead(ctx, d, meta)...)
 }
 
-func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -201,7 +201,7 @@ func resourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -218,8 +218,8 @@ func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			ThemeId:      aws.String(themeID),
 		}
 
-		if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Configuration = quicksightschema.ExpandThemeConfiguration(v.([]interface{}))
+		if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.Configuration = quicksightschema.ExpandThemeConfiguration(v.([]any))
 		}
 
 		_, err := conn.UpdateTheme(ctx, input)
@@ -261,7 +261,7 @@ func resourceThemeUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceThemeRead(ctx, d, meta)...)
 }
 
-func resourceThemeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceThemeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -367,7 +367,7 @@ func findThemePermissions(ctx context.Context, conn *quicksight.Client, input *q
 }
 
 func statusTheme(ctx context.Context, conn *quicksight.Client, awsAccountID, themeID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findThemeByTwoPartKey(ctx, conn, awsAccountID, themeID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/quicksight/theme_data_source.go
+++ b/internal/service/quicksight/theme_data_source.go
@@ -74,7 +74,7 @@ func dataSourceTheme() *schema.Resource {
 	}
 }
 
-func dataSourceThemeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceThemeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/user.go
+++ b/internal/service/quicksight/user.go
@@ -112,7 +112,7 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -158,7 +158,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -189,7 +189,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 
@@ -215,7 +215,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/user_data_source.go
+++ b/internal/service/quicksight/user_data_source.go
@@ -69,7 +69,7 @@ func dataSourceUser() *schema.Resource {
 	}
 }
 
-func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).QuickSightClient(ctx)
 

--- a/internal/service/quicksight/vpc_connection.go
+++ b/internal/service/quicksight/vpc_connection.go
@@ -424,7 +424,7 @@ func findVPCConnection(ctx context.Context, conn *quicksight.Client, input *quic
 func retryVPCConnectionCreate(ctx context.Context, conn *quicksight.Client, in *quicksight.CreateVPCConnectionInput) (*quicksight.CreateVPCConnectionOutput, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx,
 		iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateVPCConnection(ctx, in)
 		},
 		func(err error) (bool, error) {
@@ -495,7 +495,7 @@ func waitVPCConnectionDeleted(ctx context.Context, conn *quicksight.Client, awsA
 }
 
 func statusVPCConnection(ctx context.Context, conn *quicksight.Client, awsAccountID, vpcConnectionID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCConnectionByTwoPartKey(ctx, conn, awsAccountID, vpcConnectionID)
 
 		if tfresource.NotFound(err) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
