### PR TITLE
iam: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -76,6 +76,7 @@ jobs:
 
       # Services
       - run: make TEST=./internal/service/ec2 modern-check
+      - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check

--- a/internal/service/iam/access_key.go
+++ b/internal/service/iam/access_key.go
@@ -40,7 +40,7 @@ func resourceAccessKey() *schema.Resource {
 			// ListAccessKeys requires UserName field in certain scenarios:
 			//   ValidationError: Must specify userName when calling with non-User credentials
 			// To prevent import from requiring this extra information, use GetAccessKeyLastUsed.
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
 				input := &iam.GetAccessKeyLastUsedInput{
@@ -110,7 +110,7 @@ func resourceAccessKey() *schema.Resource {
 	}
 }
 
-func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -188,7 +188,7 @@ func resourceAccessKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccessKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -231,7 +231,7 @@ func resourceAccessKeyReadResult(d *schema.ResourceData, key *awstypes.AccessKey
 	d.Set("user", key.UserName)
 }
 
-func resourceAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -244,7 +244,7 @@ func resourceAccessKeyUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceAccessKeyRead(ctx, d, meta)...)
 }
 
-func resourceAccessKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccessKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/access_keys_data_source.go
+++ b/internal/service/iam/access_keys_data_source.go
@@ -49,7 +49,7 @@ func dataSourceAccessKeys() *schema.Resource {
 	}
 }
 
-func dataSourceAccessKeysRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAccessKeysRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
@@ -69,12 +69,12 @@ func dataSourceAccessKeysRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func flattenAccessKeys(apiObjects []awstypes.AccessKeyMetadata) []interface{} {
+func flattenAccessKeys(apiObjects []awstypes.AccessKeyMetadata) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if apiObject == (awstypes.AccessKeyMetadata{}) {
@@ -86,12 +86,12 @@ func flattenAccessKeys(apiObjects []awstypes.AccessKeyMetadata) []interface{} {
 	return tfList
 }
 
-func flattenAccessKey(apiObject awstypes.AccessKeyMetadata) map[string]interface{} {
+func flattenAccessKey(apiObject awstypes.AccessKeyMetadata) map[string]any {
 	if apiObject == (awstypes.AccessKeyMetadata{}) {
 		return nil
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if v := apiObject.AccessKeyId; v != nil {
 		m["access_key_id"] = aws.ToString(v)

--- a/internal/service/iam/account_alias.go
+++ b/internal/service/iam/account_alias.go
@@ -36,7 +36,7 @@ func resourceAccountAlias() *schema.Resource {
 	}
 }
 
-func resourceAccountAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountAliasCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -57,7 +57,7 @@ func resourceAccountAliasCreate(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -82,7 +82,7 @@ func resourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceAccountAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountAliasDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/account_alias_data_source.go
+++ b/internal/service/iam/account_alias_data_source.go
@@ -28,7 +28,7 @@ func dataSourceAccountAlias() *schema.Resource {
 	}
 }
 
-func dataSourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAccountAliasRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/account_password_policy.go
+++ b/internal/service/iam/account_password_policy.go
@@ -85,7 +85,7 @@ func resourceAccountPasswordPolicy() *schema.Resource {
 	}
 }
 
-func resourceAccountPasswordPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountPasswordPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -132,7 +132,7 @@ func resourceAccountPasswordPolicyUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceAccountPasswordPolicyRead(ctx, d, meta)...)
 }
 
-func resourceAccountPasswordPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountPasswordPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -162,7 +162,7 @@ func resourceAccountPasswordPolicyRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceAccountPasswordPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountPasswordPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/flex.go
+++ b/internal/service/iam/flex.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
-func expandStringListKeepEmpty(configured []interface{}) []*string {
+func expandStringListKeepEmpty(configured []any) []*string {
 	vs := make([]*string, 0, len(configured))
 	for _, v := range configured {
 		if val, ok := v.(string); ok {

--- a/internal/service/iam/group.go
+++ b/internal/service/iam/group.go
@@ -59,7 +59,7 @@ func resourceGroup() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, meta any) error {
 			if d.HasChanges(names.AttrName, names.AttrPath) {
 				return d.SetNewComputed(names.AttrARN)
 			}
@@ -69,7 +69,7 @@ func resourceGroup() *schema.Resource {
 	}
 }
 
-func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -87,7 +87,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	d.SetId(aws.ToString(output.Group.GroupName))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findGroupByName(ctx, conn, d.Id())
 	})
 
@@ -98,7 +98,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -122,7 +122,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -144,7 +144,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/group_data_source.go
+++ b/internal/service/iam/group_data_source.go
@@ -66,7 +66,7 @@ func dataSourceGroup() *schema.Resource {
 	}
 }
 
-func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -107,10 +107,10 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func dataSourceGroupUsersRead(iamUsers []awstypes.User) []map[string]interface{} {
-	users := make([]map[string]interface{}, 0, len(iamUsers))
+func dataSourceGroupUsersRead(iamUsers []awstypes.User) []map[string]any {
+	users := make([]map[string]any, 0, len(iamUsers))
 	for _, i := range iamUsers {
-		u := make(map[string]interface{})
+		u := make(map[string]any)
 		u[names.AttrARN] = aws.ToString(i.Arn)
 		u["user_id"] = aws.ToString(i.UserId)
 		u[names.AttrUserName] = aws.ToString(i.UserName)

--- a/internal/service/iam/group_membership.go
+++ b/internal/service/iam/group_membership.go
@@ -53,7 +53,7 @@ func resourceGroupMembership() *schema.Resource {
 	}
 }
 
-func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -69,7 +69,7 @@ func resourceGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceGroupMembershipRead(ctx, d, meta)...)
 }
 
-func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 	group := d.Get("group").(string)
@@ -138,7 +138,7 @@ func resourceGroupMembershipRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -170,7 +170,7 @@ func resourceGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceGroupMembershipRead(ctx, d, meta)...)
 }
 
-func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 	userList := flex.ExpandStringValueSet(d.Get("users").(*schema.Set))

--- a/internal/service/iam/group_policy.go
+++ b/internal/service/iam/group_policy.go
@@ -63,7 +63,7 @@ func resourceGroupPolicy() *schema.Resource {
 				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := verify.LegacyPolicyNormalize(v)
 					return json
 				},
@@ -72,7 +72,7 @@ func resourceGroupPolicy() *schema.Resource {
 	}
 }
 
-func resourceGroupPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -98,7 +98,7 @@ func resourceGroupPolicyPut(ctx context.Context, d *schema.ResourceData, meta in
 	if d.IsNewResource() {
 		d.SetId(fmt.Sprintf("%s:%s", groupName, policyName))
 
-		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 			return FindGroupPolicyByTwoPartKey(ctx, conn, groupName, policyName)
 		})
 
