### PR TITLE
rds: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -78,6 +78,7 @@ jobs:
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/mq modern-check
+      - run: make TEST=./internal/service/rds/... modern-check
       - run: make TEST=./internal/service/sns modern-check
       - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/wafregional modern-check

--- a/internal/service/rds/blue_green.go
+++ b/internal/service/rds/blue_green.go
@@ -68,7 +68,7 @@ func (o *blueGreenOrchestrator) Switchover(ctx context.Context, identifier strin
 		BlueGreenDeploymentIdentifier: aws.String(identifier),
 	}
 	_, err := tfresource.RetryWhen(ctx, 10*time.Minute,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return o.conn.SwitchoverBlueGreenDeployment(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/rds/certificate.go
+++ b/internal/service/rds/certificate.go
@@ -41,7 +41,7 @@ func resourceCertificate() *schema.Resource {
 	}
 }
 
-func resourceCertificatePut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCertificatePut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -63,7 +63,7 @@ func resourceCertificatePut(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceCertificateRead(ctx, d, meta)...)
 }
 
-func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -84,7 +84,7 @@ func resourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCertificateDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/certificate_data_source.go
+++ b/internal/service/rds/certificate_data_source.go
@@ -71,7 +71,7 @@ func dataSourceCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/cluster.go
+++ b/internal/service/rds/cluster.go
@@ -277,7 +277,7 @@ func resourceCluster() *schema.Resource {
 			names.AttrFinalSnapshotIdentifier: {
 				Type:     schema.TypeString,
 				Optional: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+				ValidateFunc: func(v any, k string) (ws []string, es []error) {
 					value := v.(string)
 					if !regexache.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
 						es = append(es, fmt.Errorf(
@@ -424,7 +424,7 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					if val == nil {
 						return ""
 					}
@@ -671,7 +671,7 @@ func resourceCluster() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			customdiff.ForceNewIf(names.AttrStorageType, func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf(names.AttrStorageType, func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
 				// Aurora supports mutation of the storage_type parameter, other engines do not
 				return !strings.HasPrefix(d.Get(names.AttrEngine).(string), "aurora")
 			}),
@@ -694,7 +694,7 @@ func resourceCluster() *schema.Resource {
 	}
 }
 
-func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -834,12 +834,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			requiresModifyDbCluster = true
 		}
 
-		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.ScalingConfiguration = expandScalingConfiguration(v.([]any)[0].(map[string]any))
 		}
 
-		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			modifyDbClusterInput.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			modifyDbClusterInput.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]any)[0].(map[string]any))
 			requiresModifyDbCluster = true
 		}
 
@@ -852,7 +852,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.RestoreDBClusterFromSnapshot(ctx, input)
 			},
 			errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
@@ -868,7 +868,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			return diags
 		}
 
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+		tfMap := v.([]any)[0].(map[string]any)
 		input := &rds.RestoreDBClusterFromS3Input{
 			CopyTagsToSnapshot:  aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBClusterIdentifier: aws.String(identifier),
@@ -980,7 +980,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.RestoreDBClusterFromS3(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1005,8 +1005,8 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating RDS Cluster (restore from S3) (%s): %s", identifier, err)
 		}
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 		input := &rds.RestoreDBClusterToPointInTimeInput{
 			CopyTagsToSnapshot:  aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
 			DBClusterIdentifier: aws.String(identifier),
@@ -1110,13 +1110,13 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.RestoreType = aws.String(v)
 		}
 
-		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			modifyDbClusterInput.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			modifyDbClusterInput.ScalingConfiguration = expandScalingConfiguration(v.([]any)[0].(map[string]any))
 			requiresModifyDbCluster = true
 		}
 
-		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			modifyDbClusterInput.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			modifyDbClusterInput.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]any)[0].(map[string]any))
 			requiresModifyDbCluster = true
 		}
 
@@ -1319,12 +1319,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 			input.ReplicationSourceIdentifier = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.ScalingConfiguration = expandScalingConfiguration(v.([]any)[0].(map[string]any))
 		}
 
-		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]any)[0].(map[string]any))
 		}
 
 		if v, ok := d.GetOk("source_region"); ok {
@@ -1344,7 +1344,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.CreateDBCluster(ctx, input)
 			},
 			errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
@@ -1385,7 +1385,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
-func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
 	dbc, err := findDBClusterByID(ctx, conn, d.Id())
