### PR TITLE
[doc] add `name_prefix` to aws_wafv2_rule_group

### DIFF
--- a/website/docs/r/waf_rule_group.html.markdown
+++ b/website/docs/r/waf_rule_group.html.markdown
@@ -38,7 +38,6 @@ resource "aws_waf_rule_group" "example" {
 This resource supports the following arguments:
 
 * `name` - (Optional) Name of the rule group. If omitted, Terraform will assign a random, unique name. Conflicts with `name_prefix`.
-* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `metric_name` - (Required) A friendly name for the metrics from the rule group
 * `activated_rule` - (Optional) A list of activated rules, see below
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -320,6 +320,7 @@ This resource supports the following arguments:
 * `custom_response_body` - (Optional) Defines custom response bodies that can be referenced by `custom_response` actions. See [Custom Response Body](#custom-response-body) below for details.
 * `description` - (Optional) A friendly description of the rule group.
 * `name` - (Required, Forces new resource) A friendly name of the rule group.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `rule` - (Optional) The rule blocks used to identify the web requests that you want to `allow`, `block`, or `count`. See [Rules](#rules) below for details.
 * `scope` - (Required, Forces new resource) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Description
* `name_prefix` attribute in `aws_wafv2_rule_group` was implemented in the PR #33206. However, this PR mistakenly updated the documentation for `waf` instead of `wafv2`.
* add `name_prefix` attribute to `aws_wafv2_rule_group` doc and remove it from `aws_waf_rule_group` (I confirmed that `name_prefix` is not implemented for `aws_waf_rule_group`)


### Relations

Closes #41841

### References
PR #33206

### Output from Acceptance Testing
N/A because this PR just fixes the documentation.