@@ -110,7 +110,7 @@ func resourceGroupPolicyPut(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceGroupPolicyRead(ctx, d, meta)...)
 }
 
-func resourceGroupPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -149,7 +149,7 @@ func resourceGroupPolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceGroupPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/group_policy_attachment.go
+++ b/internal/service/iam/group_policy_attachment.go
@@ -52,7 +52,7 @@ func resourceGroupPolicyAttachment() *schema.Resource {
 	}
 }
 
-func resourceGroupPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -69,7 +69,7 @@ func resourceGroupPolicyAttachmentCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceGroupPolicyAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceGroupPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -78,7 +78,7 @@ func resourceGroupPolicyAttachmentRead(ctx context.Context, d *schema.ResourceDa
 	// Human friendly ID for error messages since d.Id() is non-descriptive.
 	id := fmt.Sprintf("%s:%s", group, policyARN)
 
-	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findAttachedGroupPolicyByTwoPartKey(ctx, conn, group, policyARN)
 	}, d.IsNewResource())
 
@@ -95,7 +95,7 @@ func resourceGroupPolicyAttachmentRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceGroupPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -106,7 +106,7 @@ func resourceGroupPolicyAttachmentDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), "/", 2)
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <group-name>/<policy_arn>", d.Id())
@@ -124,7 +124,7 @@ func resourceGroupPolicyAttachmentImport(ctx context.Context, d *schema.Resource
 
 func attachPolicyToGroup(ctx context.Context, conn *iam.Client, group, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
 		return conn.AttachGroupPolicy(ctx, &iam.AttachGroupPolicyInput{
 			GroupName: aws.String(group),
 			PolicyArn: aws.String(policyARN),
@@ -140,7 +140,7 @@ func attachPolicyToGroup(ctx context.Context, conn *iam.Client, group, policyARN
 
 func detachPolicyFromGroup(ctx context.Context, conn *iam.Client, group, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
 		return conn.DetachGroupPolicy(ctx, &iam.DetachGroupPolicyInput{
 			GroupName: aws.String(group),
 			PolicyArn: aws.String(policyARN),

--- a/internal/service/iam/instance_profile.go
+++ b/internal/service/iam/instance_profile.go
@@ -91,7 +91,7 @@ func resourceInstanceProfile() *schema.Resource {
 	}
 }
 
-func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -118,7 +118,7 @@ func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, 
 
 	d.SetId(aws.ToString(output.InstanceProfile.InstanceProfileName))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findInstanceProfileByName(ctx, conn, d.Id())
 	})
 
@@ -139,7 +139,7 @@ func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, 
 		err := instanceProfileCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceInstanceProfileRead(ctx, d, meta)...)
 		}
 
@@ -155,7 +155,7 @@ func resourceInstanceProfileCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceInstanceProfileRead(ctx, d, meta)...)
 }
 
-func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -208,7 +208,7 @@ func resourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceInstanceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -239,7 +239,7 @@ func resourceInstanceProfileUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceInstanceProfileRead(ctx, d, meta)...)
 }
 
-func resourceInstanceProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInstanceProfileDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -274,7 +274,7 @@ func instanceProfileAddRole(ctx context.Context, conn *iam.Client, profileName, 
 	}
 
 	_, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.AddRoleToInstanceProfile(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -347,7 +347,7 @@ const (
 )
 
 func statusInstanceProfile(ctx context.Context, conn *iam.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findInstanceProfileByName(ctx, conn, name)
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/iam/instance_profile_data_source.go
+++ b/internal/service/iam/instance_profile_data_source.go
@@ -53,7 +53,7 @@ func dataSourceInstanceProfile() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/instance_profiles_data_source.go
+++ b/internal/service/iam/instance_profiles_data_source.go
@@ -49,7 +49,7 @@ func dataSourceInstanceProfiles() *schema.Resource {
 	}
 }
 
-func dataSourceInstanceProfilesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInstanceProfilesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)

--- a/internal/service/iam/openid_connect_provider.go
+++ b/internal/service/iam/openid_connect_provider.go
@@ -72,7 +72,7 @@ func resourceOpenIDConnectProvider() *schema.Resource {
 	}
 }
 
-func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -83,7 +83,7 @@ func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.Resource
 	}
 
 	if v, ok := d.GetOk("thumbprint_list"); ok {
-		input.ThumbprintList = flex.ExpandStringValueList(v.([]interface{}))
+		input.ThumbprintList = flex.ExpandStringValueList(v.([]any))
 	}
 
 	output, err := conn.CreateOpenIDConnectProvider(ctx, input)
@@ -107,7 +107,7 @@ func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.Resource
 		err := openIDConnectProviderCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceOpenIDConnectProviderRead(ctx, d, meta)...)
 		}
 
@@ -119,7 +119,7 @@ func resourceOpenIDConnectProviderCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceOpenIDConnectProviderRead(ctx, d, meta)...)
 }
 
-func resourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -145,12 +145,12 @@ func resourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceOpenIDConnectProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenIDConnectProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
 	if d.HasChange("thumbprint_list") {
-		if v := d.Get("thumbprint_list").([]interface{}); len(v) > 0 {
+		if v := d.Get("thumbprint_list").([]any); len(v) > 0 {
 			// Issues with an update to clear the thumbprint_list:
 			// - A cleared thumbprint_list will have a length of 0, and not enter this block.
 			// - Setting it to empty triggers an API error (the API requires either no thumbprints at
@@ -205,7 +205,7 @@ func resourceOpenIDConnectProviderUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceOpenIDConnectProviderRead(ctx, d, meta)...)
 }
 
-func resourceOpenIDConnectProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenIDConnectProviderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/openid_connect_provider_data_source.go
+++ b/internal/service/iam/openid_connect_provider_data_source.go
@@ -60,7 +60,7 @@ func dataSourceOpenIDConnectProvider() *schema.Resource {
 	}
 }
 
-func dataSourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOpenIDConnectProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)

--- a/internal/service/iam/policy.go
+++ b/internal/service/iam/policy.go
@@ -90,7 +90,7 @@ func resourcePolicy() *schema.Resource {
 				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -105,7 +105,7 @@ func resourcePolicy() *schema.Resource {
 	}
 }
 
-func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -144,7 +144,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 		err := policyCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourcePolicyRead(ctx, d, meta)...)
 		}
 
@@ -156,7 +156,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourcePolicyRead(ctx, d, meta)...)
 }
 
