### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-03-13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.38.2
 	github.com/aws/aws-sdk-go-v2/service/account v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/acm v1.31.1
-	github.com/aws/aws-sdk-go-v2/service/acmpca v1.39.1
+	github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/amp v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/drs v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.54.2

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.1

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/servicequotas v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/ses v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.43.1
-	github.com/aws/aws-sdk-go-v2/service/sfn v1.35.1
+	github.com/aws/aws-sdk-go-v2/service/sfn v1.35.2
 	github.com/aws/aws-sdk-go-v2/service/shield v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/signer v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/sns v1.34.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/acm v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/amp v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.30.1
+	github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.37.1

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/glue v1.106.1
+	github.com/aws/aws-sdk-go-v2/service/glue v1.106.2
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.32.1

--- a/go.mod
+++ b/go.mod
@@ -219,7 +219,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2
-	github.com/aws/aws-sdk-go-v2/service/s3control v1.54.1
+	github.com/aws/aws-sdk-go-v2/service/s3control v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.180.2

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.26.1
-	github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.2
+	github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.3
 	github.com/aws/aws-sdk-go-v2/service/ram v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/rbin v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/rds v1.94.1

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1
-	github.com/aws/aws-sdk-go-v2/service/codebuild v1.55.1
+	github.com/aws/aws-sdk-go-v2/service/codebuild v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.17.18
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/codeconnections v1.6.1

--- a/go.mod
+++ b/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1
-	github.com/aws/aws-sdk-go-v2/service/polly v1.47.1
+	github.com/aws/aws-sdk-go-v2/service/polly v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.26.1

--- a/go.mod
+++ b/go.mod
@@ -169,7 +169,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.21.1
+	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/mediastore v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/memorydb v1.26.1

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.46.1
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.55.1
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.17.18

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0
-	github.com/aws/aws-sdk-go-v2/service/datazone v1.26.1
+	github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/dax v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/detective v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.30.1

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/finspace v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/firehose v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/fis v1.33.1
-	github.com/aws/aws-sdk-go-v2/service/fms v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/fms v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2 h1:kkug2EBxwHbzlH9HeaAD2
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2/go.mod h1:/BibEr5ksr34abqBTQN213GrNG6GCKCB6WG7CH4zH2w=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1 h1:ac0UBlcUK+tFcFiAuNbtKqUEtM+iyQgmffEhUACGwD0=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1/go.mod h1:HJlcOk+S/wjJuR/8jPa8GhnEKdKqqiQ5wjsE1PjuO1o=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.46.1 h1:pYm/RS3V/UaSAkHAGZUJuECz7f9y8WTPmu9Q+4JcigE=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.46.1/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0 h1:lLkvA+uOu/nB/UeAUoldkSPGIzZANxpEEHA+iP6kvQs=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1 h1:7kG4zaTjHxWRkU+CZSgdPM2Yv9aLYJTbp99IVwbWN3Q=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1/go.mod h1:QPTNJjlY2i7XZhMDb7vX3Hxg2YtLucSU4kzDYxXm3k4=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.55.1 h1:Z3y7Qfv4F7F/cKjZS/ZsA7sxxx0wbQHHO9GIxgpdMMY=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/aws/aws-sdk-go-v2/service/account v1.23.1 h1:BoQ6k2XIe4G1RJUh9WI/T/PZ
 github.com/aws/aws-sdk-go-v2/service/account v1.23.1/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
 github.com/aws/aws-sdk-go-v2/service/acm v1.31.1 h1:FB1PgU6vlXbqehxZiHuYQRWo5Ou6sQrFJcUaRe27lRo=
 github.com/aws/aws-sdk-go-v2/service/acm v1.31.1/go.mod h1:3sKYAgRbuBa2QMYGh/WEclwnmfx+QoPhhX25PdSQSQM=