@@ -1465,7 +1465,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	// Expose the MasterUserSecret structure as a computed attribute
 	// https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html#:~:text=for%20future%20use.-,MasterUserSecret,-%2D%3E%20(structure)
 	if dbc.MasterUserSecret != nil {
-		if err := d.Set("master_user_secret", []interface{}{flattenManagedMasterUserSecret(dbc.MasterUserSecret)}); err != nil {
+		if err := d.Set("master_user_secret", []any{flattenManagedMasterUserSecret(dbc.MasterUserSecret)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
 		}
 	} else {
@@ -1484,14 +1484,14 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 	d.Set("replication_source_identifier", dbc.ReplicationSourceIdentifier)
 	if dbc.ScalingConfigurationInfo != nil {
-		if err := d.Set("scaling_configuration", []interface{}{flattenScalingConfigurationInfo(dbc.ScalingConfigurationInfo)}); err != nil {
+		if err := d.Set("scaling_configuration", []any{flattenScalingConfigurationInfo(dbc.ScalingConfigurationInfo)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting scaling_configuration: %s", err)
 		}
 	} else {
 		d.Set("scaling_configuration", nil)
 	}
 	if dbc.ServerlessV2ScalingConfiguration != nil {
-		if err := d.Set("serverlessv2_scaling_configuration", []interface{}{flattenServerlessV2ScalingConfigurationInfo(dbc.ServerlessV2ScalingConfiguration)}); err != nil {
+		if err := d.Set("serverlessv2_scaling_configuration", []any{flattenServerlessV2ScalingConfigurationInfo(dbc.ServerlessV2ScalingConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting serverlessv2_scaling_configuration: %s", err)
 		}
 	} else {
@@ -1524,7 +1524,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
 	// There are two ways to enable the HTTP endpoint: new way and old way.
@@ -1732,14 +1732,14 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange("scaling_configuration") {
-			if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ScalingConfiguration = expandScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ScalingConfiguration = expandScalingConfiguration(v.([]any)[0].(map[string]any))
 			}
 		}
 
 		if d.HasChange("serverlessv2_scaling_configuration") {
-			if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("serverlessv2_scaling_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ServerlessV2ScalingConfiguration = expandServerlessV2ScalingConfiguration(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -1759,7 +1759,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			timeout = 5 * time.Minute
 		)
 		_, err := tfresource.RetryWhen(ctx, timeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.ModifyDBCluster(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1839,7 +1839,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
-func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -1883,14 +1883,14 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 		timeout = 2 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteDBCluster(ctx, input)
 		},
 		func(err error) (bool, error) {
 			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
 				if v, ok := d.GetOk(names.AttrDeletionProtection); (!ok || !v.(bool)) && d.Get(names.AttrApplyImmediately).(bool) {
 					_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
-						func() (interface{}, error) {
+						func() (any, error) {
 							return conn.ModifyDBCluster(ctx, &rds.ModifyDBClusterInput{
 								ApplyImmediately:    aws.Bool(true),
 								DBClusterIdentifier: aws.String(d.Id()),
@@ -1949,7 +1949,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceClusterImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceClusterImport(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	// Neither skip_final_snapshot nor final_snapshot_identifier can be fetched
 	// from any API call, so we need to default skip_final_snapshot to true so
 	// that final_snapshot_identifier is not required
@@ -1958,7 +1958,7 @@ func resourceClusterImport(_ context.Context, d *schema.ResourceData, meta inter
 	return []*schema.ResourceData{d}, nil
 }
 
-func enableHTTPEndpointProvisioned(ctx context.Context, conn *rds.Client, arn string, o, n interface{}) error {
+func enableHTTPEndpointProvisioned(ctx context.Context, conn *rds.Client, arn string, o, n any) error {
 	if o == nil {
 		return nil
 	}
@@ -2093,7 +2093,7 @@ func findDBClusters(ctx context.Context, conn *rds.Client, input *rds.DescribeDB
 }
 
 func statusDBCluster(ctx context.Context, conn *rds.Client, id string, waitNoPendingModifiedValues bool, optFns ...func(*rds.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBClusterByID(ctx, conn, id, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -2236,7 +2236,7 @@ func waitDBClusterDeleted(ctx context.Context, conn *rds.Client, id string, time
 	return nil, err
 }
 
-func expandScalingConfiguration(tfMap map[string]interface{}) *types.ScalingConfiguration {
+func expandScalingConfiguration(tfMap map[string]any) *types.ScalingConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -2270,12 +2270,12 @@ func expandScalingConfiguration(tfMap map[string]interface{}) *types.ScalingConf
 	return apiObject
 }
 
-func flattenScalingConfigurationInfo(apiObject *types.ScalingConfigurationInfo) map[string]interface{} {
+func flattenScalingConfigurationInfo(apiObject *types.ScalingConfigurationInfo) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AutoPause; v != nil {
 		tfMap["auto_pause"] = aws.ToBool(v)
@@ -2308,7 +2308,7 @@ func flattenScalingConfigurationInfo(apiObject *types.ScalingConfigurationInfo) 
 	return tfMap
 }
 
-func expandServerlessV2ScalingConfiguration(tfMap map[string]interface{}) *types.ServerlessV2ScalingConfiguration {
+func expandServerlessV2ScalingConfiguration(tfMap map[string]any) *types.ServerlessV2ScalingConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -2332,12 +2332,12 @@ func expandServerlessV2ScalingConfiguration(tfMap map[string]interface{}) *types
 	return apiObject
 }
 
-func flattenServerlessV2ScalingConfigurationInfo(apiObject *types.ServerlessV2ScalingConfigurationInfo) map[string]interface{} {
+func flattenServerlessV2ScalingConfigurationInfo(apiObject *types.ServerlessV2ScalingConfigurationInfo) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.MaxCapacity; v != nil {
 		tfMap[names.AttrMaxCapacity] = aws.ToFloat64(v)

--- a/internal/service/rds/cluster_activity_stream.go
+++ b/internal/service/rds/cluster_activity_stream.go
@@ -66,7 +66,7 @@ func resourceClusterActivityStream() *schema.Resource {
 	}
 }
 
-func resourceClusterActivityStreamCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterActivityStreamCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -94,7 +94,7 @@ func resourceClusterActivityStreamCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceClusterActivityStreamRead(ctx, d, meta)...)
 }
 
-func resourceClusterActivityStreamRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterActivityStreamRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -118,7 +118,7 @@ func resourceClusterActivityStreamRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceClusterActivityStreamDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterActivityStreamDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -160,7 +160,7 @@ func findDBClusterWithActivityStream(ctx context.Context, conn *rds.Client, arn 
 }
 
 func statusDBClusterActivityStream(ctx context.Context, conn *rds.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBClusterWithActivityStream(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/cluster_data_source.go
+++ b/internal/service/rds/cluster_data_source.go
@@ -191,7 +191,7 @@ func dataSourceCluster() *schema.Resource {
 	}
 }
 
-func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -237,7 +237,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	}))
 	d.Set(names.AttrKMSKeyID, dbc.KmsKeyId)
 	if dbc.MasterUserSecret != nil {
-		if err := d.Set("master_user_secret", []interface{}{flattenManagedMasterUserSecret(dbc.MasterUserSecret)}); err != nil {
+		if err := d.Set("master_user_secret", []any{flattenManagedMasterUserSecret(dbc.MasterUserSecret)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
 		}
 	}

--- a/internal/service/rds/cluster_endpoint.go
+++ b/internal/service/rds/cluster_endpoint.go
@@ -85,7 +85,7 @@ func resourceClusterEndpoint() *schema.Resource {
 	}
 }
 
-func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -123,7 +123,7 @@ func resourceClusterEndpointCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterEndpointRead(ctx, d, meta)...)
 }
 
-func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -150,7 +150,7 @@ func resourceClusterEndpointRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceClusterEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -185,7 +185,7 @@ func resourceClusterEndpointUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterEndpointRead(ctx, d, meta)...)
 }
 
-func resourceClusterEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -257,7 +257,7 @@ func findDBClusterEndpoints(ctx context.Context, conn *rds.Client, input *rds.De
 }
 
 func statusClusterEndpoint(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBClusterEndpointByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/cluster_instance.go
+++ b/internal/service/rds/cluster_instance.go
@@ -210,7 +210,7 @@ func resourceClusterInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					if v != nil {
 						value := v.(string)
 						return strings.ToLower(value)
@@ -243,7 +243,7 @@ func resourceClusterInstance() *schema.Resource {
 	}
 }
 
-func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -314,7 +314,7 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateDBInstance(ctx, input)
 		},
 		errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
@@ -361,7 +361,7 @@ func resourceClusterInstanceCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterInstanceRead(ctx, d, meta)...)
 }
 
-func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -442,7 +442,7 @@ func resourceClusterInstanceRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) (diags diag.Diagnostics) {
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
@@ -508,7 +508,7 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.ModifyDBInstance(ctx, input)
 			},
 			errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
@@ -525,7 +525,7 @@ func resourceClusterInstanceUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterInstanceRead(ctx, d, meta)...)
 }
 
-func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -541,7 +541,7 @@ func resourceClusterInstanceDelete(ctx context.Context, d *schema.ResourceData, 
 
 	log.Printf("[DEBUG] Deleting RDS Cluster Instance: %s", d.Id())
 	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBClusterStateFault](ctx, d.Timeout(schema.TimeoutDelete),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteDBInstance(ctx, input)
 		},
 		"Delete the replica cluster before deleting")

--- a/internal/service/rds/cluster_migrate.go
+++ b/internal/service/rds/cluster_migrate.go
@@ -407,7 +407,7 @@ func resourceClusterResourceV0() *schema.Resource {
 	}
 }
 
-func clusterStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func clusterStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		return nil, nil
 	}

--- a/internal/service/rds/cluster_parameter_group.go
+++ b/internal/service/rds/cluster_parameter_group.go
@@ -102,7 +102,7 @@ func resourceClusterParameterGroup() *schema.Resource {
 	}
 }
 
-func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -128,7 +128,7 @@ func resourceClusterParameterGroupCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceClusterParameterGroupUpdate(ctx, d, meta)...)
 }
 
-func resourceClusterParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -194,7 +194,7 @@ func resourceClusterParameterGroupRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	const (
 		maxParamModifyChunk = 20
 	)
@@ -243,7 +243,7 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 			const (
 				timeout = 3 * time.Minute
 			)
-			_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (interface{}, error) {
+			_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
 				return conn.ResetDBClusterParameterGroup(ctx, input)
 			}, "has pending changes")
 
@@ -256,7 +256,7 @@ func resourceClusterParameterGroupUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceClusterParameterGroupRead(ctx, d, meta)...)
 }
 
-func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -264,7 +264,7 @@ func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.Resource
 	const (
 		timeout = 3 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
 		return conn.DeleteDBClusterParameterGroup(ctx, &rds.DeleteDBClusterParameterGroupInput{
 			DBClusterParameterGroupName: aws.String(d.Id()),
 		})

--- a/internal/service/rds/cluster_role_association.go
+++ b/internal/service/rds/cluster_role_association.go
@@ -63,7 +63,7 @@ func resourceClusterRoleAssociation() *schema.Resource {
 	}
 }
 
-func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -88,7 +88,7 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIAMRolePropagationMessage) {
-		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
 			return conn.AddRoleToDBCluster(ctx, input)
 		}, errCodeInvalidParameterValue, errIAMRolePropagationMessage)
 	}
