### PR TITLE
appmesh: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -75,6 +75,7 @@ jobs:
       - run: make TEST=./version/... modern-check
 
       # Services
+      - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/mq modern-check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -330,6 +330,10 @@ modern-check: prereq-go ## [CI] Check for modern Go code (best run in individual
 	@echo "make: Checking for modern Go code..."
 	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test $(TEST)
 
+modern-fix: prereq-go ## [CI] Fix checks for modern Go code (best run in individual services)
+	@echo "make: Fixing checks for modern Go code..."
+	@$(GO_VER) run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test $(TEST)
+
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \
 		echo "make: $(GO_VER) not found" ; \
@@ -707,7 +711,7 @@ ts: testacc-short ## Alias to testacc-short
 update: ## Update dependencies
 	@echo "make: Updating dependencies..."
 	$(GO_VER) get -u ./...
-	go mod tidy	
+	go mod tidy
 	cd ./tools/literally && $(GO_VER) get -u ./... && go mod tidy
 	cd ./tools/tfsdk2fw && $(GO_VER) get -u ./... && go mod tidy
 	cd .ci/tools && $(GO_VER) get -u && go mod tidy
@@ -893,6 +897,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	lint \
 	misspell \
 	modern-check \
+	modern-fix \
 	prereq-go \
 	provider-lint \
 	provider-markdown-lint \

--- a/internal/service/appmesh/flex.go
+++ b/internal/service/appmesh/flex.go
@@ -11,29 +11,29 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
+func expandClientPolicy(vClientPolicy []any) *awstypes.ClientPolicy {
 	if len(vClientPolicy) == 0 || vClientPolicy[0] == nil {
 		return nil
 	}
 
 	clientPolicy := &awstypes.ClientPolicy{}
 
-	mClientPolicy := vClientPolicy[0].(map[string]interface{})
+	mClientPolicy := vClientPolicy[0].(map[string]any)
 
-	if vTls, ok := mClientPolicy["tls"].([]interface{}); ok && len(vTls) > 0 && vTls[0] != nil {
+	if vTls, ok := mClientPolicy["tls"].([]any); ok && len(vTls) > 0 && vTls[0] != nil {
 		tls := &awstypes.ClientPolicyTls{}
 
-		mTls := vTls[0].(map[string]interface{})
+		mTls := vTls[0].(map[string]any)
 
-		if vCertificate, ok := mTls[names.AttrCertificate].([]interface{}); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
-			mCertificate := vCertificate[0].(map[string]interface{})
+		if vCertificate, ok := mTls[names.AttrCertificate].([]any); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
+			mCertificate := vCertificate[0].(map[string]any)
 
-			if vFile, ok := mCertificate["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+			if vFile, ok := mCertificate["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 				certificate := &awstypes.ClientTlsCertificateMemberFile{}
 
 				file := awstypes.ListenerTlsFileCertificate{}
 
-				mFile := vFile[0].(map[string]interface{})
+				mFile := vFile[0].(map[string]any)
 
 				if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 					file.CertificateChain = aws.String(vCertificateChain)
@@ -46,12 +46,12 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 				tls.Certificate = certificate
 			}
 
-			if vSds, ok := mCertificate["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+			if vSds, ok := mCertificate["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 				certificate := &awstypes.ClientTlsCertificateMemberSds{}
 
 				sds := awstypes.ListenerTlsSdsCertificate{}
 
-				mSds := vSds[0].(map[string]interface{})
+				mSds := vSds[0].(map[string]any)
 
 				if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 					sds.SecretName = aws.String(vSecretName)
@@ -70,20 +70,20 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 			tls.Ports = flex.ExpandInt32ValueSet(vPorts)
 		}
 
-		if vValidation, ok := mTls["validation"].([]interface{}); ok && len(vValidation) > 0 && vValidation[0] != nil {
+		if vValidation, ok := mTls["validation"].([]any); ok && len(vValidation) > 0 && vValidation[0] != nil {
 			validation := &awstypes.TlsValidationContext{}
 
-			mValidation := vValidation[0].(map[string]interface{})
+			mValidation := vValidation[0].(map[string]any)
 
-			if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]interface{}); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
+			if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]any); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
 				subjectAlternativeNames := &awstypes.SubjectAlternativeNames{}
 
-				mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]interface{})
+				mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]any)
 