-github.com/aws/aws-sdk-go-v2/service/acmpca v1.39.1 h1:17dDTx7GeyRqeNxWCFrCNQd/P8ekUMYU5sBYVjVrQ9A=
-github.com/aws/aws-sdk-go-v2/service/acmpca v1.39.1/go.mod h1:v0S5xoRSVzO4z09Fyqm6zkpeYU20qRBXwVS+BOejpcE=
+github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0 h1:+F0tG/QIUuKdkCP/H+AOvu0E4E5PAI0KOKeWH1OAkBQ=
+github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0/go.mod h1:v0S5xoRSVzO4z09Fyqm6zkpeYU20qRBXwVS+BOejpcE=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1 h1:NlS3vXebXaVo+HmeSebbV3/yrHSHoRMbLJsTjr8WegA=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1/go.mod h1:5NwZKMNRuC5UHuOShamjhZa0lw9vKY8jacSqUegSuYk=
 github.com/aws/aws-sdk-go-v2/service/amplify v1.30.1 h1:29cXBaL4oiImswwEeLLKJxz2sfFYAFIFQ1vm3xL5dPk=

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0 h1:lLkvA+uOu/nB/UeAU
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1 h1:7kG4zaTjHxWRkU+CZSgdPM2Yv9aLYJTbp99IVwbWN3Q=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1/go.mod h1:QPTNJjlY2i7XZhMDb7vX3Hxg2YtLucSU4kzDYxXm3k4=
-github.com/aws/aws-sdk-go-v2/service/codebuild v1.55.1 h1:Z3y7Qfv4F7F/cKjZS/ZsA7sxxx0wbQHHO9GIxgpdMMY=
-github.com/aws/aws-sdk-go-v2/service/codebuild v1.55.1/go.mod h1:13SjlSpfNt71ZBZZqLMSy08j9jSPA9D5179dKV9RRz4=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.56.0 h1:mZ5hgyvj5Ryql9xywBONA4zS68oyImYfwHQ8VX+Pirs=
+github.com/aws/aws-sdk-go-v2/service/codebuild v1.56.0/go.mod h1:13SjlSpfNt71ZBZZqLMSy08j9jSPA9D5179dKV9RRz4=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.17.18 h1:iDd+8Qej6hT8fJBxy0QPYuoOP9gBjGHg0zz0Zb6J7qY=
 github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.17.18/go.mod h1:7jiV/Fo5iU17sXIwWc7I1wmTr6yfZvFI5O0pI/lmpi8=
 github.com/aws/aws-sdk-go-v2/service/codecommit v1.28.1 h1:NNOxK3fdcLeE+meE7Ry4TwEzBL2Yh4HVnC63Nlj/NYg=

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0 h1:+F0tG/QIUuKdkCP/H+AOvu0E4
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0/go.mod h1:v0S5xoRSVzO4z09Fyqm6zkpeYU20qRBXwVS+BOejpcE=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1 h1:NlS3vXebXaVo+HmeSebbV3/yrHSHoRMbLJsTjr8WegA=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1/go.mod h1:5NwZKMNRuC5UHuOShamjhZa0lw9vKY8jacSqUegSuYk=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.30.1 h1:29cXBaL4oiImswwEeLLKJxz2sfFYAFIFQ1vm3xL5dPk=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.30.1/go.mod h1:f8HNneMWkB/Gs6U9yQX5CMNWSk7wS7Lg9YU1AKLLn1w=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0 h1:s4GtSn4fxLee82Hjwg8wGuw63OV63Wqd2fb5FV1vLBY=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0/go.mod h1:f8HNneMWkB/Gs6U9yQX5CMNWSk7wS7Lg9YU1AKLLn1w=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1 h1:H0reXa+fsC4kFCy3M18UKccJhdZZDTr4mKMype1rx3U=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1/go.mod h1:C9suuW30sexkILV5QRkNexNeRUtYs98agpG5nZ+zh0k=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.26.1 h1:HlFEMjDOjCzrmgO6ckPLbS8unpfp25nNPSEqtPqTX1g=

--- a/go.sum
+++ b/go.sum
@@ -359,8 +359,8 @@ github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0 h1:4EeXWfRdetoYVB9QJXOd0k
 github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0/go.mod h1:LQyji2EWloKipI5Yu/lc2pqIKz8/9T3nDm/2+cbFFo0=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1 h1:CoCjkzEn/bk5lUB7G4HinZDTZFEv9hzAgsJoowkq0ok=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1/go.mod h1:gn9Y3Js8XKrjFMN0vOwT2aqVjc0WnIH0qCKsTK5anS8=