-func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -164,7 +164,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 		policy        *awstypes.Policy
 		policyVersion *awstypes.PolicyVersion
 	}
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		iamPolicy := &policyWithVersion{}
 
 		if v, err := findPolicyByARN(ctx, conn, d.Id()); err == nil {
@@ -221,7 +221,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -251,7 +251,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourcePolicyRead(ctx, d, meta)...)
 }
 
-func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/policy_attachment.go
+++ b/internal/service/iam/policy_attachment.go
@@ -69,7 +69,7 @@ func resourcePolicyAttachment() *schema.Resource {
 	}
 }
 
-func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -98,7 +98,7 @@ func resourcePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourcePolicyAttachmentRead(ctx, d, meta)...)
 }
 
-func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -122,7 +122,7 @@ func resourcePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourcePolicyAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -143,7 +143,7 @@ func resourcePolicyAttachmentUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourcePolicyAttachmentRead(ctx, d, meta)...)
 }
 
-func resourcePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/policy_data_source.go
+++ b/internal/service/iam/policy_data_source.go
@@ -70,7 +70,7 @@ func dataSourcePolicy() *schema.Resource {
 	}
 }
 
-func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -80,7 +80,7 @@ func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	if arn == "" {
 		outputRaw, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return findPolicyByTwoPartKey(ctx, conn, name, pathPrefix)
 			},
 		)
@@ -112,7 +112,7 @@ func dataSourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta inte
 	setTagsOut(ctx, policy.Tags)
 
 	outputRaw, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return findPolicyVersion(ctx, conn, arn, aws.ToString(policy.DefaultVersionId))
 		},
 	)

--- a/internal/service/iam/policy_document_data_source.go
+++ b/internal/service/iam/policy_document_data_source.go
@@ -167,11 +167,11 @@ func dataSourcePolicyDocument() *schema.Resource {
 	}
 }
 
-func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	mergedDoc := &IAMPolicyDoc{}
 