@@ -106,7 +106,7 @@ func resourceClusterRoleAssociationCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceClusterRoleAssociationRead(ctx, d, meta)...)
 }
 
-func resourceClusterRoleAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterRoleAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -134,7 +134,7 @@ func resourceClusterRoleAssociationRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceClusterRoleAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterRoleAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -209,7 +209,7 @@ func findDBClusterRoleByTwoPartKey(ctx context.Context, conn *rds.Client, dbClus
 }
 
 func statusDBClusterRole(ctx context.Context, conn *rds.Client, dbClusterID, roleARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBClusterRoleByTwoPartKey(ctx, conn, dbClusterID, roleARN)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/cluster_snapshot.go
+++ b/internal/service/rds/cluster_snapshot.go
@@ -126,7 +126,7 @@ func resourceClusterSnapshot() *schema.Resource {
 	}
 }
 
-func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -140,7 +140,7 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBClusterStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*types.InvalidDBClusterStateFault](ctx, timeout, func() (any, error) {
 		return conn.CreateDBClusterSnapshot(ctx, input)
 	})
 
@@ -171,7 +171,7 @@ func resourceClusterSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -217,7 +217,7 @@ func resourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -242,7 +242,7 @@ func resourceClusterSnapshotUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceClusterSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceClusterSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -321,7 +321,7 @@ func findDBClusterSnapshots(ctx context.Context, conn *rds.Client, input *rds.De
 }
 
 func statusDBClusterSnapshot(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBClusterSnapshotByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/cluster_snapshot_copy.go
+++ b/internal/service/rds/cluster_snapshot_copy.go
@@ -362,7 +362,7 @@ func (r *resourceClusterSnapshotCopy) Delete(ctx context.Context, req resource.D
 		return
 	}
 
-	tflog.Debug(ctx, fmt.Sprintf("deleting %s", ResNameClusterSnapshotCopy), map[string]interface{}{
+	tflog.Debug(ctx, fmt.Sprintf("deleting %s", ResNameClusterSnapshotCopy), map[string]any{
 		names.AttrID: data.ID.ValueString(),
 	})
 

--- a/internal/service/rds/cluster_snapshot_data_source.go
+++ b/internal/service/rds/cluster_snapshot_data_source.go
@@ -113,7 +113,7 @@ func dataSourceClusterSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClusterSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/clusters_data_source.go
+++ b/internal/service/rds/clusters_data_source.go
@@ -39,7 +39,7 @@ func dataSourceClusters() *schema.Resource {
 	}
 }
 
-func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClustersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/custom_db_engine_version.go
+++ b/internal/service/rds/custom_db_engine_version.go
@@ -128,7 +128,7 @@ func resourceCustomDBEngineVersion() *schema.Resource {
 				),
 				ConflictsWith:    []string{"filename"},
 				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -162,7 +162,7 @@ func resourceCustomDBEngineVersion() *schema.Resource {
 	}
 }
 
-func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	const (
 		mutexKey = `aws_rds_custom_engine_version`
 	)
@@ -246,7 +246,7 @@ func resourceCustomDBEngineVersionCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceCustomDBEngineVersionRead(ctx, d, meta)...)
 }
 
-func resourceCustomDBEngineVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDBEngineVersionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -288,7 +288,7 @@ func resourceCustomDBEngineVersionRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceCustomDBEngineVersionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDBEngineVersionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -325,7 +325,7 @@ func resourceCustomDBEngineVersionUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceCustomDBEngineVersionRead(ctx, d, meta)...)
 }
 
-func resourceCustomDBEngineVersionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDBEngineVersionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -432,7 +432,7 @@ const (
 )
 
 func statusDBEngineVersion(ctx context.Context, conn *rds.Client, engine, engineVersion string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCustomDBEngineVersionByTwoPartKey(ctx, conn, engine, engineVersion)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/engine_version_data_source.go
+++ b/internal/service/rds/engine_version_data_source.go
@@ -173,7 +173,7 @@ func dataSourceEngineVersion() *schema.Resource {
 	}
 }
 
-func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -241,7 +241,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	prefSearch := false
 
 	// preferred versions