-github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.21.1 h1:J8/XiJJwzEb+ZJTQIKKi+vVG2iaz5t38eeV9DbpawGM=
-github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.21.1/go.mod h1:Kg9NU7xep1t/0weKQLLbHDN5LhjkZUDwJ1WA7FwOJ/U=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.22.0 h1:xTJEMO5FZeKQPLfYxiQ7OthUtDMhAqdDrBD+CtwjW/I=
+github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.22.0/go.mod h1:Kg9NU7xep1t/0weKQLLbHDN5LhjkZUDwJ1WA7FwOJ/U=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.35.1 h1:Jl5zDZ+O6B3ip50q5/rRvIYcEdjpNs36/1ukgVd89U8=
 github.com/aws/aws-sdk-go-v2/service/mediapackagevod v1.35.1/go.mod h1:uNts8HtL8GevL9H2vDPZ3MyzUw5Gp6GTlC9RpLZPUkk=
 github.com/aws/aws-sdk-go-v2/service/mediastore v1.25.1 h1:XlE1PW5qQcIgwP0BGMsl+qg0cf9tznl/6n3gUPhxFNk=

--- a/go.sum
+++ b/go.sum
@@ -459,8 +459,8 @@ github.com/aws/aws-sdk-go-v2/service/rum v1.23.1 h1:6X+frNWZ+SnRyBk3YAWy4p7PzJWP
 github.com/aws/aws-sdk-go-v2/service/rum v1.23.1/go.mod h1:epo2m9j8JQQdXVfSa6kRCu7U5reVhgdq/MsbZR/ouPg=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2 h1:jIiopHEV22b4yQP2q36Y0OmwLbsxNWdWwfZRR5QRRO4=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2/go.mod h1:U5SNqwhXB3Xe6F47kXvWihPl/ilGaEDe8HD/50Z9wxc=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.54.1 h1:9LKMNJydrLmB6VV5Hdt7r7S4shqkEPIhW3bqZGX45OY=
-github.com/aws/aws-sdk-go-v2/service/s3control v1.54.1/go.mod h1:hqimoWPQe+lvweuYZ2c1Fn4q3UyAFhbjSoABSl8Y7Pw=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.55.0 h1:r5F+0gj2vGcO6UsjUbu3THH0Gepk7AiPm7lTusnRKlY=
+github.com/aws/aws-sdk-go-v2/service/s3control v1.55.0/go.mod h1:hqimoWPQe+lvweuYZ2c1Fn4q3UyAFhbjSoABSl8Y7Pw=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1 h1:qtgPTDjxMcq3LaRv2vMiEzWCXnHWbejL+DEVUBJmwC0=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1/go.mod h1:P3QWrLPDXyc8813o8b7WnBpw7mwoo2LRyOYdxMVT++Y=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.2.1 h1:eC3wvBcMvY8syeN35Lb/k6qsxNdv1d16j1BjobG0DU8=

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/aws/aws-sdk-go-v2/service/ses v1.30.1 h1:mZtHKUiz5lo7ohuAi2DKRTv1NEQE
 github.com/aws/aws-sdk-go-v2/service/ses v1.30.1/go.mod h1:eZW5lSNTE1tQfMpl6crr/YVJYgEcnk2JQoodg6E63qM=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.43.1 h1:G+G7XkvmQj4cmqv7qJfCJnZB6MlVlL6IX7XeTGJjPmE=
 github.com/aws/aws-sdk-go-v2/service/sesv2 v1.43.1/go.mod h1:cQUamjPrzLiSFooGWT4oCiXlgmCsda/HzpfXWoueynk=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.35.1 h1:WrgZ2VISlkoUL7BA1K9Wa5f58Fl0naNhxO1s+vJc4wY=