-	if v, ok := d.GetOk("source_policy_documents"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("source_policy_documents"); ok && len(v.([]any)) > 0 {
 		// generate sid map to assure there are no duplicates in source jsons
 		sidMap := make(map[string]struct{})
 		for _, stmt := range mergedDoc.Statements {
@@ -181,7 +181,7 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		// merge sourceDocs in order specified
-		for sourceJSONIndex, sourceJSON := range v.([]interface{}) {
+		for sourceJSONIndex, sourceJSON := range v.([]any) {
 			if sourceJSON == nil {
 				continue
 			}
@@ -215,12 +215,12 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if cfgStmts, hasCfgStmts := d.GetOk("statement"); hasCfgStmts {
-		var cfgStmtIntf = cfgStmts.([]interface{})
+		var cfgStmtIntf = cfgStmts.([]any)
 		stmts := make([]*IAMPolicyStatement, len(cfgStmtIntf))
 		sidMap := make(map[string]struct{})
 
 		for i, stmtI := range cfgStmtIntf {
-			cfgStmt := stmtI.(map[string]interface{})
+			cfgStmt := stmtI.(map[string]any)
 			stmt := &IAMPolicyStatement{
 				Effect: cfgStmt["effect"].(string),
 			}
@@ -295,8 +295,8 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 	mergedDoc.Merge(doc)
 
 	// merge override_policy_documents policies into mergedDoc in order specified
-	if v, ok := d.GetOk("override_policy_documents"); ok && len(v.([]interface{})) > 0 {
-		for overrideJSONIndex, overrideJSON := range v.([]interface{}) {
+	if v, ok := d.GetOk("override_policy_documents"); ok && len(v.([]any)) > 0 {
+		for overrideJSONIndex, overrideJSON := range v.([]any) {
 			if overrideJSON == nil {
 				continue
 			}
@@ -332,7 +332,7 @@ func dataSourcePolicyDocumentRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func dataSourcePolicyDocumentReplaceVarsInList(in interface{}, version string) (interface{}, error) {
+func dataSourcePolicyDocumentReplaceVarsInList(in any, version string) (any, error) {
 	switch v := in.(type) {
 	case string:
 		if version == "2008-10-17" && strings.Contains(v, "&{") {
@@ -353,17 +353,17 @@ func dataSourcePolicyDocumentReplaceVarsInList(in interface{}, version string) (
 	}
 }
 
-func dataSourcePolicyDocumentMakeConditions(in []interface{}, version string) (IAMPolicyStatementConditionSet, error) {
+func dataSourcePolicyDocumentMakeConditions(in []any, version string) (IAMPolicyStatementConditionSet, error) {
 	out := make([]IAMPolicyStatementCondition, len(in))
 	for i, itemI := range in {
 		var err error
-		item := itemI.(map[string]interface{})
+		item := itemI.(map[string]any)
 		out[i] = IAMPolicyStatementCondition{
 			Test:     item["test"].(string),
 			Variable: item["variable"].(string),
 		}
 		out[i].Values, err = dataSourcePolicyDocumentReplaceVarsInList(
-			aws.ToStringSlice(expandStringListKeepEmpty(item[names.AttrValues].([]interface{}))),
+			aws.ToStringSlice(expandStringListKeepEmpty(item[names.AttrValues].([]any))),
 			version,
 		)
 		if err != nil {
@@ -377,11 +377,11 @@ func dataSourcePolicyDocumentMakeConditions(in []interface{}, version string) (I
 	return IAMPolicyStatementConditionSet(out), nil
 }
 
-func dataSourcePolicyDocumentMakePrincipals(in []interface{}, version string) (IAMPolicyStatementPrincipalSet, error) {
+func dataSourcePolicyDocumentMakePrincipals(in []any, version string) (IAMPolicyStatementPrincipalSet, error) {
 	out := make([]IAMPolicyStatementPrincipal, len(in))
 	for i, itemI := range in {
 		var err error
-		item := itemI.(map[string]interface{})
+		item := itemI.(map[string]any)
 		out[i] = IAMPolicyStatementPrincipal{
 			Type: item[names.AttrType].(string),
 		}

--- a/internal/service/iam/policy_model.go
+++ b/internal/service/iam/policy_model.go
@@ -27,10 +27,10 @@ type IAMPolicyDoc struct {
 type IAMPolicyStatement struct {
 	Sid           string                         `json:",omitempty"`
 	Effect        string                         `json:",omitempty"`
-	Actions       interface{}                    `json:"Action,omitempty"`
-	NotActions    interface{}                    `json:"NotAction,omitempty"`
-	Resources     interface{}                    `json:"Resource,omitempty"`
-	NotResources  interface{}                    `json:"NotResource,omitempty"`
+	Actions       any                            `json:"Action,omitempty"`
+	NotActions    any                            `json:"NotAction,omitempty"`
+	Resources     any                            `json:"Resource,omitempty"`
+	NotResources  any                            `json:"NotResource,omitempty"`
 	Principals    IAMPolicyStatementPrincipalSet `json:"Principal,omitempty"`
 	NotPrincipals IAMPolicyStatementPrincipalSet `json:"NotPrincipal,omitempty"`
 	Conditions    IAMPolicyStatementConditionSet `json:"Condition,omitempty"`
@@ -38,13 +38,13 @@ type IAMPolicyStatement struct {
 
 type IAMPolicyStatementPrincipal struct {
 	Type        string
-	Identifiers interface{}
+	Identifiers any
 }
 
 type IAMPolicyStatementCondition struct {
 	Test     string
 	Variable string
-	Values   interface{}
+	Values   any
 }
 
 type IAMPolicyStatementPrincipalSet []IAMPolicyStatementPrincipal
@@ -83,7 +83,7 @@ func (s *IAMPolicyDoc) Merge(newDoc *IAMPolicyDoc) {
 }
 
 func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
-	raw := map[string]interface{}{}
+	raw := map[string]any{}
 
 	// Although IAM documentation says that "*" and {"AWS": "*"} are equivalent
 	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html),
@@ -140,7 +140,7 @@ func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 	var out IAMPolicyStatementPrincipalSet
 
-	var data interface{}
+	var data any
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
@@ -148,14 +148,14 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 	switch t := data.(type) {
 	case string:
 		out = append(out, IAMPolicyStatementPrincipal{Type: "*", Identifiers: []string{"*"}})
-	case map[string]interface{}:
-		for key, value := range data.(map[string]interface{}) {
+	case map[string]any:
+		for key, value := range data.(map[string]any) {
 			switch vt := value.(type) {
 			case string:
 				out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: value.(string)})
-			case []interface{}:
+			case []any:
 				values := []string{}
-				for _, v := range value.([]interface{}) {
+				for _, v := range value.([]any) {
 					values = append(values, v.(string))
 				}
 				slices.Sort(values)
@@ -173,11 +173,11 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 }
 
 func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
-	raw := map[string]map[string]interface{}{}
+	raw := map[string]map[string]any{}
 
 	for _, c := range cs {
 		if _, ok := raw[c.Test]; !ok {
-			raw[c.Test] = map[string]interface{}{}
+			raw[c.Test] = map[string]any{}
 		}
 		if _, ok := raw[c.Test][c.Variable]; !ok {
 			raw[c.Test][c.Variable] = []string{}
@@ -209,7 +209,7 @@ func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
 func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 	var out IAMPolicyStatementConditionSet
 
-	var data map[string]map[string]interface{}
+	var data map[string]map[string]any
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
@@ -221,7 +221,7 @@ func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: []string{var_values}})
 			case bool:
 				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: strconv.FormatBool(var_values)})
-			case []interface{}:
+			case []any:
 				values := []string{}
 				for _, v := range var_values {
 					values = append(values, v.(string))
@@ -235,7 +235,7 @@ func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func policyDecodeConfigStringList(lI []interface{}) interface{} {
+func policyDecodeConfigStringList(lI []any) any {
 	if len(lI) == 1 {
 		return lI[0].(string)
 	}

--- a/internal/service/iam/principal_policy_simulation_data_source.go
+++ b/internal/service/iam/principal_policy_simulation_data_source.go
@@ -209,11 +209,11 @@ func dataSourcePrincipalPolicySimulation() *schema.Resource {
 	}
 }
 
-func dataSourcePrincipalPolicySimulationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePrincipalPolicySimulationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
-	setAsAWSStringSlice := func(raw interface{}) []string {
+	setAsAWSStringSlice := func(raw any) []string {
 		if raw.(*schema.Set).Len() == 0 {
 			return nil
 		}
@@ -229,7 +229,7 @@ func dataSourcePrincipalPolicySimulationRead(ctx context.Context, d *schema.Reso
 	}
 
 	for _, entryRaw := range d.Get("context").(*schema.Set).List() {
-		entryRaw := entryRaw.(map[string]interface{})
+		entryRaw := entryRaw.(map[string]any)
 		entry := awstypes.ContextEntry{
 			ContextKeyName:   aws.String(entryRaw[names.AttrKey].(string)),
 			ContextKeyType:   awstypes.ContextKeyTypeEnum(entryRaw[names.AttrType].(string)),
@@ -282,9 +282,9 @@ func dataSourcePrincipalPolicySimulationRead(ctx context.Context, d *schema.Reso
 	allowedCount := 0
 	deniedCount := 0
 
-	rawResults := make([]interface{}, len(results))
+	rawResults := make([]any, len(results))
 	for i, result := range results {
-		rawResult := map[string]interface{}{}
+		rawResult := map[string]any{}
 		rawResult["action_name"] = aws.ToString(result.EvalActionName)
 		rawResult["decision"] = string(result.EvalDecision)
 		allowed := string(result.EvalDecision) == "allowed"
@@ -314,9 +314,9 @@ func dataSourcePrincipalPolicySimulationRead(ctx context.Context, d *schema.Reso
 		}
 		rawResult["decision_details"] = decisionDetails
 
-		rawMatchedStmts := make([]interface{}, len(result.MatchedStatements))
+		rawMatchedStmts := make([]any, len(result.MatchedStatements))
 		for i, stmt := range result.MatchedStatements {
-			rawStmt := map[string]interface{}{
+			rawStmt := map[string]any{
 				"source_policy_id":   stmt.SourcePolicyId,
 				"source_policy_type": stmt.SourcePolicyType,
 			}

--- a/internal/service/iam/role.go
+++ b/internal/service/iam/role.go
@@ -64,7 +64,7 @@ func resourceRole() *schema.Resource {
 				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -112,7 +112,7 @@ func resourceRole() *schema.Resource {
 							ValidateFunc:          verify.ValidIAMPolicyJSON,
 							DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 							DiffSuppressOnRefresh: true,
-							StateFunc: func(v interface{}) string {
+							StateFunc: func(v any) string {
 								json, _ := verify.LegacyPolicyNormalize(v)
 								return json
 							},
@@ -185,7 +185,7 @@ func resourceRole() *schema.Resource {
 	}
 }
 
-func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -256,7 +256,7 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		err := roleCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceRoleRead(ctx, d, meta)...)
 		}
 
@@ -268,11 +268,11 @@ func resourceRoleCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceRoleRead(ctx, d, meta)...)
 }
 
-func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findRoleByName(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -346,7 +346,7 @@ func resourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -362,7 +362,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.UpdateAssumeRolePolicy(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -452,7 +452,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 		var policyNames []string
 		for _, policy := range remove {
-			tfMap, ok := policy.(map[string]interface{})
+			tfMap, ok := policy.(map[string]any)
 
 			if !ok {
 				continue
@@ -489,7 +489,7 @@ func resourceRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceRoleRead(ctx, d, meta)...)
 }
 
-func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -512,7 +512,7 @@ func resourceRoleDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceRoleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRoleImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set("force_detach_policies", false)
 	return []*schema.ResourceData{d}, nil
 }
@@ -554,7 +554,7 @@ func deleteRole(ctx context.Context, conn *iam.Client, roleName string, forceDet
 		RoleName: aws.String(roleName),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.DeleteConflictException](ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.DeleteConflictException](ctx, propagationTimeout, func() (any, error) {
 		return conn.DeleteRole(ctx, input)
 	})
 
@@ -601,7 +601,7 @@ func deleteRoleInstanceProfiles(ctx context.Context, conn *iam.Client, roleName 
 
 func retryCreateRole(ctx context.Context, conn *iam.Client, input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateRole(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -769,12 +769,12 @@ func deleteRoleInlinePolicies(ctx context.Context, conn *iam.Client, roleName st
 	return errors.Join(errsList...)
 }
 
-func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]interface{} {
+func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrName] = aws.ToString(apiObject.PolicyName)
 	tfMap[names.AttrPolicy] = aws.ToString(apiObject.PolicyDocument)
@@ -782,12 +782,12 @@ func flattenRoleInlinePolicy(apiObject *iam.PutRolePolicyInput) map[string]inter
 	return tfMap
 }
 
-func flattenRoleInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []interface{} {
+func flattenRoleInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if apiObject == nil {
@@ -800,7 +800,7 @@ func flattenRoleInlinePolicies(apiObjects []*iam.PutRolePolicyInput) []interface
 	return tfList
 }
 
-func expandRoleInlinePolicy(roleName string, tfMap map[string]interface{}) *iam.PutRolePolicyInput {
+func expandRoleInlinePolicy(roleName string, tfMap map[string]any) *iam.PutRolePolicyInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -826,7 +826,7 @@ func expandRoleInlinePolicy(roleName string, tfMap map[string]interface{}) *iam.
 	return apiObject
 }
 
-func expandRoleInlinePolicies(roleName string, tfList []interface{}) []*iam.PutRolePolicyInput {
+func expandRoleInlinePolicies(roleName string, tfList []any) []*iam.PutRolePolicyInput {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -834,7 +834,7 @@ func expandRoleInlinePolicies(roleName string, tfList []interface{}) []*iam.PutR
 	var apiObjects []*iam.PutRolePolicyInput
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue

--- a/internal/service/iam/role_data_source.go
+++ b/internal/service/iam/role_data_source.go
@@ -83,7 +83,7 @@ func dataSourceRole() *schema.Resource {
 	}
 }
 
-func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -122,17 +122,17 @@ func dataSourceRoleRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func flattenRoleLastUsed(apiObject *awstypes.RoleLastUsed) []interface{} {
+func flattenRoleLastUsed(apiObject *awstypes.RoleLastUsed) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrRegion: aws.ToString(apiObject.Region),
 	}
 
 	if apiObject.LastUsedDate != nil {
 		tfMap["last_used_date"] = apiObject.LastUsedDate.Format(time.RFC3339)
 	}
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/iam/role_policy.go
+++ b/internal/service/iam/role_policy.go
@@ -66,7 +66,7 @@ func resourceRolePolicy() *schema.Resource {
 				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := verify.LegacyPolicyNormalize(v)
 					return json
 				},
@@ -81,7 +81,7 @@ func resourceRolePolicy() *schema.Resource {
 	}
 }
 
-func resourceRolePolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -107,7 +107,7 @@ func resourceRolePolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 	if d.IsNewResource() {
 		d.SetId(fmt.Sprintf("%s:%s", roleName, policyName))
 
-		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 			return FindRolePolicyByTwoPartKey(ctx, conn, roleName, policyName)
 		})
 
@@ -119,7 +119,7 @@ func resourceRolePolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceRolePolicyRead(ctx, d, meta)...)
 }
 
-func resourceRolePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -158,7 +158,7 @@ func resourceRolePolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceRolePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/role_policy_attachment.go
+++ b/internal/service/iam/role_policy_attachment.go
@@ -52,7 +52,7 @@ func resourceRolePolicyAttachment() *schema.Resource {
 	}
 }
 
-func resourceRolePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -69,7 +69,7 @@ func resourceRolePolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceRolePolicyAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -78,7 +78,7 @@ func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	// Human friendly ID for error messages since d.Id() is non-descriptive.
 	id := fmt.Sprintf("%s:%s", role, policyARN)
 
-	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findAttachedRolePolicyByTwoPartKey(ctx, conn, role, policyARN)
 	}, d.IsNewResource())
 
@@ -95,7 +95,7 @@ func resourceRolePolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceRolePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRolePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -106,7 +106,7 @@ func resourceRolePolicyAttachmentDelete(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceRolePolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRolePolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), "/", 2)
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <role-name>/<policy_arn>", d.Id())
@@ -124,7 +124,7 @@ func resourceRolePolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 
 func attachPolicyToRole(ctx context.Context, conn *iam.Client, role, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
 		return conn.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
 			PolicyArn: aws.String(policyARN),
 			RoleName:  aws.String(role),
@@ -140,7 +140,7 @@ func attachPolicyToRole(ctx context.Context, conn *iam.Client, role, policyARN s
 
 func detachPolicyFromRole(ctx context.Context, conn *iam.Client, role, policyARN string) error {
 	var errConcurrentModificationException *awstypes.ConcurrentModificationException
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, propagationTimeout, func() (any, error) {
 		return conn.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
 			PolicyArn: aws.String(policyARN),
 			RoleName:  aws.String(role),

--- a/internal/service/iam/roles_data_source.go
+++ b/internal/service/iam/roles_data_source.go
@@ -48,7 +48,7 @@ func dataSourceRoles() *schema.Resource {
 	}
 }
 
-func dataSourceRolesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRolesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/saml_provider.go
+++ b/internal/service/iam/saml_provider.go
@@ -66,7 +66,7 @@ func resourceSAMLProvider() *schema.Resource {
 	}
 }
 
-func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
@@ -99,7 +99,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 		err := samlProviderCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 		}
 
@@ -111,7 +111,7 @@ func resourceSAMLProviderCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 }
 
-func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
@@ -148,7 +148,7 @@ func resourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
@@ -169,7 +169,7 @@ func resourceSAMLProviderUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceSAMLProviderRead(ctx, d, meta)...)
 }
 
-func resourceSAMLProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSAMLProviderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)

--- a/internal/service/iam/saml_provider_data_source.go
+++ b/internal/service/iam/saml_provider_data_source.go
@@ -49,7 +49,7 @@ func dataSourceSAMLProvider() *schema.Resource {
 	}
 }
 
-func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSAMLProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)

--- a/internal/service/iam/security_token_service_preferences.go
+++ b/internal/service/iam/security_token_service_preferences.go
@@ -34,7 +34,7 @@ func resourceSecurityTokenServicePreferences() *schema.Resource {
 	}
 }
 
-func resourceSecurityTokenServicePreferencesUpsert(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityTokenServicePreferencesUpsert(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -55,7 +55,7 @@ func resourceSecurityTokenServicePreferencesUpsert(ctx context.Context, d *schem
 	return append(diags, resourceSecurityTokenServicePreferencesRead(ctx, d, meta)...)
 }
 
-func resourceSecurityTokenServicePreferencesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityTokenServicePreferencesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/server_certificate.go
+++ b/internal/service/iam/server_certificate.go
@@ -106,7 +106,7 @@ func resourceServerCertificate() *schema.Resource {
 	}
 }
 
-func resourceServerCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServerCertificateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -148,7 +148,7 @@ func resourceServerCertificateCreate(ctx context.Context, d *schema.ResourceData
 		err := serverCertificateCreateTags(ctx, conn, sslCertName, tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceServerCertificateRead(ctx, d, meta)...)
 		}
 
@@ -160,7 +160,7 @@ func resourceServerCertificateCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceServerCertificateRead(ctx, d, meta)...)
 }
 
-func resourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -200,7 +200,7 @@ func resourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceServerCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServerCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
@@ -250,12 +250,12 @@ func resourceServerCertificateUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceServerCertificateRead(ctx, d, meta)...)
 }
 
-func resourceServerCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServerCertificateDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
 	log.Printf("[DEBUG] Deleting IAM Server Certificate: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.DeleteConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.DeleteConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteServerCertificate(ctx, &iam.DeleteServerCertificateInput{
 			ServerCertificateName: aws.String(d.Get(names.AttrName).(string)),
 		})
@@ -272,7 +272,7 @@ func resourceServerCertificateDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceServerCertificateImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceServerCertificateImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set(names.AttrName, d.Id())
 	// private_key can't be fetched from any API call
 	return []*schema.ResourceData{d}, nil
@@ -303,7 +303,7 @@ func findServerCertificateByName(ctx context.Context, conn *iam.Client, name str
 	return output.ServerCertificate, nil
 }
 
-func normalizeCert(cert interface{}) string {
+func normalizeCert(cert any) string {
 	if cert == nil || cert == (*string)(nil) {
 		return ""
 	}

--- a/internal/service/iam/server_certificate_data_source.go
+++ b/internal/service/iam/server_certificate_data_source.go
@@ -87,7 +87,7 @@ func dataSourceServerCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceServerCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/service_linked_role.go
+++ b/internal/service/iam/service_linked_role.go
@@ -90,7 +90,7 @@ func resourceServiceLinkedRole() *schema.Resource {
 	}
 }
 
-func resourceServiceLinkedRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceLinkedRoleCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -127,7 +127,7 @@ func resourceServiceLinkedRoleCreate(ctx context.Context, d *schema.ResourceData
 
 		// If default tags only, continue. Otherwise, error.
 		partition := meta.(*conns.AWSClient).Partition(ctx)
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceServiceLinkedRoleRead(ctx, d, meta)...)
 		}
 
@@ -139,7 +139,7 @@ func resourceServiceLinkedRoleCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceServiceLinkedRoleRead(ctx, d, meta)...)
 }
 
-func resourceServiceLinkedRoleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceLinkedRoleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -149,7 +149,7 @@ func resourceServiceLinkedRoleRead(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findRoleByName(ctx, conn, roleName)
 	}, d.IsNewResource())
 
@@ -179,7 +179,7 @@ func resourceServiceLinkedRoleRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceServiceLinkedRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceLinkedRoleUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -204,7 +204,7 @@ func resourceServiceLinkedRoleUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceServiceLinkedRoleRead(ctx, d, meta)...)
 }
 
-func resourceServiceLinkedRoleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceLinkedRoleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -279,7 +279,7 @@ func waitServiceLinkedRoleDeleted(ctx context.Context, conn *iam.Client, id stri
 }
 
 func statusServiceLinkedRoleDeletion(ctx context.Context, conn *iam.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findServiceLinkedRoleDeletionStatusByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/iam/service_specific_credential.go
+++ b/internal/service/iam/service_specific_credential.go
@@ -69,7 +69,7 @@ func resourceServiceSpecificCredential() *schema.Resource {
 	}
 }
 
-func resourceServiceSpecificCredentialCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceSpecificCredentialCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -104,7 +104,7 @@ func resourceServiceSpecificCredentialCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceServiceSpecificCredentialRead(ctx, d, meta)...)
 }
 
-func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -113,7 +113,7 @@ func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading IAM Service Specific Credential (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return FindServiceSpecificCredential(ctx, conn, serviceName, userName, credID)
 	}, d.IsNewResource())
 
@@ -138,7 +138,7 @@ func resourceServiceSpecificCredentialRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceServiceSpecificCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceSpecificCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -155,7 +155,7 @@ func resourceServiceSpecificCredentialUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceServiceSpecificCredentialRead(ctx, d, meta)...)
 }
 
-func resourceServiceSpecificCredentialDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceSpecificCredentialDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/session_context_data_source.go
+++ b/internal/service/iam/session_context_data_source.go
@@ -51,7 +51,7 @@ func dataSourceSessionContext() *schema.Resource {
 	}
 }
 
-func dataSourceSessionContextRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSessionContextRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/signing_certificate.go
+++ b/internal/service/iam/signing_certificate.go
@@ -60,7 +60,7 @@ func resourceSigningCertificate() *schema.Resource {
 	}
 }
 
-func resourceSigningCertificateCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSigningCertificateCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -94,7 +94,7 @@ func resourceSigningCertificateCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceSigningCertificateRead(ctx, d, meta)...)
 }
 
-func resourceSigningCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSigningCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -103,7 +103,7 @@ func resourceSigningCertificateRead(ctx context.Context, d *schema.ResourceData,
 		return sdkdiag.AppendErrorf(diags, "reading IAM Signing Certificate (%s): %s", d.Id(), err)
 	}
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return FindSigningCertificate(ctx, conn, userName, certId)
 	}, d.IsNewResource())
 
@@ -127,7 +127,7 @@ func resourceSigningCertificateRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceSigningCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSigningCertificateUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -150,7 +150,7 @@ func resourceSigningCertificateUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceSigningCertificateRead(ctx, d, meta)...)
 }
 