-				if vMatch, ok := mSubjectAlternativeNames["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+				if vMatch, ok := mSubjectAlternativeNames["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 					match := &awstypes.SubjectAlternativeNameMatchers{}
 
-					mMatch := vMatch[0].(map[string]interface{})
+					mMatch := vMatch[0].(map[string]any)
 
 					if vExact, ok := mMatch["exact"].(*schema.Set); ok && vExact.Len() > 0 {
 						match.Exact = flex.ExpandStringValueSet(vExact)
@@ -95,15 +95,15 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 				validation.SubjectAlternativeNames = subjectAlternativeNames
 			}
 
-			if vTrust, ok := mValidation["trust"].([]interface{}); ok && len(vTrust) > 0 && vTrust[0] != nil {
-				mTrust := vTrust[0].(map[string]interface{})
+			if vTrust, ok := mValidation["trust"].([]any); ok && len(vTrust) > 0 && vTrust[0] != nil {
+				mTrust := vTrust[0].(map[string]any)
 
-				if vAcm, ok := mTrust["acm"].([]interface{}); ok && len(vAcm) > 0 && vAcm[0] != nil {
+				if vAcm, ok := mTrust["acm"].([]any); ok && len(vAcm) > 0 && vAcm[0] != nil {
 					trust := &awstypes.TlsValidationContextTrustMemberAcm{}
 
 					acm := awstypes.TlsValidationContextAcmTrust{}
 
-					mAcm := vAcm[0].(map[string]interface{})
+					mAcm := vAcm[0].(map[string]any)
 
 					if vCertificateAuthorityArns, ok := mAcm["certificate_authority_arns"].(*schema.Set); ok && vCertificateAuthorityArns.Len() > 0 {
 						acm.CertificateAuthorityArns = flex.ExpandStringValueSet(vCertificateAuthorityArns)
@@ -113,12 +113,12 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 					validation.Trust = trust
 				}
 
-				if vFile, ok := mTrust["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+				if vFile, ok := mTrust["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 					trust := &awstypes.TlsValidationContextTrustMemberFile{}
 
 					file := awstypes.TlsValidationContextFileTrust{}
 
-					mFile := vFile[0].(map[string]interface{})
+					mFile := vFile[0].(map[string]any)
 
 					if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 						file.CertificateChain = aws.String(vCertificateChain)
@@ -128,12 +128,12 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 					validation.Trust = trust
 				}
 
-				if vSds, ok := mTrust["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+				if vSds, ok := mTrust["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 					trust := &awstypes.TlsValidationContextTrustMemberSds{}
 
 					sds := awstypes.TlsValidationContextSdsTrust{}
 
-					mSds := vSds[0].(map[string]interface{})
+					mSds := vSds[0].(map[string]any)
 
 					if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 						sds.SecretName = aws.String(vSecretName)
@@ -153,14 +153,14 @@ func expandClientPolicy(vClientPolicy []interface{}) *awstypes.ClientPolicy {
 	return clientPolicy
 }
 
-func expandDuration(vDuration []interface{}) *awstypes.Duration {
+func expandDuration(vDuration []any) *awstypes.Duration {
 	if len(vDuration) == 0 || vDuration[0] == nil {
 		return nil
 	}
 
 	duration := &awstypes.Duration{}
 
-	mDuration := vDuration[0].(map[string]interface{})
+	mDuration := vDuration[0].(map[string]any)
 
 	if vUnit, ok := mDuration[names.AttrUnit].(string); ok && vUnit != "" {
 		duration.Unit = awstypes.DurationUnit(vUnit)
@@ -172,17 +172,17 @@ func expandDuration(vDuration []interface{}) *awstypes.Duration {
 	return duration
 }
 
-func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
+func expandGRPCRoute(vGrpcRoute []any) *awstypes.GrpcRoute {
 	if len(vGrpcRoute) == 0 || vGrpcRoute[0] == nil {
 		return nil
 	}
 
-	mGrpcRoute := vGrpcRoute[0].(map[string]interface{})
+	mGrpcRoute := vGrpcRoute[0].(map[string]any)
 
 	grpcRoute := &awstypes.GrpcRoute{}
 
-	if vGrpcRouteAction, ok := mGrpcRoute[names.AttrAction].([]interface{}); ok && len(vGrpcRouteAction) > 0 && vGrpcRouteAction[0] != nil {
-		mGrpcRouteAction := vGrpcRouteAction[0].(map[string]interface{})
+	if vGrpcRouteAction, ok := mGrpcRoute[names.AttrAction].([]any); ok && len(vGrpcRouteAction) > 0 && vGrpcRouteAction[0] != nil {
+		mGrpcRouteAction := vGrpcRouteAction[0].(map[string]any)
 
 		if vWeightedTargets, ok := mGrpcRouteAction["weighted_target"].(*schema.Set); ok && vWeightedTargets.Len() > 0 {
 			weightedTargets := []awstypes.WeightedTarget{}
@@ -190,7 +190,7 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 			for _, vWeightedTarget := range vWeightedTargets.List() {
 				weightedTarget := awstypes.WeightedTarget{}
 
-				mWeightedTarget := vWeightedTarget.(map[string]interface{})
+				mWeightedTarget := vWeightedTarget.(map[string]any)
 
 				if vPort, ok := mWeightedTarget[names.AttrPort].(int); ok && vPort > 0 {
 					weightedTarget.Port = aws.Int32(int32(vPort))
@@ -211,14 +211,14 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 		}
 	}
 
-	if vGrpcRouteMatch, ok := mGrpcRoute["match"].([]interface{}); ok {
+	if vGrpcRouteMatch, ok := mGrpcRoute["match"].([]any); ok {
 		grpcRouteMatch := &awstypes.GrpcRouteMatch{}
 
 		// Empty match is allowed.
 		// https://github.com/hashicorp/terraform-provider-aws/issues/16816.
 
 		if len(vGrpcRouteMatch) > 0 && vGrpcRouteMatch[0] != nil {
-			mGrpcRouteMatch := vGrpcRouteMatch[0].(map[string]interface{})
+			mGrpcRouteMatch := vGrpcRouteMatch[0].(map[string]any)
 
 			if vMethodName, ok := mGrpcRouteMatch["method_name"].(string); ok && vMethodName != "" {
 				grpcRouteMatch.MethodName = aws.String(vMethodName)
@@ -236,7 +236,7 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 				for _, vGrpcRouteMetadata := range vGrpcRouteMetadatas.List() {
 					grpcRouteMetadata := awstypes.GrpcRouteMetadata{}
 
-					mGrpcRouteMetadata := vGrpcRouteMetadata.(map[string]interface{})
+					mGrpcRouteMetadata := vGrpcRouteMetadata.(map[string]any)
 
 					if vInvert, ok := mGrpcRouteMetadata["invert"].(bool); ok {
 						grpcRouteMetadata.Invert = aws.Bool(vInvert)
@@ -245,8 +245,8 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 						grpcRouteMetadata.Name = aws.String(vName)
 					}
 
-					if vMatch, ok := mGrpcRouteMetadata["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
-						mMatch := vMatch[0].(map[string]interface{})
+					if vMatch, ok := mGrpcRouteMetadata["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
+						mMatch := vMatch[0].(map[string]any)
 
 						if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
 							grpcRouteMetadata.Match = &awstypes.GrpcRouteMetadataMatchMethodMemberExact{Value: vExact}
@@ -261,10 +261,10 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 							grpcRouteMetadata.Match = &awstypes.GrpcRouteMetadataMatchMethodMemberSuffix{Value: vSuffix}
 						}
 
-						if vRange, ok := mMatch["range"].([]interface{}); ok && len(vRange) > 0 && vRange[0] != nil {
+						if vRange, ok := mMatch["range"].([]any); ok && len(vRange) > 0 && vRange[0] != nil {
 							memberRange := &awstypes.GrpcRouteMetadataMatchMethodMemberRange{}
 
-							mRange := vRange[0].(map[string]interface{})
+							mRange := vRange[0].(map[string]any)
 
 							if vEnd, ok := mRange["end"].(int); ok && vEnd > 0 {
 								memberRange.Value.End = aws.Int64(int64(vEnd))
@@ -287,10 +287,10 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 		grpcRoute.Match = grpcRouteMatch
 	}
 
-	if vGrpcRetryPolicy, ok := mGrpcRoute["retry_policy"].([]interface{}); ok && len(vGrpcRetryPolicy) > 0 && vGrpcRetryPolicy[0] != nil {
+	if vGrpcRetryPolicy, ok := mGrpcRoute["retry_policy"].([]any); ok && len(vGrpcRetryPolicy) > 0 && vGrpcRetryPolicy[0] != nil {
 		grpcRetryPolicy := &awstypes.GrpcRetryPolicy{}
 
-		mGrpcRetryPolicy := vGrpcRetryPolicy[0].(map[string]interface{})
+		mGrpcRetryPolicy := vGrpcRetryPolicy[0].(map[string]any)
 
 		if vMaxRetries, ok := mGrpcRetryPolicy["max_retries"].(int); ok {
 			grpcRetryPolicy.MaxRetries = aws.Int64(int64(vMaxRetries))
@@ -304,7 +304,7 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 			grpcRetryPolicy.HttpRetryEvents = flex.ExpandStringValueSet(vHttpRetryEvents)
 		}
 
-		if vPerRetryTimeout, ok := mGrpcRetryPolicy["per_retry_timeout"].([]interface{}); ok {
+		if vPerRetryTimeout, ok := mGrpcRetryPolicy["per_retry_timeout"].([]any); ok {
 			grpcRetryPolicy.PerRetryTimeout = expandDuration(vPerRetryTimeout)
 		}
 
@@ -315,44 +315,44 @@ func expandGRPCRoute(vGrpcRoute []interface{}) *awstypes.GrpcRoute {
 		grpcRoute.RetryPolicy = grpcRetryPolicy
 	}
 
-	if vGrpcTimeout, ok := mGrpcRoute[names.AttrTimeout].([]interface{}); ok {
+	if vGrpcTimeout, ok := mGrpcRoute[names.AttrTimeout].([]any); ok {
 		grpcRoute.Timeout = expandGRPCTimeout(vGrpcTimeout)
 	}
 
 	return grpcRoute
 }
 
-func expandGRPCTimeout(vGrpcTimeout []interface{}) *awstypes.GrpcTimeout {
+func expandGRPCTimeout(vGrpcTimeout []any) *awstypes.GrpcTimeout {
 	if len(vGrpcTimeout) == 0 || vGrpcTimeout[0] == nil {
 		return nil
 	}
 
 	grpcTimeout := &awstypes.GrpcTimeout{}
 
-	mGrpcTimeout := vGrpcTimeout[0].(map[string]interface{})
+	mGrpcTimeout := vGrpcTimeout[0].(map[string]any)
 
-	if vIdleTimeout, ok := mGrpcTimeout["idle"].([]interface{}); ok {
+	if vIdleTimeout, ok := mGrpcTimeout["idle"].([]any); ok {
 		grpcTimeout.Idle = expandDuration(vIdleTimeout)
 	}
 
-	if vPerRequestTimeout, ok := mGrpcTimeout["per_request"].([]interface{}); ok {
+	if vPerRequestTimeout, ok := mGrpcTimeout["per_request"].([]any); ok {
 		grpcTimeout.PerRequest = expandDuration(vPerRequestTimeout)
 	}
 
 	return grpcTimeout
 }
 
-func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
+func expandHTTPRoute(vHttpRoute []any) *awstypes.HttpRoute {
 	if len(vHttpRoute) == 0 || vHttpRoute[0] == nil {
 		return nil
 	}
 
-	mHttpRoute := vHttpRoute[0].(map[string]interface{})
+	mHttpRoute := vHttpRoute[0].(map[string]any)
 
 	httpRoute := &awstypes.HttpRoute{}
 
-	if vHttpRouteAction, ok := mHttpRoute[names.AttrAction].([]interface{}); ok && len(vHttpRouteAction) > 0 && vHttpRouteAction[0] != nil {
-		mHttpRouteAction := vHttpRouteAction[0].(map[string]interface{})
+	if vHttpRouteAction, ok := mHttpRoute[names.AttrAction].([]any); ok && len(vHttpRouteAction) > 0 && vHttpRouteAction[0] != nil {
+		mHttpRouteAction := vHttpRouteAction[0].(map[string]any)
 
 		if vWeightedTargets, ok := mHttpRouteAction["weighted_target"].(*schema.Set); ok && vWeightedTargets.Len() > 0 {
 			weightedTargets := []awstypes.WeightedTarget{}
@@ -360,7 +360,7 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 			for _, vWeightedTarget := range vWeightedTargets.List() {
 				weightedTarget := awstypes.WeightedTarget{}
 
-				mWeightedTarget := vWeightedTarget.(map[string]interface{})
+				mWeightedTarget := vWeightedTarget.(map[string]any)
 
 				if vPort, ok := mWeightedTarget[names.AttrPort].(int); ok && vPort > 0 {
 					weightedTarget.Port = aws.Int32(int32(vPort))
@@ -381,10 +381,10 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 		}
 	}
 
-	if vHttpRouteMatch, ok := mHttpRoute["match"].([]interface{}); ok && len(vHttpRouteMatch) > 0 && vHttpRouteMatch[0] != nil {
+	if vHttpRouteMatch, ok := mHttpRoute["match"].([]any); ok && len(vHttpRouteMatch) > 0 && vHttpRouteMatch[0] != nil {
 		httpRouteMatch := &awstypes.HttpRouteMatch{}
 
-		mHttpRouteMatch := vHttpRouteMatch[0].(map[string]interface{})
+		mHttpRouteMatch := vHttpRouteMatch[0].(map[string]any)
 
 		if vMethod, ok := mHttpRouteMatch["method"].(string); ok && vMethod != "" {
 			httpRouteMatch.Method = awstypes.HttpMethod(vMethod)
@@ -405,7 +405,7 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 			for _, vHttpRouteHeader := range vHttpRouteHeaders.List() {
 				httpRouteHeader := awstypes.HttpRouteHeader{}
 
-				mHttpRouteHeader := vHttpRouteHeader.(map[string]interface{})
+				mHttpRouteHeader := vHttpRouteHeader.(map[string]any)
 
 				if vInvert, ok := mHttpRouteHeader["invert"].(bool); ok {
 					httpRouteHeader.Invert = aws.Bool(vInvert)
@@ -414,8 +414,8 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 					httpRouteHeader.Name = aws.String(vName)
 				}
 
-				if vMatch, ok := mHttpRouteHeader["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
-					mMatch := vMatch[0].(map[string]interface{})
+				if vMatch, ok := mHttpRouteHeader["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
+					mMatch := vMatch[0].(map[string]any)
 
 					if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
 						httpRouteHeader.Match = &awstypes.HeaderMatchMethodMemberExact{Value: vExact}
@@ -430,10 +430,10 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 						httpRouteHeader.Match = &awstypes.HeaderMatchMethodMemberSuffix{Value: vSuffix}
 					}
 
-					if vRange, ok := mMatch["range"].([]interface{}); ok && len(vRange) > 0 && vRange[0] != nil {
+					if vRange, ok := mMatch["range"].([]any); ok && len(vRange) > 0 && vRange[0] != nil {
 						memberRange := &awstypes.HeaderMatchMethodMemberRange{}
 
-						mRange := vRange[0].(map[string]interface{})
+						mRange := vRange[0].(map[string]any)
 
 						if vEnd, ok := mRange["end"].(int); ok && vEnd > 0 {
 							memberRange.Value.End = aws.Int64(int64(vEnd))
@@ -452,10 +452,10 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 			httpRouteMatch.Headers = httpRouteHeaders
 		}
 
-		if vHttpRoutePath, ok := mHttpRouteMatch[names.AttrPath].([]interface{}); ok && len(vHttpRoutePath) > 0 && vHttpRoutePath[0] != nil {
+		if vHttpRoutePath, ok := mHttpRouteMatch[names.AttrPath].([]any); ok && len(vHttpRoutePath) > 0 && vHttpRoutePath[0] != nil {
 			httpRoutePath := &awstypes.HttpPathMatch{}
 
-			mHttpRoutePath := vHttpRoutePath[0].(map[string]interface{})
+			mHttpRoutePath := vHttpRoutePath[0].(map[string]any)
 
 			if vExact, ok := mHttpRoutePath["exact"].(string); ok && vExact != "" {
 				httpRoutePath.Exact = aws.String(vExact)
@@ -473,16 +473,16 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 			for _, vHttpRouteQueryParameter := range vHttpRouteQueryParameters.List() {
 				httpRouteQueryParameter := awstypes.HttpQueryParameter{}
 
-				mHttpRouteQueryParameter := vHttpRouteQueryParameter.(map[string]interface{})
+				mHttpRouteQueryParameter := vHttpRouteQueryParameter.(map[string]any)
 
 				if vName, ok := mHttpRouteQueryParameter[names.AttrName].(string); ok && vName != "" {
 					httpRouteQueryParameter.Name = aws.String(vName)
 				}
 
-				if vMatch, ok := mHttpRouteQueryParameter["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+				if vMatch, ok := mHttpRouteQueryParameter["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 					httpRouteQueryParameter.Match = &awstypes.QueryParameterMatch{}
 
-					mMatch := vMatch[0].(map[string]interface{})
+					mMatch := vMatch[0].(map[string]any)
 
 					if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
 						httpRouteQueryParameter.Match.Exact = aws.String(vExact)
@@ -498,10 +498,10 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 		httpRoute.Match = httpRouteMatch
 	}
 
-	if vHttpRetryPolicy, ok := mHttpRoute["retry_policy"].([]interface{}); ok && len(vHttpRetryPolicy) > 0 && vHttpRetryPolicy[0] != nil {
+	if vHttpRetryPolicy, ok := mHttpRoute["retry_policy"].([]any); ok && len(vHttpRetryPolicy) > 0 && vHttpRetryPolicy[0] != nil {
 		httpRetryPolicy := &awstypes.HttpRetryPolicy{}
 
-		mHttpRetryPolicy := vHttpRetryPolicy[0].(map[string]interface{})
+		mHttpRetryPolicy := vHttpRetryPolicy[0].(map[string]any)
 
 		if vMaxRetries, ok := mHttpRetryPolicy["max_retries"].(int); ok {
 			httpRetryPolicy.MaxRetries = aws.Int64(int64(vMaxRetries))
@@ -511,7 +511,7 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 			httpRetryPolicy.HttpRetryEvents = flex.ExpandStringValueSet(vHttpRetryEvents)
 		}
 
-		if vPerRetryTimeout, ok := mHttpRetryPolicy["per_retry_timeout"].([]interface{}); ok {
+		if vPerRetryTimeout, ok := mHttpRetryPolicy["per_retry_timeout"].([]any); ok {
 			httpRetryPolicy.PerRetryTimeout = expandDuration(vPerRetryTimeout)
 		}
 
@@ -522,44 +522,44 @@ func expandHTTPRoute(vHttpRoute []interface{}) *awstypes.HttpRoute {
 		httpRoute.RetryPolicy = httpRetryPolicy
 	}
 
-	if vHttpTimeout, ok := mHttpRoute[names.AttrTimeout].([]interface{}); ok {
+	if vHttpTimeout, ok := mHttpRoute[names.AttrTimeout].([]any); ok {
 		httpRoute.Timeout = expandHTTPTimeout(vHttpTimeout)
 	}
 
 	return httpRoute
 }
 
-func expandHTTPTimeout(vHttpTimeout []interface{}) *awstypes.HttpTimeout {
+func expandHTTPTimeout(vHttpTimeout []any) *awstypes.HttpTimeout {
 	if len(vHttpTimeout) == 0 || vHttpTimeout[0] == nil {
 		return nil
 	}
 
 	httpTimeout := &awstypes.HttpTimeout{}
 
-	mHttpTimeout := vHttpTimeout[0].(map[string]interface{})
+	mHttpTimeout := vHttpTimeout[0].(map[string]any)
 
-	if vIdleTimeout, ok := mHttpTimeout["idle"].([]interface{}); ok {
+	if vIdleTimeout, ok := mHttpTimeout["idle"].([]any); ok {
 		httpTimeout.Idle = expandDuration(vIdleTimeout)
 	}
 
-	if vPerRequestTimeout, ok := mHttpTimeout["per_request"].([]interface{}); ok {
+	if vPerRequestTimeout, ok := mHttpTimeout["per_request"].([]any); ok {
 		httpTimeout.PerRequest = expandDuration(vPerRequestTimeout)
 	}
 
 	return httpTimeout
 }
 
-func expandMeshSpec(vSpec []interface{}) *awstypes.MeshSpec {
+func expandMeshSpec(vSpec []any) *awstypes.MeshSpec {
 	spec := &awstypes.MeshSpec{}
 
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		// Empty Spec is allowed.
 		return spec
 	}
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vEgressFilter, ok := mSpec["egress_filter"].([]interface{}); ok && len(vEgressFilter) > 0 && vEgressFilter[0] != nil {
-		mEgressFilter := vEgressFilter[0].(map[string]interface{})
+	if vEgressFilter, ok := mSpec["egress_filter"].([]any); ok && len(vEgressFilter) > 0 && vEgressFilter[0] != nil {
+		mEgressFilter := vEgressFilter[0].(map[string]any)
 
 		if vType, ok := mEgressFilter[names.AttrType].(string); ok && vType != "" {
 			spec.EgressFilter = &awstypes.EgressFilter{
@@ -568,8 +568,8 @@ func expandMeshSpec(vSpec []interface{}) *awstypes.MeshSpec {
 		}
 	}
 
-	if vServiceDiscovery, ok := mSpec["service_discovery"].([]interface{}); ok && len(vServiceDiscovery) > 0 && vServiceDiscovery[0] != nil {
-		mServiceDiscovery := vServiceDiscovery[0].(map[string]interface{})
+	if vServiceDiscovery, ok := mSpec["service_discovery"].([]any); ok && len(vServiceDiscovery) > 0 && vServiceDiscovery[0] != nil {
+		mServiceDiscovery := vServiceDiscovery[0].(map[string]any)
 
 		if vIpPreference, ok := mServiceDiscovery["ip_preference"].(string); ok && vIpPreference != "" {
 			spec.ServiceDiscovery = &awstypes.MeshServiceDiscovery{
@@ -581,24 +581,24 @@ func expandMeshSpec(vSpec []interface{}) *awstypes.MeshSpec {
 	return spec
 }
 
-func expandRouteSpec(vSpec []interface{}) *awstypes.RouteSpec {
+func expandRouteSpec(vSpec []any) *awstypes.RouteSpec {
 	spec := &awstypes.RouteSpec{}
 
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		// Empty Spec is allowed.
 		return spec
 	}
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vGrpcRoute, ok := mSpec["grpc_route"].([]interface{}); ok {
+	if vGrpcRoute, ok := mSpec["grpc_route"].([]any); ok {
 		spec.GrpcRoute = expandGRPCRoute(vGrpcRoute)
 	}
 
-	if vHttp2Route, ok := mSpec["http2_route"].([]interface{}); ok {
+	if vHttp2Route, ok := mSpec["http2_route"].([]any); ok {
 		spec.Http2Route = expandHTTPRoute(vHttp2Route)
 	}
 
-	if vHttpRoute, ok := mSpec["http_route"].([]interface{}); ok {
+	if vHttpRoute, ok := mSpec["http_route"].([]any); ok {
 		spec.HttpRoute = expandHTTPRoute(vHttpRoute)
 	}
 
@@ -606,24 +606,24 @@ func expandRouteSpec(vSpec []interface{}) *awstypes.RouteSpec {
 		spec.Priority = aws.Int32(int32(vPriority))
 	}
 
-	if vTcpRoute, ok := mSpec["tcp_route"].([]interface{}); ok {
+	if vTcpRoute, ok := mSpec["tcp_route"].([]any); ok {
 		spec.TcpRoute = expandTCPRoute(vTcpRoute)
 	}
 
 	return spec
 }
 
-func expandTCPRoute(vTcpRoute []interface{}) *awstypes.TcpRoute {
+func expandTCPRoute(vTcpRoute []any) *awstypes.TcpRoute {
 	if len(vTcpRoute) == 0 || vTcpRoute[0] == nil {
 		return nil
 	}
 
-	mTcpRoute := vTcpRoute[0].(map[string]interface{})
+	mTcpRoute := vTcpRoute[0].(map[string]any)
 
 	tcpRoute := &awstypes.TcpRoute{}
 
-	if vTcpRouteAction, ok := mTcpRoute[names.AttrAction].([]interface{}); ok && len(vTcpRouteAction) > 0 && vTcpRouteAction[0] != nil {
-		mTcpRouteAction := vTcpRouteAction[0].(map[string]interface{})
+	if vTcpRouteAction, ok := mTcpRoute[names.AttrAction].([]any); ok && len(vTcpRouteAction) > 0 && vTcpRouteAction[0] != nil {
+		mTcpRouteAction := vTcpRouteAction[0].(map[string]any)
 
 		if vWeightedTargets, ok := mTcpRouteAction["weighted_target"].(*schema.Set); ok && vWeightedTargets.Len() > 0 {
 			weightedTargets := []awstypes.WeightedTarget{}
@@ -631,7 +631,7 @@ func expandTCPRoute(vTcpRoute []interface{}) *awstypes.TcpRoute {
 			for _, vWeightedTarget := range vWeightedTargets.List() {
 				weightedTarget := awstypes.WeightedTarget{}
 
-				mWeightedTarget := vWeightedTarget.(map[string]interface{})
+				mWeightedTarget := vWeightedTarget.(map[string]any)
 
 				if vPort, ok := mWeightedTarget[names.AttrPort].(int); ok && vPort > 0 {
 					weightedTarget.Port = aws.Int32(int32(vPort))
@@ -652,10 +652,10 @@ func expandTCPRoute(vTcpRoute []interface{}) *awstypes.TcpRoute {
 		}
 	}
 
-	if vTcpRouteMatch, ok := mTcpRoute["match"].([]interface{}); ok && len(vTcpRouteMatch) > 0 && vTcpRouteMatch[0] != nil {
+	if vTcpRouteMatch, ok := mTcpRoute["match"].([]any); ok && len(vTcpRouteMatch) > 0 && vTcpRouteMatch[0] != nil {
 		tcpRouteMatch := &awstypes.TcpRouteMatch{}
 
-		mTcpRouteMatch := vTcpRouteMatch[0].(map[string]interface{})
+		mTcpRouteMatch := vTcpRouteMatch[0].(map[string]any)
 
 		if vPort, ok := mTcpRouteMatch[names.AttrPort].(int); ok && vPort > 0 {
 			tcpRouteMatch.Port = aws.Int32(int32(vPort))
@@ -664,55 +664,55 @@ func expandTCPRoute(vTcpRoute []interface{}) *awstypes.TcpRoute {
 		tcpRoute.Match = tcpRouteMatch
 	}
 
-	if vTcpTimeout, ok := mTcpRoute[names.AttrTimeout].([]interface{}); ok {
+	if vTcpTimeout, ok := mTcpRoute[names.AttrTimeout].([]any); ok {
 		tcpRoute.Timeout = expandTCPTimeout(vTcpTimeout)
 	}
 
 	return tcpRoute
 }
 
-func expandTCPTimeout(vTcpTimeout []interface{}) *awstypes.TcpTimeout {
+func expandTCPTimeout(vTcpTimeout []any) *awstypes.TcpTimeout {
 	if len(vTcpTimeout) == 0 || vTcpTimeout[0] == nil {
 		return nil
 	}
 
 	tcpTimeout := &awstypes.TcpTimeout{}
 
-	mTcpTimeout := vTcpTimeout[0].(map[string]interface{})
+	mTcpTimeout := vTcpTimeout[0].(map[string]any)
 
-	if vIdleTimeout, ok := mTcpTimeout["idle"].([]interface{}); ok {
+	if vIdleTimeout, ok := mTcpTimeout["idle"].([]any); ok {
 		tcpTimeout.Idle = expandDuration(vIdleTimeout)
 	}
 
 	return tcpTimeout
 }
 
-func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
+func expandVirtualNodeSpec(vSpec []any) *awstypes.VirtualNodeSpec {
 	spec := &awstypes.VirtualNodeSpec{}
 
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		// Empty Spec is allowed.
 		return spec
 	}
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
 	if vBackends, ok := mSpec["backend"].(*schema.Set); ok && vBackends.Len() > 0 {
 		backends := []awstypes.Backend{}
 
 		for _, vBackend := range vBackends.List() {
 			backend := &awstypes.BackendMemberVirtualService{}
-			mBackend := vBackend.(map[string]interface{})
+			mBackend := vBackend.(map[string]any)
 
-			if vVirtualService, ok := mBackend["virtual_service"].([]interface{}); ok && len(vVirtualService) > 0 && vVirtualService[0] != nil {
+			if vVirtualService, ok := mBackend["virtual_service"].([]any); ok && len(vVirtualService) > 0 && vVirtualService[0] != nil {
 				virtualService := awstypes.VirtualServiceBackend{}
 
-				mVirtualService := vVirtualService[0].(map[string]interface{})
+				mVirtualService := vVirtualService[0].(map[string]any)
 
 				if vVirtualServiceName, ok := mVirtualService["virtual_service_name"].(string); ok {
 					virtualService.VirtualServiceName = aws.String(vVirtualServiceName)
 				}
 
-				if vClientPolicy, ok := mVirtualService["client_policy"].([]interface{}); ok {
+				if vClientPolicy, ok := mVirtualService["client_policy"].([]any); ok {
 					virtualService.ClientPolicy = expandClientPolicy(vClientPolicy)
 				}
 
@@ -724,33 +724,33 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 		spec.Backends = backends
 	}
 
-	if vBackendDefaults, ok := mSpec["backend_defaults"].([]interface{}); ok && len(vBackendDefaults) > 0 && vBackendDefaults[0] != nil {
+	if vBackendDefaults, ok := mSpec["backend_defaults"].([]any); ok && len(vBackendDefaults) > 0 && vBackendDefaults[0] != nil {
 		backendDefaults := &awstypes.BackendDefaults{}
 
-		mBackendDefaults := vBackendDefaults[0].(map[string]interface{})
+		mBackendDefaults := vBackendDefaults[0].(map[string]any)
 
-		if vClientPolicy, ok := mBackendDefaults["client_policy"].([]interface{}); ok {
+		if vClientPolicy, ok := mBackendDefaults["client_policy"].([]any); ok {
 			backendDefaults.ClientPolicy = expandClientPolicy(vClientPolicy)
 		}
 
 		spec.BackendDefaults = backendDefaults
 	}
 
-	if vListeners, ok := mSpec["listener"].([]interface{}); ok && len(vListeners) > 0 && vListeners[0] != nil {
+	if vListeners, ok := mSpec["listener"].([]any); ok && len(vListeners) > 0 && vListeners[0] != nil {
 		listeners := []awstypes.Listener{}
 
 		for _, vListener := range vListeners {
 			listener := awstypes.Listener{}
 
-			mListener := vListener.(map[string]interface{})
+			mListener := vListener.(map[string]any)
 
-			if vConnectionPool, ok := mListener["connection_pool"].([]interface{}); ok && len(vConnectionPool) > 0 && vConnectionPool[0] != nil {
-				mConnectionPool := vConnectionPool[0].(map[string]interface{})
+			if vConnectionPool, ok := mListener["connection_pool"].([]any); ok && len(vConnectionPool) > 0 && vConnectionPool[0] != nil {
+				mConnectionPool := vConnectionPool[0].(map[string]any)
 
-				if vGrpcConnectionPool, ok := mConnectionPool["grpc"].([]interface{}); ok && len(vGrpcConnectionPool) > 0 && vGrpcConnectionPool[0] != nil {
+				if vGrpcConnectionPool, ok := mConnectionPool["grpc"].([]any); ok && len(vGrpcConnectionPool) > 0 && vGrpcConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualNodeConnectionPoolMemberGrpc{}
 
-					mGrpcConnectionPool := vGrpcConnectionPool[0].(map[string]interface{})
+					mGrpcConnectionPool := vGrpcConnectionPool[0].(map[string]any)
 
 					grpcConnectionPool := awstypes.VirtualNodeGrpcConnectionPool{}
 
@@ -762,10 +762,10 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 					listener.ConnectionPool = connectionPool
 				}
 
-				if vHttpConnectionPool, ok := mConnectionPool["http"].([]interface{}); ok && len(vHttpConnectionPool) > 0 && vHttpConnectionPool[0] != nil {
+				if vHttpConnectionPool, ok := mConnectionPool["http"].([]any); ok && len(vHttpConnectionPool) > 0 && vHttpConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualNodeConnectionPoolMemberHttp{}
 
-					mHttpConnectionPool := vHttpConnectionPool[0].(map[string]interface{})
+					mHttpConnectionPool := vHttpConnectionPool[0].(map[string]any)
 
 					httpConnectionPool := awstypes.VirtualNodeHttpConnectionPool{}
 
@@ -780,10 +780,10 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 					listener.ConnectionPool = connectionPool
 				}
 
-				if vHttp2ConnectionPool, ok := mConnectionPool["http2"].([]interface{}); ok && len(vHttp2ConnectionPool) > 0 && vHttp2ConnectionPool[0] != nil {
+				if vHttp2ConnectionPool, ok := mConnectionPool["http2"].([]any); ok && len(vHttp2ConnectionPool) > 0 && vHttp2ConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualNodeConnectionPoolMemberHttp2{}
 
-					mHttp2ConnectionPool := vHttp2ConnectionPool[0].(map[string]interface{})
+					mHttp2ConnectionPool := vHttp2ConnectionPool[0].(map[string]any)
 
 					http2ConnectionPool := awstypes.VirtualNodeHttp2ConnectionPool{}
 
@@ -795,10 +795,10 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 					listener.ConnectionPool = connectionPool
 				}
 
-				if vTcpConnectionPool, ok := mConnectionPool["tcp"].([]interface{}); ok && len(vTcpConnectionPool) > 0 && vTcpConnectionPool[0] != nil {
+				if vTcpConnectionPool, ok := mConnectionPool["tcp"].([]any); ok && len(vTcpConnectionPool) > 0 && vTcpConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualNodeConnectionPoolMemberTcp{}
 
-					mTcpConnectionPool := vTcpConnectionPool[0].(map[string]interface{})
+					mTcpConnectionPool := vTcpConnectionPool[0].(map[string]any)
 
 					tcpConnectionPool := awstypes.VirtualNodeTcpConnectionPool{}
 
@@ -811,10 +811,10 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 				}
 			}
 
-			if vHealthCheck, ok := mListener[names.AttrHealthCheck].([]interface{}); ok && len(vHealthCheck) > 0 && vHealthCheck[0] != nil {
+			if vHealthCheck, ok := mListener[names.AttrHealthCheck].([]any); ok && len(vHealthCheck) > 0 && vHealthCheck[0] != nil {
 				healthCheck := &awstypes.HealthCheckPolicy{}
 
-				mHealthCheck := vHealthCheck[0].(map[string]interface{})
+				mHealthCheck := vHealthCheck[0].(map[string]any)
 
 				if vHealthyThreshold, ok := mHealthCheck["healthy_threshold"].(int); ok && vHealthyThreshold > 0 {
 					healthCheck.HealthyThreshold = aws.Int32(int32(vHealthyThreshold))
@@ -841,10 +841,10 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 				listener.HealthCheck = healthCheck
 			}
 
-			if vOutlierDetection, ok := mListener["outlier_detection"].([]interface{}); ok && len(vOutlierDetection) > 0 && vOutlierDetection[0] != nil {
+			if vOutlierDetection, ok := mListener["outlier_detection"].([]any); ok && len(vOutlierDetection) > 0 && vOutlierDetection[0] != nil {
 				outlierDetection := &awstypes.OutlierDetection{}
 
-				mOutlierDetection := vOutlierDetection[0].(map[string]interface{})
+				mOutlierDetection := vOutlierDetection[0].(map[string]any)
 
 				if vMaxEjectionPercent, ok := mOutlierDetection["max_ejection_percent"].(int); ok && vMaxEjectionPercent > 0 {
 					outlierDetection.MaxEjectionPercent = aws.Int32(int32(vMaxEjectionPercent))
@@ -853,21 +853,21 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 					outlierDetection.MaxServerErrors = aws.Int64(int64(vMaxServerErrors))
 				}
 
-				if vBaseEjectionDuration, ok := mOutlierDetection["base_ejection_duration"].([]interface{}); ok {
+				if vBaseEjectionDuration, ok := mOutlierDetection["base_ejection_duration"].([]any); ok {
 					outlierDetection.BaseEjectionDuration = expandDuration(vBaseEjectionDuration)
 				}
 
-				if vInterval, ok := mOutlierDetection[names.AttrInterval].([]interface{}); ok {
+				if vInterval, ok := mOutlierDetection[names.AttrInterval].([]any); ok {
 					outlierDetection.Interval = expandDuration(vInterval)
 				}
 
 				listener.OutlierDetection = outlierDetection
 			}
 
-			if vPortMapping, ok := mListener["port_mapping"].([]interface{}); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
+			if vPortMapping, ok := mListener["port_mapping"].([]any); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
 				portMapping := &awstypes.PortMapping{}
 
-				mPortMapping := vPortMapping[0].(map[string]interface{})
+				mPortMapping := vPortMapping[0].(map[string]any)
 
 				if vPort, ok := mPortMapping[names.AttrPort].(int); ok && vPort > 0 {
 					portMapping.Port = aws.Int32(int32(vPort))
@@ -879,43 +879,43 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 				listener.PortMapping = portMapping
 			}
 
-			if vTimeout, ok := mListener[names.AttrTimeout].([]interface{}); ok && len(vTimeout) > 0 && vTimeout[0] != nil {
-				mTimeout := vTimeout[0].(map[string]interface{})
+			if vTimeout, ok := mListener[names.AttrTimeout].([]any); ok && len(vTimeout) > 0 && vTimeout[0] != nil {
+				mTimeout := vTimeout[0].(map[string]any)
 
-				if vGrpcTimeout, ok := mTimeout["grpc"].([]interface{}); ok && len(vGrpcTimeout) > 0 && vGrpcTimeout[0] != nil {
+				if vGrpcTimeout, ok := mTimeout["grpc"].([]any); ok && len(vGrpcTimeout) > 0 && vGrpcTimeout[0] != nil {
 					listener.Timeout = &awstypes.ListenerTimeoutMemberGrpc{Value: *expandGRPCTimeout(vGrpcTimeout)}
 				}
 
-				if vHttpTimeout, ok := mTimeout["http"].([]interface{}); ok && len(vHttpTimeout) > 0 && vHttpTimeout[0] != nil {
+				if vHttpTimeout, ok := mTimeout["http"].([]any); ok && len(vHttpTimeout) > 0 && vHttpTimeout[0] != nil {
 					listener.Timeout = &awstypes.ListenerTimeoutMemberHttp{Value: *expandHTTPTimeout(vHttpTimeout)}
 				}
 
-				if vHttp2Timeout, ok := mTimeout["http2"].([]interface{}); ok && len(vHttp2Timeout) > 0 && vHttp2Timeout[0] != nil {
+				if vHttp2Timeout, ok := mTimeout["http2"].([]any); ok && len(vHttp2Timeout) > 0 && vHttp2Timeout[0] != nil {
 					listener.Timeout = &awstypes.ListenerTimeoutMemberHttp2{Value: *expandHTTPTimeout(vHttp2Timeout)}
 				}
 
-				if vTcpTimeout, ok := mTimeout["tcp"].([]interface{}); ok && len(vTcpTimeout) > 0 && vTcpTimeout[0] != nil {
+				if vTcpTimeout, ok := mTimeout["tcp"].([]any); ok && len(vTcpTimeout) > 0 && vTcpTimeout[0] != nil {
 					listener.Timeout = &awstypes.ListenerTimeoutMemberTcp{Value: *expandTCPTimeout(vTcpTimeout)}
 				}
 			}
 
-			if vTls, ok := mListener["tls"].([]interface{}); ok && len(vTls) > 0 && vTls[0] != nil {
+			if vTls, ok := mListener["tls"].([]any); ok && len(vTls) > 0 && vTls[0] != nil {
 				tls := &awstypes.ListenerTls{}
 
-				mTls := vTls[0].(map[string]interface{})
+				mTls := vTls[0].(map[string]any)
 
 				if vMode, ok := mTls[names.AttrMode].(string); ok && vMode != "" {
 					tls.Mode = awstypes.ListenerTlsMode(vMode)
 				}
 
-				if vCertificate, ok := mTls[names.AttrCertificate].([]interface{}); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
-					mCertificate := vCertificate[0].(map[string]interface{})
+				if vCertificate, ok := mTls[names.AttrCertificate].([]any); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
+					mCertificate := vCertificate[0].(map[string]any)
 
-					if vAcm, ok := mCertificate["acm"].([]interface{}); ok && len(vAcm) > 0 && vAcm[0] != nil {
+					if vAcm, ok := mCertificate["acm"].([]any); ok && len(vAcm) > 0 && vAcm[0] != nil {
 						certificate := &awstypes.ListenerTlsCertificateMemberAcm{}
 						acm := awstypes.ListenerTlsAcmCertificate{}
 
-						mAcm := vAcm[0].(map[string]interface{})
+						mAcm := vAcm[0].(map[string]any)
 
 						if vCertificateArn, ok := mAcm[names.AttrCertificateARN].(string); ok && vCertificateArn != "" {
 							acm.CertificateArn = aws.String(vCertificateArn)
@@ -925,12 +925,12 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 						tls.Certificate = certificate
 					}
 
-					if vFile, ok := mCertificate["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+					if vFile, ok := mCertificate["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 						certificate := &awstypes.ListenerTlsCertificateMemberFile{}
 
 						file := awstypes.ListenerTlsFileCertificate{}
 
-						mFile := vFile[0].(map[string]interface{})
+						mFile := vFile[0].(map[string]any)
 
 						if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 							file.CertificateChain = aws.String(vCertificateChain)
@@ -943,12 +943,12 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 						tls.Certificate = certificate
 					}
 
-					if vSds, ok := mCertificate["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+					if vSds, ok := mCertificate["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 						certificate := &awstypes.ListenerTlsCertificateMemberSds{}
 
 						sds := awstypes.ListenerTlsSdsCertificate{}
 
-						mSds := vSds[0].(map[string]interface{})
+						mSds := vSds[0].(map[string]any)
 
 						if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 							sds.SecretName = aws.String(vSecretName)
@@ -959,20 +959,20 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 					}
 				}
 
-				if vValidation, ok := mTls["validation"].([]interface{}); ok && len(vValidation) > 0 && vValidation[0] != nil {
+				if vValidation, ok := mTls["validation"].([]any); ok && len(vValidation) > 0 && vValidation[0] != nil {
 					validation := &awstypes.ListenerTlsValidationContext{}
 
-					mValidation := vValidation[0].(map[string]interface{})
+					mValidation := vValidation[0].(map[string]any)
 
-					if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]interface{}); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
+					if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]any); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
 						subjectAlternativeNames := &awstypes.SubjectAlternativeNames{}
 
-						mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]interface{})
+						mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]any)
 
-						if vMatch, ok := mSubjectAlternativeNames["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+						if vMatch, ok := mSubjectAlternativeNames["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 							match := &awstypes.SubjectAlternativeNameMatchers{}
 
-							mMatch := vMatch[0].(map[string]interface{})
+							mMatch := vMatch[0].(map[string]any)
 
 							if vExact, ok := mMatch["exact"].(*schema.Set); ok && vExact.Len() > 0 {
 								match.Exact = flex.ExpandStringValueSet(vExact)
@@ -984,15 +984,15 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 						validation.SubjectAlternativeNames = subjectAlternativeNames
 					}
 
-					if vTrust, ok := mValidation["trust"].([]interface{}); ok && len(vTrust) > 0 && vTrust[0] != nil {
-						mTrust := vTrust[0].(map[string]interface{})
+					if vTrust, ok := mValidation["trust"].([]any); ok && len(vTrust) > 0 && vTrust[0] != nil {
+						mTrust := vTrust[0].(map[string]any)
 
-						if vFile, ok := mTrust["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+						if vFile, ok := mTrust["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 							trust := &awstypes.ListenerTlsValidationContextTrustMemberFile{}
 
 							file := awstypes.TlsValidationContextFileTrust{}
 
-							mFile := vFile[0].(map[string]interface{})
+							mFile := vFile[0].(map[string]any)
 
 							if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 								file.CertificateChain = aws.String(vCertificateChain)
@@ -1002,12 +1002,12 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 							validation.Trust = trust
 						}
 
-						if vSds, ok := mTrust["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+						if vSds, ok := mTrust["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 							trust := &awstypes.ListenerTlsValidationContextTrustMemberSds{}
 
 							sds := awstypes.TlsValidationContextSdsTrust{}
 
-							mSds := vSds[0].(map[string]interface{})
+							mSds := vSds[0].(map[string]any)
 
 							if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 								sds.SecretName = aws.String(vSecretName)
@@ -1030,31 +1030,31 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 		spec.Listeners = listeners
 	}
 
-	if vLogging, ok := mSpec["logging"].([]interface{}); ok && len(vLogging) > 0 && vLogging[0] != nil {
+	if vLogging, ok := mSpec["logging"].([]any); ok && len(vLogging) > 0 && vLogging[0] != nil {
 		logging := &awstypes.Logging{}
 
-		mLogging := vLogging[0].(map[string]interface{})
+		mLogging := vLogging[0].(map[string]any)
 
-		if vAccessLog, ok := mLogging["access_log"].([]interface{}); ok && len(vAccessLog) > 0 && vAccessLog[0] != nil {
-			mAccessLog := vAccessLog[0].(map[string]interface{})
+		if vAccessLog, ok := mLogging["access_log"].([]any); ok && len(vAccessLog) > 0 && vAccessLog[0] != nil {
+			mAccessLog := vAccessLog[0].(map[string]any)
 
-			if vFile, ok := mAccessLog["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+			if vFile, ok := mAccessLog["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 				accessLog := &awstypes.AccessLogMemberFile{}
 
 				file := awstypes.FileAccessLog{}
 
-				mFile := vFile[0].(map[string]interface{})
+				mFile := vFile[0].(map[string]any)
 
-				if vFormat, ok := mFile[names.AttrFormat].([]interface{}); ok && len(vFormat) > 0 && vFormat[0] != nil {
-					mFormat := vFormat[0].(map[string]interface{})
+				if vFormat, ok := mFile[names.AttrFormat].([]any); ok && len(vFormat) > 0 && vFormat[0] != nil {
+					mFormat := vFormat[0].(map[string]any)
 
-					if vJsonFormatRefs, ok := mFormat[names.AttrJSON].([]interface{}); ok && len(vJsonFormatRefs) > 0 {
+					if vJsonFormatRefs, ok := mFormat[names.AttrJSON].([]any); ok && len(vJsonFormatRefs) > 0 {
 						format := &awstypes.LoggingFormatMemberJson{}
 						jsonFormatRefs := []awstypes.JsonFormatRef{}
 						for _, vJsonFormatRef := range vJsonFormatRefs {
 							mJsonFormatRef := awstypes.JsonFormatRef{
-								Key:   aws.String(vJsonFormatRef.(map[string]interface{})[names.AttrKey].(string)),
-								Value: aws.String(vJsonFormatRef.(map[string]interface{})[names.AttrValue].(string)),
+								Key:   aws.String(vJsonFormatRef.(map[string]any)[names.AttrKey].(string)),
+								Value: aws.String(vJsonFormatRef.(map[string]any)[names.AttrValue].(string)),
 							}
 							jsonFormatRefs = append(jsonFormatRefs, mJsonFormatRef)
 						}
@@ -1083,17 +1083,17 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 		spec.Logging = logging
 	}
 
-	if vServiceDiscovery, ok := mSpec["service_discovery"].([]interface{}); ok && len(vServiceDiscovery) > 0 && vServiceDiscovery[0] != nil {
-		mServiceDiscovery := vServiceDiscovery[0].(map[string]interface{})
+	if vServiceDiscovery, ok := mSpec["service_discovery"].([]any); ok && len(vServiceDiscovery) > 0 && vServiceDiscovery[0] != nil {
+		mServiceDiscovery := vServiceDiscovery[0].(map[string]any)
 
-		if vAwsCloudMap, ok := mServiceDiscovery["aws_cloud_map"].([]interface{}); ok && len(vAwsCloudMap) > 0 && vAwsCloudMap[0] != nil {
+		if vAwsCloudMap, ok := mServiceDiscovery["aws_cloud_map"].([]any); ok && len(vAwsCloudMap) > 0 && vAwsCloudMap[0] != nil {
 			serviceDiscovery := &awstypes.ServiceDiscoveryMemberAwsCloudMap{}
 
 			awsCloudMap := awstypes.AwsCloudMapServiceDiscovery{}
 
-			mAwsCloudMap := vAwsCloudMap[0].(map[string]interface{})
+			mAwsCloudMap := vAwsCloudMap[0].(map[string]any)
 
-			if vAttributes, ok := mAwsCloudMap[names.AttrAttributes].(map[string]interface{}); ok && len(vAttributes) > 0 {
+			if vAttributes, ok := mAwsCloudMap[names.AttrAttributes].(map[string]any); ok && len(vAttributes) > 0 {
 				attributes := []awstypes.AwsCloudMapInstanceAttribute{}
 
 				for k, v := range vAttributes {
@@ -1116,12 +1116,12 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 			spec.ServiceDiscovery = serviceDiscovery
 		}
 
-		if vDns, ok := mServiceDiscovery["dns"].([]interface{}); ok && len(vDns) > 0 && vDns[0] != nil {
+		if vDns, ok := mServiceDiscovery["dns"].([]any); ok && len(vDns) > 0 && vDns[0] != nil {
 			serviceDiscovery := &awstypes.ServiceDiscoveryMemberDns{}
 
 			dns := awstypes.DnsServiceDiscovery{}
 
-			mDns := vDns[0].(map[string]interface{})
+			mDns := vDns[0].(map[string]any)
 
 			if vHostname, ok := mDns["hostname"].(string); ok && vHostname != "" {
 				dns.Hostname = aws.String(vHostname)
@@ -1143,25 +1143,25 @@ func expandVirtualNodeSpec(vSpec []interface{}) *awstypes.VirtualNodeSpec {
 	return spec
 }
 
-func expandVirtualRouterSpec(vSpec []interface{}) *awstypes.VirtualRouterSpec {
+func expandVirtualRouterSpec(vSpec []any) *awstypes.VirtualRouterSpec {
 	spec := &awstypes.VirtualRouterSpec{}
 
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		// Empty Spec is allowed.
 		return spec
 	}
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vListeners, ok := mSpec["listener"].([]interface{}); ok && len(vListeners) > 0 && vListeners[0] != nil {
+	if vListeners, ok := mSpec["listener"].([]any); ok && len(vListeners) > 0 && vListeners[0] != nil {
 		listeners := []awstypes.VirtualRouterListener{}
 
 		for _, vListener := range vListeners {
 			listener := awstypes.VirtualRouterListener{}
 
-			mListener := vListener.(map[string]interface{})
+			mListener := vListener.(map[string]any)
 
-			if vPortMapping, ok := mListener["port_mapping"].([]interface{}); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
-				mPortMapping := vPortMapping[0].(map[string]interface{})
+			if vPortMapping, ok := mListener["port_mapping"].([]any); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
+				mPortMapping := vPortMapping[0].(map[string]any)
 
 				listener.PortMapping = &awstypes.PortMapping{}
 
@@ -1180,21 +1180,21 @@ func expandVirtualRouterSpec(vSpec []interface{}) *awstypes.VirtualRouterSpec {
 	return spec
 }
 
-func expandVirtualServiceSpec(vSpec []interface{}) *awstypes.VirtualServiceSpec {
+func expandVirtualServiceSpec(vSpec []any) *awstypes.VirtualServiceSpec {
 	spec := &awstypes.VirtualServiceSpec{}
 
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		// Empty Spec is allowed.
 		return spec
 	}
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vProvider, ok := mSpec["provider"].([]interface{}); ok && len(vProvider) > 0 && vProvider[0] != nil {
-		mProvider := vProvider[0].(map[string]interface{})
+	if vProvider, ok := mSpec["provider"].([]any); ok && len(vProvider) > 0 && vProvider[0] != nil {
+		mProvider := vProvider[0].(map[string]any)
 
-		if vVirtualNode, ok := mProvider["virtual_node"].([]interface{}); ok && len(vVirtualNode) > 0 && vVirtualNode[0] != nil {
+		if vVirtualNode, ok := mProvider["virtual_node"].([]any); ok && len(vVirtualNode) > 0 && vVirtualNode[0] != nil {
 			provider := &awstypes.VirtualServiceProviderMemberVirtualNode{}
-			mVirtualNode := vVirtualNode[0].(map[string]interface{})
+			mVirtualNode := vVirtualNode[0].(map[string]any)
 
 			if vVirtualNodeName, ok := mVirtualNode["virtual_node_name"].(string); ok && vVirtualNodeName != "" {
 				provider.Value = awstypes.VirtualNodeServiceProvider{
@@ -1205,9 +1205,9 @@ func expandVirtualServiceSpec(vSpec []interface{}) *awstypes.VirtualServiceSpec 
 			spec.Provider = provider
 		}
 
-		if vVirtualRouter, ok := mProvider["virtual_router"].([]interface{}); ok && len(vVirtualRouter) > 0 && vVirtualRouter[0] != nil {
+		if vVirtualRouter, ok := mProvider["virtual_router"].([]any); ok && len(vVirtualRouter) > 0 && vVirtualRouter[0] != nil {
 			provider := &awstypes.VirtualServiceProviderMemberVirtualRouter{}
-			mVirtualRouter := vVirtualRouter[0].(map[string]interface{})
+			mVirtualRouter := vVirtualRouter[0].(map[string]any)
 
 			if vVirtualRouterName, ok := mVirtualRouter["virtual_router_name"].(string); ok && vVirtualRouterName != "" {
 				provider.Value = awstypes.VirtualRouterServiceProvider{
@@ -1222,120 +1222,120 @@ func expandVirtualServiceSpec(vSpec []interface{}) *awstypes.VirtualServiceSpec 
 	return spec
 }
 
-func flattenClientPolicy(clientPolicy *awstypes.ClientPolicy) []interface{} {
+func flattenClientPolicy(clientPolicy *awstypes.ClientPolicy) []any {
 	if clientPolicy == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mClientPolicy := map[string]interface{}{}
+	mClientPolicy := map[string]any{}
 
 	if tls := clientPolicy.Tls; tls != nil {
-		mTls := map[string]interface{}{
+		mTls := map[string]any{
 			"enforce": aws.ToBool(tls.Enforce),
 			"ports":   flex.FlattenInt32ValueSet(tls.Ports),
 		}
 
 		if certificate := tls.Certificate; certificate != nil {
-			mCertificate := map[string]interface{}{}
+			mCertificate := map[string]any{}
 
 			switch v := certificate.(type) {
 			case *awstypes.ClientTlsCertificateMemberFile:
-				mFile := map[string]interface{}{
+				mFile := map[string]any{
 					names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 					names.AttrPrivateKey:       aws.ToString(v.Value.PrivateKey),
 				}
 
-				mCertificate["file"] = []interface{}{mFile}
+				mCertificate["file"] = []any{mFile}
 			case *awstypes.ClientTlsCertificateMemberSds:
-				mSds := map[string]interface{}{
+				mSds := map[string]any{
 					"secret_name": aws.ToString(v.Value.SecretName),
 				}
 
-				mCertificate["sds"] = []interface{}{mSds}
+				mCertificate["sds"] = []any{mSds}
 			}
 
-			mTls[names.AttrCertificate] = []interface{}{mCertificate}
+			mTls[names.AttrCertificate] = []any{mCertificate}
 		}
 
 		if validation := tls.Validation; validation != nil {
-			mValidation := map[string]interface{}{}
+			mValidation := map[string]any{}
 
 			if subjectAlternativeNames := validation.SubjectAlternativeNames; subjectAlternativeNames != nil {
-				mSubjectAlternativeNames := map[string]interface{}{}
+				mSubjectAlternativeNames := map[string]any{}
 
 				if match := subjectAlternativeNames.Match; match != nil {
-					mMatch := map[string]interface{}{
+					mMatch := map[string]any{
 						"exact": match.Exact,
 					}
 
-					mSubjectAlternativeNames["match"] = []interface{}{mMatch}
+					mSubjectAlternativeNames["match"] = []any{mMatch}
 				}
 
-				mValidation["subject_alternative_names"] = []interface{}{mSubjectAlternativeNames}
+				mValidation["subject_alternative_names"] = []any{mSubjectAlternativeNames}
 			}
 
 			if trust := validation.Trust; trust != nil {
-				mTrust := map[string]interface{}{}
+				mTrust := map[string]any{}
 
 				switch v := trust.(type) {
 				case *awstypes.TlsValidationContextTrustMemberAcm:
-					mAcm := map[string]interface{}{
+					mAcm := map[string]any{
 						"certificate_authority_arns": v.Value.CertificateAuthorityArns,
 					}
 
-					mTrust["acm"] = []interface{}{mAcm}
+					mTrust["acm"] = []any{mAcm}
 				case *awstypes.TlsValidationContextTrustMemberFile:
-					mFile := map[string]interface{}{
+					mFile := map[string]any{
 						names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 					}
 
-					mTrust["file"] = []interface{}{mFile}
+					mTrust["file"] = []any{mFile}
 				case *awstypes.TlsValidationContextTrustMemberSds:
-					mSds := map[string]interface{}{
+					mSds := map[string]any{
 						"secret_name": aws.ToString(v.Value.SecretName),
 					}
 
-					mTrust["sds"] = []interface{}{mSds}
+					mTrust["sds"] = []any{mSds}
 				}
 
-				mValidation["trust"] = []interface{}{mTrust}
+				mValidation["trust"] = []any{mTrust}
 			}
 
-			mTls["validation"] = []interface{}{mValidation}
+			mTls["validation"] = []any{mValidation}
 		}
 
-		mClientPolicy["tls"] = []interface{}{mTls}
+		mClientPolicy["tls"] = []any{mTls}
 	}
 
-	return []interface{}{mClientPolicy}
+	return []any{mClientPolicy}
 }
 
-func flattenDuration(duration *awstypes.Duration) []interface{} {
+func flattenDuration(duration *awstypes.Duration) []any {
 	if duration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mDuration := map[string]interface{}{
+	mDuration := map[string]any{
 		names.AttrUnit:  duration.Unit,
 		names.AttrValue: aws.ToInt64(duration.Value),
 	}
 
-	return []interface{}{mDuration}
+	return []any{mDuration}
 }
 
-func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
+func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []any {
 	if grpcRoute == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mGrpcRoute := map[string]interface{}{}
+	mGrpcRoute := map[string]any{}
 
 	if action := grpcRoute.Action; action != nil {
 		if weightedTargets := action.WeightedTargets; weightedTargets != nil {
-			vWeightedTargets := []interface{}{}
+			vWeightedTargets := []any{}
 
 			for _, weightedTarget := range weightedTargets {
-				mWeightedTarget := map[string]interface{}{
+				mWeightedTarget := map[string]any{
 					"virtual_node":   aws.ToString(weightedTarget.VirtualNode),
 					names.AttrWeight: weightedTarget.Weight,
 				}
@@ -1347,8 +1347,8 @@ func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
 				vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
 			}
 
-			mGrpcRoute[names.AttrAction] = []interface{}{
-				map[string]interface{}{
+			mGrpcRoute[names.AttrAction] = []any{
+				map[string]any{
 					"weighted_target": vWeightedTargets,
 				},
 			}
@@ -1356,16 +1356,16 @@ func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
 	}
 
 	if grpcRouteMatch := grpcRoute.Match; grpcRouteMatch != nil {
-		vGrpcRouteMetadatas := []interface{}{}
+		vGrpcRouteMetadatas := []any{}
 
 		for _, grpcRouteMetadata := range grpcRouteMatch.Metadata {
-			mGrpcRouteMetadata := map[string]interface{}{
+			mGrpcRouteMetadata := map[string]any{
 				"invert":       aws.ToBool(grpcRouteMetadata.Invert),
 				names.AttrName: aws.ToString(grpcRouteMetadata.Name),
 			}
 
 			if match := grpcRouteMetadata.Match; match != nil {
-				mMatch := map[string]interface{}{}
+				mMatch := map[string]any{}
 
 				switch v := match.(type) {
 				case *awstypes.GrpcRouteMetadataMatchMethodMemberExact:
@@ -1377,22 +1377,22 @@ func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
 				case *awstypes.GrpcRouteMetadataMatchMethodMemberSuffix:
 					mMatch["suffix"] = v.Value
 				case *awstypes.GrpcRouteMetadataMatchMethodMemberRange:
-					mRange := map[string]interface{}{
+					mRange := map[string]any{
 						"end":   aws.ToInt64(v.Value.End),
 						"start": aws.ToInt64(v.Value.Start),
 					}
 
-					mMatch["range"] = []interface{}{mRange}
+					mMatch["range"] = []any{mRange}
 				}
 
-				mGrpcRouteMetadata["match"] = []interface{}{mMatch}
+				mGrpcRouteMetadata["match"] = []any{mMatch}
 			}
 
 			vGrpcRouteMetadatas = append(vGrpcRouteMetadatas, mGrpcRouteMetadata)
 		}
 
-		mGrpcRoute["match"] = []interface{}{
-			map[string]interface{}{
+		mGrpcRoute["match"] = []any{
+			map[string]any{
 				"metadata":            vGrpcRouteMetadatas,
 				"method_name":         aws.ToString(grpcRouteMatch.MethodName),
 				names.AttrPort:        aws.ToInt32(grpcRouteMatch.Port),
@@ -1402,7 +1402,7 @@ func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
 	}
 
 	if grpcRetryPolicy := grpcRoute.RetryPolicy; grpcRetryPolicy != nil {
-		mGrpcRetryPolicy := map[string]interface{}{
+		mGrpcRetryPolicy := map[string]any{
 			"grpc_retry_events": grpcRetryPolicy.GrpcRetryEvents,
 			"http_retry_events": grpcRetryPolicy.HttpRetryEvents,
 			"max_retries":       aws.ToInt64(grpcRetryPolicy.MaxRetries),
@@ -1410,40 +1410,40 @@ func flattenGRPCRoute(grpcRoute *awstypes.GrpcRoute) []interface{} {
 			"tcp_retry_events":  grpcRetryPolicy.TcpRetryEvents,
 		}
 
-		mGrpcRoute["retry_policy"] = []interface{}{mGrpcRetryPolicy}
+		mGrpcRoute["retry_policy"] = []any{mGrpcRetryPolicy}
 	}
 
 	mGrpcRoute[names.AttrTimeout] = flattenGRPCTimeout(grpcRoute.Timeout)
 
-	return []interface{}{mGrpcRoute}
+	return []any{mGrpcRoute}
 }
 
-func flattenGRPCTimeout(grpcTimeout *awstypes.GrpcTimeout) []interface{} {
+func flattenGRPCTimeout(grpcTimeout *awstypes.GrpcTimeout) []any {
 	if grpcTimeout == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mGrpcTimeout := map[string]interface{}{
+	mGrpcTimeout := map[string]any{
 		"idle":        flattenDuration(grpcTimeout.Idle),
 		"per_request": flattenDuration(grpcTimeout.PerRequest),
 	}
 
-	return []interface{}{mGrpcTimeout}
+	return []any{mGrpcTimeout}
 }
 
-func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []interface{} {
+func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []any {
 	if httpRoute == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mHttpRoute := map[string]interface{}{}
+	mHttpRoute := map[string]any{}
 
 	if action := httpRoute.Action; action != nil {
 		if weightedTargets := action.WeightedTargets; weightedTargets != nil {
-			vWeightedTargets := []interface{}{}
+			vWeightedTargets := []any{}
 
 			for _, weightedTarget := range weightedTargets {
-				mWeightedTarget := map[string]interface{}{
+				mWeightedTarget := map[string]any{
 					"virtual_node":   aws.ToString(weightedTarget.VirtualNode),
 					names.AttrWeight: weightedTarget.Weight,
 				}
@@ -1455,8 +1455,8 @@ func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []interface{} {
 				vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
 			}
 
-			mHttpRoute[names.AttrAction] = []interface{}{
-				map[string]interface{}{
+			mHttpRoute[names.AttrAction] = []any{
+				map[string]any{
 					"weighted_target": vWeightedTargets,
 				},
 			}
@@ -1464,16 +1464,16 @@ func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []interface{} {
 	}
 
 	if httpRouteMatch := httpRoute.Match; httpRouteMatch != nil {
-		vHttpRouteHeaders := []interface{}{}
+		vHttpRouteHeaders := []any{}
 
 		for _, httpRouteHeader := range httpRouteMatch.Headers {
-			mHttpRouteHeader := map[string]interface{}{
+			mHttpRouteHeader := map[string]any{
 				"invert":       aws.ToBool(httpRouteHeader.Invert),
 				names.AttrName: aws.ToString(httpRouteHeader.Name),
 			}
 
 			if match := httpRouteHeader.Match; match != nil {
-				mMatch := map[string]interface{}{}
+				mMatch := map[string]any{}
 
 				switch v := match.(type) {
 				case *awstypes.HeaderMatchMethodMemberExact:
@@ -1485,51 +1485,51 @@ func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []interface{} {
 				case *awstypes.HeaderMatchMethodMemberSuffix:
 					mMatch["suffix"] = v.Value
 				case *awstypes.HeaderMatchMethodMemberRange:
-					mRange := map[string]interface{}{
+					mRange := map[string]any{
 						"end":   aws.ToInt64(v.Value.End),
 						"start": aws.ToInt64(v.Value.Start),
 					}
 
-					mMatch["range"] = []interface{}{mRange}
+					mMatch["range"] = []any{mRange}
 				}
 
-				mHttpRouteHeader["match"] = []interface{}{mMatch}
+				mHttpRouteHeader["match"] = []any{mMatch}
 			}
 
 			vHttpRouteHeaders = append(vHttpRouteHeaders, mHttpRouteHeader)
 		}
 
-		vHttpRoutePath := []interface{}{}
+		vHttpRoutePath := []any{}
 
 		if httpRoutePath := httpRouteMatch.Path; httpRoutePath != nil {
-			mHttpRoutePath := map[string]interface{}{
+			mHttpRoutePath := map[string]any{
 				"exact": aws.ToString(httpRoutePath.Exact),
 				"regex": aws.ToString(httpRoutePath.Regex),
 			}
 
-			vHttpRoutePath = []interface{}{mHttpRoutePath}
+			vHttpRoutePath = []any{mHttpRoutePath}
 		}
 
-		vHttpRouteQueryParameters := []interface{}{}
+		vHttpRouteQueryParameters := []any{}
 
 		for _, httpRouteQueryParameter := range httpRouteMatch.QueryParameters {
-			mHttpRouteQueryParameter := map[string]interface{}{
+			mHttpRouteQueryParameter := map[string]any{
 				names.AttrName: aws.ToString(httpRouteQueryParameter.Name),
 			}
 
 			if match := httpRouteQueryParameter.Match; match != nil {
-				mMatch := map[string]interface{}{
+				mMatch := map[string]any{
 					"exact": aws.ToString(match.Exact),
 				}
 
-				mHttpRouteQueryParameter["match"] = []interface{}{mMatch}
+				mHttpRouteQueryParameter["match"] = []any{mMatch}
 			}
 
 			vHttpRouteQueryParameters = append(vHttpRouteQueryParameters, mHttpRouteQueryParameter)
 		}
 
-		mHttpRoute["match"] = []interface{}{
-			map[string]interface{}{
+		mHttpRoute["match"] = []any{
+			map[string]any{
 				names.AttrHeader:  vHttpRouteHeaders,
 				"method":          httpRouteMatch.Method,
 				names.AttrPath:    vHttpRoutePath,
@@ -1542,66 +1542,66 @@ func flattenHTTPRoute(httpRoute *awstypes.HttpRoute) []interface{} {
 	}
 
 	if httpRetryPolicy := httpRoute.RetryPolicy; httpRetryPolicy != nil {
-		mHttpRetryPolicy := map[string]interface{}{
+		mHttpRetryPolicy := map[string]any{
 			"http_retry_events": httpRetryPolicy.HttpRetryEvents,
 			"max_retries":       aws.ToInt64(httpRetryPolicy.MaxRetries),
 			"per_retry_timeout": flattenDuration(httpRetryPolicy.PerRetryTimeout),
 			"tcp_retry_events":  httpRetryPolicy.TcpRetryEvents,
 		}
 
-		mHttpRoute["retry_policy"] = []interface{}{mHttpRetryPolicy}
+		mHttpRoute["retry_policy"] = []any{mHttpRetryPolicy}
 	}
 
 	mHttpRoute[names.AttrTimeout] = flattenHTTPTimeout(httpRoute.Timeout)
 
-	return []interface{}{mHttpRoute}
+	return []any{mHttpRoute}
 }
 
-func flattenHTTPTimeout(httpTimeout *awstypes.HttpTimeout) []interface{} {
+func flattenHTTPTimeout(httpTimeout *awstypes.HttpTimeout) []any {
 	if httpTimeout == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mHttpTimeout := map[string]interface{}{
+	mHttpTimeout := map[string]any{
 		"idle":        flattenDuration(httpTimeout.Idle),
 		"per_request": flattenDuration(httpTimeout.PerRequest),
 	}
 
-	return []interface{}{mHttpTimeout}
+	return []any{mHttpTimeout}
 }
 
-func flattenMeshSpec(spec *awstypes.MeshSpec) []interface{} {
+func flattenMeshSpec(spec *awstypes.MeshSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{}
+	mSpec := map[string]any{}
 
 	if spec.EgressFilter != nil {
-		mSpec["egress_filter"] = []interface{}{
-			map[string]interface{}{
+		mSpec["egress_filter"] = []any{
+			map[string]any{
 				names.AttrType: spec.EgressFilter.Type,
 			},
 		}
 	}
 
 	if spec.ServiceDiscovery != nil {
-		mSpec["service_discovery"] = []interface{}{
-			map[string]interface{}{
+		mSpec["service_discovery"] = []any{
+			map[string]any{
 				"ip_preference": spec.ServiceDiscovery.IpPreference,
 			},
 		}
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenRouteSpec(spec *awstypes.RouteSpec) []interface{} {
+func flattenRouteSpec(spec *awstypes.RouteSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{
+	mSpec := map[string]any{
 		"grpc_route":       flattenGRPCRoute(spec.GrpcRoute),
 		"http2_route":      flattenHTTPRoute(spec.Http2Route),
 		"http_route":       flattenHTTPRoute(spec.HttpRoute),
@@ -1609,22 +1609,22 @@ func flattenRouteSpec(spec *awstypes.RouteSpec) []interface{} {
 		"tcp_route":        flattenTCPRoute(spec.TcpRoute),
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenTCPRoute(tcpRoute *awstypes.TcpRoute) []interface{} {
+func flattenTCPRoute(tcpRoute *awstypes.TcpRoute) []any {
 	if tcpRoute == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mTcpRoute := map[string]interface{}{}
+	mTcpRoute := map[string]any{}
 
 	if action := tcpRoute.Action; action != nil {
 		if weightedTargets := action.WeightedTargets; weightedTargets != nil {
-			vWeightedTargets := []interface{}{}
+			vWeightedTargets := []any{}
 
 			for _, weightedTarget := range weightedTargets {
-				mWeightedTarget := map[string]interface{}{
+				mWeightedTarget := map[string]any{
 					"virtual_node":   aws.ToString(weightedTarget.VirtualNode),
 					names.AttrWeight: weightedTarget.Weight,
 				}
@@ -1636,8 +1636,8 @@ func flattenTCPRoute(tcpRoute *awstypes.TcpRoute) []interface{} {
 				vWeightedTargets = append(vWeightedTargets, mWeightedTarget)
 			}
 
-			mTcpRoute[names.AttrAction] = []interface{}{
-				map[string]interface{}{
+			mTcpRoute[names.AttrAction] = []any{
+				map[string]any{
 					"weighted_target": vWeightedTargets,
 				},
 			}
@@ -1645,8 +1645,8 @@ func flattenTCPRoute(tcpRoute *awstypes.TcpRoute) []interface{} {
 	}
 
 	if tcpRouteMatch := tcpRoute.Match; tcpRouteMatch != nil {
-		mTcpRoute["match"] = []interface{}{
-			map[string]interface{}{
+		mTcpRoute["match"] = []any{
+			map[string]any{
 				names.AttrPort: aws.ToInt32(tcpRouteMatch.Port),
 			},
 		}
@@ -1654,42 +1654,42 @@ func flattenTCPRoute(tcpRoute *awstypes.TcpRoute) []interface{} {
 
 	mTcpRoute[names.AttrTimeout] = flattenTCPTimeout(tcpRoute.Timeout)
 
-	return []interface{}{mTcpRoute}
+	return []any{mTcpRoute}
 }
 
-func flattenTCPTimeout(tcpTimeout *awstypes.TcpTimeout) []interface{} {
+func flattenTCPTimeout(tcpTimeout *awstypes.TcpTimeout) []any {
 	if tcpTimeout == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mTcpTimeout := map[string]interface{}{
+	mTcpTimeout := map[string]any{
 		"idle": flattenDuration(tcpTimeout.Idle),
 	}
 
-	return []interface{}{mTcpTimeout}
+	return []any{mTcpTimeout}
 }
 
-func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
+func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{}
+	mSpec := map[string]any{}
 
 	if backends := spec.Backends; backends != nil {
-		vBackends := []interface{}{}
+		vBackends := []any{}
 
 		for _, backend := range backends {
-			mBackend := map[string]interface{}{}
+			mBackend := map[string]any{}
 
 			switch v := backend.(type) {
 			case *awstypes.BackendMemberVirtualService:
-				mVirtualService := map[string]interface{}{
+				mVirtualService := map[string]any{
 					"client_policy":        flattenClientPolicy(v.Value.ClientPolicy),
 					"virtual_service_name": aws.ToString(v.Value.VirtualServiceName),
 				}
 
-				mBackend["virtual_service"] = []interface{}{mVirtualService}
+				mBackend["virtual_service"] = []any{mVirtualService}
 			}
 
 			vBackends = append(vBackends, mBackend)
@@ -1699,51 +1699,51 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 	}
 
 	if backendDefaults := spec.BackendDefaults; backendDefaults != nil {
-		mBackendDefaults := map[string]interface{}{
+		mBackendDefaults := map[string]any{
 			"client_policy": flattenClientPolicy(backendDefaults.ClientPolicy),
 		}
 
-		mSpec["backend_defaults"] = []interface{}{mBackendDefaults}
+		mSpec["backend_defaults"] = []any{mBackendDefaults}
 	}
 
 	if len(spec.Listeners) > 0 {
-		var mListeners []interface{}
+		var mListeners []any
 		// Per schema definition, set at most 1 Listener
 		for _, listener := range spec.Listeners {
-			mListener := map[string]interface{}{}
+			mListener := map[string]any{}
 
 			if connectionPool := listener.ConnectionPool; connectionPool != nil {
-				mConnectionPool := map[string]interface{}{}
+				mConnectionPool := map[string]any{}
 
 				switch v := connectionPool.(type) {
 				case *awstypes.VirtualNodeConnectionPoolMemberGrpc:
-					mGrpcConnectionPool := map[string]interface{}{
+					mGrpcConnectionPool := map[string]any{
 						"max_requests": aws.ToInt32(v.Value.MaxRequests),
 					}
-					mConnectionPool["grpc"] = []interface{}{mGrpcConnectionPool}
+					mConnectionPool["grpc"] = []any{mGrpcConnectionPool}
 				case *awstypes.VirtualNodeConnectionPoolMemberHttp:
-					mHttpConnectionPool := map[string]interface{}{
+					mHttpConnectionPool := map[string]any{
 						"max_connections":      aws.ToInt32(v.Value.MaxConnections),
 						"max_pending_requests": aws.ToInt32(v.Value.MaxPendingRequests),
 					}
-					mConnectionPool["http"] = []interface{}{mHttpConnectionPool}
+					mConnectionPool["http"] = []any{mHttpConnectionPool}
 				case *awstypes.VirtualNodeConnectionPoolMemberHttp2:
-					mHttp2ConnectionPool := map[string]interface{}{
+					mHttp2ConnectionPool := map[string]any{
 						"max_requests": aws.ToInt32(v.Value.MaxRequests),
 					}
-					mConnectionPool["http2"] = []interface{}{mHttp2ConnectionPool}
+					mConnectionPool["http2"] = []any{mHttp2ConnectionPool}
 				case *awstypes.VirtualNodeConnectionPoolMemberTcp:
-					mTcpConnectionPool := map[string]interface{}{
+					mTcpConnectionPool := map[string]any{
 						"max_connections": aws.ToInt32(v.Value.MaxConnections),
 					}
-					mConnectionPool["tcp"] = []interface{}{mTcpConnectionPool}
+					mConnectionPool["tcp"] = []any{mTcpConnectionPool}
 				}
 
-				mListener["connection_pool"] = []interface{}{mConnectionPool}
+				mListener["connection_pool"] = []any{mConnectionPool}
 			}
 
 			if healthCheck := listener.HealthCheck; healthCheck != nil {
-				mHealthCheck := map[string]interface{}{
+				mHealthCheck := map[string]any{
 					"healthy_threshold":   aws.ToInt32(healthCheck.HealthyThreshold),
 					"interval_millis":     aws.ToInt64(healthCheck.IntervalMillis),
 					names.AttrPath:        aws.ToString(healthCheck.Path),
@@ -1752,29 +1752,29 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 					"timeout_millis":      aws.ToInt64(healthCheck.TimeoutMillis),
 					"unhealthy_threshold": aws.ToInt32(healthCheck.UnhealthyThreshold),
 				}
-				mListener[names.AttrHealthCheck] = []interface{}{mHealthCheck}
+				mListener[names.AttrHealthCheck] = []any{mHealthCheck}
 			}
 
 			if outlierDetection := listener.OutlierDetection; outlierDetection != nil {
-				mOutlierDetection := map[string]interface{}{
+				mOutlierDetection := map[string]any{
 					"base_ejection_duration": flattenDuration(outlierDetection.BaseEjectionDuration),
 					names.AttrInterval:       flattenDuration(outlierDetection.Interval),
 					"max_ejection_percent":   aws.ToInt32(outlierDetection.MaxEjectionPercent),
 					"max_server_errors":      aws.ToInt64(outlierDetection.MaxServerErrors),
 				}
-				mListener["outlier_detection"] = []interface{}{mOutlierDetection}
+				mListener["outlier_detection"] = []any{mOutlierDetection}
 			}
 
 			if portMapping := listener.PortMapping; portMapping != nil {
-				mPortMapping := map[string]interface{}{
+				mPortMapping := map[string]any{
 					names.AttrPort:     aws.ToInt32(portMapping.Port),
 					names.AttrProtocol: portMapping.Protocol,
 				}
-				mListener["port_mapping"] = []interface{}{mPortMapping}
+				mListener["port_mapping"] = []any{mPortMapping}
 			}
 
 			if listenerTimeout := listener.Timeout; listenerTimeout != nil {
-				mListenerTimeout := map[string]interface{}{}
+				mListenerTimeout := map[string]any{}
 
 				switch v := listenerTimeout.(type) {
 				case *awstypes.ListenerTimeoutMemberGrpc:
@@ -1787,84 +1787,84 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 					mListenerTimeout["tcp"] = flattenTCPTimeout(&v.Value)
 				}
 
-				mListener[names.AttrTimeout] = []interface{}{mListenerTimeout}
+				mListener[names.AttrTimeout] = []any{mListenerTimeout}
 			}
 
 			if tls := listener.Tls; tls != nil {
-				mTls := map[string]interface{}{
+				mTls := map[string]any{
 					names.AttrMode: tls.Mode,
 				}
 
 				if certificate := tls.Certificate; certificate != nil {
-					mCertificate := map[string]interface{}{}
+					mCertificate := map[string]any{}
 
 					switch v := certificate.(type) {
 					case *awstypes.ListenerTlsCertificateMemberAcm:
-						mAcm := map[string]interface{}{
+						mAcm := map[string]any{
 							names.AttrCertificateARN: aws.ToString(v.Value.CertificateArn),
 						}
 
-						mCertificate["acm"] = []interface{}{mAcm}
+						mCertificate["acm"] = []any{mAcm}
 					case *awstypes.ListenerTlsCertificateMemberFile:
-						mFile := map[string]interface{}{
+						mFile := map[string]any{
 							names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 							names.AttrPrivateKey:       aws.ToString(v.Value.PrivateKey),
 						}
 
-						mCertificate["file"] = []interface{}{mFile}
+						mCertificate["file"] = []any{mFile}
 					case *awstypes.ListenerTlsCertificateMemberSds:
-						mSds := map[string]interface{}{
+						mSds := map[string]any{
 							"secret_name": aws.ToString(v.Value.SecretName),
 						}
 
-						mCertificate["sds"] = []interface{}{mSds}
+						mCertificate["sds"] = []any{mSds}
 					}
 
-					mTls[names.AttrCertificate] = []interface{}{mCertificate}
+					mTls[names.AttrCertificate] = []any{mCertificate}
 				}
 
 				if validation := tls.Validation; validation != nil {
-					mValidation := map[string]interface{}{}
+					mValidation := map[string]any{}
 
 					if subjectAlternativeNames := validation.SubjectAlternativeNames; subjectAlternativeNames != nil {
-						mSubjectAlternativeNames := map[string]interface{}{}
+						mSubjectAlternativeNames := map[string]any{}
 
 						if match := subjectAlternativeNames.Match; match != nil {
-							mMatch := map[string]interface{}{
+							mMatch := map[string]any{
 								"exact": match.Exact,
 							}
 
-							mSubjectAlternativeNames["match"] = []interface{}{mMatch}
+							mSubjectAlternativeNames["match"] = []any{mMatch}
 						}
 
-						mValidation["subject_alternative_names"] = []interface{}{mSubjectAlternativeNames}
+						mValidation["subject_alternative_names"] = []any{mSubjectAlternativeNames}
 					}
 
 					if trust := validation.Trust; trust != nil {
-						mTrust := map[string]interface{}{}
+						mTrust := map[string]any{}
 
 						switch v := trust.(type) {
 						case *awstypes.ListenerTlsValidationContextTrustMemberFile:
-							mFile := map[string]interface{}{
+							mFile := map[string]any{
 								names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 							}
 
-							mTrust["file"] = []interface{}{mFile}
+							mTrust["file"] = []any{mFile}
 						case *awstypes.ListenerTlsValidationContextTrustMemberSds:
-							mSds := map[string]interface{}{
+							mSds := map[string]any{
 								"secret_name": aws.ToString(v.Value.SecretName),
 							}
 
-							mTrust["sds"] = []interface{}{mSds}
+							mTrust["sds"] = []any{mSds}
 						}
 
-						mValidation["trust"] = []interface{}{mTrust}
+						mValidation["trust"] = []any{mTrust}
 					}
 
-					mTls["validation"] = []interface{}{mValidation}
+					mTls["validation"] = []any{mValidation}
 				}
 
-				mListener["tls"] = []interface{}{mTls}
+				mListener["tls"] = []any{mTls}
 			}
 			mListeners = append(mListeners, mListener)
 		}
@@ -1872,24 +1872,24 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 	}
 
 	if logging := spec.Logging; logging != nil {
-		mLogging := map[string]interface{}{}
+		mLogging := map[string]any{}
 
 		if accessLog := logging.AccessLog; accessLog != nil {
-			mAccessLog := map[string]interface{}{}
+			mAccessLog := map[string]any{}
 
 			switch v := accessLog.(type) {
 			case *awstypes.AccessLogMemberFile:
-				mFile := map[string]interface{}{}
+				mFile := map[string]any{}
 
 				if format := v.Value.Format; format != nil {
-					mFormat := map[string]interface{}{}
+					mFormat := map[string]any{}
 
 					switch v := format.(type) {
 					case *awstypes.LoggingFormatMemberJson:
-						vJsons := []interface{}{}
+						vJsons := []any{}
 
 						for _, j := range v.Value {
-							mJson := map[string]interface{}{
+							mJson := map[string]any{
 								names.AttrKey:   aws.ToString(j.Key),
 								names.AttrValue: aws.ToString(j.Value),
 							}
@@ -1902,41 +1902,41 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 						mFormat["text"] = v.Value
 					}
 
-					mFile[names.AttrFormat] = []interface{}{mFormat}
+					mFile[names.AttrFormat] = []any{mFormat}
 				}
 
 				mFile[names.AttrPath] = aws.ToString(v.Value.Path)
 
-				mAccessLog["file"] = []interface{}{mFile}
+				mAccessLog["file"] = []any{mFile}
 			}
 
-			mLogging["access_log"] = []interface{}{mAccessLog}
+			mLogging["access_log"] = []any{mAccessLog}
 		}
 
-		mSpec["logging"] = []interface{}{mLogging}
+		mSpec["logging"] = []any{mLogging}
 	}
 
 	if serviceDiscovery := spec.ServiceDiscovery; serviceDiscovery != nil {
-		mServiceDiscovery := map[string]interface{}{}
+		mServiceDiscovery := map[string]any{}
 
 		switch v := serviceDiscovery.(type) {
 		case *awstypes.ServiceDiscoveryMemberAwsCloudMap:
-			vAttributes := map[string]interface{}{}
+			vAttributes := map[string]any{}
 
 			for _, attribute := range v.Value.Attributes {
 				vAttributes[aws.ToString(attribute.Key)] = aws.ToString(attribute.Value)
 			}
 
-			mServiceDiscovery["aws_cloud_map"] = []interface{}{
-				map[string]interface{}{
+			mServiceDiscovery["aws_cloud_map"] = []any{
+				map[string]any{
 					names.AttrAttributes:  vAttributes,
 					"namespace_name":      aws.ToString(v.Value.NamespaceName),
 					names.AttrServiceName: aws.ToString(v.Value.ServiceName),
 				},
 			}
 		case *awstypes.ServiceDiscoveryMemberDns:
-			mServiceDiscovery["dns"] = []interface{}{
-				map[string]interface{}{
+			mServiceDiscovery["dns"] = []any{
+				map[string]any{
 					"hostname":      aws.ToString(v.Value.Hostname),
 					"ip_preference": v.Value.IpPreference,
 					"response_type": v.Value.ResponseType,
@@ -1944,63 +1944,63 @@ func flattenVirtualNodeSpec(spec *awstypes.VirtualNodeSpec) []interface{} {
 			}
 		}
 
-		mSpec["service_discovery"] = []interface{}{mServiceDiscovery}
+		mSpec["service_discovery"] = []any{mServiceDiscovery}
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenVirtualRouterSpec(spec *awstypes.VirtualRouterSpec) []interface{} {
+func flattenVirtualRouterSpec(spec *awstypes.VirtualRouterSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
-	mSpec := make(map[string]interface{})
+	mSpec := make(map[string]any)
 	if len(spec.Listeners) > 0 {
-		var mListeners []interface{}
+		var mListeners []any
 		for _, listener := range spec.Listeners {
-			mListener := map[string]interface{}{}
+			mListener := map[string]any{}
 			if listener.PortMapping != nil {
-				mPortMapping := map[string]interface{}{
+				mPortMapping := map[string]any{
 					names.AttrPort:     aws.ToInt32(listener.PortMapping.Port),
 					names.AttrProtocol: listener.PortMapping.Protocol,
 				}
-				mListener["port_mapping"] = []interface{}{mPortMapping}
+				mListener["port_mapping"] = []any{mPortMapping}
 			}
 			mListeners = append(mListeners, mListener)
 		}
 		mSpec["listener"] = mListeners
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenVirtualServiceSpec(spec *awstypes.VirtualServiceSpec) []interface{} {
+func flattenVirtualServiceSpec(spec *awstypes.VirtualServiceSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{}
+	mSpec := map[string]any{}
 
 	if provider := spec.Provider; provider != nil {
-		mProvider := map[string]interface{}{}
+		mProvider := map[string]any{}
 
 		switch v := provider.(type) {
 		case *awstypes.VirtualServiceProviderMemberVirtualNode:
-			mProvider["virtual_node"] = []interface{}{
-				map[string]interface{}{
+			mProvider["virtual_node"] = []any{
+				map[string]any{
 					"virtual_node_name": aws.ToString(v.Value.VirtualNodeName),
 				},
 			}
 		case *awstypes.VirtualServiceProviderMemberVirtualRouter:
-			mProvider["virtual_router"] = []interface{}{
-				map[string]interface{}{
+			mProvider["virtual_router"] = []any{
+				map[string]any{
 					"virtual_router_name": aws.ToString(v.Value.VirtualRouterName),
 				},
 			}
 		}
 
-		mSpec["provider"] = []interface{}{mProvider}
+		mSpec["provider"] = []any{mProvider}
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }

--- a/internal/service/appmesh/gateway_route.go
+++ b/internal/service/appmesh/gateway_route.go
@@ -507,7 +507,7 @@ func resourceGatewayRouteSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -515,7 +515,7 @@ func resourceGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, met
 	input := &appmesh.CreateGatewayRouteInput{
 		GatewayRouteName:   aws.String(name),
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
-		Spec:               expandGatewayRouteSpec(d.Get("spec").([]interface{})),
+		Spec:               expandGatewayRouteSpec(d.Get("spec").([]any)),
 		Tags:               getTagsIn(ctx),
 		VirtualGatewayName: aws.String(d.Get("virtual_gateway_name").(string)),
 	}
@@ -535,11 +535,11 @@ func resourceGatewayRouteCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceGatewayRouteRead(ctx, d, meta)...)
 }
 
-func resourceGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findGatewayRouteByFourPartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get("virtual_gateway_name").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -570,7 +570,7 @@ func resourceGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceGatewayRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGatewayRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -578,7 +578,7 @@ func resourceGatewayRouteUpdate(ctx context.Context, d *schema.ResourceData, met
 		input := &appmesh.UpdateGatewayRouteInput{
 			GatewayRouteName:   aws.String(d.Get(names.AttrName).(string)),
 			MeshName:           aws.String(d.Get("mesh_name").(string)),
-			Spec:               expandGatewayRouteSpec(d.Get("spec").([]interface{})),
+			Spec:               expandGatewayRouteSpec(d.Get("spec").([]any)),
 			VirtualGatewayName: aws.String(d.Get("virtual_gateway_name").(string)),
 		}
 
@@ -596,7 +596,7 @@ func resourceGatewayRouteUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceGatewayRouteRead(ctx, d, meta)...)
 }
 
-func resourceGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -624,7 +624,7 @@ func resourceGatewayRouteDelete(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceGatewayRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceGatewayRouteImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-gateway-name/gateway-route-name'", d.Id())
@@ -696,24 +696,24 @@ func findGatewayRoute(ctx context.Context, conn *appmesh.Client, input *appmesh.
 	return output.GatewayRoute, nil
 }
 
-func expandGatewayRouteSpec(vSpec []interface{}) *awstypes.GatewayRouteSpec {
+func expandGatewayRouteSpec(vSpec []any) *awstypes.GatewayRouteSpec {
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		return nil
 	}
 
 	spec := &awstypes.GatewayRouteSpec{}
 
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vGrpcRoute, ok := mSpec["grpc_route"].([]interface{}); ok {
+	if vGrpcRoute, ok := mSpec["grpc_route"].([]any); ok {
 		spec.GrpcRoute = expandGRPCGatewayRoute(vGrpcRoute)
 	}
 
-	if vHttp2Route, ok := mSpec["http2_route"].([]interface{}); ok {
+	if vHttp2Route, ok := mSpec["http2_route"].([]any); ok {
 		spec.Http2Route = expandHTTPGatewayRoute(vHttp2Route)
 	}
 
-	if vHttpRoute, ok := mSpec["http_route"].([]interface{}); ok {
+	if vHttpRoute, ok := mSpec["http_route"].([]any); ok {
 		spec.HttpRoute = expandHTTPGatewayRoute(vHttpRoute)
 	}
 
@@ -724,19 +724,19 @@ func expandGatewayRouteSpec(vSpec []interface{}) *awstypes.GatewayRouteSpec {
 	return spec
 }
 
-func expandGatewayRouteTarget(vRouteTarget []interface{}) *awstypes.GatewayRouteTarget {
+func expandGatewayRouteTarget(vRouteTarget []any) *awstypes.GatewayRouteTarget {
 	if len(vRouteTarget) == 0 || vRouteTarget[0] == nil {
 		return nil
 	}
 
 	routeTarget := &awstypes.GatewayRouteTarget{}
 
-	mRouteTarget := vRouteTarget[0].(map[string]interface{})
+	mRouteTarget := vRouteTarget[0].(map[string]any)
 
-	if vVirtualService, ok := mRouteTarget["virtual_service"].([]interface{}); ok && len(vVirtualService) > 0 && vVirtualService[0] != nil {
+	if vVirtualService, ok := mRouteTarget["virtual_service"].([]any); ok && len(vVirtualService) > 0 && vVirtualService[0] != nil {
 		virtualService := &awstypes.GatewayRouteVirtualService{}
 
-		mVirtualService := vVirtualService[0].(map[string]interface{})
+		mVirtualService := vVirtualService[0].(map[string]any)
 
 		if vVirtualServiceName, ok := mVirtualService["virtual_service_name"].(string); ok && vVirtualServiceName != "" {
 			virtualService.VirtualServiceName = aws.String(vVirtualServiceName)
@@ -752,31 +752,31 @@ func expandGatewayRouteTarget(vRouteTarget []interface{}) *awstypes.GatewayRoute
 	return routeTarget
 }
 
-func expandGRPCGatewayRoute(vGrpcRoute []interface{}) *awstypes.GrpcGatewayRoute {
+func expandGRPCGatewayRoute(vGrpcRoute []any) *awstypes.GrpcGatewayRoute {
 	if len(vGrpcRoute) == 0 || vGrpcRoute[0] == nil {
 		return nil
 	}
 
 	route := &awstypes.GrpcGatewayRoute{}
 
-	mGrpcRoute := vGrpcRoute[0].(map[string]interface{})
+	mGrpcRoute := vGrpcRoute[0].(map[string]any)
 
-	if vRouteAction, ok := mGrpcRoute[names.AttrAction].([]interface{}); ok && len(vRouteAction) > 0 && vRouteAction[0] != nil {
+	if vRouteAction, ok := mGrpcRoute[names.AttrAction].([]any); ok && len(vRouteAction) > 0 && vRouteAction[0] != nil {
 		routeAction := &awstypes.GrpcGatewayRouteAction{}
 
-		mRouteAction := vRouteAction[0].(map[string]interface{})
+		mRouteAction := vRouteAction[0].(map[string]any)
 
-		if vRouteTarget, ok := mRouteAction[names.AttrTarget].([]interface{}); ok {
+		if vRouteTarget, ok := mRouteAction[names.AttrTarget].([]any); ok {
 			routeAction.Target = expandGatewayRouteTarget(vRouteTarget)
 		}
 
 		route.Action = routeAction
 	}
 
-	if vRouteMatch, ok := mGrpcRoute["match"].([]interface{}); ok && len(vRouteMatch) > 0 && vRouteMatch[0] != nil {
+	if vRouteMatch, ok := mGrpcRoute["match"].([]any); ok && len(vRouteMatch) > 0 && vRouteMatch[0] != nil {
 		routeMatch := &awstypes.GrpcGatewayRouteMatch{}
 
-		mRouteMatch := vRouteMatch[0].(map[string]interface{})
+		mRouteMatch := vRouteMatch[0].(map[string]any)
 
 		if vServiceName, ok := mRouteMatch[names.AttrServiceName].(string); ok && vServiceName != "" {
 			routeMatch.ServiceName = aws.String(vServiceName)
@@ -792,15 +792,15 @@ func expandGRPCGatewayRoute(vGrpcRoute []interface{}) *awstypes.GrpcGatewayRoute
 	return route
 }
 
-func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *awstypes.HttpGatewayRouteRewrite {
+func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []any) *awstypes.HttpGatewayRouteRewrite {
 	if len(vHttpRouteRewrite) == 0 || vHttpRouteRewrite[0] == nil {
 		return nil
 	}
-	mRouteRewrite := vHttpRouteRewrite[0].(map[string]interface{})
+	mRouteRewrite := vHttpRouteRewrite[0].(map[string]any)
 	routeRewrite := &awstypes.HttpGatewayRouteRewrite{}
 
-	if vRouteHostnameRewrite, ok := mRouteRewrite["hostname"].([]interface{}); ok && len(vRouteHostnameRewrite) > 0 && vRouteHostnameRewrite[0] != nil {
-		mRouteHostnameRewrite := vRouteHostnameRewrite[0].(map[string]interface{})
+	if vRouteHostnameRewrite, ok := mRouteRewrite["hostname"].([]any); ok && len(vRouteHostnameRewrite) > 0 && vRouteHostnameRewrite[0] != nil {
+		mRouteHostnameRewrite := vRouteHostnameRewrite[0].(map[string]any)
 		routeHostnameRewrite := &awstypes.GatewayRouteHostnameRewrite{}
 		if vDefaultTargetHostname, ok := mRouteHostnameRewrite["default_target_hostname"].(string); ok && vDefaultTargetHostname != "" {
 			routeHostnameRewrite.DefaultTargetHostname = awstypes.DefaultGatewayRouteRewrite(vDefaultTargetHostname)
@@ -808,8 +808,8 @@ func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *awstypes.Ht
 		routeRewrite.Hostname = routeHostnameRewrite
 	}
 
-	if vRoutePathRewrite, ok := mRouteRewrite[names.AttrPath].([]interface{}); ok && len(vRoutePathRewrite) > 0 && vRoutePathRewrite[0] != nil {
-		mRoutePathRewrite := vRoutePathRewrite[0].(map[string]interface{})
+	if vRoutePathRewrite, ok := mRouteRewrite[names.AttrPath].([]any); ok && len(vRoutePathRewrite) > 0 && vRoutePathRewrite[0] != nil {
+		mRoutePathRewrite := vRoutePathRewrite[0].(map[string]any)
 		routePathRewrite := &awstypes.HttpGatewayRoutePathRewrite{}
 		if vExact, ok := mRoutePathRewrite["exact"].(string); ok && vExact != "" {
 			routePathRewrite.Exact = aws.String(vExact)
@@ -817,8 +817,8 @@ func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *awstypes.Ht
 		routeRewrite.Path = routePathRewrite
 	}
 
-	if vRoutePrefixRewrite, ok := mRouteRewrite[names.AttrPrefix].([]interface{}); ok && len(vRoutePrefixRewrite) > 0 && vRoutePrefixRewrite[0] != nil {
-		mRoutePrefixRewrite := vRoutePrefixRewrite[0].(map[string]interface{})
+	if vRoutePrefixRewrite, ok := mRouteRewrite[names.AttrPrefix].([]any); ok && len(vRoutePrefixRewrite) > 0 && vRoutePrefixRewrite[0] != nil {
+		mRoutePrefixRewrite := vRoutePrefixRewrite[0].(map[string]any)
 		routePrefixRewrite := &awstypes.HttpGatewayRoutePrefixRewrite{}
 		if vDefaultPrefix, ok := mRoutePrefixRewrite["default_prefix"].(string); ok && vDefaultPrefix != "" {
 			routePrefixRewrite.DefaultPrefix = awstypes.DefaultGatewayRouteRewrite(vDefaultPrefix)
@@ -832,14 +832,14 @@ func expandHTTPGatewayRouteRewrite(vHttpRouteRewrite []interface{}) *awstypes.Ht
 	return routeRewrite
 }
 
-func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGatewayRouteMatch {
+func expandHTTPGatewayRouteMatch(vHttpRouteMatch []any) *awstypes.HttpGatewayRouteMatch {
 	if len(vHttpRouteMatch) == 0 || vHttpRouteMatch[0] == nil {
 		return nil
 	}
 
 	routeMatch := &awstypes.HttpGatewayRouteMatch{}
 
-	mRouteMatch := vHttpRouteMatch[0].(map[string]interface{})
+	mRouteMatch := vHttpRouteMatch[0].(map[string]any)
 
 	if vPort, ok := mRouteMatch[names.AttrPort].(int); ok && vPort > 0 {
 		routeMatch.Port = aws.Int32(int32(vPort))
@@ -855,7 +855,7 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 		for _, vHeader := range vHeaders.List() {
 			header := awstypes.HttpGatewayRouteHeader{}
 
-			mHeader := vHeader.(map[string]interface{})
+			mHeader := vHeader.(map[string]any)
 
 			if vInvert, ok := mHeader["invert"].(bool); ok {
 				header.Invert = aws.Bool(vInvert)
@@ -864,8 +864,8 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 				header.Name = aws.String(vName)
 			}
 
-			if vMatch, ok := mHeader["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
-				mMatch := vMatch[0].(map[string]interface{})
+			if vMatch, ok := mHeader["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
+				mMatch := vMatch[0].(map[string]any)
 
 				if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
 					header.Match = &awstypes.HeaderMatchMethodMemberExact{Value: vExact}
@@ -880,10 +880,10 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 					header.Match = &awstypes.HeaderMatchMethodMemberSuffix{Value: vSuffix}
 				}
 
-				if vRange, ok := mMatch["range"].([]interface{}); ok && len(vRange) > 0 && vRange[0] != nil {
+				if vRange, ok := mMatch["range"].([]any); ok && len(vRange) > 0 && vRange[0] != nil {
 					memberRange := awstypes.MatchRange{}
 
-					mRange := vRange[0].(map[string]interface{})
+					mRange := vRange[0].(map[string]any)
 
 					if vEnd, ok := mRange["end"].(int); ok && vEnd > 0 {
 						memberRange.End = aws.Int64(int64(vEnd))
@@ -901,10 +901,10 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 		routeMatch.Headers = headers
 	}
 
-	if vHostname, ok := mRouteMatch["hostname"].([]interface{}); ok && len(vHostname) > 0 && vHostname[0] != nil {
+	if vHostname, ok := mRouteMatch["hostname"].([]any); ok && len(vHostname) > 0 && vHostname[0] != nil {
 		hostnameMatch := &awstypes.GatewayRouteHostnameMatch{}
 
-		mHostname := vHostname[0].(map[string]interface{})
+		mHostname := vHostname[0].(map[string]any)
 
 		if vExact, ok := mHostname["exact"].(string); ok && vExact != "" {
 			hostnameMatch.Exact = aws.String(vExact)
@@ -916,10 +916,10 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 		routeMatch.Hostname = hostnameMatch
 	}
 
-	if vPath, ok := mRouteMatch[names.AttrPath].([]interface{}); ok && len(vPath) > 0 && vPath[0] != nil {
+	if vPath, ok := mRouteMatch[names.AttrPath].([]any); ok && len(vPath) > 0 && vPath[0] != nil {
 		pathMatch := &awstypes.HttpPathMatch{}
 
-		mHostname := vPath[0].(map[string]interface{})
+		mHostname := vPath[0].(map[string]any)
 
 		if vExact, ok := mHostname["exact"].(string); ok && vExact != "" {
 			pathMatch.Exact = aws.String(vExact)
@@ -937,16 +937,16 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 		for _, vQueryParameter := range vQueryParameters.List() {
 			queryParameter := awstypes.HttpQueryParameter{}
 
-			mQueryParameter := vQueryParameter.(map[string]interface{})
+			mQueryParameter := vQueryParameter.(map[string]any)
 
 			if vName, ok := mQueryParameter[names.AttrName].(string); ok && vName != "" {
 				queryParameter.Name = aws.String(vName)
 			}
 
-			if vMatch, ok := mQueryParameter["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+			if vMatch, ok := mQueryParameter["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 				queryParameter.Match = &awstypes.QueryParameterMatch{}
 
-				mMatch := vMatch[0].(map[string]interface{})
+				mMatch := vMatch[0].(map[string]any)
 
 				if vExact, ok := mMatch["exact"].(string); ok && vExact != "" {
 					queryParameter.Match.Exact = aws.String(vExact)
@@ -962,108 +962,108 @@ func expandHTTPGatewayRouteMatch(vHttpRouteMatch []interface{}) *awstypes.HttpGa
 	return routeMatch
 }
 
-func expandHTTPGatewayRoute(vHttpRoute []interface{}) *awstypes.HttpGatewayRoute {
+func expandHTTPGatewayRoute(vHttpRoute []any) *awstypes.HttpGatewayRoute {
 	if len(vHttpRoute) == 0 || vHttpRoute[0] == nil {
 		return nil
 	}
 
 	route := &awstypes.HttpGatewayRoute{}
 
-	mHttpRoute := vHttpRoute[0].(map[string]interface{})
+	mHttpRoute := vHttpRoute[0].(map[string]any)
 
-	if vRouteAction, ok := mHttpRoute[names.AttrAction].([]interface{}); ok && len(vRouteAction) > 0 && vRouteAction[0] != nil {
+	if vRouteAction, ok := mHttpRoute[names.AttrAction].([]any); ok && len(vRouteAction) > 0 && vRouteAction[0] != nil {
 		routeAction := &awstypes.HttpGatewayRouteAction{}
 
-		mRouteAction := vRouteAction[0].(map[string]interface{})
+		mRouteAction := vRouteAction[0].(map[string]any)
 
-		if vRouteTarget, ok := mRouteAction[names.AttrTarget].([]interface{}); ok {
+		if vRouteTarget, ok := mRouteAction[names.AttrTarget].([]any); ok {
 			routeAction.Target = expandGatewayRouteTarget(vRouteTarget)
 		}
 
-		if vRouteRewrite, ok := mRouteAction["rewrite"].([]interface{}); ok {
+		if vRouteRewrite, ok := mRouteAction["rewrite"].([]any); ok {
 			routeAction.Rewrite = expandHTTPGatewayRouteRewrite(vRouteRewrite)
 		}
 
 		route.Action = routeAction
 	}
 
-	if vRouteMatch, ok := mHttpRoute["match"].([]interface{}); ok && len(vRouteMatch) > 0 && vRouteMatch[0] != nil {
+	if vRouteMatch, ok := mHttpRoute["match"].([]any); ok && len(vRouteMatch) > 0 && vRouteMatch[0] != nil {
 		route.Match = expandHTTPGatewayRouteMatch(vRouteMatch)
 	}
 
 	return route
 }
 
-func flattenGatewayRouteSpec(spec *awstypes.GatewayRouteSpec) []interface{} {
+func flattenGatewayRouteSpec(spec *awstypes.GatewayRouteSpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{
+	mSpec := map[string]any{
 		"grpc_route":       flattenGRPCGatewayRoute(spec.GrpcRoute),
 		"http2_route":      flattenHTTPGatewayRoute(spec.Http2Route),
 		"http_route":       flattenHTTPGatewayRoute(spec.HttpRoute),
 		names.AttrPriority: aws.ToInt32(spec.Priority),
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenGatewayRouteTarget(routeTarget *awstypes.GatewayRouteTarget) []interface{} {
+func flattenGatewayRouteTarget(routeTarget *awstypes.GatewayRouteTarget) []any {
 	if routeTarget == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mRouteTarget := map[string]interface{}{
+	mRouteTarget := map[string]any{
 		names.AttrPort: aws.ToInt32(routeTarget.Port),
 	}
 
 	if virtualService := routeTarget.VirtualService; virtualService != nil {
-		mVirtualService := map[string]interface{}{
+		mVirtualService := map[string]any{
 			"virtual_service_name": aws.ToString(virtualService.VirtualServiceName),
 		}
 
-		mRouteTarget["virtual_service"] = []interface{}{mVirtualService}
+		mRouteTarget["virtual_service"] = []any{mVirtualService}
 	}
 
-	return []interface{}{mRouteTarget}
+	return []any{mRouteTarget}
 }
 
-func flattenGRPCGatewayRoute(grpcRoute *awstypes.GrpcGatewayRoute) []interface{} {
+func flattenGRPCGatewayRoute(grpcRoute *awstypes.GrpcGatewayRoute) []any {
 	if grpcRoute == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mGrpcRoute := map[string]interface{}{}
+	mGrpcRoute := map[string]any{}
 
 	if routeAction := grpcRoute.Action; routeAction != nil {
-		mRouteAction := map[string]interface{}{
+		mRouteAction := map[string]any{
 			names.AttrTarget: flattenGatewayRouteTarget(routeAction.Target),
 		}
 
-		mGrpcRoute[names.AttrAction] = []interface{}{mRouteAction}
+		mGrpcRoute[names.AttrAction] = []any{mRouteAction}
 	}
 
 	if routeMatch := grpcRoute.Match; routeMatch != nil {
-		mRouteMatch := map[string]interface{}{
+		mRouteMatch := map[string]any{
 			names.AttrServiceName: aws.ToString(routeMatch.ServiceName),
 		}
 		if routeMatch.Port != nil {
 			mRouteMatch[names.AttrPort] = aws.ToInt32(routeMatch.Port)
 		}
 
-		mGrpcRoute["match"] = []interface{}{mRouteMatch}
+		mGrpcRoute["match"] = []any{mRouteMatch}
 	}
 
-	return []interface{}{mGrpcRoute}
+	return []any{mGrpcRoute}
 }
 
-func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []interface{} {
+func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []any {
 	if routeMatch == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mRouteMatch := map[string]interface{}{}
+	mRouteMatch := map[string]any{}
 
 	if routeMatch.Port != nil {
 		mRouteMatch[names.AttrPort] = aws.ToInt32(routeMatch.Port)
@@ -1073,15 +1073,15 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 		mRouteMatch[names.AttrPrefix] = aws.ToString(routeMatch.Prefix)
 	}
 
-	vHeaders := []interface{}{}
+	vHeaders := []any{}
 
 	for _, header := range routeMatch.Headers {
-		mHeader := map[string]interface{}{
+		mHeader := map[string]any{
 			"invert":       aws.ToBool(header.Invert),
 			names.AttrName: aws.ToString(header.Name),
 		}
 
-		mMatch := map[string]interface{}{}
+		mMatch := map[string]any{}
 
 		if match := header.Match; match != nil {
 			switch v := match.(type) {
@@ -1094,14 +1094,14 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 			case *awstypes.HeaderMatchMethodMemberSuffix:
 				mMatch["suffix"] = v.Value
 			case *awstypes.HeaderMatchMethodMemberRange:
-				mRange := map[string]interface{}{
+				mRange := map[string]any{
 					"end":   aws.ToInt64(v.Value.End),
 					"start": aws.ToInt64(v.Value.Start),
 				}
-				mMatch["range"] = []interface{}{mRange}
+				mMatch["range"] = []any{mRange}
 			}
 
-			mHeader["match"] = []interface{}{mMatch}
+			mHeader["match"] = []any{mMatch}
 		}
 
 		vHeaders = append(vHeaders, mHeader)
@@ -1110,7 +1110,7 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 	mRouteMatch[names.AttrHeader] = vHeaders
 
 	if hostname := routeMatch.Hostname; hostname != nil {
-		mHostname := map[string]interface{}{}
+		mHostname := map[string]any{}
 
 		if hostname.Exact != nil {
 			mHostname["exact"] = aws.ToString(hostname.Exact)
@@ -1119,11 +1119,11 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 			mHostname["suffix"] = aws.ToString(hostname.Suffix)
 		}
 
-		mRouteMatch["hostname"] = []interface{}{mHostname}
+		mRouteMatch["hostname"] = []any{mHostname}
 	}
 
 	if path := routeMatch.Path; path != nil {
-		mPath := map[string]interface{}{}
+		mPath := map[string]any{}
 
 		if path.Exact != nil {
 			mPath["exact"] = aws.ToString(path.Exact)
@@ -1132,22 +1132,22 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 			mPath["regex"] = aws.ToString(path.Regex)
 		}
 
-		mRouteMatch[names.AttrPath] = []interface{}{mPath}
+		mRouteMatch[names.AttrPath] = []any{mPath}
 	}
 
-	vQueryParameters := []interface{}{}
+	vQueryParameters := []any{}
 
 	for _, queryParameter := range routeMatch.QueryParameters {
-		mQueryParameter := map[string]interface{}{
+		mQueryParameter := map[string]any{
 			names.AttrName: aws.ToString(queryParameter.Name),
 		}
 
 		if match := queryParameter.Match; match != nil {
-			mMatch := map[string]interface{}{
+			mMatch := map[string]any{
 				"exact": aws.ToString(match.Exact),
 			}
 
-			mQueryParameter["match"] = []interface{}{mMatch}
+			mQueryParameter["match"] = []any{mMatch}
 		}
 
 		vQueryParameters = append(vQueryParameters, mQueryParameter)
@@ -1155,62 +1155,62 @@ func flattenHTTPGatewayRouteMatch(routeMatch *awstypes.HttpGatewayRouteMatch) []
 
 	mRouteMatch["query_parameter"] = vQueryParameters
 
-	return []interface{}{mRouteMatch}
+	return []any{mRouteMatch}
 }
 
-func flattenHTTPGatewayRouteRewrite(routeRewrite *awstypes.HttpGatewayRouteRewrite) []interface{} {
+func flattenHTTPGatewayRouteRewrite(routeRewrite *awstypes.HttpGatewayRouteRewrite) []any {
 	if routeRewrite == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mRouteRewrite := map[string]interface{}{}
+	mRouteRewrite := map[string]any{}
 
 	if rewriteHostname := routeRewrite.Hostname; rewriteHostname != nil {
-		mRewriteHostname := map[string]interface{}{
+		mRewriteHostname := map[string]any{
 			"default_target_hostname": rewriteHostname.DefaultTargetHostname,
 		}
-		mRouteRewrite["hostname"] = []interface{}{mRewriteHostname}
+		mRouteRewrite["hostname"] = []any{mRewriteHostname}
 	}
 
 	if rewritePath := routeRewrite.Path; rewritePath != nil {
-		mRewritePath := map[string]interface{}{
+		mRewritePath := map[string]any{
 			"exact": aws.ToString(rewritePath.Exact),
 		}
-		mRouteRewrite[names.AttrPath] = []interface{}{mRewritePath}
+		mRouteRewrite[names.AttrPath] = []any{mRewritePath}
 	}
 
 	if rewritePrefix := routeRewrite.Prefix; rewritePrefix != nil {
-		mRewritePrefix := map[string]interface{}{
+		mRewritePrefix := map[string]any{
 			"default_prefix": rewritePrefix.DefaultPrefix,
 		}
 		if rewritePrefixValue := rewritePrefix.Value; rewritePrefixValue != nil {
 			mRewritePrefix[names.AttrValue] = aws.ToString(rewritePrefix.Value)
 		}
-		mRouteRewrite[names.AttrPrefix] = []interface{}{mRewritePrefix}
+		mRouteRewrite[names.AttrPrefix] = []any{mRewritePrefix}
 	}
 
-	return []interface{}{mRouteRewrite}
+	return []any{mRouteRewrite}
 }
 
-func flattenHTTPGatewayRoute(httpRoute *awstypes.HttpGatewayRoute) []interface{} {
+func flattenHTTPGatewayRoute(httpRoute *awstypes.HttpGatewayRoute) []any {
 	if httpRoute == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mHttpRoute := map[string]interface{}{}
+	mHttpRoute := map[string]any{}
 
 	if routeAction := httpRoute.Action; routeAction != nil {
-		mRouteAction := map[string]interface{}{
+		mRouteAction := map[string]any{
 			names.AttrTarget: flattenGatewayRouteTarget(routeAction.Target),
 			"rewrite":        flattenHTTPGatewayRouteRewrite(routeAction.Rewrite),
 		}
 
-		mHttpRoute[names.AttrAction] = []interface{}{mRouteAction}
+		mHttpRoute[names.AttrAction] = []any{mRouteAction}
 	}
 
 	if routeMatch := httpRoute.Match; routeMatch != nil {
 		mHttpRoute["match"] = flattenHTTPGatewayRouteMatch(routeMatch)
 	}
 
-	return []interface{}{mHttpRoute}
+	return []any{mHttpRoute}
 }

--- a/internal/service/appmesh/gateway_route_data_source.go
+++ b/internal/service/appmesh/gateway_route_data_source.go
@@ -67,7 +67,7 @@ func dataSourceGatewayRoute() *schema.Resource {
 	}
 }
 
-func dataSourceGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGatewayRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/mesh.go
+++ b/internal/service/appmesh/mesh.go
@@ -121,14 +121,14 @@ func resourceMeshSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceMeshCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMeshCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &appmesh.CreateMeshInput{
 		MeshName: aws.String(name),
-		Spec:     expandMeshSpec(d.Get("spec").([]interface{})),
+		Spec:     expandMeshSpec(d.Get("spec").([]any)),
 		Tags:     getTagsIn(ctx),
 	}
 
@@ -143,11 +143,11 @@ func resourceMeshCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceMeshRead(ctx, d, meta)...)
 }
 
-func resourceMeshRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMeshRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findMeshByTwoPartKey(ctx, conn, d.Id(), d.Get("mesh_owner").(string))
 	}, d.IsNewResource())
 
@@ -176,14 +176,14 @@ func resourceMeshRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceMeshUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMeshUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateMeshInput{
 			MeshName: aws.String(d.Id()),
-			Spec:     expandMeshSpec(d.Get("spec").([]interface{})),
+			Spec:     expandMeshSpec(d.Get("spec").([]any)),
 		}
 
 		_, err := conn.UpdateMesh(ctx, input)
@@ -196,7 +196,7 @@ func resourceMeshUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceMeshRead(ctx, d, meta)...)
 }
 
-func resourceMeshDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMeshDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/mesh_data_source.go
+++ b/internal/service/appmesh/mesh_data_source.go
@@ -59,7 +59,7 @@ func dataSourceMesh() *schema.Resource {
 	}
 }
 
-func dataSourceMeshRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceMeshRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/route.go
+++ b/internal/service/appmesh/route.go
@@ -746,7 +746,7 @@ func resourceRouteSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -754,7 +754,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	input := &appmesh.CreateRouteInput{
 		MeshName:          aws.String(d.Get("mesh_name").(string)),
 		RouteName:         aws.String(name),
-		Spec:              expandRouteSpec(d.Get("spec").([]interface{})),
+		Spec:              expandRouteSpec(d.Get("spec").([]any)),
 		Tags:              getTagsIn(ctx),
 		VirtualRouterName: aws.String(d.Get("virtual_router_name").(string)),
 	}
@@ -774,11 +774,11 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findRouteByFourPartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get("virtual_router_name").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -809,7 +809,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -817,7 +817,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		input := &appmesh.UpdateRouteInput{
 			MeshName:          aws.String(d.Get("mesh_name").(string)),
 			RouteName:         aws.String(d.Get(names.AttrName).(string)),
-			Spec:              expandRouteSpec(d.Get("spec").([]interface{})),
+			Spec:              expandRouteSpec(d.Get("spec").([]any)),
 			VirtualRouterName: aws.String(d.Get("virtual_router_name").(string)),
 		}
 
@@ -835,7 +835,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -863,7 +863,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-router-name/route-name'", d.Id())

--- a/internal/service/appmesh/route_data_source.go
+++ b/internal/service/appmesh/route_data_source.go
@@ -67,7 +67,7 @@ func dataSourceRoute() *schema.Resource {
 	}
 }
 
-func dataSourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/virtual_gateway.go
+++ b/internal/service/appmesh/virtual_gateway.go
@@ -656,14 +656,14 @@ func resourceVirtualGatewaySpecSchema() *schema.Schema {
 	}
 }
 
-func resourceVirtualGatewayCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualGatewayCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &appmesh.CreateVirtualGatewayInput{
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
-		Spec:               expandVirtualGatewaySpec(d.Get("spec").([]interface{})),
+		Spec:               expandVirtualGatewaySpec(d.Get("spec").([]any)),
 		Tags:               getTagsIn(ctx),
 		VirtualGatewayName: aws.String(name),
 	}
@@ -683,11 +683,11 @@ func resourceVirtualGatewayCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVirtualGatewayRead(ctx, d, meta)...)
 }
 
-func resourceVirtualGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findVirtualGatewayByThreePartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -717,14 +717,14 @@ func resourceVirtualGatewayRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceVirtualGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualGatewayUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateVirtualGatewayInput{
 			MeshName:           aws.String(d.Get("mesh_name").(string)),
-			Spec:               expandVirtualGatewaySpec(d.Get("spec").([]interface{})),
+			Spec:               expandVirtualGatewaySpec(d.Get("spec").([]any)),
 			VirtualGatewayName: aws.String(d.Get(names.AttrName).(string)),
 		}
 
@@ -742,7 +742,7 @@ func resourceVirtualGatewayUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVirtualGatewayRead(ctx, d, meta)...)
 }
 
-func resourceVirtualGatewayDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualGatewayDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -769,7 +769,7 @@ func resourceVirtualGatewayDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceVirtualGatewayImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVirtualGatewayImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-gateway-name'", d.Id())
@@ -839,39 +839,39 @@ func findVirtualGateway(ctx context.Context, conn *appmesh.Client, input *appmes
 	return output.VirtualGateway, nil
 }
 
-func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec {
+func expandVirtualGatewaySpec(vSpec []any) *awstypes.VirtualGatewaySpec {
 	if len(vSpec) == 0 || vSpec[0] == nil {
 		return nil
 	}
 
 	spec := &awstypes.VirtualGatewaySpec{}
 
-	mSpec := vSpec[0].(map[string]interface{})
+	mSpec := vSpec[0].(map[string]any)
 
-	if vBackendDefaults, ok := mSpec["backend_defaults"].([]interface{}); ok && len(vBackendDefaults) > 0 && vBackendDefaults[0] != nil {
+	if vBackendDefaults, ok := mSpec["backend_defaults"].([]any); ok && len(vBackendDefaults) > 0 && vBackendDefaults[0] != nil {
 		backendDefaults := &awstypes.VirtualGatewayBackendDefaults{}
 
-		mBackendDefaults := vBackendDefaults[0].(map[string]interface{})
+		mBackendDefaults := vBackendDefaults[0].(map[string]any)
 
-		if vClientPolicy, ok := mBackendDefaults["client_policy"].([]interface{}); ok {
+		if vClientPolicy, ok := mBackendDefaults["client_policy"].([]any); ok {
 			backendDefaults.ClientPolicy = expandVirtualGatewayClientPolicy(vClientPolicy)
 		}
 
 		spec.BackendDefaults = backendDefaults
 	}
 
-	if vListeners, ok := mSpec["listener"].([]interface{}); ok && len(vListeners) > 0 && vListeners[0] != nil {
+	if vListeners, ok := mSpec["listener"].([]any); ok && len(vListeners) > 0 && vListeners[0] != nil {
 		listeners := []awstypes.VirtualGatewayListener{}
 
 		for _, vListener := range vListeners {
 			listener := awstypes.VirtualGatewayListener{}
 
-			mListener := vListener.(map[string]interface{})
+			mListener := vListener.(map[string]any)
 
-			if vHealthCheck, ok := mListener[names.AttrHealthCheck].([]interface{}); ok && len(vHealthCheck) > 0 && vHealthCheck[0] != nil {
+			if vHealthCheck, ok := mListener[names.AttrHealthCheck].([]any); ok && len(vHealthCheck) > 0 && vHealthCheck[0] != nil {
 				healthCheck := &awstypes.VirtualGatewayHealthCheckPolicy{}
 
-				mHealthCheck := vHealthCheck[0].(map[string]interface{})
+				mHealthCheck := vHealthCheck[0].(map[string]any)
 
 				if vHealthyThreshold, ok := mHealthCheck["healthy_threshold"].(int); ok && vHealthyThreshold > 0 {
 					healthCheck.HealthyThreshold = aws.Int32(int32(vHealthyThreshold))
@@ -898,12 +898,12 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 				listener.HealthCheck = healthCheck
 			}
 
-			if vConnectionPool, ok := mListener["connection_pool"].([]interface{}); ok && len(vConnectionPool) > 0 && vConnectionPool[0] != nil {
-				mConnectionPool := vConnectionPool[0].(map[string]interface{})
+			if vConnectionPool, ok := mListener["connection_pool"].([]any); ok && len(vConnectionPool) > 0 && vConnectionPool[0] != nil {
+				mConnectionPool := vConnectionPool[0].(map[string]any)
 
-				if vGrpcConnectionPool, ok := mConnectionPool["grpc"].([]interface{}); ok && len(vGrpcConnectionPool) > 0 && vGrpcConnectionPool[0] != nil {
+				if vGrpcConnectionPool, ok := mConnectionPool["grpc"].([]any); ok && len(vGrpcConnectionPool) > 0 && vGrpcConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualGatewayConnectionPoolMemberGrpc{}
-					mGrpcConnectionPool := vGrpcConnectionPool[0].(map[string]interface{})
+					mGrpcConnectionPool := vGrpcConnectionPool[0].(map[string]any)
 
 					grpcConnectionPool := awstypes.VirtualGatewayGrpcConnectionPool{}
 
@@ -915,9 +915,9 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 					listener.ConnectionPool = connectionPool
 				}
 
-				if vHttpConnectionPool, ok := mConnectionPool["http"].([]interface{}); ok && len(vHttpConnectionPool) > 0 && vHttpConnectionPool[0] != nil {
+				if vHttpConnectionPool, ok := mConnectionPool["http"].([]any); ok && len(vHttpConnectionPool) > 0 && vHttpConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualGatewayConnectionPoolMemberHttp{}
-					mHttpConnectionPool := vHttpConnectionPool[0].(map[string]interface{})
+					mHttpConnectionPool := vHttpConnectionPool[0].(map[string]any)
 
 					httpConnectionPool := awstypes.VirtualGatewayHttpConnectionPool{}
 
@@ -932,9 +932,9 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 					listener.ConnectionPool = connectionPool
 				}
 
-				if vHttp2ConnectionPool, ok := mConnectionPool["http2"].([]interface{}); ok && len(vHttp2ConnectionPool) > 0 && vHttp2ConnectionPool[0] != nil {
+				if vHttp2ConnectionPool, ok := mConnectionPool["http2"].([]any); ok && len(vHttp2ConnectionPool) > 0 && vHttp2ConnectionPool[0] != nil {
 					connectionPool := &awstypes.VirtualGatewayConnectionPoolMemberHttp2{}
-					mHttp2ConnectionPool := vHttp2ConnectionPool[0].(map[string]interface{})
+					mHttp2ConnectionPool := vHttp2ConnectionPool[0].(map[string]any)
 
 					http2ConnectionPool := awstypes.VirtualGatewayHttp2ConnectionPool{}
 
@@ -947,10 +947,10 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 				}
 			}
 
-			if vPortMapping, ok := mListener["port_mapping"].([]interface{}); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
+			if vPortMapping, ok := mListener["port_mapping"].([]any); ok && len(vPortMapping) > 0 && vPortMapping[0] != nil {
 				portMapping := &awstypes.VirtualGatewayPortMapping{}
 
-				mPortMapping := vPortMapping[0].(map[string]interface{})
+				mPortMapping := vPortMapping[0].(map[string]any)
 
 				if vPort, ok := mPortMapping[names.AttrPort].(int); ok && vPort > 0 {
 					portMapping.Port = aws.Int32(int32(vPort))
@@ -962,23 +962,23 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 				listener.PortMapping = portMapping
 			}
 
-			if vTls, ok := mListener["tls"].([]interface{}); ok && len(vTls) > 0 && vTls[0] != nil {
+			if vTls, ok := mListener["tls"].([]any); ok && len(vTls) > 0 && vTls[0] != nil {
 				tls := &awstypes.VirtualGatewayListenerTls{}
 
-				mTls := vTls[0].(map[string]interface{})
+				mTls := vTls[0].(map[string]any)
 
 				if vMode, ok := mTls[names.AttrMode].(string); ok && vMode != "" {
 					tls.Mode = awstypes.VirtualGatewayListenerTlsMode(vMode)
 				}
 
-				if vCertificate, ok := mTls[names.AttrCertificate].([]interface{}); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
-					mCertificate := vCertificate[0].(map[string]interface{})
+				if vCertificate, ok := mTls[names.AttrCertificate].([]any); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
+					mCertificate := vCertificate[0].(map[string]any)
 
-					if vAcm, ok := mCertificate["acm"].([]interface{}); ok && len(vAcm) > 0 && vAcm[0] != nil {
+					if vAcm, ok := mCertificate["acm"].([]any); ok && len(vAcm) > 0 && vAcm[0] != nil {
 						certificate := &awstypes.VirtualGatewayListenerTlsCertificateMemberAcm{}
 						acm := awstypes.VirtualGatewayListenerTlsAcmCertificate{}
 
-						mAcm := vAcm[0].(map[string]interface{})
+						mAcm := vAcm[0].(map[string]any)
 
 						if vCertificateArn, ok := mAcm[names.AttrCertificateARN].(string); ok && vCertificateArn != "" {
 							acm.CertificateArn = aws.String(vCertificateArn)
@@ -988,11 +988,11 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 						tls.Certificate = certificate
 					}
 
-					if vFile, ok := mCertificate["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+					if vFile, ok := mCertificate["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 						certificate := &awstypes.VirtualGatewayListenerTlsCertificateMemberFile{}
 						file := awstypes.VirtualGatewayListenerTlsFileCertificate{}
 
-						mFile := vFile[0].(map[string]interface{})
+						mFile := vFile[0].(map[string]any)
 
 						if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 							file.CertificateChain = aws.String(vCertificateChain)
@@ -1005,11 +1005,11 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 						tls.Certificate = certificate
 					}
 
-					if vSds, ok := mCertificate["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+					if vSds, ok := mCertificate["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 						certificate := &awstypes.VirtualGatewayListenerTlsCertificateMemberSds{}
 						sds := awstypes.VirtualGatewayListenerTlsSdsCertificate{}
 
-						mSds := vSds[0].(map[string]interface{})
+						mSds := vSds[0].(map[string]any)
 
 						if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 							sds.SecretName = aws.String(vSecretName)
@@ -1020,20 +1020,20 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 					}
 				}
 
-				if vValidation, ok := mTls["validation"].([]interface{}); ok && len(vValidation) > 0 && vValidation[0] != nil {
+				if vValidation, ok := mTls["validation"].([]any); ok && len(vValidation) > 0 && vValidation[0] != nil {
 					validation := &awstypes.VirtualGatewayListenerTlsValidationContext{}
 
-					mValidation := vValidation[0].(map[string]interface{})
+					mValidation := vValidation[0].(map[string]any)
 
-					if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]interface{}); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
+					if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]any); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
 						subjectAlternativeNames := &awstypes.SubjectAlternativeNames{}
 
-						mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]interface{})
+						mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]any)
 
-						if vMatch, ok := mSubjectAlternativeNames["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+						if vMatch, ok := mSubjectAlternativeNames["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 							match := &awstypes.SubjectAlternativeNameMatchers{}
 
-							mMatch := vMatch[0].(map[string]interface{})
+							mMatch := vMatch[0].(map[string]any)
 
 							if vExact, ok := mMatch["exact"].(*schema.Set); ok && vExact.Len() > 0 {
 								match.Exact = flex.ExpandStringValueSet(vExact)
@@ -1045,14 +1045,14 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 						validation.SubjectAlternativeNames = subjectAlternativeNames
 					}
 
-					if vTrust, ok := mValidation["trust"].([]interface{}); ok && len(vTrust) > 0 && vTrust[0] != nil {
-						mTrust := vTrust[0].(map[string]interface{})
+					if vTrust, ok := mValidation["trust"].([]any); ok && len(vTrust) > 0 && vTrust[0] != nil {
+						mTrust := vTrust[0].(map[string]any)
 
-						if vFile, ok := mTrust["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+						if vFile, ok := mTrust["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 							trust := &awstypes.VirtualGatewayListenerTlsValidationContextTrustMemberFile{}
 							file := awstypes.VirtualGatewayTlsValidationContextFileTrust{}
 
-							mFile := vFile[0].(map[string]interface{})
+							mFile := vFile[0].(map[string]any)
 
 							if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 								file.CertificateChain = aws.String(vCertificateChain)
@@ -1062,11 +1062,11 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 							validation.Trust = trust
 						}
 
-						if vSds, ok := mTrust["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+						if vSds, ok := mTrust["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 							trust := &awstypes.VirtualGatewayListenerTlsValidationContextTrustMemberSds{}
 							sds := awstypes.VirtualGatewayTlsValidationContextSdsTrust{}
 
-							mSds := vSds[0].(map[string]interface{})
+							mSds := vSds[0].(map[string]any)
 
 							if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 								sds.SecretName = aws.String(vSecretName)
@@ -1089,30 +1089,30 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 		spec.Listeners = listeners
 	}
 
-	if vLogging, ok := mSpec["logging"].([]interface{}); ok && len(vLogging) > 0 && vLogging[0] != nil {
+	if vLogging, ok := mSpec["logging"].([]any); ok && len(vLogging) > 0 && vLogging[0] != nil {
 		logging := &awstypes.VirtualGatewayLogging{}
 
-		mLogging := vLogging[0].(map[string]interface{})
+		mLogging := vLogging[0].(map[string]any)
 
-		if vAccessLog, ok := mLogging["access_log"].([]interface{}); ok && len(vAccessLog) > 0 && vAccessLog[0] != nil {
-			mAccessLog := vAccessLog[0].(map[string]interface{})
+		if vAccessLog, ok := mLogging["access_log"].([]any); ok && len(vAccessLog) > 0 && vAccessLog[0] != nil {
+			mAccessLog := vAccessLog[0].(map[string]any)
 
-			if vFile, ok := mAccessLog["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+			if vFile, ok := mAccessLog["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 				accessLog := &awstypes.VirtualGatewayAccessLogMemberFile{}
 				file := awstypes.VirtualGatewayFileAccessLog{}
 
-				mFile := vFile[0].(map[string]interface{})
+				mFile := vFile[0].(map[string]any)
 
-				if vFormat, ok := mFile[names.AttrFormat].([]interface{}); ok && len(vFormat) > 0 && vFormat[0] != nil {
-					mFormat := vFormat[0].(map[string]interface{})
+				if vFormat, ok := mFile[names.AttrFormat].([]any); ok && len(vFormat) > 0 && vFormat[0] != nil {
+					mFormat := vFormat[0].(map[string]any)
 
-					if vJsonFormatRefs, ok := mFormat[names.AttrJSON].([]interface{}); ok && len(vJsonFormatRefs) > 0 {
+					if vJsonFormatRefs, ok := mFormat[names.AttrJSON].([]any); ok && len(vJsonFormatRefs) > 0 {
 						format := &awstypes.LoggingFormatMemberJson{}
 						jsonFormatRefs := []awstypes.JsonFormatRef{}
 						for _, vJsonFormatRef := range vJsonFormatRefs {
 							mJsonFormatRef := awstypes.JsonFormatRef{
-								Key:   aws.String(vJsonFormatRef.(map[string]interface{})[names.AttrKey].(string)),
-								Value: aws.String(vJsonFormatRef.(map[string]interface{})[names.AttrValue].(string)),
+								Key:   aws.String(vJsonFormatRef.(map[string]any)[names.AttrKey].(string)),
+								Value: aws.String(vJsonFormatRef.(map[string]any)[names.AttrValue].(string)),
 							}
 							jsonFormatRefs = append(jsonFormatRefs, mJsonFormatRef)
 						}
@@ -1142,28 +1142,28 @@ func expandVirtualGatewaySpec(vSpec []interface{}) *awstypes.VirtualGatewaySpec 
 	return spec
 }
 
-func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.VirtualGatewayClientPolicy {
+func expandVirtualGatewayClientPolicy(vClientPolicy []any) *awstypes.VirtualGatewayClientPolicy {
 	if len(vClientPolicy) == 0 || vClientPolicy[0] == nil {
 		return nil
 	}
 
 	clientPolicy := &awstypes.VirtualGatewayClientPolicy{}
 
-	mClientPolicy := vClientPolicy[0].(map[string]interface{})
+	mClientPolicy := vClientPolicy[0].(map[string]any)
 
-	if vTls, ok := mClientPolicy["tls"].([]interface{}); ok && len(vTls) > 0 && vTls[0] != nil {
+	if vTls, ok := mClientPolicy["tls"].([]any); ok && len(vTls) > 0 && vTls[0] != nil {
 		tls := &awstypes.VirtualGatewayClientPolicyTls{}
 
-		mTls := vTls[0].(map[string]interface{})
+		mTls := vTls[0].(map[string]any)
 
-		if vCertificate, ok := mTls[names.AttrCertificate].([]interface{}); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
-			mCertificate := vCertificate[0].(map[string]interface{})
+		if vCertificate, ok := mTls[names.AttrCertificate].([]any); ok && len(vCertificate) > 0 && vCertificate[0] != nil {
+			mCertificate := vCertificate[0].(map[string]any)
 
-			if vFile, ok := mCertificate["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+			if vFile, ok := mCertificate["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 				certificate := &awstypes.VirtualGatewayClientTlsCertificateMemberFile{}
 				file := awstypes.VirtualGatewayListenerTlsFileCertificate{}
 
-				mFile := vFile[0].(map[string]interface{})
+				mFile := vFile[0].(map[string]any)
 
 				if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 					file.CertificateChain = aws.String(vCertificateChain)
@@ -1176,11 +1176,11 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 				tls.Certificate = certificate
 			}
 
-			if vSds, ok := mCertificate["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+			if vSds, ok := mCertificate["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 				certificate := &awstypes.VirtualGatewayClientTlsCertificateMemberSds{}
 				sds := awstypes.VirtualGatewayListenerTlsSdsCertificate{}
 
-				mSds := vSds[0].(map[string]interface{})
+				mSds := vSds[0].(map[string]any)
 
 				if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 					sds.SecretName = aws.String(vSecretName)
@@ -1199,20 +1199,20 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 			tls.Ports = flex.ExpandInt32ValueSet(vPorts)
 		}
 
-		if vValidation, ok := mTls["validation"].([]interface{}); ok && len(vValidation) > 0 && vValidation[0] != nil {
+		if vValidation, ok := mTls["validation"].([]any); ok && len(vValidation) > 0 && vValidation[0] != nil {
 			validation := &awstypes.VirtualGatewayTlsValidationContext{}
 
-			mValidation := vValidation[0].(map[string]interface{})
+			mValidation := vValidation[0].(map[string]any)
 
-			if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]interface{}); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
+			if vSubjectAlternativeNames, ok := mValidation["subject_alternative_names"].([]any); ok && len(vSubjectAlternativeNames) > 0 && vSubjectAlternativeNames[0] != nil {
 				subjectAlternativeNames := &awstypes.SubjectAlternativeNames{}
 
-				mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]interface{})
+				mSubjectAlternativeNames := vSubjectAlternativeNames[0].(map[string]any)
 
-				if vMatch, ok := mSubjectAlternativeNames["match"].([]interface{}); ok && len(vMatch) > 0 && vMatch[0] != nil {
+				if vMatch, ok := mSubjectAlternativeNames["match"].([]any); ok && len(vMatch) > 0 && vMatch[0] != nil {
 					match := &awstypes.SubjectAlternativeNameMatchers{}
 
-					mMatch := vMatch[0].(map[string]interface{})
+					mMatch := vMatch[0].(map[string]any)
 
 					if vExact, ok := mMatch["exact"].(*schema.Set); ok && vExact.Len() > 0 {
 						match.Exact = flex.ExpandStringValueSet(vExact)
@@ -1224,14 +1224,14 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 				validation.SubjectAlternativeNames = subjectAlternativeNames
 			}
 
-			if vTrust, ok := mValidation["trust"].([]interface{}); ok && len(vTrust) > 0 && vTrust[0] != nil {
-				mTrust := vTrust[0].(map[string]interface{})
+			if vTrust, ok := mValidation["trust"].([]any); ok && len(vTrust) > 0 && vTrust[0] != nil {
+				mTrust := vTrust[0].(map[string]any)
 
-				if vAcm, ok := mTrust["acm"].([]interface{}); ok && len(vAcm) > 0 && vAcm[0] != nil {
+				if vAcm, ok := mTrust["acm"].([]any); ok && len(vAcm) > 0 && vAcm[0] != nil {
 					trust := &awstypes.VirtualGatewayTlsValidationContextTrustMemberAcm{}
 					acm := awstypes.VirtualGatewayTlsValidationContextAcmTrust{}
 
-					mAcm := vAcm[0].(map[string]interface{})
+					mAcm := vAcm[0].(map[string]any)
 
 					if vCertificateAuthorityArns, ok := mAcm["certificate_authority_arns"].(*schema.Set); ok && vCertificateAuthorityArns.Len() > 0 {
 						acm.CertificateAuthorityArns = flex.ExpandStringValueSet(vCertificateAuthorityArns)
@@ -1241,11 +1241,11 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 					validation.Trust = trust
 				}
 
-				if vFile, ok := mTrust["file"].([]interface{}); ok && len(vFile) > 0 && vFile[0] != nil {
+				if vFile, ok := mTrust["file"].([]any); ok && len(vFile) > 0 && vFile[0] != nil {
 					trust := &awstypes.VirtualGatewayTlsValidationContextTrustMemberFile{}
 					file := awstypes.VirtualGatewayTlsValidationContextFileTrust{}
 
-					mFile := vFile[0].(map[string]interface{})
+					mFile := vFile[0].(map[string]any)
 
 					if vCertificateChain, ok := mFile[names.AttrCertificateChain].(string); ok && vCertificateChain != "" {
 						file.CertificateChain = aws.String(vCertificateChain)
@@ -1255,11 +1255,11 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 					validation.Trust = trust
 				}
 
-				if vSds, ok := mTrust["sds"].([]interface{}); ok && len(vSds) > 0 && vSds[0] != nil {
+				if vSds, ok := mTrust["sds"].([]any); ok && len(vSds) > 0 && vSds[0] != nil {
 					trust := &awstypes.VirtualGatewayTlsValidationContextTrustMemberSds{}
 					sds := awstypes.VirtualGatewayTlsValidationContextSdsTrust{}
 
-					mSds := vSds[0].(map[string]interface{})
+					mSds := vSds[0].(map[string]any)
 
 					if vSecretName, ok := mSds["secret_name"].(string); ok && vSecretName != "" {
 						sds.SecretName = aws.String(vSecretName)
@@ -1279,53 +1279,53 @@ func expandVirtualGatewayClientPolicy(vClientPolicy []interface{}) *awstypes.Vir
 	return clientPolicy
 }
 
-func flattenVirtualGatewaySpec(spec *awstypes.VirtualGatewaySpec) []interface{} {
+func flattenVirtualGatewaySpec(spec *awstypes.VirtualGatewaySpec) []any {
 	if spec == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mSpec := map[string]interface{}{}
+	mSpec := map[string]any{}
 
 	if backendDefaults := spec.BackendDefaults; backendDefaults != nil {
-		mBackendDefaults := map[string]interface{}{
+		mBackendDefaults := map[string]any{
 			"client_policy": flattenVirtualGatewayClientPolicy(backendDefaults.ClientPolicy),
 		}
 
-		mSpec["backend_defaults"] = []interface{}{mBackendDefaults}
+		mSpec["backend_defaults"] = []any{mBackendDefaults}
 	}
 
 	if len(spec.Listeners) > 0 {
-		var mListeners []interface{}
+		var mListeners []any
 		for _, listener := range spec.Listeners {
-			mListener := map[string]interface{}{}
+			mListener := map[string]any{}
 
 			if connectionPool := listener.ConnectionPool; connectionPool != nil {
-				mConnectionPool := map[string]interface{}{}
+				mConnectionPool := map[string]any{}
 
 				switch v := connectionPool.(type) {
 				case *awstypes.VirtualGatewayConnectionPoolMemberGrpc:
-					mGrpcConnectionPool := map[string]interface{}{
+					mGrpcConnectionPool := map[string]any{
 						"max_requests": aws.ToInt32(v.Value.MaxRequests),
 					}
-					mConnectionPool["grpc"] = []interface{}{mGrpcConnectionPool}
+					mConnectionPool["grpc"] = []any{mGrpcConnectionPool}
 				case *awstypes.VirtualGatewayConnectionPoolMemberHttp:
-					mHttpConnectionPool := map[string]interface{}{
+					mHttpConnectionPool := map[string]any{
 						"max_connections":      aws.ToInt32(v.Value.MaxConnections),
 						"max_pending_requests": aws.ToInt32(v.Value.MaxPendingRequests),
 					}
-					mConnectionPool["http"] = []interface{}{mHttpConnectionPool}
+					mConnectionPool["http"] = []any{mHttpConnectionPool}
 				case *awstypes.VirtualGatewayConnectionPoolMemberHttp2:
-					mHttp2ConnectionPool := map[string]interface{}{
+					mHttp2ConnectionPool := map[string]any{
 						"max_requests": aws.ToInt32(v.Value.MaxRequests),
 					}
-					mConnectionPool["http2"] = []interface{}{mHttp2ConnectionPool}
+					mConnectionPool["http2"] = []any{mHttp2ConnectionPool}
 				}
 
-				mListener["connection_pool"] = []interface{}{mConnectionPool}
+				mListener["connection_pool"] = []any{mConnectionPool}
 			}
 
 			if healthCheck := listener.HealthCheck; healthCheck != nil {
-				mHealthCheck := map[string]interface{}{
+				mHealthCheck := map[string]any{
 					"healthy_threshold":   aws.ToInt32(healthCheck.HealthyThreshold),
 					"interval_millis":     aws.ToInt64(healthCheck.IntervalMillis),
 					names.AttrPath:        aws.ToString(healthCheck.Path),
@@ -1334,92 +1334,92 @@ func flattenVirtualGatewaySpec(spec *awstypes.VirtualGatewaySpec) []interface{} 
 					"timeout_millis":      aws.ToInt64(healthCheck.TimeoutMillis),
 					"unhealthy_threshold": aws.ToInt32(healthCheck.UnhealthyThreshold),
 				}
-				mListener[names.AttrHealthCheck] = []interface{}{mHealthCheck}
+				mListener[names.AttrHealthCheck] = []any{mHealthCheck}
 			}
 
 			if portMapping := listener.PortMapping; portMapping != nil {
-				mPortMapping := map[string]interface{}{
+				mPortMapping := map[string]any{
 					names.AttrPort:     aws.ToInt32(portMapping.Port),
 					names.AttrProtocol: portMapping.Protocol,
 				}
-				mListener["port_mapping"] = []interface{}{mPortMapping}
+				mListener["port_mapping"] = []any{mPortMapping}
 			}
 
 			if tls := listener.Tls; tls != nil {
-				mTls := map[string]interface{}{
+				mTls := map[string]any{
 					names.AttrMode: tls.Mode,
 				}
 
 				if certificate := tls.Certificate; certificate != nil {
-					mCertificate := map[string]interface{}{}
+					mCertificate := map[string]any{}
 
 					switch v := certificate.(type) {
 					case *awstypes.VirtualGatewayListenerTlsCertificateMemberAcm:
-						mAcm := map[string]interface{}{
+						mAcm := map[string]any{
 							names.AttrCertificateARN: aws.ToString(v.Value.CertificateArn),
 						}
 
-						mCertificate["acm"] = []interface{}{mAcm}
+						mCertificate["acm"] = []any{mAcm}
 					case *awstypes.VirtualGatewayListenerTlsCertificateMemberFile:
-						mFile := map[string]interface{}{
+						mFile := map[string]any{
 							names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 							names.AttrPrivateKey:       aws.ToString(v.Value.PrivateKey),
 						}
 
-						mCertificate["file"] = []interface{}{mFile}
+						mCertificate["file"] = []any{mFile}
 					case *awstypes.VirtualGatewayListenerTlsCertificateMemberSds:
-						mSds := map[string]interface{}{
+						mSds := map[string]any{
 							"secret_name": aws.ToString(v.Value.SecretName),
 						}
 
-						mCertificate["sds"] = []interface{}{mSds}
+						mCertificate["sds"] = []any{mSds}
 					}
 
-					mTls[names.AttrCertificate] = []interface{}{mCertificate}
+					mTls[names.AttrCertificate] = []any{mCertificate}
 				}
 
 				if validation := tls.Validation; validation != nil {
-					mValidation := map[string]interface{}{}
+					mValidation := map[string]any{}
 
 					if subjectAlternativeNames := validation.SubjectAlternativeNames; subjectAlternativeNames != nil {
-						mSubjectAlternativeNames := map[string]interface{}{}
+						mSubjectAlternativeNames := map[string]any{}
 
 						if match := subjectAlternativeNames.Match; match != nil {
-							mMatch := map[string]interface{}{
+							mMatch := map[string]any{
 								"exact": match.Exact,
 							}
 
-							mSubjectAlternativeNames["match"] = []interface{}{mMatch}
+							mSubjectAlternativeNames["match"] = []any{mMatch}
 						}
 
-						mValidation["subject_alternative_names"] = []interface{}{mSubjectAlternativeNames}
+						mValidation["subject_alternative_names"] = []any{mSubjectAlternativeNames}
 					}
 
 					if trust := validation.Trust; trust != nil {
-						mTrust := map[string]interface{}{}
+						mTrust := map[string]any{}
 
 						switch v := trust.(type) {
 						case *awstypes.VirtualGatewayListenerTlsValidationContextTrustMemberFile:
-							mFile := map[string]interface{}{
+							mFile := map[string]any{
 								names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 							}
 
-							mTrust["file"] = []interface{}{mFile}
+							mTrust["file"] = []any{mFile}
 						case *awstypes.VirtualGatewayListenerTlsValidationContextTrustMemberSds:
-							mSds := map[string]interface{}{
+							mSds := map[string]any{
 								"secret_name": aws.ToString(v.Value.SecretName),
 							}
 
-							mTrust["sds"] = []interface{}{mSds}
+							mTrust["sds"] = []any{mSds}
 						}
 
-						mValidation["trust"] = []interface{}{mTrust}
+						mValidation["trust"] = []any{mTrust}
 					}
 
-					mTls["validation"] = []interface{}{mValidation}
+					mTls["validation"] = []any{mValidation}
 				}
 
-				mListener["tls"] = []interface{}{mTls}
+				mListener["tls"] = []any{mTls}
 			}
 			mListeners = append(mListeners, mListener)
 		}
@@ -1427,24 +1427,24 @@ func flattenVirtualGatewaySpec(spec *awstypes.VirtualGatewaySpec) []interface{} 
 	}
 
 	if logging := spec.Logging; logging != nil {
-		mLogging := map[string]interface{}{}
+		mLogging := map[string]any{}
 
 		if accessLog := logging.AccessLog; accessLog != nil {
-			mAccessLog := map[string]interface{}{}
+			mAccessLog := map[string]any{}
 
 			switch v := accessLog.(type) {
 			case *awstypes.VirtualGatewayAccessLogMemberFile:
-				mFile := map[string]interface{}{}
+				mFile := map[string]any{}
 
 				if format := v.Value.Format; format != nil {
-					mFormat := map[string]interface{}{}
+					mFormat := map[string]any{}
 
 					switch v := format.(type) {
 					case *awstypes.LoggingFormatMemberJson:
-						vJsons := []interface{}{}
+						vJsons := []any{}
 
 						for _, j := range v.Value {
-							mJson := map[string]interface{}{
+							mJson := map[string]any{
 								names.AttrKey:   aws.ToString(j.Key),
 								names.AttrValue: aws.ToString(j.Value),
 							}
@@ -1457,107 +1457,107 @@ func flattenVirtualGatewaySpec(spec *awstypes.VirtualGatewaySpec) []interface{} 
 						mFormat["text"] = v.Value
 					}
 
-					mFile[names.AttrFormat] = []interface{}{mFormat}
+					mFile[names.AttrFormat] = []any{mFormat}
 				}
 
 				mFile[names.AttrPath] = aws.ToString(v.Value.Path)
 
-				mAccessLog["file"] = []interface{}{mFile}
+				mAccessLog["file"] = []any{mFile}
 			}
 
-			mLogging["access_log"] = []interface{}{mAccessLog}
+			mLogging["access_log"] = []any{mAccessLog}
 		}
 
-		mSpec["logging"] = []interface{}{mLogging}
+		mSpec["logging"] = []any{mLogging}
 	}
 
-	return []interface{}{mSpec}
+	return []any{mSpec}
 }
 
-func flattenVirtualGatewayClientPolicy(clientPolicy *awstypes.VirtualGatewayClientPolicy) []interface{} {
+func flattenVirtualGatewayClientPolicy(clientPolicy *awstypes.VirtualGatewayClientPolicy) []any {
 	if clientPolicy == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	mClientPolicy := map[string]interface{}{}
+	mClientPolicy := map[string]any{}
 
 	if tls := clientPolicy.Tls; tls != nil {
-		mTls := map[string]interface{}{
+		mTls := map[string]any{
 			"enforce": aws.ToBool(tls.Enforce),
 			"ports":   flex.FlattenInt32ValueSet(tls.Ports),
 		}
 
 		if certificate := tls.Certificate; certificate != nil {
-			mCertificate := map[string]interface{}{}
+			mCertificate := map[string]any{}
 
 			switch v := certificate.(type) {
 			case *awstypes.VirtualGatewayClientTlsCertificateMemberFile:
-				mFile := map[string]interface{}{
+				mFile := map[string]any{
 					names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 					names.AttrPrivateKey:       aws.ToString(v.Value.PrivateKey),
 				}
 
-				mCertificate["file"] = []interface{}{mFile}
+				mCertificate["file"] = []any{mFile}
 			case *awstypes.VirtualGatewayClientTlsCertificateMemberSds:
-				mSds := map[string]interface{}{
+				mSds := map[string]any{
 					"secret_name": aws.ToString(v.Value.SecretName),
 				}
 
-				mCertificate["sds"] = []interface{}{mSds}
+				mCertificate["sds"] = []any{mSds}
 			}
 
-			mTls[names.AttrCertificate] = []interface{}{mCertificate}
+			mTls[names.AttrCertificate] = []any{mCertificate}
 		}
 
 		if validation := tls.Validation; validation != nil {
-			mValidation := map[string]interface{}{}
+			mValidation := map[string]any{}
 
 			if subjectAlternativeNames := validation.SubjectAlternativeNames; subjectAlternativeNames != nil {
-				mSubjectAlternativeNames := map[string]interface{}{}
+				mSubjectAlternativeNames := map[string]any{}
 
 				if match := subjectAlternativeNames.Match; match != nil {
-					mMatch := map[string]interface{}{
+					mMatch := map[string]any{
 						"exact": match.Exact,
 					}
 
-					mSubjectAlternativeNames["match"] = []interface{}{mMatch}
+					mSubjectAlternativeNames["match"] = []any{mMatch}
 				}
 
-				mValidation["subject_alternative_names"] = []interface{}{mSubjectAlternativeNames}
+				mValidation["subject_alternative_names"] = []any{mSubjectAlternativeNames}
 			}
 
 			if trust := validation.Trust; trust != nil {
-				mTrust := map[string]interface{}{}
+				mTrust := map[string]any{}
 
 				switch v := trust.(type) {
 				case *awstypes.VirtualGatewayTlsValidationContextTrustMemberAcm:
-					mAcm := map[string]interface{}{
+					mAcm := map[string]any{
 						"certificate_authority_arns": v.Value.CertificateAuthorityArns,
 					}
 
-					mTrust["acm"] = []interface{}{mAcm}
+					mTrust["acm"] = []any{mAcm}
 				case *awstypes.VirtualGatewayTlsValidationContextTrustMemberFile:
-					mFile := map[string]interface{}{
+					mFile := map[string]any{
 						names.AttrCertificateChain: aws.ToString(v.Value.CertificateChain),
 					}
 
-					mTrust["file"] = []interface{}{mFile}
+					mTrust["file"] = []any{mFile}
 				case *awstypes.VirtualGatewayTlsValidationContextTrustMemberSds:
-					mSds := map[string]interface{}{
+					mSds := map[string]any{
 						"secret_name": aws.ToString(v.Value.SecretName),
 					}
 
-					mTrust["sds"] = []interface{}{mSds}
+					mTrust["sds"] = []any{mSds}
 				}
 
-				mValidation["trust"] = []interface{}{mTrust}
+				mValidation["trust"] = []any{mTrust}
 			}
 
-			mTls["validation"] = []interface{}{mValidation}
+			mTls["validation"] = []any{mValidation}
 		}
 
-		mClientPolicy["tls"] = []interface{}{mTls}
+		mClientPolicy["tls"] = []any{mTls}
 	}
 
-	return []interface{}{mClientPolicy}
+	return []any{mClientPolicy}
 }

--- a/internal/service/appmesh/virtual_gateway_data_source.go
+++ b/internal/service/appmesh/virtual_gateway_data_source.go
@@ -62,7 +62,7 @@ func dataSourceVirtualGateway() *schema.Resource {
 	}
 }
 
-func dataSourceVirtualGatewayRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVirtualGatewayRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/virtual_node.go
+++ b/internal/service/appmesh/virtual_node.go
@@ -973,14 +973,14 @@ func resourceVirtualNodeSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceVirtualNodeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualNodeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &appmesh.CreateVirtualNodeInput{
 		MeshName:        aws.String(d.Get("mesh_name").(string)),
-		Spec:            expandVirtualNodeSpec(d.Get("spec").([]interface{})),
+		Spec:            expandVirtualNodeSpec(d.Get("spec").([]any)),
 		Tags:            getTagsIn(ctx),
 		VirtualNodeName: aws.String(name),
 	}
@@ -1000,11 +1000,11 @@ func resourceVirtualNodeCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceVirtualNodeRead(ctx, d, meta)...)
 }
 
-func resourceVirtualNodeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualNodeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findVirtualNodeByThreePartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -1034,14 +1034,14 @@ func resourceVirtualNodeRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceVirtualNodeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualNodeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateVirtualNodeInput{
 			MeshName:        aws.String(d.Get("mesh_name").(string)),
-			Spec:            expandVirtualNodeSpec(d.Get("spec").([]interface{})),
+			Spec:            expandVirtualNodeSpec(d.Get("spec").([]any)),
 			VirtualNodeName: aws.String(d.Get(names.AttrName).(string)),
 		}
 
@@ -1059,7 +1059,7 @@ func resourceVirtualNodeUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceVirtualNodeRead(ctx, d, meta)...)
 }
 
-func resourceVirtualNodeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualNodeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -1086,7 +1086,7 @@ func resourceVirtualNodeDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceVirtualNodeImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVirtualNodeImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-node-name'", d.Id())

--- a/internal/service/appmesh/virtual_node_data_source.go
+++ b/internal/service/appmesh/virtual_node_data_source.go
@@ -63,7 +63,7 @@ func dataSourceVirtualNode() *schema.Resource {
 	}
 }
 
-func dataSourceVirtualNodeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVirtualNodeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/virtual_node_migrate.go
+++ b/internal/service/appmesh/virtual_node_migrate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func resourceVirtualNodeMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceVirtualNodeMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found App Mesh virtual node state v0; migrating to v1")

--- a/internal/service/appmesh/virtual_node_migrate_test.go
+++ b/internal/service/appmesh/virtual_node_migrate_test.go
@@ -17,7 +17,7 @@ func TestVirtualNodeMigrateState(t *testing.T) {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1-noBackendsOrDns": {
 			StateVersion: 0,

--- a/internal/service/appmesh/virtual_router.go
+++ b/internal/service/appmesh/virtual_router.go
@@ -134,14 +134,14 @@ func resourceVirtualRouterSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceVirtualRouterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualRouterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &appmesh.CreateVirtualRouterInput{
 		MeshName:          aws.String(d.Get("mesh_name").(string)),
-		Spec:              expandVirtualRouterSpec(d.Get("spec").([]interface{})),
+		Spec:              expandVirtualRouterSpec(d.Get("spec").([]any)),
 		Tags:              getTagsIn(ctx),
 		VirtualRouterName: aws.String(name),
 	}
@@ -161,11 +161,11 @@ func resourceVirtualRouterCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceVirtualRouterRead(ctx, d, meta)...)
 }
 
-func resourceVirtualRouterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualRouterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findVirtualRouterByThreePartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -195,14 +195,14 @@ func resourceVirtualRouterRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceVirtualRouterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualRouterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateVirtualRouterInput{
 			MeshName:          aws.String(d.Get("mesh_name").(string)),
-			Spec:              expandVirtualRouterSpec(d.Get("spec").([]interface{})),
+			Spec:              expandVirtualRouterSpec(d.Get("spec").([]any)),
 			VirtualRouterName: aws.String(d.Get(names.AttrName).(string)),
 		}
 
@@ -220,7 +220,7 @@ func resourceVirtualRouterUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceVirtualRouterRead(ctx, d, meta)...)
 }
 
-func resourceVirtualRouterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualRouterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -247,7 +247,7 @@ func resourceVirtualRouterDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceVirtualRouterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVirtualRouterImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-router-name'", d.Id())

--- a/internal/service/appmesh/virtual_router_data_source.go
+++ b/internal/service/appmesh/virtual_router_data_source.go
@@ -63,7 +63,7 @@ func dataSourceVirtualRouter() *schema.Resource {
 	}
 }
 
-func dataSourceVirtualRouterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVirtualRouterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 

--- a/internal/service/appmesh/virtual_router_migrate.go
+++ b/internal/service/appmesh/virtual_router_migrate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func resourceVirtualRouterMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceVirtualRouterMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found App Mesh virtual router state v0; migrating to v1")

--- a/internal/service/appmesh/virtual_router_migrate_test.go
+++ b/internal/service/appmesh/virtual_router_migrate_test.go
@@ -18,7 +18,7 @@ func TestVirtualRouterMigrateState(t *testing.T) {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_1-emptySpec": {
 			StateVersion: 0,

--- a/internal/service/appmesh/virtual_service.go
+++ b/internal/service/appmesh/virtual_service.go
@@ -142,14 +142,14 @@ func resourceVirtualServiceSpecSchema() *schema.Schema {
 	}
 }
 
-func resourceVirtualServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualServiceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &appmesh.CreateVirtualServiceInput{
 		MeshName:           aws.String(d.Get("mesh_name").(string)),
-		Spec:               expandVirtualServiceSpec(d.Get("spec").([]interface{})),
+		Spec:               expandVirtualServiceSpec(d.Get("spec").([]any)),
 		Tags:               getTagsIn(ctx),
 		VirtualServiceName: aws.String(name),
 	}
@@ -169,11 +169,11 @@ func resourceVirtualServiceCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVirtualServiceRead(ctx, d, meta)...)
 }
 
-func resourceVirtualServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findVirtualServiceByThreePartKey(ctx, conn, d.Get("mesh_name").(string), d.Get("mesh_owner").(string), d.Get(names.AttrName).(string))
 	}, d.IsNewResource())
 
@@ -203,14 +203,14 @@ func resourceVirtualServiceRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceVirtualServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
 	if d.HasChange("spec") {
 		input := &appmesh.UpdateVirtualServiceInput{
 			MeshName:           aws.String(d.Get("mesh_name").(string)),
-			Spec:               expandVirtualServiceSpec(d.Get("spec").([]interface{})),
+			Spec:               expandVirtualServiceSpec(d.Get("spec").([]any)),
 			VirtualServiceName: aws.String(d.Get(names.AttrName).(string)),
 		}
 
@@ -228,7 +228,7 @@ func resourceVirtualServiceUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceVirtualServiceRead(ctx, d, meta)...)
 }
 
-func resourceVirtualServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVirtualServiceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 
@@ -255,7 +255,7 @@ func resourceVirtualServiceDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceVirtualServiceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVirtualServiceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'mesh-name/virtual-service-name'", d.Id())

--- a/internal/service/appmesh/virtual_service_data_source.go
+++ b/internal/service/appmesh/virtual_service_data_source.go
@@ -63,7 +63,7 @@ func dataSourceVirtualService() *schema.Resource {
 	}
 }
 
-func dataSourceVirtualServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVirtualServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppMeshClient(ctx)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