-github.com/aws/aws-sdk-go-v2/service/sfn v1.35.1/go.mod h1:kXdSfltGTEP+CzJ9o7nc/+JBSlipQubNSCWeLI9rDOA=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.35.2 h1:e5pSSE4jyOTaGL1EFiqJ/65sVT461XkZsIYmQYOASyo=
+github.com/aws/aws-sdk-go-v2/service/sfn v1.35.2/go.mod h1:kXdSfltGTEP+CzJ9o7nc/+JBSlipQubNSCWeLI9rDOA=
 github.com/aws/aws-sdk-go-v2/service/shield v1.30.1 h1:5G3wzvGBE+MXWsSfU3PiJNWZnGtyjyhM7T/ACRXONlg=
 github.com/aws/aws-sdk-go-v2/service/shield v1.30.1/go.mod h1:N8aW1UaquZgOSDOatDfc5MSd0len86qqwq1gxoorc/8=
 github.com/aws/aws-sdk-go-v2/service/signer v1.27.1 h1:A8AtyAKjDMcIe98w50REGxETvMkj8u1ELRQAaRioSN0=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1 h1:wZp9y89ZuA3SXXXMl3k
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1/go.mod h1:AsHLBZVzMdJOZ6M73hFduNi138902gV4I9T6LWVONtk=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0 h1:vSsDQQASlA7kHu1SnU5KOZ9F9ruhouf0e46aGxnUDh0=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0/go.mod h1:Cl1F1d83JEmNC22jPyRexP6mNnWSpIzQg8gy7lnjIUU=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.26.1 h1:C463mGS9wmi0y3Zs3IiRv3oRcj8xI1uRk3wmPPSqq8k=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.26.1/go.mod h1:3a69kSZREiFCWUvaV+8wZ6y43trMz2hjCjPjxJHw2Bg=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0 h1:NidFLawkO9aQEQSsQfxuqXkYJ8EWrVX71BitwIqOz7M=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0/go.mod h1:3a69kSZREiFCWUvaV+8wZ6y43trMz2hjCjPjxJHw2Bg=
 github.com/aws/aws-sdk-go-v2/service/dax v1.24.1 h1:5uBAjTB52126zNRWFCnMs5IDrHbnPggFc+/7cWW42BU=
 github.com/aws/aws-sdk-go-v2/service/dax v1.24.1/go.mod h1:FTMIKMqG/2AiO0P1LSCN6PeY4BNkQcxAzPSpne6oE6w=
 github.com/aws/aws-sdk-go-v2/service/detective v1.32.2 h1:UTirCa+bkiMDMb7sNBSsarvONyA0XADl36pTIOqnvzs=

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1 h1:h2YbGqsnzL36l2B/Bd/dvrHfrKo/
 github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1/go.mod h1:StDU/D7R42LhrKp24PGzvxyKjjDm0lwo9JMwuy2qbo4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0 h1:EJXx6zb+lOe/Do2bO0d0dwVnIRGoP5J5xZ0BTn3LbqM=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0 h1:WpLv8X3/Ct0ZRvx8QL91V9ndnIOi1WDfz0+F4ZEKwns=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0 h1:EXSJVsts7D18nt4A2Ii9HlpqDB7/mk9RDqG7+Aqc5Ls=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0 h1:Ak4Ggvvbg8WYxPLoyLOtes1cIMQePvCAi/dUGqm8hOY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0/go.mod h1:iQ1skgw1XRK+6Lgkb0I9ODatAP72WoTILh0zXQ5DtbU=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.1 h1:Tgvq4EuB0AcM2Au4kOmEHt/sm2BSwKrOzsM402g3iwg=

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1 h1:hPNjjlYHJE/oX+ok+CRudfjE
 github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1/go.mod h1:iu2+iJGASnGBzM0wM1ilN42xfabxyIlcdZyctpgm//4=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1 h1:FeZccFrSQar3DzmGaygFo9sqBQtx15hkGB1n+jVXDpc=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1/go.mod h1:WIJ+qX03sGSWC6+BSA1LBO6Jmkewbu4TvwXspbai9N4=
