### PR TITLE
s3: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -79,6 +79,7 @@ jobs:
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check
+      - run: make TEST=./internal/service/s3 modern-check
       - run: make TEST=./internal/service/sns modern-check
       - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/wafregional modern-check

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -393,7 +393,7 @@ func resourceBucket() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -683,7 +683,7 @@ func resourceBucket() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringIsJSON,
-							StateFunc: func(v interface{}) string {
+							StateFunc: func(v any) string {
 								json, _ := structure.NormalizeJsonString(v)
 								return json
 							},
@@ -705,7 +705,7 @@ func resourceBucket() *schema.Resource {
 	}
 }
 
-func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -751,11 +751,11 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	// S3 Object Lock can only be enabled on bucket creation.
-	if v := expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{})); v != nil && v.ObjectLockEnabled == types.ObjectLockEnabledEnabled {
+	if v := expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]any)); v != nil && v.ObjectLockEnabled == types.ObjectLockEnabledEnabled {
 		input.ObjectLockEnabledForBucket = aws.Bool(true)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return conn.CreateBucket(ctx, input)
 	}, errCodeOperationAborted)
 
@@ -765,7 +765,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.SetId(bucket)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, d.Timeout(schema.TimeoutCreate), func() (any, error) {
 		return findBucket(ctx, conn, d.Id())
 	})
 
@@ -780,7 +780,7 @@ func resourceBucketCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceBucketUpdate(ctx, d, meta)...)
 }
 
-func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -1150,7 +1150,7 @@ func resourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -1166,7 +1166,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		if policy == "" {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1181,7 +1181,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				Policy: aws.String(policy),
 			}
 
-			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketPolicy(ctx, input)
 			}, errCodeMalformedPolicy, errCodeNoSuchBucket)
 