-func resourceSigningCertificateDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSigningCertificateDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 	log.Printf("[INFO] Deleting IAM Signing Certificate: %s", d.Id())

--- a/internal/service/iam/state_funcs.go
+++ b/internal/service/iam/state_funcs.go
@@ -8,7 +8,7 @@ import (
 ) // StateTrimSpace is a StateFunc that trims extraneous whitespace from strings.
 // This prevents differences caused by an API canonicalizing a string with a
 // trailing newline character removed.
-func StateTrimSpace(v interface{}) string {
+func StateTrimSpace(v any) string {
 	s, ok := v.(string)
 
 	if !ok {

--- a/internal/service/iam/user.go
+++ b/internal/service/iam/user.go
@@ -87,7 +87,7 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -124,7 +124,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		err := userCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceUserRead(ctx, d, meta)...)
 		}
 
@@ -136,11 +136,11 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findUserByName(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -171,7 +171,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -219,7 +219,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/user_data_source.go
+++ b/internal/service/iam/user_data_source.go
@@ -50,7 +50,7 @@ func dataSourceUser() *schema.Resource {
 	}
 }
 
-func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/user_group_membership.go
+++ b/internal/service/iam/user_group_membership.go
@@ -52,7 +52,7 @@ func resourceUserGroupMembership() *schema.Resource {
 	}
 }
 