-github.com/aws/aws-sdk-go-v2/service/glue v1.106.1 h1:OYx855o5eYaymW30LgbhVPFjB6QGWB06DwCBQS783Qk=
-github.com/aws/aws-sdk-go-v2/service/glue v1.106.1/go.mod h1:6FqWCqW0Py6VOvY42NQyf9e7N+sNVnDEiHFklCCCoQc=
+github.com/aws/aws-sdk-go-v2/service/glue v1.106.2 h1:9xUYl4v035DaMfEWHOZz5zlVfZ5L/7Urrswdg2YYweY=
+github.com/aws/aws-sdk-go-v2/service/glue v1.106.2/go.mod h1:6FqWCqW0Py6VOvY42NQyf9e7N+sNVnDEiHFklCCCoQc=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1 h1:Pdp15V5bCybVSRGL5wm5a53KuAcAjS0h9fGeBPKe6wU=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1/go.mod h1:2R4VRe/oR5E3pRm9cLMCYTUNv4qLZOXwNtlTOKTFwCE=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.28.1 h1:b3Qx6kj+lYlJ6LHHHi0kaYIu7gkSlI5u1ylk17oO39U=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/aws/aws-sdk-go-v2/service/drs v1.31.1 h1:DwJNF5bnIU7gMgkGxmg4kRX69Gf+
 github.com/aws/aws-sdk-go-v2/service/drs v1.31.1/go.mod h1:nQRaL4v9kL/iWu6Qh0f5OsT3KsUQM/xESdp9c5aReM4=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1 h1:h2YbGqsnzL36l2B/Bd/dvrHfrKo/b7HVpZykL3yIQn8=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1/go.mod h1:StDU/D7R42LhrKp24PGzvxyKjjDm0lwo9JMwuy2qbo4=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1 h1:DEys4E5Q2p735j56lteNVyByIBDAlMrO5VIEd9RC0/4=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.41.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0 h1:EJXx6zb+lOe/Do2bO0d0dwVnIRGoP5J5xZ0BTn3LbqM=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0 h1:WpLv8X3/Ct0ZRvx8QL91V9ndnIOi1WDfz0+F4ZEKwns=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.209.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0 h1:Ak4Ggvvbg8WYxPLoyLOtes1cIMQePvCAi/dUGqm8hOY=

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/aws/aws-sdk-go-v2/service/firehose v1.37.1 h1:yXNip8RoRol81Uwrq5SsZnR
 github.com/aws/aws-sdk-go-v2/service/firehose v1.37.1/go.mod h1:6i3MXkR7cPgCVGgtCwxl7NEmdgkYgNRUmGGONMo9ehc=
 github.com/aws/aws-sdk-go-v2/service/fis v1.33.1 h1:+hDZmQ0er7R0ocClVoATKHsAo8jXzzotoYvY3RS/V6s=
 github.com/aws/aws-sdk-go-v2/service/fis v1.33.1/go.mod h1:2kPhevhXIbi6WFuc+ss9krg2bNAuRqzBGZQX+7TMD/o=