@@ -1195,8 +1195,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket CORS Configuration.
 	//
 	if d.HasChange("cors_rule") {
-		if v, ok := d.GetOk("cors_rule"); !ok || len(v.([]interface{})) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		if v, ok := d.GetOk("cors_rule"); !ok || len(v.([]any)) == 0 {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1209,11 +1209,11 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input := &s3.PutBucketCorsInput{
 				Bucket: aws.String(d.Id()),
 				CORSConfiguration: &types.CORSConfiguration{
-					CORSRules: expandBucketCORSRules(d.Get("cors_rule").([]interface{})),
+					CORSRules: expandBucketCORSRules(d.Get("cors_rule").([]any)),
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketCors(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1227,8 +1227,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket Website Configuration.
 	//
 	if d.HasChange("website") {
-		if v, ok := d.GetOk("website"); !ok || len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		if v, ok := d.GetOk("website"); !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketWebsite(ctx, &s3.DeleteBucketWebsiteInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1238,7 +1238,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket (%s) website configuration: %s", d.Id(), err)
 			}
 		} else {
-			websiteConfig, err := expandBucketWebsiteConfiguration(v.([]interface{}))
+			websiteConfig, err := expandBucketWebsiteConfiguration(v.([]any))
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}
@@ -1248,7 +1248,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				WebsiteConfiguration: websiteConfig,
 			}
 
-			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketWebsite(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1262,7 +1262,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket Versioning.
 	//
 	if d.HasChange("versioning") {
-		v := d.Get("versioning").([]interface{})
+		v := d.Get("versioning").([]any)
 		var versioningConfig *types.VersioningConfiguration
 
 		if d.IsNewResource() {
@@ -1277,7 +1277,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				VersioningConfiguration: versioningConfig,
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketVersioning(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1301,7 +1301,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutBucketAcl(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1327,7 +1327,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutBucketAcl(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1345,8 +1345,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			BucketLoggingStatus: &types.BucketLoggingStatus{},
 		}
 
-		if v, ok := d.GetOk("logging"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			tfMap := v.([]interface{})[0].(map[string]interface{})
+		if v, ok := d.GetOk("logging"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			tfMap := v.([]any)[0].(map[string]any)
 
 			input.BucketLoggingStatus.LoggingEnabled = &types.LoggingEnabled{}
 
@@ -1359,7 +1359,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			}
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutBucketLogging(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1372,8 +1372,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket Lifecycle Configuration.
 	//
 	if d.HasChange("lifecycle_rule") {
-		if v, ok := d.GetOk("lifecycle_rule"); !ok || len(v.([]interface{})) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		if v, ok := d.GetOk("lifecycle_rule"); !ok || len(v.([]any)) == 0 {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketLifecycle(ctx, &s3.DeleteBucketLifecycleInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1386,11 +1386,11 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input := &s3.PutBucketLifecycleConfigurationInput{
 				Bucket: aws.String(d.Id()),
 				LifecycleConfiguration: &types.BucketLifecycleConfiguration{
-					Rules: expandBucketLifecycleRules(ctx, v.([]interface{})),
+					Rules: expandBucketLifecycleRules(ctx, v.([]any)),
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketLifecycleConfiguration(ctx, input)
 			}, errCodeNoSuchBucket)
 
@@ -1411,7 +1411,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			Bucket: aws.String(d.Id()),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutBucketAccelerateConfiguration(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1431,7 +1431,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			},
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutBucketRequestPayment(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1444,8 +1444,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket Replication Configuration.
 	//
 	if d.HasChange("replication_configuration") {
-		if v, ok := d.GetOk("replication_configuration"); !ok || len(v.([]interface{})) == 0 || v.([]interface{})[0] == nil {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		if v, ok := d.GetOk("replication_configuration"); !ok || len(v.([]any)) == 0 || v.([]any)[0] == nil {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketReplication(ctx, &s3.DeleteBucketReplicationInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1458,8 +1458,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			hasVersioning := false
 
 			// Validate that bucket versioning is enabled.
-			if v, ok := d.GetOk("versioning"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := d.GetOk("versioning"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
 
 				if tfMap[names.AttrEnabled].(bool) {
 					hasVersioning = true
@@ -1472,11 +1472,11 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 			input := &s3.PutBucketReplicationInput{
 				Bucket:                   aws.String(d.Id()),
-				ReplicationConfiguration: expandBucketReplicationConfiguration(ctx, v.([]interface{})),
+				ReplicationConfiguration: expandBucketReplicationConfiguration(ctx, v.([]any)),
 			}
 
 			_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutUpdate),
-				func() (interface{}, error) {
+				func() (any, error) {
 					return conn.PutBucketReplication(ctx, input)
 				},
 				func(err error) (bool, error) {
@@ -1498,8 +1498,8 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	// Bucket Server-side Encryption Configuration.
 	//
 	if d.HasChange("server_side_encryption_configuration") {
-		if v, ok := d.GetOk("server_side_encryption_configuration"); !ok || len(v.([]interface{})) == 0 {
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		if v, ok := d.GetOk("server_side_encryption_configuration"); !ok || len(v.([]any)) == 0 {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.DeleteBucketEncryption(ctx, &s3.DeleteBucketEncryptionInput{
 					Bucket: aws.String(d.Id()),
 				})
@@ -1512,11 +1512,11 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			input := &s3.PutBucketEncryptionInput{
 				Bucket: aws.String(d.Id()),
 				ServerSideEncryptionConfiguration: &types.ServerSideEncryptionConfiguration{
-					Rules: expandBucketServerSideEncryptionRules(v.([]interface{})),
+					Rules: expandBucketServerSideEncryptionRules(v.([]any)),
 				},
 			}
 
-			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+			_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 				return conn.PutBucketEncryption(ctx, input)
 			}, errCodeNoSuchBucket, errCodeOperationAborted)
 
@@ -1533,10 +1533,10 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		// S3 Object Lock configuration cannot be deleted, only updated.
 		input := &s3.PutObjectLockConfigurationInput{
 			Bucket:                  aws.String(d.Id()),
-			ObjectLockConfiguration: expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{})),
+			ObjectLockConfiguration: expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]any)),
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.PutObjectLockConfiguration(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -1548,7 +1548,7 @@ func resourceBucketUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceBucketRead(ctx, d, meta)...)
 }
 
-func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -1566,7 +1566,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 			// Delete everything including locked objects.
 			// Don't ignore any object errors or we could recurse infinitely.
 			var objectLockEnabled bool
-			if v := expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]interface{})); v != nil {
+			if v := expandBucketObjectLockConfiguration(d.Get("object_lock_configuration").([]any)); v != nil {
 				objectLockEnabled = v.ObjectLockEnabled == types.ObjectLockEnabledEnabled
 			}
 
@@ -1585,7 +1585,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta inte
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return findBucket(ctx, conn, d.Id())
 	})
 
@@ -1653,7 +1653,7 @@ func findBucketRegion(ctx context.Context, awsClient *conns.AWSClient, bucket st
 }
 
 func retryWhenNoSuchBucketError[T any](ctx context.Context, timeout time.Duration, f func() (T, error)) (T, error) {
-	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout, func() (any, error) {
 		return f()
 	}, errCodeNoSuchBucket)
 
@@ -1710,7 +1710,7 @@ func bucketWebsiteEndpointAndDomain(bucket, region string) (string, string) {
 // Bucket CORS Configuration.
 //
 
-func expandBucketCORSRules(l []interface{}) []types.CORSRule {
+func expandBucketCORSRules(l []any) []types.CORSRule {
 	if len(l) == 0 {
 		return nil
 	}
@@ -1718,26 +1718,26 @@ func expandBucketCORSRules(l []interface{}) []types.CORSRule {
 	var rules []types.CORSRule
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		rule := types.CORSRule{}
 
-		if v, ok := tfMap["allowed_headers"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["allowed_headers"].([]any); ok && len(v) > 0 {
 			rule.AllowedHeaders = flex.ExpandStringValueListEmpty(v)
 		}
 
-		if v, ok := tfMap["allowed_methods"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["allowed_methods"].([]any); ok && len(v) > 0 {
 			rule.AllowedMethods = flex.ExpandStringValueListEmpty(v)
 		}
 
-		if v, ok := tfMap["allowed_origins"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["allowed_origins"].([]any); ok && len(v) > 0 {
 			rule.AllowedOrigins = flex.ExpandStringValueListEmpty(v)
 		}
 
-		if v, ok := tfMap["expose_headers"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["expose_headers"].([]any); ok && len(v) > 0 {
 			rule.ExposeHeaders = flex.ExpandStringValueListEmpty(v)
 		}
 
@@ -1751,11 +1751,11 @@ func expandBucketCORSRules(l []interface{}) []types.CORSRule {
 	return rules
 }
 
-func flattenBucketCORSRules(rules []types.CORSRule) []interface{} {
-	var results []interface{}
+func flattenBucketCORSRules(rules []types.CORSRule) []any {
+	var results []any
 
 	for _, rule := range rules {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"max_age_seconds": rule.MaxAgeSeconds,
 		}
 
@@ -1785,12 +1785,12 @@ func flattenBucketCORSRules(rules []types.CORSRule) []interface{} {
 // Bucket Website Configuration.
 //
 
-func expandBucketWebsiteConfiguration(l []interface{}) (*types.WebsiteConfiguration, error) {
+func expandBucketWebsiteConfiguration(l []any) (*types.WebsiteConfiguration, error) {
 	if len(l) == 0 || l[0] == nil {
 		return nil, nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil, nil
 	}
@@ -1844,12 +1844,12 @@ func expandBucketWebsiteConfiguration(l []interface{}) (*types.WebsiteConfigurat
 	return websiteConfig, nil
 }
 
-func flattenBucketWebsite(apiObject *s3.GetBucketWebsiteOutput) ([]interface{}, error) {
+func flattenBucketWebsite(apiObject *s3.GetBucketWebsiteOutput) ([]any, error) {
 	if apiObject == nil {
-		return []interface{}{}, nil
+		return []any{}, nil
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if v := apiObject.IndexDocument; v != nil {
 		m["index_document"] = aws.ToString(v.Suffix)
@@ -1898,22 +1898,22 @@ func flattenBucketWebsite(apiObject *s3.GetBucketWebsiteOutput) ([]interface{}, 
 	// We have special handling for the website configuration,
 	// so only return the configuration if there is one.
 	if len(m) == 0 {
-		return []interface{}{}, nil
+		return []any{}, nil
 	}
 
-	return []interface{}{m}, nil
+	return []any{m}, nil
 }
 
 //
 // Bucket Versioning.
 //
 
-func expandBucketVersioningConfigurationCreate(l []interface{}) *types.VersioningConfiguration {
+func expandBucketVersioningConfigurationCreate(l []any) *types.VersioningConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1940,12 +1940,12 @@ func expandBucketVersioningConfigurationCreate(l []interface{}) *types.Versionin
 	return apiObject
 }
 
-func expandBucketVersioningConfigurationUpdate(l []interface{}) *types.VersioningConfiguration {
+func expandBucketVersioningConfigurationUpdate(l []any) *types.VersioningConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -1971,28 +1971,28 @@ func expandBucketVersioningConfigurationUpdate(l []interface{}) *types.Versionin
 	return apiObject
 }
 
-func flattenBucketVersioning(config *s3.GetBucketVersioningOutput) []interface{} {
+func flattenBucketVersioning(config *s3.GetBucketVersioningOutput) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrEnabled: config.Status == types.BucketVersioningStatusEnabled,
 		"mfa_delete":      config.MFADelete == types.MFADeleteStatusEnabled,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 //
 // Bucket ACL.
 //
 
-func expandBucketGrants(l []interface{}) []types.Grant {
+func expandBucketGrants(l []any) []types.Grant {
 	var grants []types.Grant
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2031,14 +2031,14 @@ func expandBucketGrants(l []interface{}) []types.Grant {
 	return grants
 }
 
-func flattenBucketGrants(apiObject *s3.GetBucketAclOutput) []interface{} {
+func flattenBucketGrants(apiObject *s3.GetBucketAclOutput) []any {
 	if len(apiObject.Grants) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	getGrant := func(grants []interface{}, grantee map[string]interface{}) (interface{}, bool) {
+	getGrant := func(grants []any, grantee map[string]any) (any, bool) {
 		for _, grant := range grants {
-			tfMap := grant.(map[string]interface{})
+			tfMap := grant.(map[string]any)
 			if tfMap[names.AttrType] == grantee[names.AttrType] && tfMap[names.AttrID] == grantee[names.AttrID] && tfMap[names.AttrURI] == grantee[names.AttrURI] && tfMap[names.AttrPermissions].(*schema.Set).Len() > 0 {
 				return grant, true
 			}
@@ -2046,12 +2046,12 @@ func flattenBucketGrants(apiObject *s3.GetBucketAclOutput) []interface{} {
 		return nil, false
 	}
 
-	results := make([]interface{}, 0, len(apiObject.Grants))
+	results := make([]any, 0, len(apiObject.Grants))
 
 	for _, apiObject := range apiObject.Grants {
 		grantee := apiObject.Grantee
 
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrType: grantee.Type,
 		}
 
@@ -2064,9 +2064,9 @@ func flattenBucketGrants(apiObject *s3.GetBucketAclOutput) []interface{} {
 		}
 
 		if v, ok := getGrant(results, m); ok {
-			v.(map[string]interface{})[names.AttrPermissions].(*schema.Set).Add(string(apiObject.Permission))
+			v.(map[string]any)[names.AttrPermissions].(*schema.Set).Add(string(apiObject.Permission))
 		} else {
-			m[names.AttrPermissions] = schema.NewSet(schema.HashString, []interface{}{string(apiObject.Permission)})
+			m[names.AttrPermissions] = schema.NewSet(schema.HashString, []any{string(apiObject.Permission)})
 			results = append(results, m)
 		}
 	}
@@ -2078,12 +2078,12 @@ func flattenBucketGrants(apiObject *s3.GetBucketAclOutput) []interface{} {
 // Bucket Logging.
 //
 
-func flattenBucketLoggingEnabled(apiObject *types.LoggingEnabled) []interface{} {
+func flattenBucketLoggingEnabled(apiObject *types.LoggingEnabled) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if apiObject.TargetBucket != nil {
 		m["target_bucket"] = aws.ToString(apiObject.TargetBucket)
@@ -2093,14 +2093,14 @@ func flattenBucketLoggingEnabled(apiObject *types.LoggingEnabled) []interface{} 
 		m["target_prefix"] = aws.ToString(apiObject.TargetPrefix)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 //
 // Bucket Lifecycle Configuration.
 //
 
-func expandBucketLifecycleRules(ctx context.Context, tfList []interface{}) []types.LifecycleRule {
+func expandBucketLifecycleRules(ctx context.Context, tfList []any) []types.LifecycleRule {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -2108,7 +2108,7 @@ func expandBucketLifecycleRules(ctx context.Context, tfList []interface{}) []typ
 	var apiObjects []types.LifecycleRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2121,7 +2121,7 @@ func expandBucketLifecycleRules(ctx context.Context, tfList []interface{}) []typ
 			}
 		}
 
-		if v, ok := tfMap["expiration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["expiration"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.Expiration = expandBucketLifecycleExpiration(v)
 		}
 
@@ -2147,8 +2147,8 @@ func expandBucketLifecycleRules(ctx context.Context, tfList []interface{}) []typ
 			apiObject.ID = aws.String(id.PrefixedUniqueId("tf-s3-lifecycle-"))
 		}
 
-		if v, ok := tfMap["noncurrent_version_expiration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			apiObject.NoncurrentVersionExpiration = expandBucketNoncurrentVersionExpiration(v[0].(map[string]interface{}))
+		if v, ok := tfMap["noncurrent_version_expiration"].([]any); ok && len(v) > 0 && v[0] != nil {
+			apiObject.NoncurrentVersionExpiration = expandBucketNoncurrentVersionExpiration(v[0].(map[string]any))
 		}
 
 		if v, ok := tfMap["noncurrent_version_transition"].(*schema.Set); ok && v.Len() > 0 {
@@ -2178,7 +2178,7 @@ func expandBucketLifecycleRules(ctx context.Context, tfList []interface{}) []typ
 	return apiObjects
 }
 
-func expandBucketLifecycleExpiration(tfList []interface{}) *types.LifecycleExpiration {
+func expandBucketLifecycleExpiration(tfList []any) *types.LifecycleExpiration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -2189,7 +2189,7 @@ func expandBucketLifecycleExpiration(tfList []interface{}) *types.LifecycleExpir
 		return apiObject
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	if v, ok := tfMap["date"].(string); ok && v != "" {
 		t, _ := time.Parse(time.RFC3339, v+"T00:00:00Z")
@@ -2203,7 +2203,7 @@ func expandBucketLifecycleExpiration(tfList []interface{}) *types.LifecycleExpir
 	return apiObject
 }
 
-func expandBucketNoncurrentVersionExpiration(tfMap map[string]interface{}) *types.NoncurrentVersionExpiration {
+func expandBucketNoncurrentVersionExpiration(tfMap map[string]any) *types.NoncurrentVersionExpiration {
 	if len(tfMap) == 0 {
 		return nil
 	}
@@ -2219,7 +2219,7 @@ func expandBucketNoncurrentVersionExpiration(tfMap map[string]interface{}) *type
 	return apiObject
 }
 
-func expandBucketNoncurrentVersionTransition(tfList []interface{}) []types.NoncurrentVersionTransition {
+func expandBucketNoncurrentVersionTransition(tfList []any) []types.NoncurrentVersionTransition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -2227,7 +2227,7 @@ func expandBucketNoncurrentVersionTransition(tfList []interface{}) []types.Noncu
 	var apiObjects []types.NoncurrentVersionTransition
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2248,7 +2248,7 @@ func expandBucketNoncurrentVersionTransition(tfList []interface{}) []types.Noncu
 	return apiObjects
 }
 
-func expandBucketTransitions(tfList []interface{}) []types.Transition {
+func expandBucketTransitions(tfList []any) []types.Transition {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -2256,7 +2256,7 @@ func expandBucketTransitions(tfList []interface{}) []types.Transition {
 	var apiObjects []types.Transition
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2280,15 +2280,15 @@ func expandBucketTransitions(tfList []interface{}) []types.Transition {
 	return apiObjects
 }
 
-func flattenBucketLifecycleRules(ctx context.Context, apiObjects []types.LifecycleRule) []interface{} {
+func flattenBucketLifecycleRules(ctx context.Context, apiObjects []types.LifecycleRule) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		if apiObject := apiObject.AbortIncompleteMultipartUpload; apiObject != nil {
 			if v := apiObject.DaysAfterInitiation; v != nil {
@@ -2331,13 +2331,13 @@ func flattenBucketLifecycleRules(ctx context.Context, apiObjects []types.Lifecyc
 		tfMap[names.AttrEnabled] = apiObject.Status == types.ExpirationStatusEnabled
 
 		if apiObject := apiObject.NoncurrentVersionExpiration; apiObject != nil {
-			m := make(map[string]interface{})
+			m := make(map[string]any)
 
 			if v := apiObject.NoncurrentDays; v != nil {
 				m["days"] = aws.ToInt32(v)
 			}
 
-			tfMap["noncurrent_version_expiration"] = []interface{}{m}
+			tfMap["noncurrent_version_expiration"] = []any{m}
 		}
 
 		if v := apiObject.NoncurrentVersionTransitions; v != nil {
@@ -2354,12 +2354,12 @@ func flattenBucketLifecycleRules(ctx context.Context, apiObjects []types.Lifecyc
 	return tfList
 }
 
-func flattenBucketLifecycleExpiration(apiObject *types.LifecycleExpiration) []interface{} {
+func flattenBucketLifecycleExpiration(apiObject *types.LifecycleExpiration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.Date; v != nil {
 		tfMap["date"] = v.Format("2006-01-02")
@@ -2373,18 +2373,18 @@ func flattenBucketLifecycleExpiration(apiObject *types.LifecycleExpiration) []in
 		tfMap["expired_object_delete_marker"] = aws.ToBool(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBucketNoncurrentVersionTransitions(apiObjects []types.NoncurrentVersionTransition) []interface{} {
+func flattenBucketNoncurrentVersionTransitions(apiObjects []types.NoncurrentVersionTransition) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrStorageClass: apiObject.StorageClass,
 		}
 
@@ -2398,15 +2398,15 @@ func flattenBucketNoncurrentVersionTransitions(apiObjects []types.NoncurrentVers
 	return tfList
 }
 
-func flattenBucketTransitions(apiObjects []types.Transition) []interface{} {
+func flattenBucketTransitions(apiObjects []types.Transition) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrStorageClass: apiObject.StorageClass,
 		}
 
@@ -2428,12 +2428,12 @@ func flattenBucketTransitions(apiObjects []types.Transition) []interface{} {
 // Bucket Replication Configuration.
 //
 
-func expandBucketReplicationConfiguration(ctx context.Context, tfList []interface{}) *types.ReplicationConfiguration {
+func expandBucketReplicationConfiguration(ctx context.Context, tfList []any) *types.ReplicationConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2451,11 +2451,11 @@ func expandBucketReplicationConfiguration(ctx context.Context, tfList []interfac
 	return apiObject
 }
 
-func expandBucketReplicationRules(ctx context.Context, tfList []interface{}) []types.ReplicationRule {
+func expandBucketReplicationRules(ctx context.Context, tfList []any) []types.ReplicationRule {
 	var rules []types.ReplicationRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2468,7 +2468,7 @@ func expandBucketReplicationRules(ctx context.Context, tfList []interface{}) []t
 			continue
 		}
 
-		if v, ok := tfMap[names.AttrDestination].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap[names.AttrDestination].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.Destination = expandBucketDestination(v)
 		} else {
 			apiObject.Destination = &types.Destination{}
@@ -2478,13 +2478,13 @@ func expandBucketReplicationRules(ctx context.Context, tfList []interface{}) []t
 			apiObject.ID = aws.String(v)
 		}
 
-		if v, ok := tfMap["source_selection_criteria"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["source_selection_criteria"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.SourceSelectionCriteria = expandBucketSourceSelectionCriteria(v)
 		}
 
-		if v, ok := tfMap[names.AttrFilter].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap[names.AttrFilter].([]any); ok && len(v) > 0 && v[0] != nil {
 			// XML schema V2.
-			tfFilterMap := v[0].(map[string]interface{})
+			tfFilterMap := v[0].(map[string]any)
 			var filter *types.ReplicationRuleFilter
 
 			if tags := Tags(tftags.New(ctx, tfFilterMap[names.AttrTags]).IgnoreAWS()); len(tags) > 0 {
@@ -2523,12 +2523,12 @@ func expandBucketReplicationRules(ctx context.Context, tfList []interface{}) []t
 	return rules
 }
 
-func expandBucketDestination(tfList []interface{}) *types.Destination {
+func expandBucketDestination(tfList []any) *types.Destination {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2553,16 +2553,16 @@ func expandBucketDestination(tfList []interface{}) *types.Destination {
 		apiObject.Account = aws.String(v)
 	}
 
-	if v, ok := tfMap["access_control_translation"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tfMap := v[0].(map[string]interface{})
+	if v, ok := tfMap["access_control_translation"].([]any); ok && len(v) > 0 && v[0] != nil {
+		tfMap := v[0].(map[string]any)
 
 		apiObject.AccessControlTranslation = &types.AccessControlTranslation{
 			Owner: types.OwnerOverride(tfMap[names.AttrOwner].(string)),
 		}
 	}
 
-	if v, ok := tfMap["metrics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tfMap := v[0].(map[string]interface{})
+	if v, ok := tfMap["metrics"].([]any); ok && len(v) > 0 && v[0] != nil {
+		tfMap := v[0].(map[string]any)
 
 		apiObject.Metrics = &types.Metrics{
 			EventThreshold: &types.ReplicationTimeValue{
@@ -2572,8 +2572,8 @@ func expandBucketDestination(tfList []interface{}) *types.Destination {
 		}
 	}
 
-	if v, ok := tfMap["replication_time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tfMap := v[0].(map[string]interface{})
+	if v, ok := tfMap["replication_time"].([]any); ok && len(v) > 0 && v[0] != nil {
+		tfMap := v[0].(map[string]any)
 
 		apiObject.ReplicationTime = &types.ReplicationTime{
 			Status: types.ReplicationTimeStatus(tfMap[names.AttrStatus].(string)),
@@ -2586,20 +2586,20 @@ func expandBucketDestination(tfList []interface{}) *types.Destination {
 	return apiObject
 }
 
-func expandBucketSourceSelectionCriteria(tfList []interface{}) *types.SourceSelectionCriteria {
+func expandBucketSourceSelectionCriteria(tfList []any) *types.SourceSelectionCriteria {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &types.SourceSelectionCriteria{}
 
-	if v, ok := tfMap["sse_kms_encrypted_objects"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		tfMap := v[0].(map[string]interface{})
+	if v, ok := tfMap["sse_kms_encrypted_objects"].([]any); ok && len(v) > 0 && v[0] != nil {
+		tfMap := v[0].(map[string]any)
 		kmsEncryptedObjects := &types.SseKmsEncryptedObjects{}
 
 		if tfMap[names.AttrEnabled].(bool) {
@@ -2614,12 +2614,12 @@ func expandBucketSourceSelectionCriteria(tfList []interface{}) *types.SourceSele
 	return apiObject
 }
 
-func flattenBucketReplicationConfiguration(ctx context.Context, apiObject *types.ReplicationConfiguration) []interface{} {
+func flattenBucketReplicationConfiguration(ctx context.Context, apiObject *types.ReplicationConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.Role; v != nil {
 		tfMap[names.AttrRole] = aws.ToString(v)
@@ -2629,18 +2629,18 @@ func flattenBucketReplicationConfiguration(ctx context.Context, apiObject *types
 		tfMap["rules"] = flattenBucketReplicationRules(ctx, v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBucketReplicationRules(ctx context.Context, apiObjects []types.ReplicationRule) []interface{} {
+func flattenBucketReplicationRules(ctx context.Context, apiObjects []types.ReplicationRule) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrStatus: apiObject.Status,
 		}
 
@@ -2680,21 +2680,21 @@ func flattenBucketReplicationRules(ctx context.Context, apiObjects []types.Repli
 	return tfList
 }
 
-func flattenBucketDestination(apiObject *types.Destination) []interface{} {
+func flattenBucketDestination(apiObject *types.Destination) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStorageClass: apiObject.StorageClass,
 	}
 
 	if apiObject := apiObject.AccessControlTranslation; apiObject != nil {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrOwner: apiObject.Owner,
 		}
 
-		tfMap["access_control_translation"] = []interface{}{m}
+		tfMap["access_control_translation"] = []any{m}
 	}
 
 	if apiObject.Account != nil {
@@ -2712,7 +2712,7 @@ func flattenBucketDestination(apiObject *types.Destination) []interface{} {
 	}
 
 	if apiObject := apiObject.Metrics; apiObject != nil {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrStatus: apiObject.Status,
 		}
 
@@ -2720,27 +2720,27 @@ func flattenBucketDestination(apiObject *types.Destination) []interface{} {
 			m["minutes"] = aws.ToInt32(apiObject.EventThreshold.Minutes)
 		}
 
-		tfMap["metrics"] = []interface{}{m}
+		tfMap["metrics"] = []any{m}
 	}
 
 	if apiObject := apiObject.ReplicationTime; apiObject != nil {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"minutes":        aws.ToInt32(apiObject.Time.Minutes),
 			names.AttrStatus: apiObject.Status,
 		}
 
-		tfMap["replication_time"] = []interface{}{m}
+		tfMap["replication_time"] = []any{m}
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBucketReplicationRuleFilter(ctx context.Context, apiObject *types.ReplicationRuleFilter) []interface{} {
+func flattenBucketReplicationRuleFilter(ctx context.Context, apiObject *types.ReplicationRuleFilter) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.And; v != nil {
 		tfMap[names.AttrPrefix] = aws.ToString(v.Prefix)
@@ -2755,29 +2755,29 @@ func flattenBucketReplicationRuleFilter(ctx context.Context, apiObject *types.Re
 		tfMap[names.AttrTags] = keyValueTags(ctx, []types.Tag{*v}).IgnoreAWS().Map()
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBucketSourceSelectionCriteria(apiObject *types.SourceSelectionCriteria) []interface{} {
+func flattenBucketSourceSelectionCriteria(apiObject *types.SourceSelectionCriteria) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.SseKmsEncryptedObjects; v != nil {
 		tfMap["sse_kms_encrypted_objects"] = flattenBucketSSEKMSEncryptedObjects(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenBucketSSEKMSEncryptedObjects(apiObject *types.SseKmsEncryptedObjects) []interface{} {
+func flattenBucketSSEKMSEncryptedObjects(apiObject *types.SseKmsEncryptedObjects) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.Status == types.SseKmsEncryptedObjectsStatusEnabled {
 		tfMap[names.AttrEnabled] = true
@@ -2785,35 +2785,35 @@ func flattenBucketSSEKMSEncryptedObjects(apiObject *types.SseKmsEncryptedObjects
 		tfMap[names.AttrEnabled] = false
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 //
 // Bucket Server-side Encryption Configuration.
 //
 
-func expandBucketServerSideEncryptionRules(l []interface{}) []types.ServerSideEncryptionRule {
+func expandBucketServerSideEncryptionRules(l []any) []types.ServerSideEncryptionRule {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	var rules []types.ServerSideEncryptionRule
 
-	if l, ok := tfMap[names.AttrRule].([]interface{}); ok && len(l) > 0 {
+	if l, ok := tfMap[names.AttrRule].([]any); ok && len(l) > 0 {
 		for _, tfMapRaw := range l {
-			tfMap, ok := tfMapRaw.(map[string]interface{})
+			tfMap, ok := tfMapRaw.(map[string]any)
 			if !ok {
 				continue
 			}
 
 			rule := types.ServerSideEncryptionRule{}
 
-			if v, ok := tfMap["apply_server_side_encryption_by_default"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+			if v, ok := tfMap["apply_server_side_encryption_by_default"].([]any); ok && len(v) > 0 && v[0] != nil {
 				rule.ApplyServerSideEncryptionByDefault = expandBucketServerSideEncryptionByDefault(v)
 			}
 
@@ -2828,12 +2828,12 @@ func expandBucketServerSideEncryptionRules(l []interface{}) []types.ServerSideEn
 	return rules
 }
 
-func expandBucketServerSideEncryptionByDefault(l []interface{}) *types.ServerSideEncryptionByDefault {
+func expandBucketServerSideEncryptionByDefault(l []any) *types.ServerSideEncryptionByDefault {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2851,27 +2851,27 @@ func expandBucketServerSideEncryptionByDefault(l []interface{}) *types.ServerSid
 	return sse
 }
 
-func flattenBucketServerSideEncryptionConfiguration(apiObject *types.ServerSideEncryptionConfiguration) []interface{} {
+func flattenBucketServerSideEncryptionConfiguration(apiObject *types.ServerSideEncryptionConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrRule: flattenBucketServerSideEncryptionRules(apiObject.Rules),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenBucketServerSideEncryptionRules(rules []types.ServerSideEncryptionRule) []interface{} {
-	var results []interface{}
+func flattenBucketServerSideEncryptionRules(rules []types.ServerSideEncryptionRule) []any {
+	var results []any
 
 	for _, rule := range rules {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		if apiObject := rule.ApplyServerSideEncryptionByDefault; apiObject != nil {
-			m["apply_server_side_encryption_by_default"] = []interface{}{
-				map[string]interface{}{
+			m["apply_server_side_encryption_by_default"] = []any{
+				map[string]any{
 					"kms_master_key_id": aws.ToString(apiObject.KMSMasterKeyID),
 					"sse_algorithm":     apiObject.SSEAlgorithm,
 				},
@@ -2892,12 +2892,12 @@ func flattenBucketServerSideEncryptionRules(rules []types.ServerSideEncryptionRu
 // Bucket Object Lock Configuration.
 //
 
-func expandBucketObjectLockConfiguration(l []interface{}) *types.ObjectLockConfiguration {
+func expandBucketObjectLockConfiguration(l []any) *types.ObjectLockConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2908,11 +2908,11 @@ func expandBucketObjectLockConfiguration(l []interface{}) *types.ObjectLockConfi
 		apiObject.ObjectLockEnabled = types.ObjectLockEnabled(v)
 	}
 
-	if v, ok := tfMap[names.AttrRule].([]interface{}); ok && len(v) > 0 {
-		tfMap := v[0].(map[string]interface{})
+	if v, ok := tfMap[names.AttrRule].([]any); ok && len(v) > 0 {
+		tfMap := v[0].(map[string]any)
 
-		if v, ok := tfMap["default_retention"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			tfMap := v[0].(map[string]interface{})
+		if v, ok := tfMap["default_retention"].([]any); ok && len(v) > 0 && v[0] != nil {
+			tfMap := v[0].(map[string]any)
 
 			apiObject.Rule = &types.ObjectLockRule{
 				DefaultRetention: &types.DefaultRetention{},
@@ -2933,20 +2933,20 @@ func expandBucketObjectLockConfiguration(l []interface{}) *types.ObjectLockConfi
 	return apiObject
 }
 
-func flattenObjectLockConfiguration(apiObject *types.ObjectLockConfiguration) []interface{} {
+func flattenObjectLockConfiguration(apiObject *types.ObjectLockConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"object_lock_enabled": apiObject.ObjectLockEnabled,
 	}
 
 	if apiObject.Rule != nil && apiObject.Rule.DefaultRetention != nil {
 		apiObject := apiObject.Rule.DefaultRetention
-		tfMap := map[string]interface{}{
-			"default_retention": []interface{}{
-				map[string]interface{}{
+		tfMap := map[string]any{
+			"default_retention": []any{
+				map[string]any{
 					"days":         aws.ToInt32(apiObject.Days),
 					names.AttrMode: apiObject.Mode,
 					"years":        aws.ToInt32(apiObject.Years),
@@ -2954,10 +2954,10 @@ func flattenObjectLockConfiguration(apiObject *types.ObjectLockConfiguration) []
 			},
 		}
 
-		m[names.AttrRule] = []interface{}{tfMap}
+		m[names.AttrRule] = []any{tfMap}
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 // validBucketName validates any S3 bucket name that is not inside the us-east-1 region.
@@ -2994,7 +2994,7 @@ func validBucketName(value string, region string) error {
 	return nil
 }
 
-func validBucketLifecycleTimestamp(v interface{}, k string) (ws []string, errors []error) {
+func validBucketLifecycleTimestamp(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(time.RFC3339, fmt.Sprintf("%sT00:00:00Z", value))
 	if err != nil {

--- a/internal/service/s3/bucket_accelerate_configuration.go
+++ b/internal/service/s3/bucket_accelerate_configuration.go
@@ -57,7 +57,7 @@ func resourceBucketAccelerateConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketAccelerateConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -90,7 +90,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketAccelerateConfiguration(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -101,7 +101,7 @@ func resourceBucketAccelerateConfigurationCreate(ctx context.Context, d *schema.
 	return append(diags, resourceBucketAccelerateConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketAccelerateConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAccelerateConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -133,7 +133,7 @@ func resourceBucketAccelerateConfigurationRead(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceBucketAccelerateConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAccelerateConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -165,7 +165,7 @@ func resourceBucketAccelerateConfigurationUpdate(ctx context.Context, d *schema.
 	return append(diags, resourceBucketAccelerateConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketAccelerateConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAccelerateConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/bucket_acl.go
+++ b/internal/service/s3/bucket_acl.go
@@ -148,7 +148,7 @@ func resourceBucketACL() *schema.Resource {
 	}
 }
 
-func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -168,11 +168,11 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta i
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	if v, ok := d.GetOk("access_control_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.AccessControlPolicy = expandAccessControlPolicy(v.([]interface{}))
+	if v, ok := d.GetOk("access_control_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.AccessControlPolicy = expandAccessControlPolicy(v.([]any))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketAcl(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -186,7 +186,7 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	d.SetId(BucketACLCreateResourceID(bucket, expectedBucketOwner, acl))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketACL(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -197,7 +197,7 @@ func resourceBucketACLCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceBucketACLRead(ctx, d, meta)...)
 }
 
-func resourceBucketACLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketACLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -232,7 +232,7 @@ func resourceBucketACLRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceBucketACLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketACLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -253,7 +253,7 @@ func resourceBucketACLUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if d.HasChange("access_control_policy") {
-		input.AccessControlPolicy = expandAccessControlPolicy(d.Get("access_control_policy").([]interface{}))
+		input.AccessControlPolicy = expandAccessControlPolicy(d.Get("access_control_policy").([]any))
 	}
 
 	if d.HasChange("acl") {
@@ -303,12 +303,12 @@ func findBucketACL(ctx context.Context, conn *s3.Client, bucket, expectedBucketO
 	return output, nil
 }
 
-func expandAccessControlPolicy(l []interface{}) *types.AccessControlPolicy {
+func expandAccessControlPolicy(l []any) *types.AccessControlPolicy {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -319,25 +319,25 @@ func expandAccessControlPolicy(l []interface{}) *types.AccessControlPolicy {
 		result.Grants = expandGrants(v.List())
 	}
 
-	if v, ok := tfMap[names.AttrOwner].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap[names.AttrOwner].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.Owner = expandOwner(v)
 	}
 
 	return result
 }
 
-func expandGrants(l []interface{}) []types.Grant {
+func expandGrants(l []any) []types.Grant {
 	var grants []types.Grant
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		grant := types.Grant{}
 
-		if v, ok := tfMap["grantee"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["grantee"].([]any); ok && len(v) > 0 && v[0] != nil {
 			grant.Grantee = expandACLGrantee(v)
 		}
 
@@ -351,12 +351,12 @@ func expandGrants(l []interface{}) []types.Grant {
 	return grants
 }
 
-func expandACLGrantee(l []interface{}) *types.Grantee {
+func expandACLGrantee(l []any) *types.Grantee {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -382,12 +382,12 @@ func expandACLGrantee(l []interface{}) *types.Grantee {
 	return result
 }
 
-func expandOwner(l []interface{}) *types.Owner {
+func expandOwner(l []any) *types.Owner {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -405,12 +405,12 @@ func expandOwner(l []interface{}) *types.Owner {
 	return owner
 }
 
-func flattenBucketACL(apiObject *s3.GetBucketAclOutput) []interface{} {
+func flattenBucketACL(apiObject *s3.GetBucketAclOutput) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if len(apiObject.Grants) > 0 {
 		m["grant"] = flattenGrants(apiObject.Grants)
@@ -420,14 +420,14 @@ func flattenBucketACL(apiObject *s3.GetBucketAclOutput) []interface{} {
 		m[names.AttrOwner] = flattenOwner(apiObject.Owner)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenGrants(grants []types.Grant) []interface{} {
-	var results []interface{}
+func flattenGrants(grants []types.Grant) []any {
+	var results []any
 
 	for _, grant := range grants {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"permission": grant.Permission,
 		}
 
@@ -441,12 +441,12 @@ func flattenGrants(grants []types.Grant) []interface{} {
 	return results
 }
 
-func flattenACLGrantee(grantee *types.Grantee) []interface{} {
+func flattenACLGrantee(grantee *types.Grantee) []any {
 	if grantee == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrType: grantee.Type,
 	}
 
@@ -466,15 +466,15 @@ func flattenACLGrantee(grantee *types.Grantee) []interface{} {
 		m[names.AttrURI] = aws.ToString(grantee.URI)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenOwner(owner *types.Owner) []interface{} {
+func flattenOwner(owner *types.Owner) []any {
 	if owner == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if owner.DisplayName != nil {
 		m[names.AttrDisplayName] = aws.ToString(owner.DisplayName)
@@ -484,7 +484,7 @@ func flattenOwner(owner *types.Owner) []interface{} {
 		m[names.AttrID] = aws.ToString(owner.ID)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 // BucketACLCreateResourceID is a method for creating an ID string

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -134,18 +134,18 @@ func resourceBucketAnalyticsConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	analyticsConfiguration := &types.AnalyticsConfiguration{
 		Id:                   aws.String(name),
-		StorageClassAnalysis: expandStorageClassAnalysis(d.Get("storage_class_analysis").([]interface{})),
+		StorageClassAnalysis: expandStorageClassAnalysis(d.Get("storage_class_analysis").([]any)),
 	}
 
-	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		analyticsConfiguration.Filter = expandAnalyticsFilter(ctx, v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		analyticsConfiguration.Filter = expandAnalyticsFilter(ctx, v.([]any)[0].(map[string]any))
 	}
 
 	bucket := d.Get(names.AttrBucket).(string)
@@ -158,7 +158,7 @@ func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.Reso
 		AnalyticsConfiguration: analyticsConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketAnalyticsConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -173,7 +173,7 @@ func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.Reso
 	if d.IsNewResource() {
 		d.SetId(fmt.Sprintf("%s:%s", bucket, name))
 
-		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 			return findAnalyticsConfiguration(ctx, conn, bucket, name)
 		})
 
@@ -185,7 +185,7 @@ func resourceBucketAnalyticsConfigurationPut(ctx context.Context, d *schema.Reso
 	return append(diags, resourceBucketAnalyticsConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketAnalyticsConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAnalyticsConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -222,7 +222,7 @@ func resourceBucketAnalyticsConfigurationRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func resourceBucketAnalyticsConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketAnalyticsConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -249,7 +249,7 @@ func resourceBucketAnalyticsConfigurationDelete(ctx context.Context, d *schema.R
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Analytics Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findAnalyticsConfiguration(ctx, conn, bucket, name)
 	})
 
@@ -270,7 +270,7 @@ func BucketAnalyticsConfigurationParseID(id string) (string, string, error) {
 	return bucket, name, nil
 }
 
-func expandAnalyticsFilter(ctx context.Context, m map[string]interface{}) types.AnalyticsFilter {
+func expandAnalyticsFilter(ctx context.Context, m map[string]any) types.AnalyticsFilter {
 	var prefix string
 	if v, ok := m[names.AttrPrefix]; ok {
 		prefix = v.(string)
@@ -312,47 +312,47 @@ func expandAnalyticsFilter(ctx context.Context, m map[string]interface{}) types.
 	return analyticsFilter
 }
 
-func expandStorageClassAnalysis(l []interface{}) *types.StorageClassAnalysis {
+func expandStorageClassAnalysis(l []any) *types.StorageClassAnalysis {
 	result := &types.StorageClassAnalysis{}
 
 	if len(l) == 0 || l[0] == nil {
 		return result
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 	if v, ok := m["data_export"]; ok {
 		dataExport := &types.StorageClassAnalysisDataExport{}
 		result.DataExport = dataExport
 
-		foo := v.([]interface{})
+		foo := v.([]any)
 		if len(foo) != 0 && foo[0] != nil {
-			bar := foo[0].(map[string]interface{})
+			bar := foo[0].(map[string]any)
 			if v, ok := bar["output_schema_version"]; ok {
 				dataExport.OutputSchemaVersion = types.StorageClassAnalysisSchemaVersion(v.(string))
 			}
 
-			dataExport.Destination = expandAnalyticsExportDestination(bar[names.AttrDestination].([]interface{}))
+			dataExport.Destination = expandAnalyticsExportDestination(bar[names.AttrDestination].([]any))
 		}
 	}
 
 	return result
 }
 
-func expandAnalyticsExportDestination(edl []interface{}) *types.AnalyticsExportDestination {
+func expandAnalyticsExportDestination(edl []any) *types.AnalyticsExportDestination {
 	result := &types.AnalyticsExportDestination{}
 
 	if len(edl) != 0 && edl[0] != nil {
-		edm := edl[0].(map[string]interface{})
-		result.S3BucketDestination = expandAnalyticsS3BucketDestination(edm["s3_bucket_destination"].([]interface{}))
+		edm := edl[0].(map[string]any)
+		result.S3BucketDestination = expandAnalyticsS3BucketDestination(edm["s3_bucket_destination"].([]any))
 	}
 	return result
 }
 
-func expandAnalyticsS3BucketDestination(bdl []interface{}) *types.AnalyticsS3BucketDestination { // nosemgrep:ci.s3-in-func-name
+func expandAnalyticsS3BucketDestination(bdl []any) *types.AnalyticsS3BucketDestination { // nosemgrep:ci.s3-in-func-name
 	result := &types.AnalyticsS3BucketDestination{}
 
 	if len(bdl) != 0 && bdl[0] != nil {
-		bdm := bdl[0].(map[string]interface{})
+		bdm := bdl[0].(map[string]any)
 		result.Bucket = aws.String(bdm["bucket_arn"].(string))
 		result.Format = types.AnalyticsS3ExportFileFormat(bdm[names.AttrFormat].(string))
 
@@ -368,8 +368,8 @@ func expandAnalyticsS3BucketDestination(bdl []interface{}) *types.AnalyticsS3Buc
 	return result
 }
 
-func flattenAnalyticsFilter(ctx context.Context, analyticsFilter types.AnalyticsFilter) []map[string]interface{} {
-	result := make(map[string]interface{})
+func flattenAnalyticsFilter(ctx context.Context, analyticsFilter types.AnalyticsFilter) []map[string]any {
+	result := make(map[string]any)
 
 	switch v := analyticsFilter.(type) {
 	case *types.AnalyticsFilterMemberAnd:
@@ -390,46 +390,46 @@ func flattenAnalyticsFilter(ctx context.Context, analyticsFilter types.Analytics
 		return nil
 	}
 
-	return []map[string]interface{}{result}
+	return []map[string]any{result}
 }
 
-func flattenStorageClassAnalysis(storageClassAnalysis *types.StorageClassAnalysis) []map[string]interface{} {
+func flattenStorageClassAnalysis(storageClassAnalysis *types.StorageClassAnalysis) []map[string]any {
 	if storageClassAnalysis == nil || storageClassAnalysis.DataExport == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
 	dataExport := storageClassAnalysis.DataExport
-	de := map[string]interface{}{
+	de := map[string]any{
 		"output_schema_version": dataExport.OutputSchemaVersion,
 	}
 	if dataExport.Destination != nil {
 		de[names.AttrDestination] = flattenAnalyticsExportDestination(dataExport.Destination)
 	}
-	result := map[string]interface{}{
-		"data_export": []interface{}{de},
+	result := map[string]any{
+		"data_export": []any{de},
 	}
 
-	return []map[string]interface{}{result}
+	return []map[string]any{result}
 }
 
-func flattenAnalyticsExportDestination(destination *types.AnalyticsExportDestination) []interface{} {
+func flattenAnalyticsExportDestination(destination *types.AnalyticsExportDestination) []any {
 	if destination == nil || destination.S3BucketDestination == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{
-		map[string]interface{}{
+	return []any{
+		map[string]any{
 			"s3_bucket_destination": flattenAnalyticsS3BucketDestination(destination.S3BucketDestination),
 		},
 	}
 }
 
-func flattenAnalyticsS3BucketDestination(bucketDestination *types.AnalyticsS3BucketDestination) []interface{} { // nosemgrep:ci.s3-in-func-name
+func flattenAnalyticsS3BucketDestination(bucketDestination *types.AnalyticsS3BucketDestination) []any { // nosemgrep:ci.s3-in-func-name
 	if bucketDestination == nil {
 		return nil
 	}
 
-	result := map[string]interface{}{
+	result := map[string]any{
 		"bucket_arn":     aws.ToString(bucketDestination.Bucket),
 		names.AttrFormat: bucketDestination.Format,
 	}
@@ -440,7 +440,7 @@ func flattenAnalyticsS3BucketDestination(bucketDestination *types.AnalyticsS3Buc
 		result[names.AttrPrefix] = aws.ToString(bucketDestination.Prefix)
 	}
 
-	return []interface{}{result}
+	return []any{result}
 }
 
 func findAnalyticsConfiguration(ctx context.Context, conn *s3.Client, bucket, id string) (*types.AnalyticsConfiguration, error) {

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -90,7 +90,7 @@ func resourceBucketCorsConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -109,7 +109,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketCors(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -123,7 +123,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findCORSRules(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -134,7 +134,7 @@ func resourceBucketCorsConfigurationCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceBucketCorsConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -168,7 +168,7 @@ func resourceBucketCorsConfigurationRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -200,7 +200,7 @@ func resourceBucketCorsConfigurationUpdate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceBucketCorsConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -230,7 +230,7 @@ func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findCORSRules(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -269,7 +269,7 @@ func findCORSRules(ctx context.Context, conn *s3.Client, bucket, expectedBucketO
 	return output.CORSRules, nil
 }
 
-func expandCORSRules(l []interface{}) []types.CORSRule {
+func expandCORSRules(l []any) []types.CORSRule {
 	if len(l) == 0 {
 		return nil
 	}
@@ -277,7 +277,7 @@ func expandCORSRules(l []interface{}) []types.CORSRule {
 	var rules []types.CORSRule
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -314,11 +314,11 @@ func expandCORSRules(l []interface{}) []types.CORSRule {
 	return rules
 }
 
-func flattenCORSRules(rules []types.CORSRule) []interface{} {
-	var results []interface{}
+func flattenCORSRules(rules []types.CORSRule) []any {
+	var results []any
 
 	for _, rule := range rules {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"max_age_seconds": rule.MaxAgeSeconds,
 		}
 

--- a/internal/service/s3/bucket_data_source.go
+++ b/internal/service/s3/bucket_data_source.go
@@ -60,7 +60,7 @@ func dataSourceBucket() *schema.Resource {
 	}
 }
 
-func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceBucketRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	awsClient := meta.(*conns.AWSClient)
 	conn := awsClient.S3Client(ctx)

--- a/internal/service/s3/bucket_intelligent_tiering_configuration.go
+++ b/internal/service/s3/bucket_intelligent_tiering_configuration.go
@@ -95,7 +95,7 @@ func resourceBucketIntelligentTieringConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -105,8 +105,8 @@ func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *sc
 		Status: types.IntelligentTieringStatus(d.Get(names.AttrStatus).(string)),
 	}
 
-	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		intelligentTieringConfiguration.Filter = expandIntelligentTieringFilter(ctx, v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		intelligentTieringConfiguration.Filter = expandIntelligentTieringFilter(ctx, v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("tiering"); ok && v.(*schema.Set).Len() > 0 {
@@ -123,7 +123,7 @@ func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *sc
 		IntelligentTieringConfiguration: intelligentTieringConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketIntelligentTieringConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -138,7 +138,7 @@ func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *sc
 	if d.IsNewResource() {
 		d.SetId(BucketIntelligentTieringConfigurationCreateResourceID(bucket, name))
 
-		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 			return findIntelligentTieringConfiguration(ctx, conn, bucket, name)
 		})
 
@@ -150,7 +150,7 @@ func resourceBucketIntelligentTieringConfigurationPut(ctx context.Context, d *sc
 	return append(diags, resourceBucketIntelligentTieringConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketIntelligentTieringConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketIntelligentTieringConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -177,7 +177,7 @@ func resourceBucketIntelligentTieringConfigurationRead(ctx context.Context, d *s
 
 	d.Set(names.AttrBucket, bucket)
 	if output.Filter != nil {
-		if err := d.Set(names.AttrFilter, []interface{}{flattenIntelligentTieringFilter(ctx, output.Filter)}); err != nil {
+		if err := d.Set(names.AttrFilter, []any{flattenIntelligentTieringFilter(ctx, output.Filter)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting filter: %s", err)
 		}
 	} else {
@@ -192,7 +192,7 @@ func resourceBucketIntelligentTieringConfigurationRead(ctx context.Context, d *s
 	return diags
 }
 
-func resourceBucketIntelligentTieringConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketIntelligentTieringConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -219,7 +219,7 @@ func resourceBucketIntelligentTieringConfigurationDelete(ctx context.Context, d 
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Intelligent-Tiering Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findIntelligentTieringConfiguration(ctx, conn, bucket, name)
 	})
 
@@ -275,7 +275,7 @@ func findIntelligentTieringConfiguration(ctx context.Context, conn *s3.Client, b
 	return output.IntelligentTieringConfiguration, nil
 }
 
-func expandIntelligentTieringFilter(ctx context.Context, tfMap map[string]interface{}) *types.IntelligentTieringFilter {
+func expandIntelligentTieringFilter(ctx context.Context, tfMap map[string]any) *types.IntelligentTieringFilter {
 	if tfMap == nil {
 		return nil
 	}
@@ -288,7 +288,7 @@ func expandIntelligentTieringFilter(ctx context.Context, tfMap map[string]interf
 
 	var tags []types.Tag
 
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok {
 		tags = Tags(tftags.New(ctx, v))
 	}
 
@@ -320,7 +320,7 @@ func expandIntelligentTieringFilter(ctx context.Context, tfMap map[string]interf
 	return apiObject
 }
 
-func expandTiering(tfMap map[string]interface{}) *types.Tiering {
+func expandTiering(tfMap map[string]any) *types.Tiering {
 	if tfMap == nil {
 		return nil
 	}
@@ -338,7 +338,7 @@ func expandTiering(tfMap map[string]interface{}) *types.Tiering {
 	return apiObject
 }
 
-func expandTierings(tfList []interface{}) []types.Tiering {
+func expandTierings(tfList []any) []types.Tiering {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -346,7 +346,7 @@ func expandTierings(tfList []interface{}) []types.Tiering {
 	var apiObjects []types.Tiering
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -364,12 +364,12 @@ func expandTierings(tfList []interface{}) []types.Tiering {
 	return apiObjects
 }
 
-func flattenIntelligentTieringFilter(ctx context.Context, apiObject *types.IntelligentTieringFilter) map[string]interface{} {
+func flattenIntelligentTieringFilter(ctx context.Context, apiObject *types.IntelligentTieringFilter) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.And == nil {
 		if v := apiObject.Prefix; v != nil {
@@ -394,8 +394,8 @@ func flattenIntelligentTieringFilter(ctx context.Context, apiObject *types.Intel
 	return tfMap
 }
 
-func flattenTiering(apiObject types.Tiering) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenTiering(apiObject types.Tiering) map[string]any {
+	tfMap := map[string]any{
 		"access_tier": apiObject.AccessTier,
 		"days":        apiObject.Days,
 	}
@@ -403,12 +403,12 @@ func flattenTiering(apiObject types.Tiering) map[string]interface{} {
 	return tfMap
 }
 
-func flattenTierings(apiObjects []types.Tiering) []interface{} {
+func flattenTierings(apiObjects []types.Tiering) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenTiering(apiObject))

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -653,7 +653,7 @@ func lifecycleRulesEqual(rules1, rules2 []awstypes.LifecycleRule) bool {
 }
 
 func statusLifecycleRulesEquals(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string, rules []awstypes.LifecycleRule) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findBucketLifecycleConfiguration(ctx, conn, bucket, expectedBucketOwner)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/s3/bucket_logging.go
+++ b/internal/service/s3/bucket_logging.go
@@ -136,7 +136,7 @@ func resourceBucketLogging() *schema.Resource {
 	}
 }
 
-func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -162,11 +162,11 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 		input.BucketLoggingStatus.LoggingEnabled.TargetGrants = expandTargetGrants(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("target_object_key_format"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat = expandTargetObjectKeyFormat(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("target_object_key_format"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat = expandTargetObjectKeyFormat(v.([]any)[0].(map[string]any))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketLogging(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -180,7 +180,7 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findLoggingEnabled(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -191,7 +191,7 @@ func resourceBucketLoggingCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceBucketLoggingRead(ctx, d, meta)...)
 }
 
-func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -223,7 +223,7 @@ func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "setting target_grant: %s", err)
 	}
 	if loggingEnabled.TargetObjectKeyFormat != nil {
-		if err := d.Set("target_object_key_format", []interface{}{flattenTargetObjectKeyFormat(loggingEnabled.TargetObjectKeyFormat)}); err != nil {
+		if err := d.Set("target_object_key_format", []any{flattenTargetObjectKeyFormat(loggingEnabled.TargetObjectKeyFormat)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting target_object_key_format: %s", err)
 		}
 	} else {
@@ -234,7 +234,7 @@ func resourceBucketLoggingRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -264,8 +264,8 @@ func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, me
 		input.BucketLoggingStatus.LoggingEnabled.TargetGrants = expandTargetGrants(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("target_object_key_format"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat = expandTargetObjectKeyFormat(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("target_object_key_format"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.BucketLoggingStatus.LoggingEnabled.TargetObjectKeyFormat = expandTargetObjectKeyFormat(v.([]any)[0].(map[string]any))
 	}
 
 	_, err = conn.PutBucketLogging(ctx, input)
@@ -277,7 +277,7 @@ func resourceBucketLoggingUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceBucketLoggingRead(ctx, d, meta)...)
 }
 
-func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketLoggingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -341,18 +341,18 @@ func findLoggingEnabled(ctx context.Context, conn *s3.Client, bucketName, expect
 	return output.LoggingEnabled, nil
 }
 
-func expandTargetGrants(l []interface{}) []types.TargetGrant {
+func expandTargetGrants(l []any) []types.TargetGrant {
 	var grants []types.TargetGrant
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		grant := types.TargetGrant{}
 
-		if v, ok := tfMap["grantee"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["grantee"].([]any); ok && len(v) > 0 && v[0] != nil {
 			grant.Grantee = expandLoggingGrantee(v)
 		}
 
@@ -366,12 +366,12 @@ func expandTargetGrants(l []interface{}) []types.TargetGrant {
 	return grants
 }
 
-func expandLoggingGrantee(l []interface{}) *types.Grantee {
+func expandLoggingGrantee(l []any) *types.Grantee {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -401,11 +401,11 @@ func expandLoggingGrantee(l []interface{}) *types.Grantee {
 	return grantee
 }
 
-func flattenTargetGrants(grants []types.TargetGrant) []interface{} {
-	var results []interface{}
+func flattenTargetGrants(grants []types.TargetGrant) []any {
+	var results []any
 
 	for _, grant := range grants {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"permission": grant.Permission,
 		}
 
@@ -419,12 +419,12 @@ func flattenTargetGrants(grants []types.TargetGrant) []interface{} {
 	return results
 }
 
-func flattenLoggingGrantee(g *types.Grantee) []interface{} {
+func flattenLoggingGrantee(g *types.Grantee) []any {
 	if g == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrType: g.Type,
 	}
 
@@ -444,28 +444,28 @@ func flattenLoggingGrantee(g *types.Grantee) []interface{} {
 		m[names.AttrURI] = aws.ToString(g.URI)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func expandTargetObjectKeyFormat(tfMap map[string]interface{}) *types.TargetObjectKeyFormat {
+func expandTargetObjectKeyFormat(tfMap map[string]any) *types.TargetObjectKeyFormat {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &types.TargetObjectKeyFormat{}
 
-	if v, ok := tfMap["partitioned_prefix"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.PartitionedPrefix = expandPartitionedPrefix(v[0].(map[string]interface{}))
+	if v, ok := tfMap["partitioned_prefix"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.PartitionedPrefix = expandPartitionedPrefix(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["simple_prefix"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := tfMap["simple_prefix"]; ok && len(v.([]any)) > 0 {
 		apiObject.SimplePrefix = &types.SimplePrefix{}
 	}
 
 	return apiObject
 }
 
-func expandPartitionedPrefix(tfMap map[string]interface{}) *types.PartitionedPrefix {
+func expandPartitionedPrefix(tfMap map[string]any) *types.PartitionedPrefix {
 	if tfMap == nil {
 		return nil
 	}
@@ -479,30 +479,30 @@ func expandPartitionedPrefix(tfMap map[string]interface{}) *types.PartitionedPre
 	return apiObject
 }
 
-func flattenTargetObjectKeyFormat(apiObject *types.TargetObjectKeyFormat) map[string]interface{} {
+func flattenTargetObjectKeyFormat(apiObject *types.TargetObjectKeyFormat) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.PartitionedPrefix; v != nil {
-		tfMap["partitioned_prefix"] = []interface{}{flattenPartitionedPrefix(v)}
+		tfMap["partitioned_prefix"] = []any{flattenPartitionedPrefix(v)}
 	}
 
 	if apiObject.SimplePrefix != nil {
-		tfMap["simple_prefix"] = make([]map[string]interface{}, 1)
+		tfMap["simple_prefix"] = make([]map[string]any, 1)
 	}
 
 	return tfMap
 }
 
-func flattenPartitionedPrefix(apiObject *types.PartitionedPrefix) map[string]interface{} {
+func flattenPartitionedPrefix(apiObject *types.PartitionedPrefix) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"partition_date_source": apiObject.PartitionDateSource,
 	}
 

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -79,7 +79,7 @@ func resourceBucketMetric() *schema.Resource {
 	}
 }
 
-func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -89,7 +89,7 @@ func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	if v, ok := d.GetOk(names.AttrFilter); ok {
-		if tfMap, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+		if tfMap, ok := v.([]any)[0].(map[string]any); ok {
 			metricsConfiguration.Filter = expandMetricsFilter(ctx, tfMap)
 		}
 	}
@@ -104,7 +104,7 @@ func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta i
 		MetricsConfiguration: metricsConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketMetricsConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -119,7 +119,7 @@ func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta i
 	if d.IsNewResource() {
 		d.SetId(fmt.Sprintf("%s:%s", bucket, name))
 
-		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 			return findMetricsConfiguration(ctx, conn, bucket, name)
 		})
 
@@ -131,7 +131,7 @@ func resourceBucketMetricPut(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceBucketMetricRead(ctx, d, meta)...)
 }
 
-func resourceBucketMetricRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketMetricRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -158,7 +158,7 @@ func resourceBucketMetricRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.Set(names.AttrBucket, bucket)
 	if mc.Filter != nil {
-		if err := d.Set(names.AttrFilter, []interface{}{flattenMetricsFilter(ctx, mc.Filter)}); err != nil {
+		if err := d.Set(names.AttrFilter, []any{flattenMetricsFilter(ctx, mc.Filter)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting filter")
 		}
 	}
@@ -167,7 +167,7 @@ func resourceBucketMetricRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceBucketMetricDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketMetricDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -194,7 +194,7 @@ func resourceBucketMetricDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Metric (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findMetricsConfiguration(ctx, conn, bucket, name)
 	})
 
@@ -205,7 +205,7 @@ func resourceBucketMetricDelete(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func expandMetricsFilter(ctx context.Context, m map[string]interface{}) types.MetricsFilter {
+func expandMetricsFilter(ctx context.Context, m map[string]any) types.MetricsFilter {
 	var accessPoint string
 	if v, ok := m["access_point"]; ok {
 		accessPoint = v.(string)
@@ -274,8 +274,8 @@ func expandMetricsFilter(ctx context.Context, m map[string]interface{}) types.Me
 	return metricsFilter
 }
 
-func flattenMetricsFilter(ctx context.Context, metricsFilter types.MetricsFilter) map[string]interface{} {
-	m := make(map[string]interface{})
+func flattenMetricsFilter(ctx context.Context, metricsFilter types.MetricsFilter) map[string]any {
+	m := make(map[string]any)
 
 	switch v := metricsFilter.(type) {
 	case *types.MetricsFilterMemberAnd:

--- a/internal/service/s3/bucket_notification.go
+++ b/internal/service/s3/bucket_notification.go
@@ -142,7 +142,7 @@ func resourceBucketNotification() *schema.Resource {
 	}
 }
 
-func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	const (
 		filterRulesSliceStartLen = 2
 	)
@@ -159,12 +159,12 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		eventbridgeConfig = &types.EventBridgeConfiguration{}
 	}
 
-	lambdaFunctionNotifications := d.Get("lambda_function").([]interface{})
+	lambdaFunctionNotifications := d.Get("lambda_function").([]any)
 	lambdaConfigs := make([]types.LambdaFunctionConfiguration, 0, len(lambdaFunctionNotifications))
 	for i, c := range lambdaFunctionNotifications {
 		lc := types.LambdaFunctionConfiguration{}
 
-		c := c.(map[string]interface{})
+		c := c.(map[string]any)
 
 		if val, ok := c[names.AttrID].(string); ok && val != "" {
 			lc.Id = aws.String(val)
@@ -203,12 +203,12 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		lambdaConfigs = append(lambdaConfigs, lc)
 	}
 
-	queueNotifications := d.Get("queue").([]interface{})
+	queueNotifications := d.Get("queue").([]any)
 	queueConfigs := make([]types.QueueConfiguration, 0, len(queueNotifications))
 	for i, c := range queueNotifications {
 		qc := types.QueueConfiguration{}
 
-		c := c.(map[string]interface{})
+		c := c.(map[string]any)
 
 		if val, ok := c[names.AttrID].(string); ok && val != "" {
 			qc.Id = aws.String(val)
@@ -247,12 +247,12 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		queueConfigs = append(queueConfigs, qc)
 	}
 
-	topicNotifications := d.Get("topic").([]interface{})
+	topicNotifications := d.Get("topic").([]any)
 	topicConfigs := make([]types.TopicConfiguration, 0, len(topicNotifications))
 	for i, c := range topicNotifications {
 		tc := types.TopicConfiguration{}
 
-		c := c.(map[string]interface{})
+		c := c.(map[string]any)
 
 		if val, ok := c[names.AttrID].(string); ok && val != "" {
 			tc.Id = aws.String(val)
@@ -309,7 +309,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 		NotificationConfiguration: notificationConfiguration,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketNotificationConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -324,7 +324,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 	if d.IsNewResource() {
 		d.SetId(bucket)
 
-		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 			return findBucketNotificationConfiguration(ctx, conn, bucket, "")
 		})
 
@@ -336,7 +336,7 @@ func resourceBucketNotificationPut(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceBucketNotificationRead(ctx, d, meta)...)
 }
 
-func resourceBucketNotificationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketNotificationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -372,7 +372,7 @@ func resourceBucketNotificationRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceBucketNotificationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketNotificationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -430,8 +430,8 @@ func findBucketNotificationConfiguration(ctx context.Context, conn *s3.Client, b
 	return output, nil
 }
 
-func flattenNotificationConfigurationFilter(filter *types.NotificationConfigurationFilter) map[string]interface{} {
-	filterRules := map[string]interface{}{}
+func flattenNotificationConfigurationFilter(filter *types.NotificationConfigurationFilter) map[string]any {
+	filterRules := map[string]any{}
 	if filter.Key == nil || filter.Key.FilterRules == nil {
 		return filterRules
 	}
@@ -447,14 +447,14 @@ func flattenNotificationConfigurationFilter(filter *types.NotificationConfigurat
 	return filterRules
 }
 
-func flattenTopicConfigurations(configs []types.TopicConfiguration) []map[string]interface{} {
-	topicNotifications := make([]map[string]interface{}, 0, len(configs))
+func flattenTopicConfigurations(configs []types.TopicConfiguration) []map[string]any {
+	topicNotifications := make([]map[string]any, 0, len(configs))
 	for _, notification := range configs {
-		var conf map[string]interface{}
+		var conf map[string]any
 		if filter := notification.Filter; filter != nil {
 			conf = flattenNotificationConfigurationFilter(filter)
 		} else {
-			conf = map[string]interface{}{}
+			conf = map[string]any{}
 		}
 
 		conf[names.AttrID] = aws.ToString(notification.Id)
@@ -466,14 +466,14 @@ func flattenTopicConfigurations(configs []types.TopicConfiguration) []map[string
 	return topicNotifications
 }
 
-func flattenQueueConfigurations(configs []types.QueueConfiguration) []map[string]interface{} {
-	queueNotifications := make([]map[string]interface{}, 0, len(configs))
+func flattenQueueConfigurations(configs []types.QueueConfiguration) []map[string]any {
+	queueNotifications := make([]map[string]any, 0, len(configs))
 	for _, notification := range configs {
-		var conf map[string]interface{}
+		var conf map[string]any
 		if filter := notification.Filter; filter != nil {
 			conf = flattenNotificationConfigurationFilter(filter)
 		} else {
-			conf = map[string]interface{}{}
+			conf = map[string]any{}
 		}
 
 		conf[names.AttrID] = aws.ToString(notification.Id)
@@ -485,14 +485,14 @@ func flattenQueueConfigurations(configs []types.QueueConfiguration) []map[string
 	return queueNotifications
 }
 
-func flattenLambdaFunctionConfigurations(configs []types.LambdaFunctionConfiguration) []map[string]interface{} {
-	lambdaFunctionNotifications := make([]map[string]interface{}, 0, len(configs))
+func flattenLambdaFunctionConfigurations(configs []types.LambdaFunctionConfiguration) []map[string]any {
+	lambdaFunctionNotifications := make([]map[string]any, 0, len(configs))
 	for _, notification := range configs {
-		var conf map[string]interface{}
+		var conf map[string]any
 		if filter := notification.Filter; filter != nil {
 			conf = flattenNotificationConfigurationFilter(filter)
 		} else {
-			conf = map[string]interface{}{}
+			conf = map[string]any{}
 		}
 
 		conf[names.AttrID] = aws.ToString(notification.Id)

--- a/internal/service/s3/bucket_object_data_source.go
+++ b/internal/service/s3/bucket_object_data_source.go
@@ -141,7 +141,7 @@ func dataSourceBucketObject() *schema.Resource {
 	}
 }
 
-func dataSourceBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceBucketObjectRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/bucket_object_lock_configuration.go
+++ b/internal/service/s3/bucket_object_lock_configuration.go
@@ -98,7 +98,7 @@ func resourceBucketObjectLockConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -113,7 +113,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 			// ObjectLockEnabled is required by the API, even if configured directly on the S3 bucket
 			// during creation, else a MalformedXML error will be returned.
 			ObjectLockEnabled: types.ObjectLockEnabled(d.Get("object_lock_enabled").(string)),
-			Rule:              expandObjectLockRule(d.Get(names.AttrRule).([]interface{})),
+			Rule:              expandObjectLockRule(d.Get(names.AttrRule).([]any)),
 		},
 	}
 	if expectedBucketOwner != "" {
@@ -128,7 +128,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 		input.Token = aws.String(v.(string))
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutObjectLockConfiguration(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -142,7 +142,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findObjectLockConfiguration(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -153,7 +153,7 @@ func resourceBucketObjectLockConfigurationCreate(ctx context.Context, d *schema.
 	return append(diags, resourceBucketObjectLockConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketObjectLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketObjectLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -188,7 +188,7 @@ func resourceBucketObjectLockConfigurationRead(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -207,7 +207,7 @@ func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.
 			// ObjectLockEnabled is required by the API, even if configured directly on the S3 bucket
 			// during creation, else a MalformedXML error will be returned.
 			ObjectLockEnabled: types.ObjectLockEnabled(d.Get("object_lock_enabled").(string)),
-			Rule:              expandObjectLockRule(d.Get(names.AttrRule).([]interface{})),
+			Rule:              expandObjectLockRule(d.Get(names.AttrRule).([]any)),
 		},
 	}
 	if expectedBucketOwner != "" {
@@ -231,7 +231,7 @@ func resourceBucketObjectLockConfigurationUpdate(ctx context.Context, d *schema.
 	return append(diags, resourceBucketObjectLockConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketObjectLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -303,31 +303,31 @@ func findObjectLockConfiguration(ctx context.Context, conn *s3.Client, bucket, e
 	return output.ObjectLockConfiguration, nil
 }
 
-func expandObjectLockRule(l []interface{}) *types.ObjectLockRule {
+func expandObjectLockRule(l []any) *types.ObjectLockRule {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	rule := &types.ObjectLockRule{}
 
-	if v, ok := tfMap["default_retention"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["default_retention"].([]any); ok && len(v) > 0 && v[0] != nil {
 		rule.DefaultRetention = expandDefaultRetention(v)
 	}
 
 	return rule
 }
 
-func expandDefaultRetention(l []interface{}) *types.DefaultRetention {
+func expandDefaultRetention(l []any) *types.DefaultRetention {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -349,30 +349,30 @@ func expandDefaultRetention(l []interface{}) *types.DefaultRetention {
 	return dr
 }
 
-func flattenObjectLockRule(rule *types.ObjectLockRule) []interface{} {
+func flattenObjectLockRule(rule *types.ObjectLockRule) []any {
 	if rule == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if rule.DefaultRetention != nil {
 		m["default_retention"] = flattenDefaultRetention(rule.DefaultRetention)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenDefaultRetention(dr *types.DefaultRetention) []interface{} {
+func flattenDefaultRetention(dr *types.DefaultRetention) []any {
 	if dr == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"days":         dr.Days,
 		names.AttrMode: dr.Mode,
 		"years":        dr.Years,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/s3/bucket_objects_data_source.go
+++ b/internal/service/s3/bucket_objects_data_source.go
@@ -77,7 +77,7 @@ func dataSourceBucketObjects() *schema.Resource {
 	}
 }
 
-func dataSourceBucketObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceBucketObjectsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/bucket_ownership_controls.go
+++ b/internal/service/s3/bucket_ownership_controls.go
@@ -61,7 +61,7 @@ func resourceBucketOwnershipControls() *schema.Resource {
 	}
 }
 
-func resourceBucketOwnershipControlsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketOwnershipControlsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -72,7 +72,7 @@ func resourceBucketOwnershipControlsCreate(ctx context.Context, d *schema.Resour
 	input := &s3.PutBucketOwnershipControlsInput{
 		Bucket: aws.String(bucket),
 		OwnershipControls: &types.OwnershipControls{
-			Rules: expandOwnershipControlsRules(d.Get(names.AttrRule).([]interface{})),
+			Rules: expandOwnershipControlsRules(d.Get(names.AttrRule).([]any)),
 		},
 	}
 
@@ -88,7 +88,7 @@ func resourceBucketOwnershipControlsCreate(ctx context.Context, d *schema.Resour
 
 	d.SetId(bucket)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findOwnershipControls(ctx, conn, bucket)
 	})
 
@@ -99,7 +99,7 @@ func resourceBucketOwnershipControlsCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceBucketOwnershipControlsRead(ctx, d, meta)...)
 }
 
-func resourceBucketOwnershipControlsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketOwnershipControlsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -128,7 +128,7 @@ func resourceBucketOwnershipControlsRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceBucketOwnershipControlsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketOwnershipControlsUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceBucketOwnershipControlsUpdate(ctx context.Context, d *schema.Resour
 	input := &s3.PutBucketOwnershipControlsInput{
 		Bucket: aws.String(bucket),
 		OwnershipControls: &types.OwnershipControls{
-			Rules: expandOwnershipControlsRules(d.Get(names.AttrRule).([]interface{})),
+			Rules: expandOwnershipControlsRules(d.Get(names.AttrRule).([]any)),
 		},
 	}
 
@@ -153,7 +153,7 @@ func resourceBucketOwnershipControlsUpdate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceBucketOwnershipControlsRead(ctx, d, meta)...)
 }
 
-func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -163,7 +163,7 @@ func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.Resour
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Bucket Ownership Controls: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
 		return conn.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{
 			Bucket: aws.String(bucket),
 		})
@@ -177,7 +177,7 @@ func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Ownership Controls (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findOwnershipControls(ctx, conn, bucket)
 	})
 
@@ -213,7 +213,7 @@ func findOwnershipControls(ctx context.Context, conn *s3.Client, bucket string) 
 	return output.OwnershipControls, nil
 }
 
-func expandOwnershipControlsRules(tfList []interface{}) []types.OwnershipControlsRule {
+func expandOwnershipControlsRules(tfList []any) []types.OwnershipControlsRule {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -221,7 +221,7 @@ func expandOwnershipControlsRules(tfList []interface{}) []types.OwnershipControl
 	var apiObjects []types.OwnershipControlsRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -233,7 +233,7 @@ func expandOwnershipControlsRules(tfList []interface{}) []types.OwnershipControl
 	return apiObjects
 }
 
-func expandOwnershipControlsRule(tfMap map[string]interface{}) types.OwnershipControlsRule {
+func expandOwnershipControlsRule(tfMap map[string]any) types.OwnershipControlsRule {
 	apiObject := types.OwnershipControlsRule{}
 
 	if v, ok := tfMap["object_ownership"].(string); ok && v != "" {
@@ -243,12 +243,12 @@ func expandOwnershipControlsRule(tfMap map[string]interface{}) types.OwnershipCo
 	return apiObject
 }
 
-func flattenOwnershipControlsRules(apiObjects []types.OwnershipControlsRule) []interface{} {
+func flattenOwnershipControlsRules(apiObjects []types.OwnershipControlsRule) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenOwnershipControlsRule(apiObject))
@@ -257,8 +257,8 @@ func flattenOwnershipControlsRules(apiObjects []types.OwnershipControlsRule) []i
 	return tfList
 }
 
-func flattenOwnershipControlsRule(apiObject types.OwnershipControlsRule) map[string]interface{} {
-	tfMap := map[string]interface{}{
+func flattenOwnershipControlsRule(apiObject types.OwnershipControlsRule) map[string]any {
+	tfMap := map[string]any{
 		"object_ownership": apiObject.ObjectOwnership,
 	}
 

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -46,7 +46,7 @@ func resourceBucketPolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -55,7 +55,7 @@ func resourceBucketPolicy() *schema.Resource {
 	}
 }
 
-func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -73,7 +73,7 @@ func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta i
 		Policy: aws.String(policy),
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketPolicy(ctx, input)
 	}, errCodeMalformedPolicy, errCodeNoSuchBucket)
 
@@ -84,7 +84,7 @@ func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta i
 	if d.IsNewResource() {
 		d.SetId(bucket)
 
-		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 			return findBucketPolicy(ctx, conn, bucket)
 		})
 
@@ -96,7 +96,7 @@ func resourceBucketPolicyPut(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceBucketPolicyRead(ctx, d, meta)...)
 }
 
-func resourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -128,7 +128,7 @@ func resourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceBucketPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -150,7 +150,7 @@ func resourceBucketPolicyDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Policy (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketPolicy(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_policy_data_source.go
+++ b/internal/service/s3/bucket_policy_data_source.go
@@ -32,7 +32,7 @@ func dataSourceBucketPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceBucketPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -62,7 +62,7 @@ func resourceBucketPublicAccessBlock() *schema.Resource {
 	}
 }
 
-func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -80,7 +80,7 @@ func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.Resour
 		},
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutPublicAccessBlock(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -94,7 +94,7 @@ func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.Resour
 
 	d.SetId(bucket)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findPublicAccessBlockConfiguration(ctx, conn, bucket)
 	})
 
@@ -105,7 +105,7 @@ func resourceBucketPublicAccessBlockCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceBucketPublicAccessBlockRead(ctx, d, meta)...)
 }
 
-func resourceBucketPublicAccessBlockRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPublicAccessBlockRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -135,7 +135,7 @@ func resourceBucketPublicAccessBlockRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -173,7 +173,7 @@ func resourceBucketPublicAccessBlockUpdate(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -195,7 +195,7 @@ func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findPublicAccessBlockConfiguration(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -312,7 +312,7 @@ func resourceBucketReplicationConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketReplicationConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketReplicationConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -324,7 +324,7 @@ func resourceBucketReplicationConfigurationCreate(ctx context.Context, d *schema
 		Bucket: aws.String(bucket),
 		ReplicationConfiguration: &types.ReplicationConfiguration{
 			Role:  aws.String(d.Get(names.AttrRole).(string)),
-			Rules: expandReplicationRules(ctx, d.Get(names.AttrRule).([]interface{})),
+			Rules: expandReplicationRules(ctx, d.Get(names.AttrRule).([]any)),
 		},
 	}
 
@@ -360,7 +360,7 @@ func resourceBucketReplicationConfigurationCreate(ctx context.Context, d *schema
 
 	d.SetId(bucket)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findReplicationConfiguration(ctx, conn, bucket)
 	})
 
@@ -371,7 +371,7 @@ func resourceBucketReplicationConfigurationCreate(ctx context.Context, d *schema
 	return append(diags, resourceBucketReplicationConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketReplicationConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketReplicationConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -401,7 +401,7 @@ func resourceBucketReplicationConfigurationRead(ctx context.Context, d *schema.R
 	return diags
 }
 
-func resourceBucketReplicationConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketReplicationConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -414,7 +414,7 @@ func resourceBucketReplicationConfigurationUpdate(ctx context.Context, d *schema
 		Bucket: aws.String(bucket),
 		ReplicationConfiguration: &types.ReplicationConfiguration{
 			Role:  aws.String(d.Get(names.AttrRole).(string)),
-			Rules: expandReplicationRules(ctx, d.Get(names.AttrRule).([]interface{})),
+			Rules: expandReplicationRules(ctx, d.Get(names.AttrRule).([]any)),
 		},
 	}
 
@@ -431,7 +431,7 @@ func resourceBucketReplicationConfigurationUpdate(ctx context.Context, d *schema
 	return append(diags, resourceBucketReplicationConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketReplicationConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketReplicationConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -453,7 +453,7 @@ func resourceBucketReplicationConfigurationDelete(ctx context.Context, d *schema
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Replication Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findReplicationConfiguration(ctx, conn, bucket)
 	})
 
@@ -489,26 +489,26 @@ func findReplicationConfiguration(ctx context.Context, conn *s3.Client, bucket s
 	return output.ReplicationConfiguration, nil
 }
 
-func expandReplicationRules(ctx context.Context, tfList []interface{}) []types.ReplicationRule {
+func expandReplicationRules(ctx context.Context, tfList []any) []types.ReplicationRule {
 	var apiObjects []types.ReplicationRule
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		apiObject := types.ReplicationRule{}
 
-		if v, ok := tfMap["delete_marker_replication"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["delete_marker_replication"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.DeleteMarkerReplication = expandDeleteMarkerReplication(v)
 		}
 
-		if v, ok := tfMap[names.AttrDestination].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap[names.AttrDestination].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.Destination = expandDestination(v)
 		}
 
-		if v, ok := tfMap["existing_object_replication"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["existing_object_replication"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.ExistingObjectReplication = expandExistingObjectReplication(v)
 		}
 
@@ -516,7 +516,7 @@ func expandReplicationRules(ctx context.Context, tfList []interface{}) []types.R
 			apiObject.ID = aws.String(v)
 		}
 
-		if v, ok := tfMap["source_selection_criteria"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["source_selection_criteria"].([]any); ok && len(v) > 0 && v[0] != nil {
 			apiObject.SourceSelectionCriteria = expandSourceSelectionCriteria(v)
 		}
 
@@ -527,7 +527,7 @@ func expandReplicationRules(ctx context.Context, tfList []interface{}) []types.R
 		// Support the empty filter block in terraform i.e. 'filter {}',
 		// which implies the replication rule does not require a specific filter,
 		// by expanding the "filter" array even if the first element is nil.
-		if v, ok := tfMap[names.AttrFilter].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap[names.AttrFilter].([]any); ok && len(v) > 0 {
 			// XML schema V2
 			apiObject.Filter = expandReplicationRuleFilter(ctx, v)
 			apiObject.Priority = aws.Int32(int32(tfMap[names.AttrPriority].(int)))
@@ -542,12 +542,12 @@ func expandReplicationRules(ctx context.Context, tfList []interface{}) []types.R
 	return apiObjects
 }
 
-func expandDeleteMarkerReplication(tfList []interface{}) *types.DeleteMarkerReplication {
+func expandDeleteMarkerReplication(tfList []any) *types.DeleteMarkerReplication {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -561,19 +561,19 @@ func expandDeleteMarkerReplication(tfList []interface{}) *types.DeleteMarkerRepl
 	return apiObject
 }
 
-func expandDestination(tfList []interface{}) *types.Destination {
+func expandDestination(tfList []any) *types.Destination {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &types.Destination{}
 
-	if v, ok := tfMap["access_control_translation"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["access_control_translation"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.AccessControlTranslation = expandAccessControlTranslation(v)
 	}
 
@@ -585,15 +585,15 @@ func expandDestination(tfList []interface{}) *types.Destination {
 		apiObject.Bucket = aws.String(v)
 	}
 
-	if v, ok := tfMap[names.AttrEncryptionConfiguration].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap[names.AttrEncryptionConfiguration].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.EncryptionConfiguration = expandEncryptionConfiguration(v)
 	}
 
-	if v, ok := tfMap["metrics"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["metrics"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Metrics = expandMetrics(v)
 	}
 
-	if v, ok := tfMap["replication_time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["replication_time"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ReplicationTime = expandReplicationTime(v)
 	}
 
@@ -604,12 +604,12 @@ func expandDestination(tfList []interface{}) *types.Destination {
 	return apiObject
 }
 
-func expandAccessControlTranslation(tfList []interface{}) *types.AccessControlTranslation {
+func expandAccessControlTranslation(tfList []any) *types.AccessControlTranslation {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -623,12 +623,12 @@ func expandAccessControlTranslation(tfList []interface{}) *types.AccessControlTr
 	return apiObject
 }
 
-func expandEncryptionConfiguration(tfList []interface{}) *types.EncryptionConfiguration {
+func expandEncryptionConfiguration(tfList []any) *types.EncryptionConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -642,19 +642,19 @@ func expandEncryptionConfiguration(tfList []interface{}) *types.EncryptionConfig
 	return apiObject
 }
 
-func expandMetrics(tfList []interface{}) *types.Metrics {
+func expandMetrics(tfList []any) *types.Metrics {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &types.Metrics{}
 
-	if v, ok := tfMap["event_threshold"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["event_threshold"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.EventThreshold = expandReplicationTimeValue(v)
 	}
 
@@ -665,12 +665,12 @@ func expandMetrics(tfList []interface{}) *types.Metrics {
 	return apiObject
 }
 
-func expandReplicationTime(tfList []interface{}) *types.ReplicationTime {
+func expandReplicationTime(tfList []any) *types.ReplicationTime {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -681,19 +681,19 @@ func expandReplicationTime(tfList []interface{}) *types.ReplicationTime {
 		apiObject.Status = types.ReplicationTimeStatus(v)
 	}
 
-	if v, ok := tfMap["time"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["time"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.Time = expandReplicationTimeValue(v)
 	}
 
 	return apiObject
 }
 
-func expandReplicationTimeValue(tfList []interface{}) *types.ReplicationTimeValue {
+func expandReplicationTimeValue(tfList []any) *types.ReplicationTimeValue {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -707,12 +707,12 @@ func expandReplicationTimeValue(tfList []interface{}) *types.ReplicationTimeValu
 	return apiObject
 }
 
-func expandExistingObjectReplication(tfList []interface{}) *types.ExistingObjectReplication {
+func expandExistingObjectReplication(tfList []any) *types.ExistingObjectReplication {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -726,35 +726,35 @@ func expandExistingObjectReplication(tfList []interface{}) *types.ExistingObject
 	return apiObject
 }
 
-func expandSourceSelectionCriteria(tfList []interface{}) *types.SourceSelectionCriteria {
+func expandSourceSelectionCriteria(tfList []any) *types.SourceSelectionCriteria {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 
 	apiObject := &types.SourceSelectionCriteria{}
 
-	if v, ok := tfMap["replica_modifications"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["replica_modifications"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.ReplicaModifications = expandReplicaModifications(v)
 	}
 
-	if v, ok := tfMap["sse_kms_encrypted_objects"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["sse_kms_encrypted_objects"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.SseKmsEncryptedObjects = expandSSEKMSEncryptedObjects(v)
 	}
 
 	return apiObject
 }
 
-func expandReplicaModifications(tfList []interface{}) *types.ReplicaModifications {
+func expandReplicaModifications(tfList []any) *types.ReplicaModifications {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -768,12 +768,12 @@ func expandReplicaModifications(tfList []interface{}) *types.ReplicaModification
 	return apiObject
 }
 
-func expandSSEKMSEncryptedObjects(tfList []interface{}) *types.SseKmsEncryptedObjects {
+func expandSSEKMSEncryptedObjects(tfList []any) *types.SseKmsEncryptedObjects {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -787,23 +787,23 @@ func expandSSEKMSEncryptedObjects(tfList []interface{}) *types.SseKmsEncryptedOb
 	return apiObject
 }
 
-func expandReplicationRuleFilter(ctx context.Context, tfList []interface{}) *types.ReplicationRuleFilter {
+func expandReplicationRuleFilter(ctx context.Context, tfList []any) *types.ReplicationRuleFilter {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return &types.ReplicationRuleFilter{}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	var apiObject *types.ReplicationRuleFilter
 
-	if v, ok := tfMap["and"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["and"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject = &types.ReplicationRuleFilter{
 			And: expandReplicationRuleAndOperator(ctx, v),
 		}
 	}
 
-	if v, ok := tfMap["tag"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["tag"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject = &types.ReplicationRuleFilter{
-			Tag: expandTag(v[0].(map[string]interface{})),
+			Tag: expandTag(v[0].(map[string]any)),
 		}
 	}
 
@@ -821,12 +821,12 @@ func expandReplicationRuleFilter(ctx context.Context, tfList []interface{}) *typ
 	return apiObject
 }
 
-func expandReplicationRuleAndOperator(ctx context.Context, tfList []interface{}) *types.ReplicationRuleAndOperator {
+func expandReplicationRuleAndOperator(ctx context.Context, tfList []any) *types.ReplicationRuleAndOperator {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -837,7 +837,7 @@ func expandReplicationRuleAndOperator(ctx context.Context, tfList []interface{})
 		apiObject.Prefix = aws.String(v)
 	}
 
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok && len(v) > 0 {
 		if tags := Tags(tftags.New(ctx, v).IgnoreAWS()); len(tags) > 0 {
 			apiObject.Tags = tags
 		}
@@ -846,7 +846,7 @@ func expandReplicationRuleAndOperator(ctx context.Context, tfList []interface{})
 	return apiObject
 }
 
-func expandTag(tfMap map[string]interface{}) *types.Tag {
+func expandTag(tfMap map[string]any) *types.Tag {
 	if len(tfMap) == 0 {
 		return nil
 	}
@@ -864,15 +864,15 @@ func expandTag(tfMap map[string]interface{}) *types.Tag {
 	return apiObject
 }
 
-func flattenReplicationRules(ctx context.Context, apiObjects []types.ReplicationRule) []interface{} {
+func flattenReplicationRules(ctx context.Context, apiObjects []types.ReplicationRule) []any {
 	if len(apiObjects) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrStatus: apiObject.Status,
 		}
 
@@ -914,24 +914,24 @@ func flattenReplicationRules(ctx context.Context, apiObjects []types.Replication
 	return tfList
 }
 
-func flattenDeleteMarkerReplication(apiObject *types.DeleteMarkerReplication) []interface{} {
+func flattenDeleteMarkerReplication(apiObject *types.DeleteMarkerReplication) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenDestination(apiObject *types.Destination) []interface{} {
+func flattenDestination(apiObject *types.Destination) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStorageClass: apiObject.StorageClass,
 	}
 
@@ -959,41 +959,41 @@ func flattenDestination(apiObject *types.Destination) []interface{} {
 		tfMap["replication_time"] = flattenReplicationReplicationTime(apiObject.ReplicationTime)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenAccessControlTranslation(apiObject *types.AccessControlTranslation) []interface{} {
+func flattenAccessControlTranslation(apiObject *types.AccessControlTranslation) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrOwner: apiObject.Owner,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenEncryptionConfiguration(apiObject *types.EncryptionConfiguration) []interface{} {
+func flattenEncryptionConfiguration(apiObject *types.EncryptionConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.ReplicaKmsKeyID != nil {
 		tfMap["replica_kms_key_id"] = aws.ToString(apiObject.ReplicaKmsKeyID)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMetrics(apiObject *types.Metrics) []interface{} {
+func flattenMetrics(apiObject *types.Metrics) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
@@ -1001,27 +1001,27 @@ func flattenMetrics(apiObject *types.Metrics) []interface{} {
 		tfMap["event_threshold"] = flattenReplicationTimeValue(apiObject.EventThreshold)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReplicationTimeValue(apiObject *types.ReplicationTimeValue) []interface{} {
+func flattenReplicationTimeValue(apiObject *types.ReplicationTimeValue) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"minutes": aws.ToInt32(apiObject.Minutes),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReplicationReplicationTime(apiObject *types.ReplicationTime) []interface{} {
+func flattenReplicationReplicationTime(apiObject *types.ReplicationTime) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
@@ -1029,27 +1029,27 @@ func flattenReplicationReplicationTime(apiObject *types.ReplicationTime) []inter
 		tfMap["time"] = flattenReplicationTimeValue(apiObject.Time)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenExistingObjectReplication(apiObject *types.ExistingObjectReplication) []interface{} {
+func flattenExistingObjectReplication(apiObject *types.ExistingObjectReplication) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReplicationRuleFilter(ctx context.Context, apiObject *types.ReplicationRuleFilter) []interface{} {
+func flattenReplicationRuleFilter(ctx context.Context, apiObject *types.ReplicationRuleFilter) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.And; v != nil {
 		tfMap["and"] = flattenReplicationRuleAndOperator(ctx, v)
@@ -1063,15 +1063,15 @@ func flattenReplicationRuleFilter(ctx context.Context, apiObject *types.Replicat
 		tfMap["tag"] = flattenTag(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReplicationRuleAndOperator(ctx context.Context, apiObject *types.ReplicationRuleAndOperator) []interface{} {
+func flattenReplicationRuleAndOperator(ctx context.Context, apiObject *types.ReplicationRuleAndOperator) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.Prefix; v != nil {
 		tfMap[names.AttrPrefix] = aws.ToString(v)
@@ -1081,15 +1081,15 @@ func flattenReplicationRuleAndOperator(ctx context.Context, apiObject *types.Rep
 		tfMap[names.AttrTags] = keyValueTags(ctx, v).IgnoreAWS().Map()
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSourceSelectionCriteria(apiObject *types.SourceSelectionCriteria) []interface{} {
+func flattenSourceSelectionCriteria(apiObject *types.SourceSelectionCriteria) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.ReplicaModifications != nil {
 		tfMap["replica_modifications"] = flattenReplicaModifications(apiObject.ReplicaModifications)
@@ -1099,39 +1099,39 @@ func flattenSourceSelectionCriteria(apiObject *types.SourceSelectionCriteria) []
 		tfMap["sse_kms_encrypted_objects"] = flattenSSEKMSEncryptedObjects(apiObject.SseKmsEncryptedObjects)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReplicaModifications(apiObject *types.ReplicaModifications) []interface{} {
+func flattenReplicaModifications(apiObject *types.ReplicaModifications) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSSEKMSEncryptedObjects(apiObject *types.SseKmsEncryptedObjects) []interface{} {
+func flattenSSEKMSEncryptedObjects(apiObject *types.SseKmsEncryptedObjects) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrStatus: apiObject.Status,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTag(apiObject *types.Tag) []interface{} {
+func flattenTag(apiObject *types.Tag) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.Key; v != nil {
 		tfMap[names.AttrKey] = aws.ToString(v)
@@ -1141,5 +1141,5 @@ func flattenTag(apiObject *types.Tag) []interface{} {
 		tfMap[names.AttrValue] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/s3/bucket_request_payment_configuration.go
+++ b/internal/service/s3/bucket_request_payment_configuration.go
@@ -57,7 +57,7 @@ func resourceBucketRequestPaymentConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -76,7 +76,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketRequestPayment(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -90,7 +90,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketRequestPayment(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -101,7 +101,7 @@ func resourceBucketRequestPaymentConfigurationCreate(ctx context.Context, d *sch
 	return append(diags, resourceBucketRequestPaymentConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketRequestPaymentConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketRequestPaymentConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -133,7 +133,7 @@ func resourceBucketRequestPaymentConfigurationRead(ctx context.Context, d *schem
 	return diags
 }
 
-func resourceBucketRequestPaymentConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketRequestPaymentConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -165,7 +165,7 @@ func resourceBucketRequestPaymentConfigurationUpdate(ctx context.Context, d *sch
 	return append(diags, resourceBucketRequestPaymentConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketRequestPaymentConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketRequestPaymentConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/bucket_server_side_encryption_configuration.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration.go
@@ -82,7 +82,7 @@ func resourceBucketServerSideEncryptionConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -101,7 +101,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketEncryption(ctx, input)
 	}, errCodeNoSuchBucket, errCodeOperationAborted)
 
@@ -111,7 +111,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findServerSideEncryptionConfiguration(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -122,7 +122,7 @@ func resourceBucketServerSideEncryptionConfigurationCreate(ctx context.Context, 
 	return append(diags, resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -156,7 +156,7 @@ func resourceBucketServerSideEncryptionConfigurationRead(ctx context.Context, d 
 	return diags
 }
 
-func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -179,7 +179,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketEncryption(ctx, input)
 	}, errCodeNoSuchBucket, errCodeOperationAborted)
 
@@ -190,7 +190,7 @@ func resourceBucketServerSideEncryptionConfigurationUpdate(ctx context.Context, 
 	return append(diags, resourceBucketServerSideEncryptionConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketServerSideEncryptionConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -253,12 +253,12 @@ func findServerSideEncryptionConfiguration(ctx context.Context, conn *s3.Client,
 	return output.ServerSideEncryptionConfiguration, nil
 }
 
-func expandServerSideEncryptionByDefault(l []interface{}) *types.ServerSideEncryptionByDefault {
+func expandServerSideEncryptionByDefault(l []any) *types.ServerSideEncryptionByDefault {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -276,18 +276,18 @@ func expandServerSideEncryptionByDefault(l []interface{}) *types.ServerSideEncry
 	return sse
 }
 
-func expandServerSideEncryptionRules(l []interface{}) []types.ServerSideEncryptionRule {
+func expandServerSideEncryptionRules(l []any) []types.ServerSideEncryptionRule {
 	var rules []types.ServerSideEncryptionRule
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		rule := types.ServerSideEncryptionRule{}
 
-		if v, ok := tfMap["apply_server_side_encryption_by_default"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["apply_server_side_encryption_by_default"].([]any); ok && len(v) > 0 && v[0] != nil {
 			rule.ApplyServerSideEncryptionByDefault = expandServerSideEncryptionByDefault(v)
 		}
 
@@ -301,11 +301,11 @@ func expandServerSideEncryptionRules(l []interface{}) []types.ServerSideEncrypti
 	return rules
 }
 
-func flattenServerSideEncryptionRules(rules []types.ServerSideEncryptionRule) []interface{} {
-	var results []interface{}
+func flattenServerSideEncryptionRules(rules []types.ServerSideEncryptionRule) []any {
+	var results []any
 
 	for _, rule := range rules {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		if rule.ApplyServerSideEncryptionByDefault != nil {
 			m["apply_server_side_encryption_by_default"] = flattenServerSideEncryptionByDefault(rule.ApplyServerSideEncryptionByDefault)
@@ -321,12 +321,12 @@ func flattenServerSideEncryptionRules(rules []types.ServerSideEncryptionRule) []
 	return results
 }
 
-func flattenServerSideEncryptionByDefault(sse *types.ServerSideEncryptionByDefault) []interface{} {
+func flattenServerSideEncryptionByDefault(sse *types.ServerSideEncryptionByDefault) []any {
 	if sse == nil {
 		return nil
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"sse_algorithm": sse.SSEAlgorithm,
 	}
 
@@ -334,5 +334,5 @@ func flattenServerSideEncryptionByDefault(sse *types.ServerSideEncryptionByDefau
 		m["kms_master_key_id"] = aws.ToString(sse.KMSMasterKeyID)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2504,7 +2505,7 @@ func testAccCheckBucketDestroyWithProvider(ctx context.Context) acctest.TestChec
 
 			// S3 seems to be highly eventually consistent. Even if one connection reports that the queue is gone,
 			// another connection may still report it as present.
-			_, err := tfresource.RetryUntilNotFound(ctx, tfs3.BucketPropagationTimeout, func() (interface{}, error) {
+			_, err := tfresource.RetryUntilNotFound(ctx, tfs3.BucketPropagationTimeout, func() (any, error) {
 				return tfs3.FindBucket(ctx, conn, rs.Primary.ID)
 			})
 
@@ -2687,13 +2688,7 @@ func testAccCheckBucketTagKeys(ctx context.Context, n string, keys ...string) re
 		}
 
 		for _, want := range keys {
-			ok := false
-			for _, key := range got.Keys() {
-				if want == key {
-					ok = true
-					break
-				}
-			}
+			ok := slices.Contains(got.Keys(), want)
 			if !ok {
 				return fmt.Errorf("key %s not found in S3 Bucket (%s) tag set", bucket, want)
 			}

--- a/internal/service/s3/bucket_versioning.go
+++ b/internal/service/s3/bucket_versioning.go
@@ -79,7 +79,7 @@ func resourceBucketVersioning() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, v any) error {
 				// This CustomizeDiff acts as a plan-time validation to prevent MalformedXML errors
 				// when updating bucket versioning to "Disabled" on existing resources
 				// as it's not supported by the AWS S3 API.
@@ -100,7 +100,7 @@ func resourceBucketVersioning() *schema.Resource {
 	}
 }
 
-func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -110,7 +110,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	expectedBucketOwner := d.Get(names.AttrExpectedBucketOwner).(string)
 
-	versioningConfiguration := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{}))
+	versioningConfiguration := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]any))
 
 	// To support migration from v3 to v4 of the provider, we need to support
 	// versioning resources that represent unversioned S3 buckets as was previously
@@ -129,7 +129,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 			input.MFA = aws.String(v.(string))
 		}
 
-		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 			return conn.PutBucketVersioning(ctx, input)
 		}, errCodeNoSuchBucket)
 
@@ -151,7 +151,7 @@ func resourceBucketVersioningCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
 }
 
-func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -185,7 +185,7 @@ func resourceBucketVersioningRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -200,7 +200,7 @@ func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData,
 
 	input := &s3.PutBucketVersioningInput{
 		Bucket:                  aws.String(bucket),
-		VersioningConfiguration: expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})),
+		VersioningConfiguration: expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]any)),
 	}
 	if expectedBucketOwner != "" {
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
@@ -219,11 +219,11 @@ func resourceBucketVersioningUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceBucketVersioningRead(ctx, d, meta)...)
 }
 
-func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
-	if v := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]interface{})); v != nil && string(v.Status) == bucketVersioningStatusDisabled {
+	if v := expandBucketVersioningConfiguration(d.Get("versioning_configuration").([]any)); v != nil && string(v.Status) == bucketVersioningStatusDisabled {
 		log.Printf("[DEBUG] Removing S3 bucket versioning for unversioned bucket (%s) from state", d.Id())
 		return diags
 	}
@@ -269,12 +269,12 @@ func resourceBucketVersioningDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func expandBucketVersioningConfiguration(l []interface{}) *types.VersioningConfiguration {
+func expandBucketVersioningConfiguration(l []any) *types.VersioningConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -292,12 +292,12 @@ func expandBucketVersioningConfiguration(l []interface{}) *types.VersioningConfi
 	return result
 }
 
-func flattenVersioning(config *s3.GetBucketVersioningOutput) []interface{} {
+func flattenVersioning(config *s3.GetBucketVersioningOutput) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"mfa_delete": config.MFADelete,
 	}
 
@@ -308,7 +308,7 @@ func flattenVersioning(config *s3.GetBucketVersioningOutput) []interface{} {
 		m[names.AttrStatus] = bucketVersioningStatusDisabled
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 func findBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) (*s3.GetBucketVersioningOutput, error) {
@@ -340,7 +340,7 @@ func findBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expected
 }
 
 func statusBucketVersioning(ctx context.Context, conn *s3.Client, bucket, expectedBucketOwner string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findBucketVersioning(ctx, conn, bucket, expectedBucketOwner)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -163,7 +163,7 @@ func resourceBucketWebsiteConfiguration() *schema.Resource {
 				Computed:      true,
 				ConflictsWith: []string{"routing_rule"},
 				ValidateFunc:  validation.StringIsJSON,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -180,26 +180,26 @@ func resourceBucketWebsiteConfiguration() *schema.Resource {
 	}
 }
 
-func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
 	websiteConfig := &types.WebsiteConfiguration{}
 
-	if v, ok := d.GetOk("error_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.ErrorDocument = expandErrorDocument(v.([]interface{}))
+	if v, ok := d.GetOk("error_document"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.ErrorDocument = expandErrorDocument(v.([]any))
 	}
 
-	if v, ok := d.GetOk("index_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.IndexDocument = expandIndexDocument(v.([]interface{}))
+	if v, ok := d.GetOk("index_document"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.IndexDocument = expandIndexDocument(v.([]any))
 	}
 
-	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.RedirectAllRequestsTo = expandRedirectAllRequestsTo(v.([]interface{}))
+	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.RedirectAllRequestsTo = expandRedirectAllRequestsTo(v.([]any))
 	}
 
-	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.RoutingRules = expandRoutingRules(v.([]interface{}))
+	if v, ok := d.GetOk("routing_rule"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.RoutingRules = expandRoutingRules(v.([]any))
 	}
 
 	if v, ok := d.GetOk("routing_rules"); ok {
@@ -223,7 +223,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 		input.ExpectedBucketOwner = aws.String(expectedBucketOwner)
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, bucketPropagationTimeout, func() (any, error) {
 		return conn.PutBucketWebsite(ctx, input)
 	}, errCodeNoSuchBucket)
 
@@ -237,7 +237,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 
 	d.SetId(createResourceID(bucket, expectedBucketOwner))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketWebsite(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -248,7 +248,7 @@ func resourceBucketWebsiteConfigurationCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceBucketWebsiteConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -308,7 +308,7 @@ func resourceBucketWebsiteConfigurationRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -323,21 +323,21 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 
 	websiteConfig := &types.WebsiteConfiguration{}
 
-	if v, ok := d.GetOk("error_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.ErrorDocument = expandErrorDocument(v.([]interface{}))
+	if v, ok := d.GetOk("error_document"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.ErrorDocument = expandErrorDocument(v.([]any))
 	}
 
-	if v, ok := d.GetOk("index_document"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.IndexDocument = expandIndexDocument(v.([]interface{}))
+	if v, ok := d.GetOk("index_document"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.IndexDocument = expandIndexDocument(v.([]any))
 	}
 
-	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		websiteConfig.RedirectAllRequestsTo = expandRedirectAllRequestsTo(v.([]interface{}))
+	if v, ok := d.GetOk("redirect_all_requests_to"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		websiteConfig.RedirectAllRequestsTo = expandRedirectAllRequestsTo(v.([]any))
 	}
 
 	if d.HasChanges("routing_rule", "routing_rules") {
 		if d.HasChange("routing_rule") {
-			websiteConfig.RoutingRules = expandRoutingRules(d.Get("routing_rule").([]interface{}))
+			websiteConfig.RoutingRules = expandRoutingRules(d.Get("routing_rule").([]any))
 		} else {
 			var unmarshalledRules []types.RoutingRule
 			if err := json.Unmarshal([]byte(d.Get("routing_rules").(string)), &unmarshalledRules); err != nil {
@@ -347,8 +347,8 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 		}
 	} else {
 		// Still send the current RoutingRules configuration
-		if v, ok := d.GetOk("routing_rule"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			websiteConfig.RoutingRules = expandRoutingRules(v.([]interface{}))
+		if v, ok := d.GetOk("routing_rule"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			websiteConfig.RoutingRules = expandRoutingRules(v.([]any))
 		}
 
 		if v, ok := d.GetOk("routing_rules"); ok {
@@ -377,7 +377,7 @@ func resourceBucketWebsiteConfigurationUpdate(ctx context.Context, d *schema.Res
 	return append(diags, resourceBucketWebsiteConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -407,7 +407,7 @@ func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.Res
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Website Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
 		return findBucketWebsite(ctx, conn, bucket, expectedBucketOwner)
 	})
 
@@ -474,12 +474,12 @@ func findBucketLocation(ctx context.Context, conn *s3.Client, bucket, expectedBu
 	return output, nil
 }
 
-func expandErrorDocument(l []interface{}) *types.ErrorDocument {
+func expandErrorDocument(l []any) *types.ErrorDocument {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -493,12 +493,12 @@ func expandErrorDocument(l []interface{}) *types.ErrorDocument {
 	return result
 }
 
-func expandIndexDocument(l []interface{}) *types.IndexDocument {
+func expandIndexDocument(l []any) *types.IndexDocument {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -512,12 +512,12 @@ func expandIndexDocument(l []interface{}) *types.IndexDocument {
 	return result
 }
 
-func expandRedirectAllRequestsTo(l []interface{}) *types.RedirectAllRequestsTo {
+func expandRedirectAllRequestsTo(l []any) *types.RedirectAllRequestsTo {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -535,22 +535,22 @@ func expandRedirectAllRequestsTo(l []interface{}) *types.RedirectAllRequestsTo {
 	return result
 }
 
-func expandRoutingRules(l []interface{}) []types.RoutingRule {
+func expandRoutingRules(l []any) []types.RoutingRule {
 	var results []types.RoutingRule
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		rule := types.RoutingRule{}
 
-		if v, ok := tfMap[names.AttrCondition].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap[names.AttrCondition].([]any); ok && len(v) > 0 && v[0] != nil {
 			rule.Condition = expandCondition(v)
 		}
 
-		if v, ok := tfMap["redirect"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		if v, ok := tfMap["redirect"].([]any); ok && len(v) > 0 && v[0] != nil {
 			rule.Redirect = expandRedirect(v)
 		}
 
@@ -560,12 +560,12 @@ func expandRoutingRules(l []interface{}) []types.RoutingRule {
 	return results
 }
 
-func expandCondition(l []interface{}) *types.Condition {
+func expandCondition(l []any) *types.Condition {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -583,12 +583,12 @@ func expandCondition(l []interface{}) *types.Condition {
 	return result
 }
 
-func expandRedirect(l []interface{}) *types.Redirect {
+func expandRedirect(l []any) *types.Redirect {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -618,40 +618,40 @@ func expandRedirect(l []interface{}) *types.Redirect {
 	return result
 }
 
-func flattenIndexDocument(i *types.IndexDocument) []interface{} {
+func flattenIndexDocument(i *types.IndexDocument) []any {
 	if i == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if i.Suffix != nil {
 		m["suffix"] = aws.ToString(i.Suffix)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenErrorDocument(e *types.ErrorDocument) []interface{} {
+func flattenErrorDocument(e *types.ErrorDocument) []any {
 	if e == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if e.Key != nil {
 		m[names.AttrKey] = aws.ToString(e.Key)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenRedirectAllRequestsTo(r *types.RedirectAllRequestsTo) []interface{} {
+func flattenRedirectAllRequestsTo(r *types.RedirectAllRequestsTo) []any {
 	if r == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrProtocol: string(r.Protocol),
 	}
 
@@ -659,14 +659,14 @@ func flattenRedirectAllRequestsTo(r *types.RedirectAllRequestsTo) []interface{} 
 		m["host_name"] = aws.ToString(r.HostName)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenRoutingRules(rules []types.RoutingRule) []interface{} {
-	var results []interface{}
+func flattenRoutingRules(rules []types.RoutingRule) []any {
+	var results []any
 
 	for _, rule := range rules {
-		m := make(map[string]interface{})
+		m := make(map[string]any)
 
 		if rule.Condition != nil {
 			m[names.AttrCondition] = flattenCondition(rule.Condition)
@@ -682,12 +682,12 @@ func flattenRoutingRules(rules []types.RoutingRule) []interface{} {
 	return results
 }
 
-func flattenCondition(c *types.Condition) []interface{} {
+func flattenCondition(c *types.Condition) []any {
 	if c == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if c.KeyPrefixEquals != nil {
 		m["key_prefix_equals"] = aws.ToString(c.KeyPrefixEquals)
@@ -697,15 +697,15 @@ func flattenCondition(c *types.Condition) []interface{} {
 		m["http_error_code_returned_equals"] = aws.ToString(c.HttpErrorCodeReturnedEquals)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenRedirect(r *types.Redirect) []interface{} {
+func flattenRedirect(r *types.Redirect) []any {
 	if r == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrProtocol: string(r.Protocol),
 	}
 
@@ -725,7 +725,7 @@ func flattenRedirect(r *types.Redirect) []interface{} {
 		m["replace_key_prefix_with"] = aws.ToString(r.ReplaceKeyPrefixWith)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 func normalizeRoutingRules(w []types.RoutingRule) (string, error) {
@@ -734,12 +734,12 @@ func normalizeRoutingRules(w []types.RoutingRule) (string, error) {
 		return "", err
 	}
 
-	var rules []map[string]interface{}
+	var rules []map[string]any
 	if err := json.Unmarshal(withNulls, &rules); err != nil {
 		return "", err
 	}
 
-	var cleanRules []map[string]interface{}
+	var cleanRules []map[string]any
 	for _, rule := range rules {
 		cleanRules = append(cleanRules, removeNilOrEmptyProtocol(rule))
 	}
@@ -753,8 +753,8 @@ func normalizeRoutingRules(w []types.RoutingRule) (string, error) {
 }
 
 // removeNilOrEmptyProtocol removes nils and empty ("") Protocol values from a RoutingRule JSON document.
-func removeNilOrEmptyProtocol(data map[string]interface{}) map[string]interface{} {
-	withoutNil := make(map[string]interface{})
+func removeNilOrEmptyProtocol(data map[string]any) map[string]any {
+	withoutNil := make(map[string]any)
 
 	for k, v := range data {
 		if v == nil {
@@ -762,7 +762,7 @@ func removeNilOrEmptyProtocol(data map[string]interface{}) map[string]interface{
 		}
 
 		switch v := v.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			withoutNil[k] = removeNilOrEmptyProtocol(v)
 		case string:
 			// With AWS SDK for Go v2 Protocol changed type from *string to types.Protocol.

--- a/internal/service/s3/canonical_user_id_data_source.go
+++ b/internal/service/s3/canonical_user_id_data_source.go
@@ -29,7 +29,7 @@ func dataSourceCanonicalUserID() *schema.Resource {
 	}
 }
 
-func dataSourceCanonicalUserIDRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCanonicalUserIDRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/object.go
+++ b/internal/service/s3/object.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -58,7 +59,7 @@ func resourceObject() *schema.Resource {
 
 		CustomizeDiff: customdiff.Sequence(
 			resourceObjectCustomizeDiff,
-			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
 				if ignoreProviderDefaultTags(ctx, d) {
 					return d.SetNew(names.AttrTagsAll, d.Get(names.AttrTags))
 				}
@@ -250,12 +251,12 @@ func resourceObject() *schema.Resource {
 	}
 }
 
-func resourceObjectCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	return append(diags, resourceObjectUpload(ctx, d, meta)...)
 }
 
-func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -322,7 +323,7 @@ func resourceObjectRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceObjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if hasObjectContentChanges(d) {
 		return append(diags, resourceObjectUpload(ctx, d, meta)...)
@@ -403,7 +404,7 @@ func resourceObjectUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceObjectRead(ctx, d, meta)...)
 }
 
-func resourceObjectDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -434,7 +435,7 @@ func resourceObjectDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceObjectImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceObjectImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	id := d.Id()
 	id = strings.TrimPrefix(id, "s3://")
 	parts := strings.Split(id, "/")
@@ -453,7 +454,7 @@ func resourceObjectImport(ctx context.Context, d *schema.ResourceData, meta inte
 	return []*schema.ResourceData{d}, nil
 }
 
-func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -546,7 +547,7 @@ func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		input.Metadata = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.Metadata = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("object_lock_legal_hold_status"); ok {
@@ -605,8 +606,8 @@ func resourceObjectUpload(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceObjectRead(ctx, d, meta)...)
 }
 
-func validateMetadataIsLowerCase(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(map[string]interface{})
+func validateMetadataIsLowerCase(v any, k string) (ws []string, errors []error) {
+	value := v.(map[string]any)
 
 	for k := range value {
 		if k != strings.ToLower(k) {
@@ -617,7 +618,7 @@ func validateMetadataIsLowerCase(v interface{}, k string) (ws []string, errors [
 	return
 }
 
-func resourceObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func resourceObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	if hasObjectContentChanges(d) {
 		return d.SetNewComputed("version_id")
 	}
@@ -631,7 +632,7 @@ func resourceObjectCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta
 }
 
 func hasObjectContentChanges(d sdkv2.ResourceDiffer) bool {
-	for _, key := range []string{
+	return slices.ContainsFunc([]string{
 		"bucket_key_enabled",
 		"cache_control",
 		"checksum_algorithm",
@@ -649,12 +650,7 @@ func hasObjectContentChanges(d sdkv2.ResourceDiffer) bool {
 		"source_hash",
 		names.AttrStorageClass,
 		"website_redirect",
-	} {
-		if d.HasChange(key) {
-			return true
-		}
-	}
-	return false
+	}, d.HasChange)
 }
 
 func findObjectByBucketAndKey(ctx context.Context, conn *s3.Client, bucket, key, etag, checksumAlgorithm string, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
@@ -725,8 +721,8 @@ func sdkv1CompatibleCleanKey(key string) string {
 }
 
 func ignoreProviderDefaultTags(ctx context.Context, d sdkv2.ResourceDiffer) bool {
-	if v, ok := d.GetOk("override_provider"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		if data := expandOverrideProviderModel(ctx, v.([]interface{})[0].(map[string]interface{})); data != nil && data.DefaultTagsConfig != nil {
+	if v, ok := d.GetOk("override_provider"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		if data := expandOverrideProviderModel(ctx, v.([]any)[0].(map[string]any)); data != nil && data.DefaultTagsConfig != nil {
 			return len(data.DefaultTagsConfig.Tags) == 0
 		}
 	}
@@ -738,33 +734,33 @@ type overrideProviderModel struct {
 	DefaultTagsConfig *tftags.DefaultConfig
 }
 
-func expandOverrideProviderModel(ctx context.Context, tfMap map[string]interface{}) *overrideProviderModel {
+func expandOverrideProviderModel(ctx context.Context, tfMap map[string]any) *overrideProviderModel {
 	if tfMap == nil {
 		return nil
 	}
 
 	data := &overrideProviderModel{}
 
-	if v, ok := tfMap["default_tags"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["default_tags"].([]any); ok && len(v) > 0 {
 		if v[0] != nil {
-			data.DefaultTagsConfig = expandDefaultTags(ctx, v[0].(map[string]interface{}))
+			data.DefaultTagsConfig = expandDefaultTags(ctx, v[0].(map[string]any))
 		} else {
 			// Ensure that DefaultTagsConfig is not nil as it's checked in ignoreProviderDefaultTags.
-			data.DefaultTagsConfig = expandDefaultTags(ctx, map[string]interface{}{})
+			data.DefaultTagsConfig = expandDefaultTags(ctx, map[string]any{})
 		}
 	}
 
 	return data
 }
 
-func expandDefaultTags(ctx context.Context, tfMap map[string]interface{}) *tftags.DefaultConfig {
+func expandDefaultTags(ctx context.Context, tfMap map[string]any) *tftags.DefaultConfig {
 	if tfMap == nil {
 		return nil
 	}
 
 	data := &tftags.DefaultConfig{}
 
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok {
 		data.Tags = tftags.New(ctx, v)
 	}
 

--- a/internal/service/s3/object_copy.go
+++ b/internal/service/s3/object_copy.go
@@ -40,7 +40,7 @@ func resourceObjectCopy() *schema.Resource {
 		UpdateWithoutTimeout: resourceObjectCopyUpdate,
 		DeleteWithoutTimeout: resourceObjectCopyDelete,
 
-		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
 			if ignoreProviderDefaultTags(ctx, d) {
 				return d.SetNew(names.AttrTagsAll, d.Get(names.AttrTags))
 			}
@@ -362,12 +362,12 @@ func resourceObjectCopy() *schema.Resource {
 	}
 }
 
-func resourceObjectCopyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCopyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	return append(diags, resourceObjectCopyDoCopy(ctx, d, meta)...)
 }
 
-func resourceObjectCopyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCopyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -436,7 +436,7 @@ func resourceObjectCopyRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceObjectCopyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCopyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// if any of these exist, let the API decide whether to copy
@@ -493,7 +493,7 @@ func resourceObjectCopyUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceObjectCopyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCopyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -523,7 +523,7 @@ func resourceObjectCopyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceObjectCopyDoCopy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObjectCopyDoCopy(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 
@@ -635,7 +635,7 @@ func resourceObjectCopyDoCopy(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if v, ok := d.GetOk("metadata"); ok {
-		input.Metadata = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.Metadata = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("metadata_directive"); ok {
@@ -683,7 +683,7 @@ func resourceObjectCopyDoCopy(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
-	tags := tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{}))
+	tags := tftags.New(ctx, d.Get(names.AttrTags).(map[string]any))
 	if ignoreProviderDefaultTags(ctx, d) {
 		tags = tags.RemoveDefaultConfig(defaultTagsConfig)
 	} else {
@@ -724,7 +724,7 @@ type s3Grants struct {
 	WriteACP    *string
 }
 
-func expandObjectCopyGrant(tfMap map[string]interface{}) string {
+func expandObjectCopyGrant(tfMap map[string]any) string {
 	if tfMap == nil {
 		return ""
 	}
@@ -763,7 +763,7 @@ func expandObjectCopyGrant(tfMap map[string]interface{}) string {
 	return fmt.Sprintf("uri=%s", aws.ToString(apiObject.URI))
 }
 
-func expandObjectCopyGrants(tfList []interface{}) *s3Grants {
+func expandObjectCopyGrants(tfList []any) *s3Grants {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -774,7 +774,7 @@ func expandObjectCopyGrants(tfList []interface{}) *s3Grants {
 	grantWriteACP := make([]string, 0)
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -817,9 +817,9 @@ func expandObjectCopyGrants(tfList []interface{}) *s3Grants {
 	return apiObjects
 }
 
-func grantHash(v interface{}) int {
+func grantHash(v any) int {
 	var buf bytes.Buffer
-	m, ok := v.(map[string]interface{})
+	m, ok := v.(map[string]any)
 
 	if !ok {
 		return 0

--- a/internal/service/s3/object_data_source.go
+++ b/internal/service/s3/object_data_source.go
@@ -164,7 +164,7 @@ func dataSourceObject() *schema.Resource {
 	}
 }
 
-func dataSourceObjectRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceObjectRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/objects_data_source.go
+++ b/internal/service/s3/objects_data_source.go
@@ -85,7 +85,7 @@ func dataSourceObjects() *schema.Resource {
 	}
 }
 
-func dataSourceObjectsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceObjectsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).S3Client(ctx)
 

--- a/internal/service/s3/objects_data_source_test.go
+++ b/internal/service/s3/objects_data_source_test.go
@@ -143,7 +143,7 @@ func TestAccS3ObjectsDataSource_maxKeysLarge(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_s3_objects.test"
 	var keys []string
-	for i := 0; i < 1500; i++ {
+	for i := range 1500 {
 		keys = append(keys, fmt.Sprintf("data%d", i))
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