-func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -69,7 +69,7 @@ func resourceUserGroupMembershipCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceUserGroupMembershipRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupMembershipRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -142,7 +142,7 @@ func resourceUserGroupMembershipRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceUserGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupMembershipUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -174,7 +174,7 @@ func resourceUserGroupMembershipUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceUserGroupMembershipRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupMembershipDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 	user := d.Get("user").(string)
@@ -232,7 +232,7 @@ func removeUserFromGroup(ctx context.Context, conn *iam.Client, user, group stri
 	return nil
 }
 
-func resourceUserGroupMembershipImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceUserGroupMembershipImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), "/")
 	if len(idParts) < 2 {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <user-name>/<group-name1>/...", d.Id())

--- a/internal/service/iam/user_group_membership_test.go
+++ b/internal/service/iam/user_group_membership_test.go
@@ -196,7 +196,7 @@ func testAccUserGroupMembershipImportStateIdFunc(resourceName string) resource.I
 
 		groupCount, _ := strconv.Atoi(rs.Primary.Attributes["groups.#"])
 		stateId := rs.Primary.Attributes["user"]
-		for i := 0; i < groupCount; i++ {
+		for i := range groupCount {
 			groupName := rs.Primary.Attributes[fmt.Sprintf("group.%d", i)]
 			stateId = fmt.Sprintf("%s/%s", stateId, groupName)
 		}

--- a/internal/service/iam/user_login_profile.go
+++ b/internal/service/iam/user_login_profile.go
@@ -34,7 +34,7 @@ func resourceUserLoginProfile() *schema.Resource {
 		DeleteWithoutTimeout: resourceUserLoginProfileDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("encrypted_password", "")
 				d.Set("key_fingerprint", "")
 				return []*schema.ResourceData{d}, nil
@@ -105,7 +105,7 @@ func GeneratePassword(length int) (string, error) {
 	// Even in the worst case, this tends to take less than 10 tries to find a
 	// matching password. Any sufficiently long password is likely to succeed
 	// on the first try
-	for n := 0; n < 100000; n++ {
+	for range 100000 {
 		for i := range result {
 			r, err := rand.Int(rand.Reader, charsetSize)
 			if err != nil {
@@ -137,7 +137,7 @@ func CheckPwdPolicy(pass []byte) bool {
 		bytes.ContainsAny(pass, charUpper))
 }
 
-func resourceUserLoginProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserLoginProfileCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 	username := d.Get("user").(string)
@@ -181,7 +181,7 @@ func resourceUserLoginProfileCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceUserLoginProfileRead(ctx, d, meta)...)
 }
 
-func resourceUserLoginProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserLoginProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -229,7 +229,7 @@ func resourceUserLoginProfileRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceUserLoginProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserLoginProfileDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/user_policy.go
+++ b/internal/service/iam/user_policy.go
@@ -58,7 +58,7 @@ func resourceUserPolicy() *schema.Resource {
 				ValidateFunc:          verify.ValidIAMPolicyJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := verify.LegacyPolicyNormalize(v)
 					return json
 				},
@@ -72,7 +72,7 @@ func resourceUserPolicy() *schema.Resource {
 	}
 }
 
-func resourceUserPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -98,7 +98,7 @@ func resourceUserPolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 	if d.IsNewResource() {
 		d.SetId(fmt.Sprintf("%s:%s", userName, policyName))
 
-		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 			return FindUserPolicyByTwoPartKey(ctx, conn, userName, policyName)
 		})
 
@@ -110,7 +110,7 @@ func resourceUserPolicyPut(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceUserPolicyRead(ctx, d, meta)...)
 }
 
-func resourceUserPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -149,7 +149,7 @@ func resourceUserPolicyRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceUserPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/user_policy_attachment.go
+++ b/internal/service/iam/user_policy_attachment.go
@@ -51,7 +51,7 @@ func resourceUserPolicyAttachment() *schema.Resource {
 	}
 }
 
-func resourceUserPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -68,7 +68,7 @@ func resourceUserPolicyAttachmentCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceUserPolicyAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -77,7 +77,7 @@ func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	// Human friendly ID for error messages since d.Id() is non-descriptive.
 	id := fmt.Sprintf("%s:%s", user, policyARN)
 
-	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findAttachedUserPolicyByTwoPartKey(ctx, conn, user, policyARN)
 	}, d.IsNewResource())
 
