### PR TITLE
feat: add attribute `create_time` to data source

### DIFF
--- a/.changelog/41839.txt
+++ b/.changelog/41839.txt
@@ -1,3 +1,6 @@
 ```release-note:enhancement
+resource/aws_ebs_volume: Add `create_time` attribute
+```
+```release-note:enhancement
 data-source/aws_ebs_volume: Add `create_time` attribute
 ```

--- a/.changelog/41839.txt
+++ b/.changelog/41839.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+data-source/aws_ebs_volume: Add `create_time` attribute
+```

--- a/internal/service/ec2/ebs_volume.go
+++ b/internal/service/ec2/ebs_volume.go
@@ -58,6 +58,10 @@ func resourceEBSVolume() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			names.AttrCreateTime: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrEncrypted: {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -208,6 +212,7 @@ func resourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta any
 	}
 	d.Set(names.AttrARN, arn.String())
 	d.Set(names.AttrAvailabilityZone, volume.AvailabilityZone)
+	d.Set(names.AttrCreateTime, volume.CreateTime.Format(time.RFC3339))
 	d.Set(names.AttrEncrypted, volume.Encrypted)
 	d.Set(names.AttrIOPS, volume.Iops)
 	d.Set(names.AttrKMSKeyID, volume.KmsKeyId)

--- a/internal/service/ec2/ebs_volume_data_source.go
+++ b/internal/service/ec2/ebs_volume_data_source.go
@@ -41,6 +41,10 @@ func dataSourceEBSVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrCreateTime: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			names.AttrEncrypted: {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -143,6 +147,7 @@ func dataSourceEBSVolumeRead(ctx context.Context, d *schema.ResourceData, meta a
 	}
 	d.Set(names.AttrARN, arn.String())
 	d.Set(names.AttrAvailabilityZone, volume.AvailabilityZone)
+	d.Set(names.AttrCreateTime, volume.CreateTime.Format(time.RFC3339))
 	d.Set(names.AttrEncrypted, volume.Encrypted)
 	d.Set(names.AttrIOPS, volume.Iops)
 	d.Set(names.AttrKMSKeyID, volume.KmsKeyId)

--- a/internal/service/ec2/ebs_volume_data_source_test.go
+++ b/internal/service/ec2/ebs_volume_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccEC2EBSVolumeDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSVolumeIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
-					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrCreateTime),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrCreateTime, resourceName, names.AttrCreateTime),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSize, resourceName, names.AttrSize),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTags, resourceName, names.AttrTags),
 					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),

--- a/internal/service/ec2/ebs_volume_data_source_test.go
+++ b/internal/service/ec2/ebs_volume_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccEC2EBSVolumeDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEBSVolumeIDDataSource(dataSourceName),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrCreateTime),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSize, resourceName, names.AttrSize),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrTags, resourceName, names.AttrTags),
 					resource.TestCheckResourceAttrPair(dataSourceName, "outpost_arn", resourceName, "outpost_arn"),

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -38,6 +38,7 @@ func TestAccEC2EBSVolume_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ec2", regexache.MustCompile(`volume/vol-.+`)),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrIOPS, "100"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrKMSKeyID, ""),

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -37,15 +37,15 @@ This data source supports the following arguments:
 several valid keys, for a full reference, check out
 [describe-volumes in the AWS CLI reference][1].
 * `most_recent` - (Optional) If more than one result is returned, use the most
-recent Volume.
+recent volume.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - Volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
-* `availability_zone` - AZ where the EBS volume exists.
-* `create_time` - The time stamp when volume creation was initiated.
+* `availability_zone` - Availability zone where the EBS volume exists.
+* `create_time` - Timestamp when volume creation was initiated.
 * `encrypted` - Whether the disk is encrypted.
 * `id` - Volume ID (e.g., vol-59fcb34e).
 * `iops` - Amount of IOPS for the disk.

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -46,7 +46,8 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - Volume ID (e.g., vol-59fcb34e).
 * `volume_id` - Volume ID (e.g., vol-59fcb34e).
 * `arn` - Volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
-* `availability_zone` - AZ where the EBS volume exists.
+* `availability_zone` - AZ where the EBS volume exists.        
+* `create_time` - The time stamp when volume creation was initiated.
 * `encrypted` - Whether the disk is encrypted.
 * `iops` - Amount of IOPS for the disk.
 * `multi_attach_enabled` - (Optional) Specifies whether Amazon EBS Multi-Attach is enabled.

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -33,31 +33,31 @@ data "aws_ebs_volume" "ebs_volume" {
 
 This data source supports the following arguments:
 
-* `most_recent` - (Optional) If more than one result is returned, use the most
-recent Volume.
 * `filter` - (Optional) One or more name/value pairs to filter off of. There are
 several valid keys, for a full reference, check out
 [describe-volumes in the AWS CLI reference][1].
+* `most_recent` - (Optional) If more than one result is returned, use the most
+recent Volume.
 
 ## Attribute Reference
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `id` - Volume ID (e.g., vol-59fcb34e).
-* `volume_id` - Volume ID (e.g., vol-59fcb34e).
 * `arn` - Volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
 * `availability_zone` - AZ where the EBS volume exists.
 * `create_time` - The time stamp when volume creation was initiated.
 * `encrypted` - Whether the disk is encrypted.
+* `id` - Volume ID (e.g., vol-59fcb34e).
 * `iops` - Amount of IOPS for the disk.
+* `kms_key_id` - ARN for the KMS encryption key.
 * `multi_attach_enabled` - (Optional) Specifies whether Amazon EBS Multi-Attach is enabled.
+* `outpost_arn` - ARN of the Outpost.
 * `size` - Size of the drive in GiBs.
 * `snapshot_id` - Snapshot_id the EBS volume is based off.
-* `outpost_arn` - ARN of the Outpost.
-* `volume_type` - Type of EBS volume.
-* `kms_key_id` - ARN for the KMS encryption key.
 * `tags` - Map of tags for the resource.
 * `throughput` - Throughput that the volume supports, in MiB/s.
+* `volume_id` - Volume ID (e.g., vol-59fcb34e).
+* `volume_type` - Type of EBS volume.
 
 ## Timeouts
 

--- a/website/docs/d/ebs_volume.html.markdown
+++ b/website/docs/d/ebs_volume.html.markdown
@@ -46,7 +46,7 @@ This data source exports the following attributes in addition to the arguments a
 * `id` - Volume ID (e.g., vol-59fcb34e).
 * `volume_id` - Volume ID (e.g., vol-59fcb34e).
 * `arn` - Volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
-* `availability_zone` - AZ where the EBS volume exists.        
+* `availability_zone` - AZ where the EBS volume exists.
 * `create_time` - The time stamp when volume creation was initiated.
 * `encrypted` - Whether the disk is encrypted.
 * `iops` - Amount of IOPS for the disk.

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -23,9 +23,9 @@ resource "aws_ebs_volume" "example" {
 }
 ```
 