-	if l := d.Get("preferred_versions").([]interface{}); len(l) > 0 {
+	if l := d.Get("preferred_versions").([]any); len(l) > 0 {
 		var preferredVersions []awstypes.DBEngineVersion
 
 		for _, elem := range l {
@@ -267,7 +267,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// preferred upgrade targets
-	if l := d.Get("preferred_upgrade_targets").([]interface{}); len(l) > 0 {
+	if l := d.Get("preferred_upgrade_targets").([]any); len(l) > 0 {
 		var prefUTs []awstypes.DBEngineVersion
 
 	engineVersionsLoop:
@@ -296,7 +296,7 @@ func dataSourceEngineVersionRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// preferred major targets
-	if l := d.Get("preferred_major_targets").([]interface{}); len(l) > 0 {
+	if l := d.Get("preferred_major_targets").([]any); len(l) > 0 {
 		var prefMTs []awstypes.DBEngineVersion
 
 	majorsLoop:

--- a/internal/service/rds/event_categories_data_source.go
+++ b/internal/service/rds/event_categories_data_source.go
@@ -40,7 +40,7 @@ func dataSourceEventCategories() *schema.Resource {
 	}
 }
 
-func dataSourceEventCategoriesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEventCategoriesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/event_subscription.go
+++ b/internal/service/rds/event_subscription.go
@@ -103,7 +103,7 @@ func resourceEventSubscription() *schema.Resource {
 	}
 }
 
-func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -142,7 +142,7 @@ func resourceEventSubscriptionCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceEventSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -171,7 +171,7 @@ func resourceEventSubscriptionRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -241,7 +241,7 @@ func resourceEventSubscriptionUpdate(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceEventSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -324,7 +324,7 @@ func findEventSubscriptions(ctx context.Context, conn *rds.Client, input *rds.De
 }
 
 func statusEventSubscription(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findEventSubscriptionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/export_task.go
+++ b/internal/service/rds/export_task.go
@@ -288,7 +288,7 @@ func FindExportTaskByID(ctx context.Context, conn *rds.Client, id string) (*awst
 }
 
 func statusExportTask(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		out, err := FindExportTaskByID(ctx, conn, id)
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/rds/export_task_test.go
+++ b/internal/service/rds/export_task_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -153,12 +154,7 @@ func isInDestroyedStatus(s string) bool {
 		tfrds.StatusFailed,
 		tfrds.StatusCanceled,
 	}
-	for _, status := range deletedStatuses {
-		if s == status {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(deletedStatuses, s)
 }
 
 func testAccExportTaskConfigBase(rName string) string {

--- a/internal/service/rds/flex.go
+++ b/internal/service/rds/flex.go
@@ -11,12 +11,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func flattenManagedMasterUserSecret(apiObject *types.MasterUserSecret) map[string]interface{} {
+func flattenManagedMasterUserSecret(apiObject *types.MasterUserSecret) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.KmsKeyId; v != nil {
 		tfMap[names.AttrKMSKeyID] = aws.ToString(v)
@@ -33,11 +33,11 @@ func flattenManagedMasterUserSecret(apiObject *types.MasterUserSecret) map[strin
 	return tfMap
 }
 
-func expandParameters(tfList []interface{}) []types.Parameter {
+func expandParameters(tfList []any) []types.Parameter {
 	var apiObjects []types.Parameter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -61,15 +61,15 @@ func expandParameters(tfList []interface{}) []types.Parameter {
 	return apiObjects
 }
 
-func flattenParameters(apiObject []types.Parameter) []interface{} {
-	apiObjects := make([]interface{}, 0)
+func flattenParameters(apiObject []types.Parameter) []any {
+	apiObjects := make([]any, 0)
 
 	for _, apiObject := range apiObject {
 		if apiObject.ParameterName == nil {
 			continue
 		}
 
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		tfMap["apply_method"] = strings.ToLower(string(apiObject.ApplyMethod))
 		tfMap[names.AttrName] = strings.ToLower(aws.ToString(apiObject.ParameterName))

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -142,7 +142,7 @@ func resourceGlobalCluster() *schema.Resource {
 	}
 }
 
-func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -202,7 +202,7 @@ func resourceGlobalClusterCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
-func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -251,7 +251,7 @@ func resourceGlobalClusterRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -285,7 +285,7 @@ func resourceGlobalClusterUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceGlobalClusterRead(ctx, d, meta)...)
 }
 
-func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutDelete))
@@ -298,7 +298,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		globalClusterMembers := d.Get("global_cluster_members").(*schema.Set)
 		if globalClusterMembers.Len() > 0 {
 			for _, tfMapRaw := range globalClusterMembers.List() {
-				tfMap, ok := tfMapRaw.(map[string]interface{})
+				tfMap, ok := tfMapRaw.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -362,7 +362,7 @@ func resourceGlobalClusterDelete(ctx context.Context, d *schema.ResourceData, me
 		globalClusterClusterDeleteTimeout = 5 * time.Minute
 	)
 	timeout := max(deadline.Remaining(), globalClusterClusterDeleteTimeout)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidGlobalClusterStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidGlobalClusterStateFault](ctx, timeout, func() (any, error) {
 		return conn.DeleteGlobalCluster(ctx, &rds.DeleteGlobalClusterInput{
 			GlobalClusterIdentifier: aws.String(d.Id()),
 		})
@@ -459,7 +459,7 @@ func findGlobalClusters(ctx context.Context, conn *rds.Client, input *rds.Descri
 }
 
 func statusGlobalCluster(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGlobalClusterByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -528,7 +528,7 @@ func waitGlobalClusterDeleted(ctx context.Context, conn *rds.Client, id string, 
 }
 
 func waitGlobalClusterMemberRemoved(ctx context.Context, conn *rds.Client, dbClusterARN string, timeout time.Duration) (*types.GlobalCluster, error) { //nolint:unparam
-	outputRaw, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
 		return findGlobalClusterByDBClusterARN(ctx, conn, dbClusterARN)
 	})
 
@@ -581,7 +581,7 @@ func globalClusterUpgradeMajorEngineVersion(ctx context.Context, conn *rds.Clien
 	}
 
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.ModifyGlobalCluster(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -642,7 +642,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, conn *rds.Clien
 	leelooMultiPass := false // only one pass is needed
 
 	for _, tfMapRaw := range clusterMembers.List() {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		// DBClusterIdentifier supposedly can be either ARN or ID, and both used to work,
 		// but as of now, only ID works.
@@ -678,7 +678,7 @@ func globalClusterUpgradeMinorEngineVersion(ctx context.Context, conn *rds.Clien
 
 		log.Printf("[INFO] Performing RDS Global Cluster (%s) Cluster (%s) minor version (%s) upgrade", globalClusterID, clusterID, engineVersion)
 		_, err = tfresource.RetryWhen(ctx, timeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.ModifyDBCluster(ctx, input, optFn)
 			},
 			func(err error) (bool, error) {
@@ -783,15 +783,15 @@ func waitGlobalClusterMemberUpdated(ctx context.Context, conn *rds.Client, id st
 	return nil, err
 }
 
-func flattenGlobalClusterMembers(apiObjects []types.GlobalClusterMember) []interface{} {
+func flattenGlobalClusterMembers(apiObjects []types.GlobalClusterMember) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"db_cluster_arn": aws.ToString(apiObject.DBClusterArn),
 			"is_writer":      aws.ToBool(apiObject.IsWriter),
 		}

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -303,7 +303,7 @@ func resourceInstance() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
@@ -404,7 +404,7 @@ func resourceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					if v != nil {
 						value := v.(string)
 						return strings.ToLower(value)
@@ -740,7 +740,7 @@ func resourceInstance() *schema.Resource {
 	}
 }
 
-func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -833,8 +833,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.DomainAuthSecretArn = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
-			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]any)) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := d.GetOk("domain_fqdn"); ok {
@@ -1039,7 +1039,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			return diags
 		}
 
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+		tfMap := v.([]any)[0].(map[string]any)
 		input := &rds.RestoreDBInstanceFromS3Input{
 			AllocatedStorage:        aws.Int32(int32(d.Get(names.AttrAllocatedStorage).(int))),
 			AutoMinorVersionUpgrade: aws.Bool(d.Get(names.AttrAutoMinorVersionUpgrade).(bool)),
@@ -1171,7 +1171,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.RestoreDBInstanceFromS3(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1277,8 +1277,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.DomainAuthSecretArn = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
-			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]any)) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := d.GetOk("domain_fqdn"); ok {
@@ -1426,7 +1426,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.RestoreDBInstanceFromDBSnapshot(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1465,8 +1465,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 		resourceID = aws.ToString(output.DBInstance.DbiResourceId)
 		d.SetId(resourceID)
-	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 		input := &rds.RestoreDBInstanceToPointInTimeInput{
 			AutoMinorVersionUpgrade:    aws.Bool(d.Get(names.AttrAutoMinorVersionUpgrade).(bool)),
 			CopyTagsToSnapshot:         aws.Bool(d.Get("copy_tags_to_snapshot").(bool)),
@@ -1547,8 +1547,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.DomainAuthSecretArn = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
-			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]any)) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := d.GetOk("enabled_cloudwatch_logs_exports"); ok && v.(*schema.Set).Len() > 0 {
@@ -1642,7 +1642,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.RestoreDBInstanceToPointInTime(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1733,8 +1733,8 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 			input.DomainAuthSecretArn = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
-			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]any)) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := d.GetOk("domain_fqdn"); ok {
@@ -1858,7 +1858,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.CreateDBInstance(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1934,7 +1934,7 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
-func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -2025,7 +2025,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	// Expose the MasterUserSecret structure as a computed attribute
 	// https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/create-db-cluster.html#:~:text=for%20future%20use.-,MasterUserSecret,-%2D%3E%20(structure)
 	if v.MasterUserSecret != nil {
-		if err := d.Set("master_user_secret", []interface{}{flattenManagedMasterUserSecret(v.MasterUserSecret)}); err != nil {
+		if err := d.Set("master_user_secret", []any{flattenManagedMasterUserSecret(v.MasterUserSecret)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
 		}
 	} else {
@@ -2091,7 +2091,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if v.ListenerEndpoint != nil {
-		if err := d.Set("listener_endpoint", []interface{}{flattenEndpoint(v.ListenerEndpoint)}); err != nil {
+		if err := d.Set("listener_endpoint", []any{flattenEndpoint(v.ListenerEndpoint)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting listener_endpoint: %s", err)
 		}
 	} else {
@@ -2105,7 +2105,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 	deadline := tfresource.NewDeadline(d.Timeout(schema.TimeoutUpdate))
@@ -2350,7 +2350,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceInstanceRead(ctx, d, meta)...)
 }
 
-func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -2377,7 +2377,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterCombination, "disable deletion pro") {
 		if v, ok := d.GetOk(names.AttrDeletionProtection); (!ok || !v.(bool)) && d.Get(names.AttrApplyImmediately).(bool) {
 			_, ierr := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-				func() (interface{}, error) {
+				func() (any, error) {
 					return conn.ModifyDBInstance(ctx, &rds.ModifyDBInstanceInput{
 						ApplyImmediately:     aws.Bool(true),
 						DBInstanceIdentifier: aws.String(d.Get(names.AttrIdentifier).(string)),
@@ -2426,7 +2426,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceInstanceImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceInstanceImport(_ context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	// Neither skip_final_snapshot nor final_snapshot_identifier can be fetched
 	// from any API call, so we need to default skip_final_snapshot to true so
 	// that final_snapshot_identifier is not required.
@@ -2437,7 +2437,7 @@ func resourceInstanceImport(_ context.Context, d *schema.ResourceData, meta inte
 
 func dbInstanceCreateReadReplica(ctx context.Context, conn *rds.Client, input *rds.CreateDBInstanceReadReplicaInput) (*rds.CreateDBInstanceReadReplicaOutput, error) {
 	outputRaw, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateDBInstanceReadReplica(ctx, input)
 		},
 		errCodeInvalidParameterValue, "ENHANCED_MONITORING")
@@ -2517,8 +2517,8 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 	} else if d.HasChanges("domain_auth_secret_arn", "domain_dns_ips", "domain_fqdn", "domain_ou") {
 		needsModify = true
 		input.DomainAuthSecretArn = aws.String(d.Get("domain_auth_secret_arn").(string))
-		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]interface{})) > 0 {
-			input.DomainDnsIps = flex.ExpandStringValueList(v.([]interface{}))
+		if v, ok := d.GetOk("domain_dns_ips"); ok && len(v.([]any)) > 0 {
+			input.DomainDnsIps = flex.ExpandStringValueList(v.([]any))
 		}
 		input.DomainFqdn = aws.String(d.Get("domain_fqdn").(string))
 		input.DomainOu = aws.String(d.Get("domain_ou").(string))
@@ -2706,7 +2706,7 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 
 func dbInstanceModify(ctx context.Context, conn *rds.Client, resourceID string, input *rds.ModifyDBInstanceInput, timeout time.Duration) error {
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.ModifyDBInstance(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -2870,7 +2870,7 @@ func findDBInstances(ctx context.Context, conn *rds.Client, input *rds.DescribeD
 }
 
 func statusDBInstance(ctx context.Context, conn *rds.Client, id string, optFns ...func(*rds.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBInstanceByID(ctx, conn, id, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -3066,7 +3066,7 @@ func findBlueGreenDeployments(ctx context.Context, conn *rds.Client, input *rds.
 }
 
 func statusBlueGreenDeployment(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findBlueGreenDeploymentByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -3170,12 +3170,12 @@ func dbInstanceValidBlueGreenEngines() []string {
 	}
 }
 
-func flattenEndpoint(apiObject *types.Endpoint) map[string]interface{} {
+func flattenEndpoint(apiObject *types.Endpoint) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Address; v != nil {
 		tfMap[names.AttrAddress] = aws.ToString(v)

--- a/internal/service/rds/instance_automated_backups_replication.go
+++ b/internal/service/rds/instance_automated_backups_replication.go
@@ -78,7 +78,7 @@ func resourceInstanceAutomatedBackupsReplication() *schema.Resource {
 	}
 }
 
-func resourceInstanceAutomatedBackupsReplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceAutomatedBackupsReplicationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -111,7 +111,7 @@ func resourceInstanceAutomatedBackupsReplicationCreate(ctx context.Context, d *s
 	return append(diags, resourceInstanceAutomatedBackupsReplicationRead(ctx, d, meta)...)
 }
 
-func resourceInstanceAutomatedBackupsReplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceAutomatedBackupsReplicationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -134,7 +134,7 @@ func resourceInstanceAutomatedBackupsReplicationRead(ctx context.Context, d *sch
 	return diags
 }
 
-func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceAutomatedBackupsReplicationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -251,7 +251,7 @@ func findDBInstanceAutomatedBackups(ctx context.Context, conn *rds.Client, input
 }
 
 func statusDBInstanceAutomatedBackup(ctx context.Context, conn *rds.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBInstanceAutomatedBackupByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/instance_data_source.go
+++ b/internal/service/rds/instance_data_source.go
@@ -217,7 +217,7 @@ func dataSourceInstance() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -281,7 +281,7 @@ func dataSourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set("license_model", instance.LicenseModel)
 	d.Set("master_username", instance.MasterUsername)
 	if instance.MasterUserSecret != nil {
-		if err := d.Set("master_user_secret", []interface{}{flattenManagedMasterUserSecret(instance.MasterUserSecret)}); err != nil {
+		if err := d.Set("master_user_secret", []any{flattenManagedMasterUserSecret(instance.MasterUserSecret)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
 		}
 	}

--- a/internal/service/rds/instance_migrate.go
+++ b/internal/service/rds/instance_migrate.go
@@ -377,7 +377,7 @@ func resourceInstanceResourceV0() *schema.Resource {
 	}
 }
 
-func instanceStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func instanceStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		return nil, nil
 	}
@@ -834,7 +834,7 @@ func resourceInstanceResourceV1() *schema.Resource {
 	}
 }
 
-func instanceStateUpgradeV1(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func instanceStateUpgradeV1(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		return nil, nil
 	}

--- a/internal/service/rds/instance_role_association.go
+++ b/internal/service/rds/instance_role_association.go
@@ -69,7 +69,7 @@ func resourceInstanceRoleAssociation() *schema.Resource {
 	}
 }
 
-func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -94,7 +94,7 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 	}
 
 	if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, errIAMRolePropagationMessage) {
-		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
 			return conn.AddRoleToDBInstance(ctx, input)
 		}, errCodeInvalidParameterValue, errIAMRolePropagationMessage)
 	}
@@ -112,7 +112,7 @@ func resourceInstanceRoleAssociationCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceInstanceRoleAssociationRead(ctx, d, meta)...)
 }
 
-func resourceInstanceRoleAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRoleAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -140,7 +140,7 @@ func resourceInstanceRoleAssociationRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceInstanceRoleAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceRoleAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -203,7 +203,7 @@ func findDBInstanceRoleByTwoPartKey(ctx context.Context, conn *rds.Client, dbIns
 }
 
 func statusDBInstanceRoleAssociation(ctx context.Context, conn *rds.Client, dbInstanceIdentifier, roleARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBInstanceRoleByTwoPartKey(ctx, conn, dbInstanceIdentifier, roleARN)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/instances_data_source.go
+++ b/internal/service/rds/instances_data_source.go
@@ -41,7 +41,7 @@ func dataSourceInstances() *schema.Resource {
 	}
 }
 
-func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -54,7 +54,7 @@ func dataSourceInstancesRead(ctx context.Context, d *schema.ResourceData, meta i
 	filter := tfslices.PredicateTrue[*types.DBInstance]()
 	if v, ok := d.GetOk(names.AttrTags); ok {
 		filter = func(x *types.DBInstance) bool {
-			return KeyValueTags(ctx, x.TagList).ContainsAll(tftags.New(ctx, v.(map[string]interface{})))
+			return KeyValueTags(ctx, x.TagList).ContainsAll(tftags.New(ctx, v.(map[string]any)))
 		}
 	}
 

--- a/internal/service/rds/integration.go
+++ b/internal/service/rds/integration.go
@@ -294,7 +294,7 @@ func findIntegrations(ctx context.Context, conn *rds.Client, input *rds.Describe
 }
 
 func statusIntegration(ctx context.Context, conn *rds.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findIntegrationByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/option_group.go
+++ b/internal/service/rds/option_group.go
@@ -139,7 +139,7 @@ func resourceOptionGroup() *schema.Resource {
 	}
 }
 
-func resourceOptionGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOptionGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -163,7 +163,7 @@ func resourceOptionGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceOptionGroupUpdate(ctx, d, meta)...)
 }
 
-func resourceOptionGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOptionGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -194,7 +194,7 @@ func resourceOptionGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceOptionGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOptionGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -229,7 +229,7 @@ func resourceOptionGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 				input.OptionsToRemove = optionsToRemove
 			}
 
-			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
 				return conn.ModifyOptionGroup(ctx, input)
 			}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 
@@ -242,7 +242,7 @@ func resourceOptionGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceOptionGroupRead(ctx, d, meta)...)
 }
 
-func resourceOptionGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOptionGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -252,7 +252,7 @@ func resourceOptionGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("[DEBUG] Deleting RDS DB Option Group: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*types.InvalidOptionGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*types.InvalidOptionGroupStateFault](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteOptionGroup(ctx, &rds.DeleteOptionGroupInput{
 			OptionGroupName: aws.String(d.Id()),
 		})
@@ -327,17 +327,17 @@ func findOptionGroups(ctx context.Context, conn *rds.Client, input *rds.Describe
 	return output, nil
 }
 
-func flattenOptionNames(tfList []interface{}) []string {
-	return tfslices.ApplyToAll(tfList, func(v interface{}) string {
-		return v.(map[string]interface{})["option_name"].(string)
+func flattenOptionNames(tfList []any) []string {
+	return tfslices.ApplyToAll(tfList, func(v any) string {
+		return v.(map[string]any)["option_name"].(string)
 	})
 }
 
-func expandOptionConfigurations(tfList []interface{}) []types.OptionConfiguration {
+func expandOptionConfigurations(tfList []any) []types.OptionConfiguration {
 	var apiObjects []types.OptionConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := types.OptionConfiguration{
 			OptionName: aws.String(tfMap["option_name"].(string)),
@@ -369,8 +369,8 @@ func expandOptionConfigurations(tfList []interface{}) []types.OptionConfiguratio
 	return apiObjects
 }
 
-func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionConfiguration) []interface{} {
-	tfList := make([]interface{}, 0)
+func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionConfiguration) []any {
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
 		if apiObject.OptionName == nil {
@@ -385,7 +385,7 @@ func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionC
 			configuredOption = &v[0]
 		}
 
-		optionSettings := make([]interface{}, 0)
+		optionSettings := make([]any, 0)
 		for _, apiOptionSetting := range apiObject.OptionSettings {
 			// The RDS API responds with all settings. Omit settings that match default value,
 			// but only if unconfigured. This is to prevent operators from continually needing
@@ -407,7 +407,7 @@ func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionC
 				continue
 			}
 
-			optionSetting := map[string]interface{}{
+			optionSetting := map[string]any{
 				names.AttrName:  optionSettingName,
 				names.AttrValue: optionSettingValue,
 			}
@@ -421,7 +421,7 @@ func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionC
 			optionSettings = append(optionSettings, optionSetting)
 		}
 
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"db_security_group_memberships": tfslices.ApplyToAll(apiObject.DBSecurityGroupMemberships, func(v types.DBSecurityGroupMembership) string {
 				return aws.ToString(v.DBSecurityGroupName)
 			}),
@@ -446,11 +446,11 @@ func flattenOptions(apiObjects []types.Option, configuredObjects []types.OptionC
 	return tfList
 }
 
-func expandOptionSettings(tfList []interface{}) []types.OptionSetting {
+func expandOptionSettings(tfList []any) []types.OptionSetting {
 	apiObjects := make([]types.OptionSetting, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := types.OptionSetting{
 			Name:  aws.String(tfMap[names.AttrName].(string)),

--- a/internal/service/rds/orderable_instance_data_source.go
+++ b/internal/service/rds/orderable_instance_data_source.go
@@ -182,7 +182,7 @@ func dataSourceOrderableInstance() *schema.Resource {
 	}
 }
 
-func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -305,9 +305,9 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "no RDS Orderable DB Instance Options found matching criteria; try different search")
 	}
 
-	if v, ok := d.GetOk("supported_engine_modes"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("supported_engine_modes"); ok && len(v.([]any)) > 0 {
 		var matches []awstypes.OrderableDBInstanceOption
-		search := flex.ExpandStringValueList(v.([]interface{}))
+		search := flex.ExpandStringValueList(v.([]any))
 
 		for _, ic := range instanceClassResults {
 		searchedModes:
@@ -328,9 +328,9 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 		instanceClassResults = matches
 	}
 
-	if v, ok := d.GetOk("supported_network_types"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("supported_network_types"); ok && len(v.([]any)) > 0 {
 		var matches []awstypes.OrderableDBInstanceOption
-		search := flex.ExpandStringValueList(v.([]interface{}))
+		search := flex.ExpandStringValueList(v.([]any))
 
 		for _, ic := range instanceClassResults {
 		searchedNetworks:
@@ -353,9 +353,9 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 
 	prefSearch := false
 
-	if v, ok := d.GetOk("preferred_engine_versions"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("preferred_engine_versions"); ok && len(v.([]any)) > 0 {
 		var matches []awstypes.OrderableDBInstanceOption
-		search := flex.ExpandStringValueList(v.([]interface{}))
+		search := flex.ExpandStringValueList(v.([]any))
 
 		for _, s := range search {
 			for _, ic := range instanceClassResults {
@@ -376,9 +376,9 @@ func dataSourceOrderableInstanceRead(ctx context.Context, d *schema.ResourceData
 
 	latestVersion := d.Get("engine_latest_version").(bool)
 
-	if v, ok := d.GetOk("preferred_instance_classes"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("preferred_instance_classes"); ok && len(v.([]any)) > 0 {
 		var matches []awstypes.OrderableDBInstanceOption
-		search := flex.ExpandStringValueList(v.([]interface{}))
+		search := flex.ExpandStringValueList(v.([]any))
 
 		for _, s := range search {
 			for _, ic := range instanceClassResults {

--- a/internal/service/rds/parameter_group.go
+++ b/internal/service/rds/parameter_group.go
@@ -109,7 +109,7 @@ func resourceParameterGroup() *schema.Resource {
 	}
 }
 
-func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -135,7 +135,7 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceParameterGroupUpdate(ctx, d, meta)...)
 }
 
-func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -234,7 +234,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	const (
 		maxParamModifyChunk = 20
 	)
@@ -307,7 +307,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceParameterGroupRead(ctx, d, meta)...)
 }
 
-func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -320,7 +320,7 @@ func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, m
 	const (
 		timeout = 3 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*types.InvalidDBParameterGroupStateFault](ctx, timeout, func() (any, error) {
 		return conn.DeleteDBParameterGroup(ctx, &rds.DeleteDBParameterGroupInput{
 			DBParameterGroupName: aws.String(d.Id()),
 		})
@@ -423,9 +423,9 @@ func findDBParameters(ctx context.Context, conn *rds.Client, input *rds.Describe
 	return output, nil
 }
 
-func resourceParameterHash(v interface{}) int {
+func resourceParameterHash(v any) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m := v.(map[string]any)
 	// Store the value as a lower case string, to match how we store them in FlattenParameters
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m[names.AttrName].(string))))
 	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["apply_method"].(string))))

--- a/internal/service/rds/parameter_group_data_source.go
+++ b/internal/service/rds/parameter_group_data_source.go
@@ -41,7 +41,7 @@ func dataSourceParameterGroup() *schema.Resource {
 	}
 }
 
-func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/proxy.go
+++ b/internal/service/rds/proxy.go
@@ -141,7 +141,7 @@ func resourceProxy() *schema.Resource {
 	}
 }
 
-func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -186,7 +186,7 @@ func resourceProxyCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceProxyRead(ctx, d, meta)...)
 }
 
-func resourceProxyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -217,7 +217,7 @@ func resourceProxyRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -258,7 +258,7 @@ func resourceProxyUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceProxyRead(ctx, d, meta)...)
 }
 
-func resourceProxyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -341,7 +341,7 @@ func findDBProxies(ctx context.Context, conn *rds.Client, input *rds.DescribeDBP
 }
 
 func statusDBProxy(ctx context.Context, conn *rds.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBProxyByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -407,7 +407,7 @@ func waitDBProxyUpdated(ctx context.Context, conn *rds.Client, name string, time
 	return nil, err
 }
 
-func expandUserAuthConfigs(tfList []interface{}) []types.UserAuthConfig {
+func expandUserAuthConfigs(tfList []any) []types.UserAuthConfig {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -415,7 +415,7 @@ func expandUserAuthConfigs(tfList []interface{}) []types.UserAuthConfig {
 	apiObjects := make([]types.UserAuthConfig, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -452,8 +452,8 @@ func expandUserAuthConfigs(tfList []interface{}) []types.UserAuthConfig {
 	return apiObjects
 }
 
-func flattenUserAuthConfigInfo(apiObject types.UserAuthConfigInfo) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenUserAuthConfigInfo(apiObject types.UserAuthConfigInfo) map[string]any {
+	tfMap := map[string]any{
 		"auth_scheme":               apiObject.AuthScheme,
 		"client_password_auth_type": apiObject.ClientPasswordAuthType,
 		"iam_auth":                  apiObject.IAMAuth,
@@ -474,8 +474,8 @@ func flattenUserAuthConfigInfo(apiObject types.UserAuthConfigInfo) map[string]in
 	return tfMap
 }
 
-func flattenUserAuthConfigInfos(apiObjects []types.UserAuthConfigInfo) []interface{} {
-	tfList := []interface{}{}
+func flattenUserAuthConfigInfos(apiObjects []types.UserAuthConfigInfo) []any {
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenUserAuthConfigInfo(apiObject))

--- a/internal/service/rds/proxy_data_source.go
+++ b/internal/service/rds/proxy_data_source.go
@@ -101,7 +101,7 @@ func dataSourceProxy() *schema.Resource {
 	}
 }
 
-func dataSourceProxyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceProxyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/proxy_default_target_group.go
+++ b/internal/service/rds/proxy_default_target_group.go
@@ -104,7 +104,7 @@ func resourceProxyDefaultTargetGroup() *schema.Resource {
 	}
 }
 
-func resourceProxyDefaultTargetGroupPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyDefaultTargetGroupPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -114,8 +114,8 @@ func resourceProxyDefaultTargetGroupPut(ctx context.Context, d *schema.ResourceD
 		TargetGroupName: aws.String("default"),
 	}
 
-	if v, ok := d.GetOk("connection_pool_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ConnectionPoolConfig = expandConnectionPoolConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("connection_pool_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ConnectionPoolConfig = expandConnectionPoolConfiguration(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.ModifyDBProxyTargetGroup(ctx, input)
@@ -138,7 +138,7 @@ func resourceProxyDefaultTargetGroupPut(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceProxyDefaultTargetGroupRead(ctx, d, meta)...)
 }
 
-func resourceProxyDefaultTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyDefaultTargetGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -156,7 +156,7 @@ func resourceProxyDefaultTargetGroupRead(ctx context.Context, d *schema.Resource
 
 	d.Set(names.AttrARN, tg.TargetGroupArn)
 	if tg.ConnectionPoolConfig != nil {
-		if err := d.Set("connection_pool_config", []interface{}{flattenConnectionPoolConfigurationInfo(tg.ConnectionPoolConfig)}); err != nil {
+		if err := d.Set("connection_pool_config", []any{flattenConnectionPoolConfigurationInfo(tg.ConnectionPoolConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting connection_pool_config: %s", err)
 		}
 	} else {
@@ -217,7 +217,7 @@ func findDBProxyTargetGroups(ctx context.Context, conn *rds.Client, input *rds.D
 }
 
 func statusDefaultDBProxyTargetGroup(ctx context.Context, conn *rds.Client, dbProxyName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDefaultDBProxyTargetGroupByDBProxyName(ctx, conn, dbProxyName)
 
 		if tfresource.NotFound(err) {
@@ -249,7 +249,7 @@ func waitDefaultDBProxyTargetGroupAvailable(ctx context.Context, conn *rds.Clien
 	return nil, err
 }
 
-func expandConnectionPoolConfiguration(tfMap map[string]interface{}) *types.ConnectionPoolConfiguration {
+func expandConnectionPoolConfiguration(tfMap map[string]any) *types.ConnectionPoolConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -271,12 +271,12 @@ func expandConnectionPoolConfiguration(tfMap map[string]interface{}) *types.Conn
 	return apiObject
 }
 
-func flattenConnectionPoolConfigurationInfo(apiObject *types.ConnectionPoolConfigurationInfo) map[string]interface{} {
+func flattenConnectionPoolConfigurationInfo(apiObject *types.ConnectionPoolConfigurationInfo) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["connection_borrow_timeout"] = aws.ToInt32(apiObject.ConnectionBorrowTimeout)
 	tfMap["init_query"] = aws.ToString(apiObject.InitQuery)

--- a/internal/service/rds/proxy_endpoint.go
+++ b/internal/service/rds/proxy_endpoint.go
@@ -101,7 +101,7 @@ func resourceProxyEndpoint() *schema.Resource {
 	}
 }
 
-func resourceProxyEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -134,7 +134,7 @@ func resourceProxyEndpointCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceProxyEndpointRead(ctx, d, meta)...)
 }
 
-func resourceProxyEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -168,7 +168,7 @@ func resourceProxyEndpointRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceProxyEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -197,7 +197,7 @@ func resourceProxyEndpointUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceProxyEndpointRead(ctx, d, meta)...)
 }
 
-func resourceProxyEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -305,7 +305,7 @@ func findDBProxyEndpoints(ctx context.Context, conn *rds.Client, input *rds.Desc
 }
 
 func statusDBProxyEndpoint(ctx context.Context, conn *rds.Client, dbProxyName, dbProxyEndpointName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBProxyEndpointByTwoPartKey(ctx, conn, dbProxyName, dbProxyEndpointName)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/proxy_target.go
+++ b/internal/service/rds/proxy_target.go
@@ -96,7 +96,7 @@ func resourceProxyTarget() *schema.Resource {
 	}
 }
 
-func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -119,7 +119,7 @@ func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 		timeout = 5 * time.Minute
 	)
 	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidDBInstanceStateFault](ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.RegisterDBProxyTargets(ctx, input)
 		},
 		"CREATING")
@@ -134,7 +134,7 @@ func resourceProxyTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceProxyTargetRead(ctx, d, meta)...)
 }
 
-func resourceProxyTargetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyTargetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -173,7 +173,7 @@ func resourceProxyTargetRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceProxyTargetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProxyTargetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/reserved_instance.go
+++ b/internal/service/rds/reserved_instance.go
@@ -130,7 +130,7 @@ func resourceReservedInstance() *schema.Resource {
 	}
 }
 
-func resourceReservedInstanceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReservedInstanceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -162,7 +162,7 @@ func resourceReservedInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceReservedInstanceRead(ctx, d, meta)...)
 }
 
-func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -198,7 +198,7 @@ func resourceReservedInstanceRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceReservedInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReservedInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceReservedInstanceRead(ctx, d, meta)
 }
@@ -262,7 +262,7 @@ func findReservedDBInstances(ctx context.Context, conn *rds.Client, input *rds.D
 }
 
 func statusReservedInstance(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findReservedDBInstanceByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -297,14 +297,14 @@ func waitReservedInstanceCreated(ctx context.Context, conn *rds.Client, id strin
 	return nil, err
 }
 
-func flattenRecurringCharges(apiObjects []types.RecurringCharge) []interface{} {
+func flattenRecurringCharges(apiObjects []types.RecurringCharge) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"recurring_charge_amount":    aws.ToFloat64(apiObject.RecurringChargeAmount),
 			"recurring_charge_frequency": aws.ToString(apiObject.RecurringChargeFrequency),
 		}

--- a/internal/service/rds/reserved_instance_offering_data_source.go
+++ b/internal/service/rds/reserved_instance_offering_data_source.go
@@ -69,7 +69,7 @@ func dataSourceReservedOffering() *schema.Resource {
 	}
 }
 
-func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceReservedOfferingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/shard_group.go
+++ b/internal/service/rds/shard_group.go
@@ -346,7 +346,7 @@ func findDBShardGroups(ctx context.Context, conn *rds.Client, input *rds.Describ
 }
 
 func statusShardGroup(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBShardGroupByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/snapshot.go
+++ b/internal/service/rds/snapshot.go
@@ -133,7 +133,7 @@ func resourceSnapshot() *schema.Resource {
 	}
 }
 
-func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -173,7 +173,7 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -223,7 +223,7 @@ func resourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -248,7 +248,7 @@ func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -327,7 +327,7 @@ func findDBSnapshots(ctx context.Context, conn *rds.Client, input *rds.DescribeD
 }
 
 func statusDBSnapshot(ctx context.Context, conn *rds.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDBSnapshotByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/rds/snapshot_copy.go
+++ b/internal/service/rds/snapshot_copy.go
@@ -151,7 +151,7 @@ func resourceSnapshotCopy() *schema.Resource {
 	}
 }
 
-func resourceSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -219,7 +219,7 @@ func resourceSnapshotCopyCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceSnapshotCopyRead(ctx, d, meta)...)
 }
 
-func resourceSnapshotCopyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCopyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -266,7 +266,7 @@ func resourceSnapshotCopyRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceSnapshotCopyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCopyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -291,7 +291,7 @@ func resourceSnapshotCopyUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceSnapshotCopyRead(ctx, d, meta)...)
 }
 
-func resourceSnapshotCopyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSnapshotCopyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/snapshot_data_source.go
+++ b/internal/service/rds/snapshot_data_source.go
@@ -132,7 +132,7 @@ func dataSourceSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -85,7 +85,7 @@ func resourceSubnetGroup() *schema.Resource {
 	}
 }
 
-func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -108,7 +108,7 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
-func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -137,7 +137,7 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -158,7 +158,7 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
-func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 
@@ -175,7 +175,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting RDS Subnet Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
 		return findDBSubnetGroupByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/rds/subnet_group_data_source.go
+++ b/internal/service/rds/subnet_group_data_source.go
@@ -57,7 +57,7 @@ func dataSourceSubnetGroup() *schema.Resource {
 	}
 }
 
-func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RDSClient(ctx)
 

--- a/internal/service/rds/validate.go
+++ b/internal/service/rds/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validEventSubscriptionName(v interface{}, k string) (ws []string, errors []error) {
+func validEventSubscriptionName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[A-Za-z][0-9A-Za-z-]*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -32,7 +32,7 @@ func validEventSubscriptionName(v interface{}, k string) (ws []string, errors []
 	return
 }
 
-func validEventSubscriptionNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+func validEventSubscriptionNamePrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[A-Za-z][0-9A-Za-z-]*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -50,7 +50,7 @@ func validEventSubscriptionNamePrefix(v interface{}, k string) (ws []string, err
 	return
 }
 
-func validOptionGroupName(v interface{}, k string) (ws []string, errors []error) {
+func validOptionGroupName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -75,7 +75,7 @@ func validOptionGroupName(v interface{}, k string) (ws []string, errors []error)
 	return
 }
 
-func validOptionGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+func validOptionGroupNamePrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -96,7 +96,7 @@ func validOptionGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 	return
 }
 
-func validParamGroupName(v interface{}, k string) (ws []string, errors []error) {
+func validParamGroupName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z.-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -121,7 +121,7 @@ func validParamGroupName(v interface{}, k string) (ws []string, errors []error) 
 	return
 }
 
-func validParamGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+func validParamGroupNamePrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -142,7 +142,7 @@ func validParamGroupNamePrefix(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
+func validSubnetGroupName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z_ .-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -159,7 +159,7 @@ func validSubnetGroupName(v interface{}, k string) (ws []string, errors []error)
 	return
 }
 
-func validSubnetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+func validSubnetGroupNamePrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z_ .-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -172,7 +172,7 @@ func validSubnetGroupNamePrefix(v interface{}, k string) (ws []string, errors []
 	return
 }
 
-func validIdentifier(v interface{}, k string) (ws []string, errors []error) {
+func validIdentifier(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -193,7 +193,7 @@ func validIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validIdentifierPrefix(v interface{}, k string) (ws []string, errors []error) {
+func validIdentifierPrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