@@ -94,7 +94,7 @@ func resourceUserPolicyAttachmentRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceUserPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -105,7 +105,7 @@ func resourceUserPolicyAttachmentDelete(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), "/", 2)
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <user-name>/<policy_arn>", d.Id())
@@ -122,7 +122,7 @@ func resourceUserPolicyAttachmentImport(ctx context.Context, d *schema.ResourceD
 }
 
 func attachPolicyToUser(ctx context.Context, conn *iam.Client, user, policyARN string) error {
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (any, error) {
 		return conn.AttachUserPolicy(ctx, &iam.AttachUserPolicyInput{
 			PolicyArn: aws.String(policyARN),
 			UserName:  aws.String(user),
@@ -137,7 +137,7 @@ func attachPolicyToUser(ctx context.Context, conn *iam.Client, user, policyARN s
 }
 
 func detachPolicyFromUser(ctx context.Context, conn *iam.Client, user, policyARN string) error {
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, propagationTimeout, func() (any, error) {
 		return conn.DetachUserPolicy(ctx, &iam.DetachUserPolicyInput{
 			PolicyArn: aws.String(policyARN),
 			UserName:  aws.String(user),

--- a/internal/service/iam/user_ssh_key.go
+++ b/internal/service/iam/user_ssh_key.go
@@ -76,7 +76,7 @@ func resourceUserSSHKey() *schema.Resource {
 	}
 }
 
-func resourceUserSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -94,7 +94,7 @@ func resourceUserSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	d.SetId(aws.ToString(output.SSHPublicKey.SSHPublicKeyId))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findSSHPublicKeyByThreePartKey(ctx, conn, d.Id(), d.Get("encoding").(string), username)
 	})
 
@@ -119,7 +119,7 @@ func resourceUserSSHKeyCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceUserSSHKeyRead(ctx, d, meta)...)
 }
 
-func resourceUserSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -148,7 +148,7 @@ func resourceUserSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceUserSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -167,7 +167,7 @@ func resourceUserSSHKeyUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceUserSSHKeyRead(ctx, d, meta)...)
 }
 
-func resourceUserSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -188,7 +188,7 @@ func resourceUserSSHKeyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceUserSSHKeyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceUserSSHKeyImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), ":", 3)
 
 	if len(idParts) != 3 || idParts[0] == "" || idParts[1] == "" || idParts[2] == "" {

--- a/internal/service/iam/user_ssh_key_data_source.go
+++ b/internal/service/iam/user_ssh_key_data_source.go
@@ -51,7 +51,7 @@ func dataSourceUserSSHKey() *schema.Resource {
 	}
 }
 