-github.com/aws/aws-sdk-go-v2/service/fms v1.40.1 h1:SjD2MNFSh20CEiGVQluWq322FPQ1zhiOF0YOISc12y4=
-github.com/aws/aws-sdk-go-v2/service/fms v1.40.1/go.mod h1:RE7GFuAV5b2ekaJkfF9W0wbruu5GAEZaMvjt0OyONUw=
+github.com/aws/aws-sdk-go-v2/service/fms v1.40.2 h1:29k7q7Q/eiT7dG39nQ10kGPGPTYcksbeMKFhVF5GDFA=
+github.com/aws/aws-sdk-go-v2/service/fms v1.40.2/go.mod h1:RE7GFuAV5b2ekaJkfF9W0wbruu5GAEZaMvjt0OyONUw=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1 h1:BGKwZSdyz4Ni72snyzYrNhjR7dwyv0up0DiAX00Mmjc=
 github.com/aws/aws-sdk-go-v2/service/fsx v1.53.1/go.mod h1:XKQ2ur+eKU8hvDvNTK7pb0VS4IVxd6YyxtV4rZ1DTtY=
 github.com/aws/aws-sdk-go-v2/service/gamelift v1.40.1 h1:wq8++dg78s7Bmed5CnPpVUqoOLr3LT+XOLVQhcE3DV8=

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/aws/aws-sdk-go-v2/service/qbusiness v1.23.1 h1:zfpQyxMxzmPcqMOdAnxuhZ
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.23.1/go.mod h1:yC/gX6FcgKWmtKJU2d5fyQb1QHTUuuERAfC7HLQTPJE=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.26.1 h1:D6cnuuZshBMVCzti04slHK3hwpGX21WntQxSdhq8Gqs=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.26.1/go.mod h1:KHgfc8tLcKSLPhzem2r90gG61VmC61AsMBvchY9G3fQ=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.2 h1:5xVkZYe2F3AslMqbd5k2l+a517wFKaK3RfgXeQV6S58=
-github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.2/go.mod h1:EgcKvBnrhU3YRFQYM60Arz5pJ4vmteDgQ4TQtzdpcxE=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.3 h1:hxR1icmOzmmtLXlO79HjR+r2JvkxO8j6SPSrnMYnC3c=
+github.com/aws/aws-sdk-go-v2/service/quicksight v1.84.3/go.mod h1:EgcKvBnrhU3YRFQYM60Arz5pJ4vmteDgQ4TQtzdpcxE=
 github.com/aws/aws-sdk-go-v2/service/ram v1.30.1 h1:i3iD1PEWGtm6D7x/7cb2/fNzpN6EQsph6D3UdiRJ9iM=
 github.com/aws/aws-sdk-go-v2/service/ram v1.30.1/go.mod h1:mF4+1uxwac9AbukG2ucUQAp+cIUN4dOCwlXHzuRKT6I=
 github.com/aws/aws-sdk-go-v2/service/rbin v1.22.1 h1:u+ar/geriIpq07/rHQVJ5F5J944OLeBQyeus4J3GHzs=

--- a/go.sum
+++ b/go.sum
@@ -409,8 +409,8 @@ github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1 h1:CLUjV2mR7ELuh
 github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1/go.mod h1:UfJ+CG2eqRldWl1lLd2e1/glFbp7Ln3ZZgSkvMHvNh4=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1 h1:zhU2uG3XkbumH4QATCM7HWyVLGL/P/eoQDAuDCb6XHE=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1/go.mod h1:2EbU5EjVT3Gu9OevmKa2nLT3daim8GIqnAHtGDcowvw=
-github.com/aws/aws-sdk-go-v2/service/polly v1.47.1 h1:7RTp7+JOajPEYk+O0OIChFcUboVqRbjDzO+w6bqY3vY=
-github.com/aws/aws-sdk-go-v2/service/polly v1.47.1/go.mod h1:X0rTcGb5WvdI+44CccO5/czSPJbIJovKWcE+/V/+4PQ=
+github.com/aws/aws-sdk-go-v2/service/polly v1.47.2 h1:hVy4hlfRSlumXLlkS46iuzhsLfeCp1+TxeEVyjaQ6Fw=
+github.com/aws/aws-sdk-go-v2/service/polly v1.47.2/go.mod h1:X0rTcGb5WvdI+44CccO5/czSPJbIJovKWcE+/V/+4PQ=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.34.1 h1:tbWWyDVa/U4cr4dsKehNmFi1842yB1Ffw7kBZE+30bQ=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.34.1/go.mod h1:giTP9ufzBQJRB6bc7P30PO8s35hCp6au5uM70zkohU4=
 github.com/aws/aws-sdk-go-v2/service/qbusiness v1.23.1 h1:zfpQyxMxzmPcqMOdAnxuhZHEKsVEY0gPqEtLQt5xBBs=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [`Release 2024-03-13`](https://github.com/aws/aws-sdk-go-v2/commit/67579f790bd1d46e6363a28b5e8c2fc53c854928) as [`dependabot` failed](https://github.com/hashicorp/terraform-provider-aws/network/updates/980499807).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: https://github.com/hashicorp/terraform-provider-aws/issues/39287.