-~> **NOTE:** At least one of `size` or `snapshot_id` is required when specifying an EBS volume
-
 ## Argument Reference
+
+~> **NOTE:** At least one of `size` or `snapshot_id` is required when specifying an EBS volume
 
 This resource supports the following arguments:
 
@@ -33,14 +33,14 @@ This resource supports the following arguments:
 * `encrypted` - (Optional) If true, the disk will be encrypted.
 * `final_snapshot` - (Optional) If true, snapshot will be created before volume deletion. Any tags on the volume will be migrated to the snapshot. By default set to false
 * `iops` - (Optional) The amount of IOPS to provision for the disk. Only valid for `type` of `io1`, `io2` or `gp3`.
+* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true. Note: Terraform must be running with credentials which have the `GenerateDataKeyWithoutPlaintext` permission on the specified KMS key as required by the [EBS KMS CMK volume provisioning process](https://docs.aws.amazon.com/kms/latest/developerguide/services-ebs.html#ebs-cmk) to prevent a volume from being created and almost immediately deleted.
 * `multi_attach_enabled` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on `io1` and `io2` volumes.
+* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
 * `size` - (Optional) The size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
-* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
-* `type` - (Optional) The type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true. Note: Terraform must be running with credentials which have the `GenerateDataKeyWithoutPlaintext` permission on the specified KMS key as required by the [EBS KMS CMK volume provisioning process](https://docs.aws.amazon.com/kms/latest/developerguide/services-ebs.html#ebs-cmk) to prevent a volume from being created and almost immediately deleted.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `throughput` - (Optional) The throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
+* `type` - (Optional) The type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
 
 ~> **NOTE:** When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of.
 
@@ -48,8 +48,9 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The volume ID (e.g., vol-59fcb34e).
 * `arn` - The volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
+* `create_time` - The time stamp when volume creation was initiated.
+* `id` - The volume ID (e.g., vol-59fcb34e).
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -25,22 +25,22 @@ resource "aws_ebs_volume" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** At least one of `size` or `snapshot_id` is required when specifying an EBS volume
+~> **NOTE:** At least one of `size` or `snapshot_id` is required.
 
 This resource supports the following arguments:
 
-* `availability_zone` - (Required) The AZ where the EBS volume will exist.
+* `availability_zone` - (Required) Availability zone where the EBS volume will exist.
 * `encrypted` - (Optional) If true, the disk will be encrypted.
 * `final_snapshot` - (Optional) If true, snapshot will be created before volume deletion. Any tags on the volume will be migrated to the snapshot. By default set to false
-* `iops` - (Optional) The amount of IOPS to provision for the disk. Only valid for `type` of `io1`, `io2` or `gp3`.
-* `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true. Note: Terraform must be running with credentials which have the `GenerateDataKeyWithoutPlaintext` permission on the specified KMS key as required by the [EBS KMS CMK volume provisioning process](https://docs.aws.amazon.com/kms/latest/developerguide/services-ebs.html#ebs-cmk) to prevent a volume from being created and almost immediately deleted.
+* `iops` - (Optional) Amount of IOPS to provision for the disk. Only valid for `type` of `io1`, `io2` or `gp3`.
+* `kms_key_id` - (Optional) ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true. Note: Terraform must be running with credentials which have the `GenerateDataKeyWithoutPlaintext` permission on the specified KMS key as required by the [EBS KMS CMK volume provisioning process](https://docs.aws.amazon.com/kms/latest/developerguide/services-ebs.html#ebs-cmk) to prevent a volume from being created and almost immediately deleted.
 * `multi_attach_enabled` - (Optional) Specifies whether to enable Amazon EBS Multi-Attach. Multi-Attach is supported on `io1` and `io2` volumes.
-* `outpost_arn` - (Optional) The Amazon Resource Name (ARN) of the Outpost.
-* `size` - (Optional) The size of the drive in GiBs.
+* `outpost_arn` - (Optional) Amazon Resource Name (ARN) of the Outpost.
+* `size` - (Optional) Size of the drive in GiBs.
 * `snapshot_id` (Optional) A snapshot to base the EBS volume off of.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
-* `throughput` - (Optional) The throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
-* `type` - (Optional) The type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
+* `throughput` - (Optional) Throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
+* `type` - (Optional) Type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
 
 ~> **NOTE:** When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of.
 
@@ -48,9 +48,9 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
-* `create_time` - The time stamp when volume creation was initiated.
-* `id` - The volume ID (e.g., vol-59fcb34e).
+* `arn` - Volume ARN (e.g., arn:aws:ec2:us-east-1:123456789012:volume/vol-59fcb34e).
+* `create_time` - Timestamp when volume creation was initiated.
+* `id` - Volume ID (e.g., vol-59fcb34e).
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
### Description

Add the attribute `create_time` to data source `aws_ebs_volume`

### Relations

Closes #41796 

### References

- [Data source documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ebs_volume)
- [API Documentation CreateVolume - ResponseElement](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVolume.html#API_CreateVolume_ResponseElements)

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccEC2EBSVolumeDataSource_basic PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2EBSVolumeDataSource_basic'  -timeout 360m -vet=off
2025/03/13 20:12:44 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2EBSVolumeDataSource_basic
=== PAUSE TestAccEC2EBSVolumeDataSource_basic
=== CONT  TestAccEC2EBSVolumeDataSource_basic
--- PASS: TestAccEC2EBSVolumeDataSource_basic (48.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        48.336s
...
```
