### PR TITLE
docs: add missed backtick in generated resource tagging section

### DIFF
--- a/docs/resource-tagging.md
+++ b/docs/resource-tagging.md
@@ -490,7 +490,7 @@ Some acceptance tests also require a TLS key and certificate.
 This can be included by setting the annotation `@Testing(tlsKey=true)`,
 which will add the Terraform variables `certificate_pem` and `private_key_pem` to the configuration.
 By default, the common name for the certificate is `example.com`.
-To override the common name, set the annotation `@Testing(tlsKeyDomain=<reference>) to reference an existing variable.
+To override the common name, set the annotation `@Testing(tlsKeyDomain=<reference>)` to reference an existing variable.
 For example, the API Gateway v2 Domain Name sets the variable `rName` to `acctest.RandomSubdomain()`
 and sets the annotation `@Testing(tlsKeyDomain=rName)` to reference it.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Causes the contributor docs to look strange in this section.

<img width="695" alt="image" src="https://github.com/user-attachments/assets/1d750b7f-f86a-45d3-9964-045b4ee51b78" />