-func dataSourceUserSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserSSHKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/user_test.go
+++ b/internal/service/iam/user_test.go
@@ -757,7 +757,7 @@ func testAccCheckUserAttachPolicy(ctx context.Context, user *awstypes.User) reso
 			return fmt.Errorf("externally creating IAM Policy (%s): %s", aws.ToString(user.UserName), err)
 		}
 
-		_, err = tfresource.RetryWhenNewResourceNotFound(ctx, 2*time.Minute, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNewResourceNotFound(ctx, 2*time.Minute, func() (any, error) {
 			return tfiam.FindPolicyByARN(ctx, conn, aws.ToString(output.Policy.Arn))
 		}, true)
 		if err != nil {
@@ -789,7 +789,7 @@ func testAccCheckUserInlinePolicy(ctx context.Context, user *awstypes.User) reso
 			return fmt.Errorf("externally putting IAM User (%s) policy: %s", aws.ToString(user.UserName), err)
 		}
 
-		_, err = tfresource.RetryWhenNotFound(ctx, 2*time.Minute, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenNotFound(ctx, 2*time.Minute, func() (any, error) {
 			return tfiam.FindUserPolicyByTwoPartKey(ctx, conn, aws.ToString(user.UserName), aws.ToString(user.UserName))
 		})
 		if err != nil {

--- a/internal/service/iam/users_data_source.go
+++ b/internal/service/iam/users_data_source.go
@@ -43,7 +43,7 @@ func dataSourceUsers() *schema.Resource {
 	}
 }
 
-func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUsersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/validate.go
+++ b/internal/service/iam/validate.go
@@ -26,7 +26,7 @@ func validResourceName(max int) schema.SchemaValidateFunc {
 var validAccountAlias = validation.All(
 	validation.StringLenBetween(3, 63),
 	validation.StringMatch(regexache.MustCompile(`^[0-9a-z][0-9a-z-]+$`), "must start with an alphanumeric character and only contain lowercase alphanumeric characters and hyphens"),
-	func(v interface{}, k string) (ws []string, es []error) {
+	func(v any, k string) (ws []string, es []error) {
 		val := v.(string)
 		if strings.Contains(val, "--") {
 			es = append(es, fmt.Errorf("%q must not contain consecutive hyphens", k))
@@ -40,7 +40,7 @@ var validAccountAlias = validation.All(
 
 var validOpenIDURL = validation.All(
 	validation.IsURLWithHTTPS,
-	func(v interface{}, k string) (ws []string, es []error) {
+	func(v any, k string) (ws []string, es []error) {
 		value := v.(string)
 		u, err := url.Parse(value)
 		if err != nil {
@@ -57,7 +57,7 @@ var validOpenIDURL = validation.All(
 var validRolePolicyRole = validation.All(
 	validation.StringLenBetween(1, 128),
 	validation.StringMatch(regexache.MustCompile(`[\w+=,.@-]+`), ""),
-	func(v interface{}, k string) (ws []string, es []error) {
+	func(v any, k string) (ws []string, es []error) {
 		if _, errs := verify.ValidARN(v, k); len(errs) == 0 {
 			es = append(es, fmt.Errorf("%q must be the role's name not its ARN", k))
 		}

--- a/internal/service/iam/virtual_mfa_device.go
+++ b/internal/service/iam/virtual_mfa_device.go
@@ -84,7 +84,7 @@ func resourceVirtualMFADevice() *schema.Resource {
 	}
 }
 
-func resourceVirtualMFADeviceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualMFADeviceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -121,7 +121,7 @@ func resourceVirtualMFADeviceCreate(ctx context.Context, d *schema.ResourceData,
 		err := virtualMFADeviceCreateTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceVirtualMFADeviceRead(ctx, d, meta)...)
 		}
 
@@ -133,7 +133,7 @@ func resourceVirtualMFADeviceCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceVirtualMFADeviceRead(ctx, d, meta)...)
 }
 
-func resourceVirtualMFADeviceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualMFADeviceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 
@@ -178,7 +178,7 @@ func resourceVirtualMFADeviceRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceVirtualMFADeviceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualMFADeviceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -186,7 +186,7 @@ func resourceVirtualMFADeviceUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceVirtualMFADeviceRead(ctx, d, meta)...)
 }
 
-func resourceVirtualMFADeviceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualMFADeviceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).IAMClient(ctx)
 

--- a/internal/service/iam/wait.go
+++ b/internal/service/iam/wait.go
@@ -54,7 +54,7 @@ func waitRoleARNIsNotUniqueID(ctx context.Context, conn *iam.Client, id string, 
 }
 
 func statusRoleCreate(ctx context.Context, conn *iam.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		role, err := findRoleByName(ctx, conn, id)
 
 		if tfresource.NotFound(err) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
