### PR TITLE
glue: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -77,6 +77,7 @@ jobs:
       # Services
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/ec2 modern-check
+      - run: make TEST=./internal/service/glue modern-check
       - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/mq modern-check

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -150,7 +150,7 @@ func ResourceCatalogDatabase() *schema.Resource {
 	}
 }
 
-func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
@@ -169,19 +169,19 @@ func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if v, ok := d.GetOk(names.AttrParameters); ok {
-		dbInput.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		dbInput.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("federated_database"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		dbInput.FederatedDatabase = expandDatabaseFederatedDatabase(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("federated_database"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		dbInput.FederatedDatabase = expandDatabaseFederatedDatabase(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("target_database"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		dbInput.TargetDatabase = expandDatabaseTargetDatabase(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("target_database"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		dbInput.TargetDatabase = expandDatabaseTargetDatabase(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]interface{})) > 0 {
-		dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]interface{}))
+	if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
+		dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]any))
 	}
 
 	input := &glue.CreateDatabaseInput{
@@ -200,7 +200,7 @@ func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceCatalogDatabaseRead(ctx, d, meta)...)
 }
 
-func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -228,15 +228,15 @@ func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if v, ok := d.GetOk(names.AttrParameters); ok {
-			dbInput.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+			dbInput.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 		}
 
-		if v, ok := d.GetOk("federated_database"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			dbInput.FederatedDatabase = expandDatabaseFederatedDatabase(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("federated_database"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			dbInput.FederatedDatabase = expandDatabaseFederatedDatabase(v.([]any)[0].(map[string]any))
 		}
 
-		if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]interface{})) > 0 {
-			dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]interface{}))
+		if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
+			dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]any))
 		}
 
 		dbUpdateInput.DatabaseInput = dbInput
@@ -249,7 +249,7 @@ func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceCatalogDatabaseRead(ctx, d, meta)...)
 }
 
-func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -285,7 +285,7 @@ func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set(names.AttrParameters, database.Parameters)
 
 	if database.FederatedDatabase != nil {
-		if err := d.Set("federated_database", []interface{}{flattenDatabaseFederatedDatabase(database.FederatedDatabase)}); err != nil {
+		if err := d.Set("federated_database", []any{flattenDatabaseFederatedDatabase(database.FederatedDatabase)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting federated_database: %s", err)
 		}
 	} else {
@@ -293,7 +293,7 @@ func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if database.TargetDatabase != nil {
-		if err := d.Set("target_database", []interface{}{flattenDatabaseTargetDatabase(database.TargetDatabase)}); err != nil {
+		if err := d.Set("target_database", []any{flattenDatabaseTargetDatabase(database.TargetDatabase)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting target_database: %s", err)
 		}
 	} else {
@@ -307,7 +307,7 @@ func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceCatalogDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogDatabaseDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -343,7 +343,7 @@ func createCatalogID(d *schema.ResourceData, accountid string) (catalogID string
 	return
 }
 
-func expandDatabaseFederatedDatabase(tfMap map[string]interface{}) *awstypes.FederatedDatabase {
+func expandDatabaseFederatedDatabase(tfMap map[string]any) *awstypes.FederatedDatabase {
 	if tfMap == nil {
 		return nil
 	}
@@ -361,7 +361,7 @@ func expandDatabaseFederatedDatabase(tfMap map[string]interface{}) *awstypes.Fed
 	return apiObject
 }
 
-func expandDatabaseTargetDatabase(tfMap map[string]interface{}) *awstypes.DatabaseIdentifier {
+func expandDatabaseTargetDatabase(tfMap map[string]any) *awstypes.DatabaseIdentifier {
 	if tfMap == nil {
 		return nil
 	}
@@ -383,12 +383,12 @@ func expandDatabaseTargetDatabase(tfMap map[string]interface{}) *awstypes.Databa
 	return apiObject
 }
 
-func flattenDatabaseFederatedDatabase(apiObject *awstypes.FederatedDatabase) map[string]interface{} {
+func flattenDatabaseFederatedDatabase(apiObject *awstypes.FederatedDatabase) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ConnectionName; v != nil {
 		tfMap["connection_name"] = aws.ToString(v)
@@ -401,12 +401,12 @@ func flattenDatabaseFederatedDatabase(apiObject *awstypes.FederatedDatabase) map
 	return tfMap
 }
 
-func flattenDatabaseTargetDatabase(apiObject *awstypes.DatabaseIdentifier) map[string]interface{} {
+func flattenDatabaseTargetDatabase(apiObject *awstypes.DatabaseIdentifier) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CatalogId; v != nil {
 		tfMap[names.AttrCatalogID] = aws.ToString(v)
@@ -423,7 +423,7 @@ func flattenDatabaseTargetDatabase(apiObject *awstypes.DatabaseIdentifier) map[s
 	return tfMap
 }
 
-func expandDatabasePrincipalPermissions(tfList []interface{}) []awstypes.PrincipalPermissions {
+func expandDatabasePrincipalPermissions(tfList []any) []awstypes.PrincipalPermissions {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -431,7 +431,7 @@ func expandDatabasePrincipalPermissions(tfList []interface{}) []awstypes.Princip
 	var apiObjects []awstypes.PrincipalPermissions
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -445,21 +445,21 @@ func expandDatabasePrincipalPermissions(tfList []interface{}) []awstypes.Princip
 	return apiObjects
 }
 
-func expandDatabasePrincipalPermission(tfMap map[string]interface{}) awstypes.PrincipalPermissions {
+func expandDatabasePrincipalPermission(tfMap map[string]any) awstypes.PrincipalPermissions {
 	apiObject := awstypes.PrincipalPermissions{}
 
 	if v, ok := tfMap[names.AttrPermissions].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.Permissions = flex.ExpandStringyValueSet[awstypes.Permission](v)
 	}
 
-	if v, ok := tfMap[names.AttrPrincipal].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Principal = expandDatabasePrincipal(v[0].(map[string]interface{}))
+	if v, ok := tfMap[names.AttrPrincipal].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Principal = expandDatabasePrincipal(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandDatabasePrincipal(tfMap map[string]interface{}) *awstypes.DataLakePrincipal {
+func expandDatabasePrincipal(tfMap map[string]any) *awstypes.DataLakePrincipal {
 	if tfMap == nil {
 		return nil
 	}
@@ -473,12 +473,12 @@ func expandDatabasePrincipal(tfMap map[string]interface{}) *awstypes.DataLakePri
 	return apiObject
 }
 
-func flattenDatabasePrincipalPermissions(apiObjects []awstypes.PrincipalPermissions) []interface{} {
+func flattenDatabasePrincipalPermissions(apiObjects []awstypes.PrincipalPermissions) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenDatabasePrincipalPermission(apiObject))
@@ -487,26 +487,26 @@ func flattenDatabasePrincipalPermissions(apiObjects []awstypes.PrincipalPermissi
 	return tfList
 }
 
-func flattenDatabasePrincipalPermission(apiObject awstypes.PrincipalPermissions) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenDatabasePrincipalPermission(apiObject awstypes.PrincipalPermissions) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Permissions; v != nil {
 		tfMap[names.AttrPermissions] = flex.FlattenStringyValueSet(v)
 	}
 
 	if v := apiObject.Principal; v != nil {
-		tfMap[names.AttrPrincipal] = []interface{}{flattenDatabasePrincipal(v)}
+		tfMap[names.AttrPrincipal] = []any{flattenDatabasePrincipal(v)}
 	}
 
 	return tfMap
 }
 
-func flattenDatabasePrincipal(apiObject *awstypes.DataLakePrincipal) map[string]interface{} {
+func flattenDatabasePrincipal(apiObject *awstypes.DataLakePrincipal) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DataLakePrincipalIdentifier; v != nil {
 		tfMap["data_lake_principal_identifier"] = aws.ToString(v)

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -404,7 +404,7 @@ func ReadTableID(id string) (string, string, string, error) {
 	return idParts[0], idParts[1], idParts[2], nil
 }
 
-func resourceCatalogTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
@@ -416,7 +416,7 @@ func resourceCatalogTableCreate(ctx context.Context, d *schema.ResourceData, met
 		DatabaseName:         aws.String(dbName),
 		OpenTableFormatInput: expandOpenTableFormat(d),
 		TableInput:           expandTableInput(d),
-		PartitionIndexes:     expandTablePartitionIndexes(d.Get("partition_index").([]interface{})),
+		PartitionIndexes:     expandTablePartitionIndexes(d.Get("partition_index").([]any)),
 	}
 
 	_, err := conn.CreateTable(ctx, input)
@@ -429,7 +429,7 @@ func resourceCatalogTableCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceCatalogTableRead(ctx, d, meta)...)
 }
 
-func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -482,7 +482,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if table.TargetTable != nil {
-		if err := d.Set("target_table", []interface{}{flattenTableTargetTable(table.TargetTable)}); err != nil {
+		if err := d.Set("target_table", []any{flattenTableTargetTable(table.TargetTable)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting target_table: %s", err)
 		}
 	} else {
@@ -510,7 +510,7 @@ func resourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -552,7 +552,7 @@ func resourceCatalogTableUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceCatalogTableRead(ctx, d, meta)...)
 }
 
-func resourceCatalogTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCatalogTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -624,11 +624,11 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 	}
 
 	if v, ok := d.GetOk("storage_descriptor"); ok {
-		tableInput.StorageDescriptor = expandStorageDescriptor(v.([]interface{}))
+		tableInput.StorageDescriptor = expandStorageDescriptor(v.([]any))
 	}
 
 	if v, ok := d.GetOk("partition_keys"); ok {
-		tableInput.PartitionKeys = expandColumns(v.([]interface{}))
+		tableInput.PartitionKeys = expandColumns(v.([]any))
 	} else if _, ok = d.GetOk("open_table_format_input"); !ok {
 		tableInput.PartitionKeys = []awstypes.Column{}
 	}
@@ -646,11 +646,11 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 	}
 
 	if v, ok := d.GetOk(names.AttrParameters); ok {
-		tableInput.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		tableInput.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("target_table"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tableInput.TargetTable = expandTableTargetTable(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("target_table"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tableInput.TargetTable = expandTableTargetTable(v.([]any)[0].(map[string]any))
 	}
 
 	return tableInput
@@ -659,15 +659,15 @@ func expandTableInput(d *schema.ResourceData) *awstypes.TableInput {
 func expandOpenTableFormat(s *schema.ResourceData) *awstypes.OpenTableFormatInput {
 	if v, ok := s.GetOk("open_table_format_input"); ok {
 		openTableFormatInput := &awstypes.OpenTableFormatInput{
-			IcebergInput: expandIcebergInput(v.([]interface{})[0].(map[string]interface{})),
+			IcebergInput: expandIcebergInput(v.([]any)[0].(map[string]any)),
 		}
 		return openTableFormatInput
 	}
 	return nil
 }
 
-func expandIcebergInput(s map[string]interface{}) *awstypes.IcebergInput {
-	var iceberg = s["iceberg_input"].([]interface{})[0].(map[string]interface{})
+func expandIcebergInput(s map[string]any) *awstypes.IcebergInput {
+	var iceberg = s["iceberg_input"].([]any)[0].(map[string]any)
 	icebergInput := &awstypes.IcebergInput{
 		MetadataOperation: awstypes.MetadataOperation(iceberg["metadata_operation"].(string)),
 	}
@@ -677,39 +677,39 @@ func expandIcebergInput(s map[string]interface{}) *awstypes.IcebergInput {
 	return icebergInput
 }
 
-func expandTablePartitionIndexes(a []interface{}) []awstypes.PartitionIndex {
+func expandTablePartitionIndexes(a []any) []awstypes.PartitionIndex {
 	partitionIndexes := make([]awstypes.PartitionIndex, 0, len(a))
 
 	for _, m := range a {
-		partitionIndexes = append(partitionIndexes, expandTablePartitionIndex(m.(map[string]interface{})))
+		partitionIndexes = append(partitionIndexes, expandTablePartitionIndex(m.(map[string]any)))
 	}
 
 	return partitionIndexes
 }
 
-func expandTablePartitionIndex(m map[string]interface{}) awstypes.PartitionIndex {
+func expandTablePartitionIndex(m map[string]any) awstypes.PartitionIndex {
 	partitionIndex := awstypes.PartitionIndex{
 		IndexName: aws.String(m["index_name"].(string)),
-		Keys:      flex.ExpandStringValueList(m["keys"].([]interface{})),
+		Keys:      flex.ExpandStringValueList(m["keys"].([]any)),
 	}
 
 	return partitionIndex
 }
 
-func expandStorageDescriptor(l []interface{}) *awstypes.StorageDescriptor {
+func expandStorageDescriptor(l []any) *awstypes.StorageDescriptor {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	storageDescriptor := &awstypes.StorageDescriptor{}
 
 	if v, ok := s["additional_locations"]; ok {
-		storageDescriptor.AdditionalLocations = flex.ExpandStringValueList(v.([]interface{}))
+		storageDescriptor.AdditionalLocations = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := s["columns"]; ok {
-		storageDescriptor.Columns = expandColumns(v.([]interface{}))
+		storageDescriptor.Columns = expandColumns(v.([]any))
 	}
 
 	if v, ok := s[names.AttrLocation]; ok {
@@ -733,41 +733,41 @@ func expandStorageDescriptor(l []interface{}) *awstypes.StorageDescriptor {
 	}
 
 	if v, ok := s["ser_de_info"]; ok {
-		storageDescriptor.SerdeInfo = expandSerDeInfo(v.([]interface{}))
+		storageDescriptor.SerdeInfo = expandSerDeInfo(v.([]any))
 	}
 
 	if v, ok := s["bucket_columns"]; ok {
-		storageDescriptor.BucketColumns = flex.ExpandStringValueList(v.([]interface{}))
+		storageDescriptor.BucketColumns = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := s["sort_columns"]; ok {
-		storageDescriptor.SortColumns = expandSortColumns(v.([]interface{}))
+		storageDescriptor.SortColumns = expandSortColumns(v.([]any))
 	}
 
 	if v, ok := s["skewed_info"]; ok {
-		storageDescriptor.SkewedInfo = expandSkewedInfo(v.([]interface{}))
+		storageDescriptor.SkewedInfo = expandSkewedInfo(v.([]any))
 	}
 
 	if v, ok := s[names.AttrParameters]; ok {
-		storageDescriptor.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		storageDescriptor.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := s["stored_as_sub_directories"]; ok {
 		storageDescriptor.StoredAsSubDirectories = v.(bool)
 	}
 
-	if v, ok := s["schema_reference"]; ok && len(v.([]interface{})) > 0 {
+	if v, ok := s["schema_reference"]; ok && len(v.([]any)) > 0 {
 		storageDescriptor.Columns = nil
-		storageDescriptor.SchemaReference = expandTableSchemaReference(v.([]interface{}))
+		storageDescriptor.SchemaReference = expandTableSchemaReference(v.([]any))
 	}
 
 	return storageDescriptor
 }
 
-func expandColumns(columns []interface{}) []awstypes.Column {
+func expandColumns(columns []any) []awstypes.Column {
 	columnSlice := []awstypes.Column{}
 	for _, element := range columns {
-		elementMap := element.(map[string]interface{})
+		elementMap := element.(map[string]any)
 
 		column := awstypes.Column{
 			Name: aws.String(elementMap[names.AttrName].(string)),
@@ -782,7 +782,7 @@ func expandColumns(columns []interface{}) []awstypes.Column {
 		}
 
 		if v, ok := elementMap[names.AttrParameters]; ok {
-			column.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+			column.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 		}
 
 		columnSlice = append(columnSlice, column)
@@ -791,20 +791,20 @@ func expandColumns(columns []interface{}) []awstypes.Column {
 	return columnSlice
 }
 
-func expandSerDeInfo(l []interface{}) *awstypes.SerDeInfo {
+func expandSerDeInfo(l []any) *awstypes.SerDeInfo {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	serDeInfo := &awstypes.SerDeInfo{}
 
 	if v := s[names.AttrName]; len(v.(string)) > 0 {
 		serDeInfo.Name = aws.String(v.(string))
 	}
 
-	if v := s[names.AttrParameters]; len(v.(map[string]interface{})) > 0 {
-		serDeInfo.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+	if v := s[names.AttrParameters]; len(v.(map[string]any)) > 0 {
+		serDeInfo.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v := s["serialization_library"]; len(v.(string)) > 0 {
@@ -814,11 +814,11 @@ func expandSerDeInfo(l []interface{}) *awstypes.SerDeInfo {
 	return serDeInfo
 }
 
-func expandSortColumns(columns []interface{}) []awstypes.Order {
+func expandSortColumns(columns []any) []awstypes.Order {
 	orderSlice := make([]awstypes.Order, len(columns))
 
 	for i, element := range columns {
-		elementMap := element.(map[string]interface{})
+		elementMap := element.(map[string]any)
 
 		order := awstypes.Order{
 			Column: aws.String(elementMap["column"].(string)),
@@ -834,35 +834,35 @@ func expandSortColumns(columns []interface{}) []awstypes.Order {
 	return orderSlice
 }
 
-func expandSkewedInfo(l []interface{}) *awstypes.SkewedInfo {
+func expandSkewedInfo(l []any) *awstypes.SkewedInfo {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	skewedInfo := &awstypes.SkewedInfo{}
 
 	if v, ok := s["skewed_column_names"]; ok {
-		skewedInfo.SkewedColumnNames = flex.ExpandStringValueList(v.([]interface{}))
+		skewedInfo.SkewedColumnNames = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := s["skewed_column_value_location_maps"]; ok {
-		skewedInfo.SkewedColumnValueLocationMaps = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		skewedInfo.SkewedColumnValueLocationMaps = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := s["skewed_column_values"]; ok {
-		skewedInfo.SkewedColumnValues = flex.ExpandStringValueList(v.([]interface{}))
+		skewedInfo.SkewedColumnValues = flex.ExpandStringValueList(v.([]any))
 	}
 
 	return skewedInfo
 }
 
-func expandTableSchemaReference(l []interface{}) *awstypes.SchemaReference {
+func expandTableSchemaReference(l []any) *awstypes.SchemaReference {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	schemaRef := &awstypes.SchemaReference{}
 
 	if v, ok := s["schema_version_id"].(string); ok && v != "" {
@@ -870,7 +870,7 @@ func expandTableSchemaReference(l []interface{}) *awstypes.SchemaReference {
 	}
 
 	if v, ok := s["schema_id"]; ok {
-		schemaRef.SchemaId = expandTableSchemaReferenceSchemaID(v.([]interface{}))
+		schemaRef.SchemaId = expandTableSchemaReferenceSchemaID(v.([]any))
 	}
 
 	if v, ok := s["schema_version_number"].(int); ok {
@@ -880,12 +880,12 @@ func expandTableSchemaReference(l []interface{}) *awstypes.SchemaReference {
 	return schemaRef
 }
 
-func expandTableSchemaReferenceSchemaID(l []interface{}) *awstypes.SchemaId {
+func expandTableSchemaReferenceSchemaID(l []any) *awstypes.SchemaId {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	schemaID := &awstypes.SchemaId{}
 
 	if v, ok := s["registry_name"].(string); ok && v != "" {
@@ -903,15 +903,15 @@ func expandTableSchemaReferenceSchemaID(l []interface{}) *awstypes.SchemaId {
 	return schemaID
 }
 
-func flattenStorageDescriptor(s *awstypes.StorageDescriptor) []map[string]interface{} {
+func flattenStorageDescriptor(s *awstypes.StorageDescriptor) []map[string]any {
 	if s == nil {
-		storageDescriptors := make([]map[string]interface{}, 0)
+		storageDescriptors := make([]map[string]any, 0)
 		return storageDescriptors
 	}
 
-	storageDescriptors := make([]map[string]interface{}, 1)
+	storageDescriptors := make([]map[string]any, 1)
 
-	storageDescriptor := make(map[string]interface{})
+	storageDescriptor := make(map[string]any)
 
 	storageDescriptor["additional_locations"] = flex.FlattenStringValueList(s.AdditionalLocations)
 	storageDescriptor["columns"] = flattenColumns(s.Columns)
@@ -936,8 +936,8 @@ func flattenStorageDescriptor(s *awstypes.StorageDescriptor) []map[string]interf
 	return storageDescriptors
 }
 
-func flattenColumns(cs []awstypes.Column) []map[string]interface{} {
-	columnsSlice := make([]map[string]interface{}, len(cs))
+func flattenColumns(cs []awstypes.Column) []map[string]any {
+	columnsSlice := make([]map[string]any, len(cs))
 	if len(cs) > 0 {
 		for i, v := range cs {
 			columnsSlice[i] = flattenColumn(v)
@@ -947,8 +947,8 @@ func flattenColumns(cs []awstypes.Column) []map[string]interface{} {
 	return columnsSlice
 }
 
-func flattenColumn(c awstypes.Column) map[string]interface{} {
-	column := make(map[string]interface{})
+func flattenColumn(c awstypes.Column) map[string]any {
+	column := make(map[string]any)
 
 	if v := aws.ToString(c.Name); v != "" {
 		column[names.AttrName] = v
@@ -969,8 +969,8 @@ func flattenColumn(c awstypes.Column) map[string]interface{} {
 	return column
 }
 
-func flattenPartitionIndexes(cs []awstypes.PartitionIndexDescriptor) []map[string]interface{} {
-	partitionIndexSlice := make([]map[string]interface{}, len(cs))
+func flattenPartitionIndexes(cs []awstypes.PartitionIndexDescriptor) []map[string]any {
+	partitionIndexSlice := make([]map[string]any, len(cs))
 	if len(cs) > 0 {
 		for i, v := range cs {
 			partitionIndexSlice[i] = flattenPartitionIndex(v)
@@ -980,8 +980,8 @@ func flattenPartitionIndexes(cs []awstypes.PartitionIndexDescriptor) []map[strin
 	return partitionIndexSlice
 }
 
-func flattenPartitionIndex(c awstypes.PartitionIndexDescriptor) map[string]interface{} {
-	partitionIndex := make(map[string]interface{})
+func flattenPartitionIndex(c awstypes.PartitionIndexDescriptor) map[string]any {
+	partitionIndex := make(map[string]any)
 
 	if v := aws.ToString(c.IndexName); v != "" {
 		partitionIndex["index_name"] = v
@@ -1002,14 +1002,14 @@ func flattenPartitionIndex(c awstypes.PartitionIndexDescriptor) map[string]inter
 	return partitionIndex
 }
 
-func flattenSerDeInfo(s *awstypes.SerDeInfo) []map[string]interface{} {
+func flattenSerDeInfo(s *awstypes.SerDeInfo) []map[string]any {
 	if s == nil {
-		serDeInfos := make([]map[string]interface{}, 0)
+		serDeInfos := make([]map[string]any, 0)
 		return serDeInfos
 	}
 
-	serDeInfos := make([]map[string]interface{}, 1)
-	serDeInfo := make(map[string]interface{})
+	serDeInfos := make([]map[string]any, 1)
+	serDeInfo := make(map[string]any)
 
 	if v := aws.ToString(s.Name); v != "" {
 		serDeInfo[names.AttrName] = v
@@ -1023,10 +1023,10 @@ func flattenSerDeInfo(s *awstypes.SerDeInfo) []map[string]interface{} {
 	return serDeInfos
 }
 
-func flattenOrders(os []awstypes.Order) []map[string]interface{} {
-	orders := make([]map[string]interface{}, len(os))
+func flattenOrders(os []awstypes.Order) []map[string]any {
+	orders := make([]map[string]any, len(os))
 	for i, v := range os {
-		order := make(map[string]interface{})
+		order := make(map[string]any)
 		order["column"] = aws.ToString(v.Column)
 		order["sort_order"] = int(v.SortOrder)
 		orders[i] = order
@@ -1035,15 +1035,15 @@ func flattenOrders(os []awstypes.Order) []map[string]interface{} {
 	return orders
 }
 
-func flattenSkewedInfo(s *awstypes.SkewedInfo) []map[string]interface{} {
+func flattenSkewedInfo(s *awstypes.SkewedInfo) []map[string]any {
 	if s == nil {
-		skewedInfoSlice := make([]map[string]interface{}, 0)
+		skewedInfoSlice := make([]map[string]any, 0)
 		return skewedInfoSlice
 	}
 
-	skewedInfoSlice := make([]map[string]interface{}, 1)
+	skewedInfoSlice := make([]map[string]any, 1)
 
-	skewedInfo := make(map[string]interface{})
+	skewedInfo := make(map[string]any)
 	skewedInfo["skewed_column_names"] = flex.FlattenStringValueList(s.SkewedColumnNames)
 	skewedInfo["skewed_column_value_location_maps"] = s.SkewedColumnValueLocationMaps
 	skewedInfo["skewed_column_values"] = flex.FlattenStringValueList(s.SkewedColumnValues)
@@ -1052,15 +1052,15 @@ func flattenSkewedInfo(s *awstypes.SkewedInfo) []map[string]interface{} {
 	return skewedInfoSlice
 }
 
-func flattenTableSchemaReference(s *awstypes.SchemaReference) []map[string]interface{} {
+func flattenTableSchemaReference(s *awstypes.SchemaReference) []map[string]any {
 	if s == nil {
-		schemaReferenceInfoSlice := make([]map[string]interface{}, 0)
+		schemaReferenceInfoSlice := make([]map[string]any, 0)
 		return schemaReferenceInfoSlice
 	}
 
-	schemaReferenceInfoSlice := make([]map[string]interface{}, 1)
+	schemaReferenceInfoSlice := make([]map[string]any, 1)
 
-	schemaReferenceInfo := make(map[string]interface{})
+	schemaReferenceInfo := make(map[string]any)
 
 	if s.SchemaVersionId != nil {
 		schemaReferenceInfo["schema_version_id"] = aws.ToString(s.SchemaVersionId)
@@ -1079,15 +1079,15 @@ func flattenTableSchemaReference(s *awstypes.SchemaReference) []map[string]inter
 	return schemaReferenceInfoSlice
 }
 
-func flattenTableSchemaReferenceSchemaID(s *awstypes.SchemaId) []map[string]interface{} {
+func flattenTableSchemaReferenceSchemaID(s *awstypes.SchemaId) []map[string]any {
 	if s == nil {
-		schemaIDInfoSlice := make([]map[string]interface{}, 0)
+		schemaIDInfoSlice := make([]map[string]any, 0)
 		return schemaIDInfoSlice
 	}
 
-	schemaIDInfoSlice := make([]map[string]interface{}, 1)
+	schemaIDInfoSlice := make([]map[string]any, 1)
 
-	schemaIDInfo := make(map[string]interface{})
+	schemaIDInfo := make(map[string]any)
 
 	if s.RegistryName != nil {
 		schemaIDInfo["registry_name"] = aws.ToString(s.RegistryName)
@@ -1106,7 +1106,7 @@ func flattenTableSchemaReferenceSchemaID(s *awstypes.SchemaId) []map[string]inte
 	return schemaIDInfoSlice
 }
 
-func expandTableTargetTable(tfMap map[string]interface{}) *awstypes.TableIdentifier {
+func expandTableTargetTable(tfMap map[string]any) *awstypes.TableIdentifier {
 	if tfMap == nil {
 		return nil
 	}
@@ -1132,12 +1132,12 @@ func expandTableTargetTable(tfMap map[string]interface{}) *awstypes.TableIdentif
 	return apiObject
 }
 
-func flattenTableTargetTable(apiObject *awstypes.TableIdentifier) map[string]interface{} {
+func flattenTableTargetTable(apiObject *awstypes.TableIdentifier) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CatalogId; v != nil {
 		tfMap[names.AttrCatalogID] = aws.ToString(v)

--- a/internal/service/glue/catalog_table_data_source.go
+++ b/internal/service/glue/catalog_table_data_source.go
@@ -330,7 +330,7 @@ func DataSourceCatalogTable() *schema.Resource {
 	}
 }
 
-func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
@@ -399,7 +399,7 @@ func dataSourceCatalogTableRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	if table.TargetTable != nil {
-		if err := d.Set("target_table", []interface{}{flattenTableTargetTable(table.TargetTable)}); err != nil {
+		if err := d.Set("target_table", []any{flattenTableTargetTable(table.TargetTable)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting target_table: %s", err)
 		}
 	} else {

--- a/internal/service/glue/catalog_table_optimizer.go
+++ b/internal/service/glue/catalog_table_optimizer.go
@@ -308,7 +308,7 @@ func (r *resourceCatalogTableOptimizer) Delete(ctx context.Context, request reso
 		return
 	}
 
-	tflog.Debug(ctx, "deleting Glue Catalog Table Optimizer", map[string]interface{}{
+	tflog.Debug(ctx, "deleting Glue Catalog Table Optimizer", map[string]any{
 		names.AttrCatalogID:    data.CatalogID.ValueString(),
 		names.AttrDatabaseName: data.DatabaseName.ValueString(),
 		names.AttrTableName:    data.TableName.ValueString(),

--- a/internal/service/glue/classifier.go
+++ b/internal/service/glue/classifier.go
@@ -34,7 +34,7 @@ func ResourceClassifier() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, v any) error {
 				// ForceNew when changing classifier type
 				// InvalidInputException: UpdateClassifierRequest can't change the type of the classifier
 				if diff.HasChange("csv_classifier") && diff.HasChange("grok_classifier") {
@@ -199,7 +199,7 @@ func ResourceClassifier() *schema.Resource {
 	}
 }
 
-func resourceClassifierCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClassifierCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	name := d.Get(names.AttrName).(string)
@@ -207,22 +207,22 @@ func resourceClassifierCreate(ctx context.Context, d *schema.ResourceData, meta 
 	input := &glue.CreateClassifierInput{}
 
 	if v, ok := d.GetOk("csv_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.CsvClassifier = expandCSVClassifierCreate(name, m)
 	}
 
 	if v, ok := d.GetOk("grok_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.GrokClassifier = expandGrokClassifierCreate(name, m)
 	}
 
 	if v, ok := d.GetOk("json_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.JsonClassifier = expandJSONClassifierCreate(name, m)
 	}
 
 	if v, ok := d.GetOk("xml_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.XMLClassifier = expandXmlClassifierCreate(name, m)
 	}
 
@@ -237,7 +237,7 @@ func resourceClassifierCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceClassifierRead(ctx, d, meta)...)
 }
 
-func resourceClassifierRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClassifierRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -273,29 +273,29 @@ func resourceClassifierRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceClassifierUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClassifierUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
 	input := &glue.UpdateClassifierInput{}
 
 	if v, ok := d.GetOk("csv_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.CsvClassifier = expandCSVClassifierUpdate(d.Id(), m)
 	}
 
 	if v, ok := d.GetOk("grok_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.GrokClassifier = expandGrokClassifierUpdate(d.Id(), m)
 	}
 
 	if v, ok := d.GetOk("json_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.JsonClassifier = expandJSONClassifierUpdate(d.Id(), m)
 	}
 
 	if v, ok := d.GetOk("xml_classifier"); ok {
-		m := v.([]interface{})[0].(map[string]interface{})
+		m := v.([]any)[0].(map[string]any)
 		input.XMLClassifier = expandXmlClassifierUpdate(d.Id(), m)
 	}
 
@@ -308,7 +308,7 @@ func resourceClassifierUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceClassifierDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClassifierDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -337,7 +337,7 @@ func DeleteClassifier(ctx context.Context, conn *glue.Client, name string) error
 	return nil
 }
 
-func expandCSVClassifierCreate(name string, m map[string]interface{}) *awstypes.CreateCsvClassifierRequest {
+func expandCSVClassifierCreate(name string, m map[string]any) *awstypes.CreateCsvClassifierRequest {
 	csvClassifier := &awstypes.CreateCsvClassifierRequest{
 		AllowSingleColumn:    aws.Bool(m["allow_single_column"].(bool)),
 		ContainsHeader:       awstypes.CsvHeaderOption(m["contains_header"].(string)),
@@ -350,11 +350,11 @@ func expandCSVClassifierCreate(name string, m map[string]interface{}) *awstypes.
 		csvClassifier.QuoteSymbol = aws.String(v)
 	}
 
-	if v, ok := m[names.AttrHeader].([]interface{}); ok {
+	if v, ok := m[names.AttrHeader].([]any); ok {
 		csvClassifier.Header = flex.ExpandStringValueList(v)
 	}
 
-	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["custom_datatypes"].([]any); ok && len(v) > 0 {
 		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
 			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
 		}
@@ -368,7 +368,7 @@ func expandCSVClassifierCreate(name string, m map[string]interface{}) *awstypes.
 	return csvClassifier
 }
 
-func expandCSVClassifierUpdate(name string, m map[string]interface{}) *awstypes.UpdateCsvClassifierRequest {
+func expandCSVClassifierUpdate(name string, m map[string]any) *awstypes.UpdateCsvClassifierRequest {
 	csvClassifier := &awstypes.UpdateCsvClassifierRequest{
 		AllowSingleColumn:    aws.Bool(m["allow_single_column"].(bool)),
 		ContainsHeader:       awstypes.CsvHeaderOption(m["contains_header"].(string)),
@@ -381,11 +381,11 @@ func expandCSVClassifierUpdate(name string, m map[string]interface{}) *awstypes.
 		csvClassifier.QuoteSymbol = aws.String(v)
 	}
 
-	if v, ok := m[names.AttrHeader].([]interface{}); ok {
+	if v, ok := m[names.AttrHeader].([]any); ok {
 		csvClassifier.Header = flex.ExpandStringValueList(v)
 	}
 
-	if v, ok := m["custom_datatypes"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["custom_datatypes"].([]any); ok && len(v) > 0 {
 		if confV, confOk := m["custom_datatype_configured"].(bool); confOk {
 			csvClassifier.CustomDatatypeConfigured = aws.Bool(confV)
 		}
@@ -399,7 +399,7 @@ func expandCSVClassifierUpdate(name string, m map[string]interface{}) *awstypes.
 	return csvClassifier
 }
 
-func expandGrokClassifierCreate(name string, m map[string]interface{}) *awstypes.CreateGrokClassifierRequest {
+func expandGrokClassifierCreate(name string, m map[string]any) *awstypes.CreateGrokClassifierRequest {
 	grokClassifier := &awstypes.CreateGrokClassifierRequest{
 		Classification: aws.String(m["classification"].(string)),
 		GrokPattern:    aws.String(m["grok_pattern"].(string)),
@@ -413,7 +413,7 @@ func expandGrokClassifierCreate(name string, m map[string]interface{}) *awstypes
 	return grokClassifier
 }
 
-func expandGrokClassifierUpdate(name string, m map[string]interface{}) *awstypes.UpdateGrokClassifierRequest {
+func expandGrokClassifierUpdate(name string, m map[string]any) *awstypes.UpdateGrokClassifierRequest {
 	grokClassifier := &awstypes.UpdateGrokClassifierRequest{
 		Classification: aws.String(m["classification"].(string)),
 		GrokPattern:    aws.String(m["grok_pattern"].(string)),
@@ -427,7 +427,7 @@ func expandGrokClassifierUpdate(name string, m map[string]interface{}) *awstypes
 	return grokClassifier
 }
 
-func expandJSONClassifierCreate(name string, m map[string]interface{}) *awstypes.CreateJsonClassifierRequest {
+func expandJSONClassifierCreate(name string, m map[string]any) *awstypes.CreateJsonClassifierRequest {
 	jsonClassifier := &awstypes.CreateJsonClassifierRequest{
 		JsonPath: aws.String(m["json_path"].(string)),
 		Name:     aws.String(name),
@@ -436,7 +436,7 @@ func expandJSONClassifierCreate(name string, m map[string]interface{}) *awstypes
 	return jsonClassifier
 }
 
-func expandJSONClassifierUpdate(name string, m map[string]interface{}) *awstypes.UpdateJsonClassifierRequest {
+func expandJSONClassifierUpdate(name string, m map[string]any) *awstypes.UpdateJsonClassifierRequest {
 	jsonClassifier := &awstypes.UpdateJsonClassifierRequest{
 		JsonPath: aws.String(m["json_path"].(string)),
 		Name:     aws.String(name),
@@ -445,7 +445,7 @@ func expandJSONClassifierUpdate(name string, m map[string]interface{}) *awstypes
 	return jsonClassifier
 }
 
-func expandXmlClassifierCreate(name string, m map[string]interface{}) *awstypes.CreateXMLClassifierRequest {
+func expandXmlClassifierCreate(name string, m map[string]any) *awstypes.CreateXMLClassifierRequest {
 	xmlClassifier := &awstypes.CreateXMLClassifierRequest{
 		Classification: aws.String(m["classification"].(string)),
 		Name:           aws.String(name),
@@ -455,7 +455,7 @@ func expandXmlClassifierCreate(name string, m map[string]interface{}) *awstypes.
 	return xmlClassifier
 }
 
-func expandXmlClassifierUpdate(name string, m map[string]interface{}) *awstypes.UpdateXMLClassifierRequest {
+func expandXmlClassifierUpdate(name string, m map[string]any) *awstypes.UpdateXMLClassifierRequest {
 	xmlClassifier := &awstypes.UpdateXMLClassifierRequest{
 		Classification: aws.String(m["classification"].(string)),
 		Name:           aws.String(name),
@@ -469,12 +469,12 @@ func expandXmlClassifierUpdate(name string, m map[string]interface{}) *awstypes.
 	return xmlClassifier
 }
 
-func flattenCSVClassifier(csvClassifier *awstypes.CsvClassifier) []map[string]interface{} {
+func flattenCSVClassifier(csvClassifier *awstypes.CsvClassifier) []map[string]any {
 	if csvClassifier == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"allow_single_column":        aws.ToBool(csvClassifier.AllowSingleColumn),
 		"contains_header":            string(csvClassifier.ContainsHeader),
 		"delimiter":                  aws.ToString(csvClassifier.Delimiter),
@@ -486,44 +486,44 @@ func flattenCSVClassifier(csvClassifier *awstypes.CsvClassifier) []map[string]in
 		"serde":                      string(csvClassifier.Serde),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenGrokClassifier(grokClassifier *awstypes.GrokClassifier) []map[string]interface{} {
+func flattenGrokClassifier(grokClassifier *awstypes.GrokClassifier) []map[string]any {
 	if grokClassifier == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"classification":  aws.ToString(grokClassifier.Classification),
 		"custom_patterns": aws.ToString(grokClassifier.CustomPatterns),
 		"grok_pattern":    aws.ToString(grokClassifier.GrokPattern),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenJSONClassifier(jsonClassifier *awstypes.JsonClassifier) []map[string]interface{} {
+func flattenJSONClassifier(jsonClassifier *awstypes.JsonClassifier) []map[string]any {
 	if jsonClassifier == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"json_path": aws.ToString(jsonClassifier.JsonPath),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenXmlClassifier(xmlClassifier *awstypes.XMLClassifier) []map[string]interface{} {
+func flattenXmlClassifier(xmlClassifier *awstypes.XMLClassifier) []map[string]any {
 	if xmlClassifier == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"classification": aws.ToString(xmlClassifier.Classification),
 		"row_tag":        aws.ToString(xmlClassifier.RowTag),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }

--- a/internal/service/glue/connection.go
+++ b/internal/service/glue/connection.go
@@ -113,7 +113,7 @@ func ResourceConnection() *schema.Resource {
 	}
 }
 
-func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -142,7 +142,7 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceConnectionRead(ctx, d, meta)...)
 }
 
-func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -188,7 +188,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -214,7 +214,7 @@ func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -260,7 +260,7 @@ func DeleteConnection(ctx context.Context, conn *glue.Client, catalogID, connect
 func expandConnectionInput(d *schema.ResourceData) *awstypes.ConnectionInput {
 	connectionProperties := make(map[string]string)
 	if val, ok := d.GetOkExists("connection_properties"); ok {
-		for k, v := range val.(map[string]interface{}) {
+		for k, v := range val.(map[string]any) {
 			connectionProperties[k] = v.(string)
 		}
 	}
@@ -276,18 +276,18 @@ func expandConnectionInput(d *schema.ResourceData) *awstypes.ConnectionInput {
 	}
 
 	if v, ok := d.GetOk("match_criteria"); ok {
-		connectionInput.MatchCriteria = flex.ExpandStringValueList(v.([]interface{}))
+		connectionInput.MatchCriteria = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("physical_connection_requirements"); ok && v.([]interface{})[0] != nil {
-		physicalConnectionRequirementsMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("physical_connection_requirements"); ok && v.([]any)[0] != nil {
+		physicalConnectionRequirementsMap := v.([]any)[0].(map[string]any)
 		connectionInput.PhysicalConnectionRequirements = expandPhysicalConnectionRequirements(physicalConnectionRequirementsMap)
 	}
 
 	return connectionInput
 }
 
-func expandPhysicalConnectionRequirements(m map[string]interface{}) *awstypes.PhysicalConnectionRequirements {
+func expandPhysicalConnectionRequirements(m map[string]any) *awstypes.PhysicalConnectionRequirements {
 	physicalConnectionRequirements := &awstypes.PhysicalConnectionRequirements{}
 
 	if v, ok := m[names.AttrAvailabilityZone]; ok {
@@ -305,18 +305,18 @@ func expandPhysicalConnectionRequirements(m map[string]interface{}) *awstypes.Ph
 	return physicalConnectionRequirements
 }
 
-func flattenPhysicalConnectionRequirements(physicalConnectionRequirements *awstypes.PhysicalConnectionRequirements) []map[string]interface{} {
+func flattenPhysicalConnectionRequirements(physicalConnectionRequirements *awstypes.PhysicalConnectionRequirements) []map[string]any {
 	if physicalConnectionRequirements == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrAvailabilityZone: aws.ToString(physicalConnectionRequirements.AvailabilityZone),
 		"security_group_id_list":   flex.FlattenStringValueSet(physicalConnectionRequirements.SecurityGroupIdList),
 		names.AttrSubnetID:         aws.ToString(physicalConnectionRequirements.SubnetId),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
 func connectionPropertyKey_Values() []string {

--- a/internal/service/glue/connection_data_source.go
+++ b/internal/service/glue/connection_data_source.go
@@ -88,7 +88,7 @@ func DataSourceConnection() *schema.Resource {
 	}
 }
 
-func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)

--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -94,7 +94,7 @@ func ResourceCrawler() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -427,7 +427,7 @@ func ResourceCrawler() *schema.Resource {
 	}
 }
 
-func resourceCrawlerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCrawlerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	glueConn := meta.(*conns.AWSClient).GlueClient(ctx)
 	name := d.Get(names.AttrName).(string)
@@ -480,7 +480,7 @@ func resourceCrawlerCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceCrawlerRead(ctx, d, meta)...)
 }
 
-func resourceCrawlerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCrawlerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -573,7 +573,7 @@ func resourceCrawlerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceCrawlerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCrawlerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	glueConn := meta.(*conns.AWSClient).GlueClient(ctx)
 	name := d.Get(names.AttrName).(string)
@@ -629,7 +629,7 @@ func resourceCrawlerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceCrawlerRead(ctx, d, meta)...)
 }
 
-func resourceCrawlerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCrawlerDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	glueConn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -664,10 +664,10 @@ func createCrawlerInput(ctx context.Context, d *schema.ResourceData, crawlerName
 		crawlerInput.Schedule = aws.String(schedule.(string))
 	}
 	if classifiers, ok := d.GetOk("classifiers"); ok {
-		crawlerInput.Classifiers = flex.ExpandStringValueList(classifiers.([]interface{}))
+		crawlerInput.Classifiers = flex.ExpandStringValueList(classifiers.([]any))
 	}
 
-	crawlerInput.SchemaChangePolicy = expandSchemaChangePolicy(d.Get("schema_change_policy").([]interface{}))
+	crawlerInput.SchemaChangePolicy = expandSchemaChangePolicy(d.Get("schema_change_policy").([]any))
 
 	if tablePrefix, ok := d.GetOk("table_prefix"); ok {
 		crawlerInput.TablePrefix = aws.String(tablePrefix.(string))
@@ -689,15 +689,15 @@ func createCrawlerInput(ctx context.Context, d *schema.ResourceData, crawlerName
 	}
 
 	if v, ok := d.GetOk("lineage_configuration"); ok {
-		crawlerInput.LineageConfiguration = expandCrawlerLineageConfiguration(v.([]interface{}))
+		crawlerInput.LineageConfiguration = expandCrawlerLineageConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("lake_formation_configuration"); ok {
-		crawlerInput.LakeFormationConfiguration = expandLakeFormationConfiguration(v.([]interface{}))
+		crawlerInput.LakeFormationConfiguration = expandLakeFormationConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("recrawl_policy"); ok {
-		crawlerInput.RecrawlPolicy = expandCrawlerRecrawlPolicy(v.([]interface{}))
+		crawlerInput.RecrawlPolicy = expandCrawlerRecrawlPolicy(v.([]any))
 	}
 
 	return crawlerInput, nil
@@ -721,10 +721,10 @@ func updateCrawlerInput(d *schema.ResourceData, crawlerName string) (*glue.Updat
 	}
 
 	if classifiers, ok := d.GetOk("classifiers"); ok {
-		crawlerInput.Classifiers = flex.ExpandStringValueList(classifiers.([]interface{}))
+		crawlerInput.Classifiers = flex.ExpandStringValueList(classifiers.([]any))
 	}
 
-	crawlerInput.SchemaChangePolicy = expandSchemaChangePolicy(d.Get("schema_change_policy").([]interface{}))
+	crawlerInput.SchemaChangePolicy = expandSchemaChangePolicy(d.Get("schema_change_policy").([]any))
 
 	crawlerInput.TablePrefix = aws.String(d.Get("table_prefix").(string))
 
@@ -743,28 +743,28 @@ func updateCrawlerInput(d *schema.ResourceData, crawlerName string) (*glue.Updat
 	}
 
 	if v, ok := d.GetOk("lineage_configuration"); ok {
-		crawlerInput.LineageConfiguration = expandCrawlerLineageConfiguration(v.([]interface{}))
+		crawlerInput.LineageConfiguration = expandCrawlerLineageConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("lake_formation_configuration"); ok {
-		crawlerInput.LakeFormationConfiguration = expandLakeFormationConfiguration(v.([]interface{}))
+		crawlerInput.LakeFormationConfiguration = expandLakeFormationConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("recrawl_policy"); ok {
-		crawlerInput.RecrawlPolicy = expandCrawlerRecrawlPolicy(v.([]interface{}))
+		crawlerInput.RecrawlPolicy = expandCrawlerRecrawlPolicy(v.([]any))
 	}
 
 	return crawlerInput, nil
 }
 
-func expandSchemaChangePolicy(v []interface{}) *awstypes.SchemaChangePolicy {
+func expandSchemaChangePolicy(v []any) *awstypes.SchemaChangePolicy {
 	if len(v) == 0 {
 		return nil
 	}
 
 	schemaPolicy := &awstypes.SchemaChangePolicy{}
 
-	member := v[0].(map[string]interface{})
+	member := v[0].(map[string]any)
 
 	if updateBehavior, ok := member["update_behavior"]; ok && updateBehavior.(string) != "" {
 		schemaPolicy.UpdateBehavior = awstypes.UpdateBehavior(updateBehavior.(string))
@@ -782,54 +782,54 @@ func expandCrawlerTargets(d *schema.ResourceData) *awstypes.CrawlerTargets {
 	log.Print("[DEBUG] Creating crawler target")
 
 	if v, ok := d.GetOk("dynamodb_target"); ok {
-		crawlerTargets.DynamoDBTargets = expandDynamoDBTargets(v.([]interface{}))
+		crawlerTargets.DynamoDBTargets = expandDynamoDBTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("jdbc_target"); ok {
-		crawlerTargets.JdbcTargets = expandJDBCTargets(v.([]interface{}))
+		crawlerTargets.JdbcTargets = expandJDBCTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("s3_target"); ok {
-		crawlerTargets.S3Targets = expandS3Targets(v.([]interface{}))
+		crawlerTargets.S3Targets = expandS3Targets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("catalog_target"); ok {
-		crawlerTargets.CatalogTargets = expandCatalogTargets(v.([]interface{}))
+		crawlerTargets.CatalogTargets = expandCatalogTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("mongodb_target"); ok {
-		crawlerTargets.MongoDBTargets = expandMongoDBTargets(v.([]interface{}))
+		crawlerTargets.MongoDBTargets = expandMongoDBTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("delta_target"); ok {
-		crawlerTargets.DeltaTargets = expandDeltaTargets(v.([]interface{}))
+		crawlerTargets.DeltaTargets = expandDeltaTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("hudi_target"); ok {
-		crawlerTargets.HudiTargets = expandHudiTargets(v.([]interface{}))
+		crawlerTargets.HudiTargets = expandHudiTargets(v.([]any))
 	}
 
 	if v, ok := d.GetOk("iceberg_target"); ok {
-		crawlerTargets.IcebergTargets = expandIcebergTargets(v.([]interface{}))
+		crawlerTargets.IcebergTargets = expandIcebergTargets(v.([]any))
 	}
 
 	return crawlerTargets
 }
 
-func expandDynamoDBTargets(targets []interface{}) []awstypes.DynamoDBTarget {
+func expandDynamoDBTargets(targets []any) []awstypes.DynamoDBTarget {
 	if len(targets) < 1 {
 		return []awstypes.DynamoDBTarget{}
 	}
 
 	perms := make([]awstypes.DynamoDBTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandDynamoDBTarget(cfg)
 	}
 	return perms
 }
 
-func expandDynamoDBTarget(cfg map[string]interface{}) awstypes.DynamoDBTarget {
+func expandDynamoDBTarget(cfg map[string]any) awstypes.DynamoDBTarget {
 	target := awstypes.DynamoDBTarget{
 		Path:    aws.String(cfg[names.AttrPath].(string)),
 		ScanAll: aws.Bool(cfg["scan_all"].(bool)),
@@ -842,20 +842,20 @@ func expandDynamoDBTarget(cfg map[string]interface{}) awstypes.DynamoDBTarget {
 	return target
 }
 
-func expandS3Targets(targets []interface{}) []awstypes.S3Target {
+func expandS3Targets(targets []any) []awstypes.S3Target {
 	if len(targets) < 1 {
 		return []awstypes.S3Target{}
 	}
 
 	perms := make([]awstypes.S3Target, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandS3Target(cfg)
 	}
 	return perms
 }
 
-func expandS3Target(cfg map[string]interface{}) awstypes.S3Target {
+func expandS3Target(cfg map[string]any) awstypes.S3Target {
 	target := awstypes.S3Target{
 		Path: aws.String(cfg[names.AttrPath].(string)),
 	}
@@ -865,7 +865,7 @@ func expandS3Target(cfg map[string]interface{}) awstypes.S3Target {
 	}
 
 	if v, ok := cfg["exclusions"]; ok {
-		target.Exclusions = flex.ExpandStringValueList(v.([]interface{}))
+		target.Exclusions = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := cfg["sample_size"]; ok && v.(int) > 0 {
@@ -883,53 +883,53 @@ func expandS3Target(cfg map[string]interface{}) awstypes.S3Target {
 	return target
 }
 
-func expandJDBCTargets(targets []interface{}) []awstypes.JdbcTarget {
+func expandJDBCTargets(targets []any) []awstypes.JdbcTarget {
 	if len(targets) < 1 {
 		return []awstypes.JdbcTarget{}
 	}
 
 	perms := make([]awstypes.JdbcTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandJDBCTarget(cfg)
 	}
 	return perms
 }
 
-func expandJDBCTarget(cfg map[string]interface{}) awstypes.JdbcTarget {
+func expandJDBCTarget(cfg map[string]any) awstypes.JdbcTarget {
 	target := awstypes.JdbcTarget{
 		Path:           aws.String(cfg[names.AttrPath].(string)),
 		ConnectionName: aws.String(cfg["connection_name"].(string)),
 	}
 
-	if v, ok := cfg["enable_additional_metadata"].([]interface{}); ok {
+	if v, ok := cfg["enable_additional_metadata"].([]any); ok {
 		target.EnableAdditionalMetadata = flex.ExpandStringyValueList[awstypes.JdbcMetadataEntry](v)
 	}
 
-	if v, ok := cfg["exclusions"].([]interface{}); ok {
+	if v, ok := cfg["exclusions"].([]any); ok {
 		target.Exclusions = flex.ExpandStringValueList(v)
 	}
 
 	return target
 }
 
-func expandCatalogTargets(targets []interface{}) []awstypes.CatalogTarget {
+func expandCatalogTargets(targets []any) []awstypes.CatalogTarget {
 	if len(targets) < 1 {
 		return []awstypes.CatalogTarget{}
 	}
 
 	perms := make([]awstypes.CatalogTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandCatalogTarget(cfg)
 	}
 	return perms
 }
 
-func expandCatalogTarget(cfg map[string]interface{}) awstypes.CatalogTarget {
+func expandCatalogTarget(cfg map[string]any) awstypes.CatalogTarget {
 	target := awstypes.CatalogTarget{
 		DatabaseName: aws.String(cfg[names.AttrDatabaseName].(string)),
-		Tables:       flex.ExpandStringValueList(cfg["tables"].([]interface{})),
+		Tables:       flex.ExpandStringValueList(cfg["tables"].([]any)),
 	}
 
 	if v, ok := cfg["connection_name"].(string); ok {
@@ -947,20 +947,20 @@ func expandCatalogTarget(cfg map[string]interface{}) awstypes.CatalogTarget {
 	return target
 }
 
-func expandMongoDBTargets(targets []interface{}) []awstypes.MongoDBTarget {
+func expandMongoDBTargets(targets []any) []awstypes.MongoDBTarget {
 	if len(targets) < 1 {
 		return []awstypes.MongoDBTarget{}
 	}
 
 	perms := make([]awstypes.MongoDBTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandMongoDBTarget(cfg)
 	}
 	return perms
 }
 
-func expandMongoDBTarget(cfg map[string]interface{}) awstypes.MongoDBTarget {
+func expandMongoDBTarget(cfg map[string]any) awstypes.MongoDBTarget {
 	target := awstypes.MongoDBTarget{
 		ConnectionName: aws.String(cfg["connection_name"].(string)),
 		Path:           aws.String(cfg[names.AttrPath].(string)),
@@ -970,20 +970,20 @@ func expandMongoDBTarget(cfg map[string]interface{}) awstypes.MongoDBTarget {
 	return target
 }
 
-func expandDeltaTargets(targets []interface{}) []awstypes.DeltaTarget {
+func expandDeltaTargets(targets []any) []awstypes.DeltaTarget {
 	if len(targets) < 1 {
 		return []awstypes.DeltaTarget{}
 	}
 
 	perms := make([]awstypes.DeltaTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandDeltaTarget(cfg)
 	}
 	return perms
 }
 
-func expandDeltaTarget(cfg map[string]interface{}) awstypes.DeltaTarget {
+func expandDeltaTarget(cfg map[string]any) awstypes.DeltaTarget {
 	target := awstypes.DeltaTarget{
 		CreateNativeDeltaTable: aws.Bool(cfg["create_native_delta_table"].(bool)),
 		DeltaTables:            flex.ExpandStringValueSet(cfg["delta_tables"].(*schema.Set)),
@@ -997,27 +997,27 @@ func expandDeltaTarget(cfg map[string]interface{}) awstypes.DeltaTarget {
 	return target
 }
 
-func expandHudiTargets(targets []interface{}) []awstypes.HudiTarget {
+func expandHudiTargets(targets []any) []awstypes.HudiTarget {
 	if len(targets) < 1 {
 		return []awstypes.HudiTarget{}
 	}
 
 	perms := make([]awstypes.HudiTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandHudiTarget(cfg)
 	}
 	return perms
 }
 
-func expandHudiTarget(cfg map[string]interface{}) awstypes.HudiTarget {
+func expandHudiTarget(cfg map[string]any) awstypes.HudiTarget {
 	target := awstypes.HudiTarget{
 		Paths:                 flex.ExpandStringValueSet(cfg["paths"].(*schema.Set)),
 		MaximumTraversalDepth: aws.Int32(int32(cfg["maximum_traversal_depth"].(int))),
 	}
 
 	if v, ok := cfg["exclusions"]; ok {
-		target.Exclusions = flex.ExpandStringValueList(v.([]interface{}))
+		target.Exclusions = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := cfg["connection_name"].(string); ok {
@@ -1027,27 +1027,27 @@ func expandHudiTarget(cfg map[string]interface{}) awstypes.HudiTarget {
 	return target
 }
 
-func expandIcebergTargets(targets []interface{}) []awstypes.IcebergTarget {
+func expandIcebergTargets(targets []any) []awstypes.IcebergTarget {
 	if len(targets) < 1 {
 		return []awstypes.IcebergTarget{}
 	}
 
 	perms := make([]awstypes.IcebergTarget, len(targets))
 	for i, rawCfg := range targets {
-		cfg := rawCfg.(map[string]interface{})
+		cfg := rawCfg.(map[string]any)
 		perms[i] = expandIcebergTarget(cfg)
 	}
 	return perms
 }
 
-func expandIcebergTarget(cfg map[string]interface{}) awstypes.IcebergTarget {
+func expandIcebergTarget(cfg map[string]any) awstypes.IcebergTarget {
 	target := awstypes.IcebergTarget{
 		Paths:                 flex.ExpandStringValueSet(cfg["paths"].(*schema.Set)),
 		MaximumTraversalDepth: aws.Int32(int32(cfg["maximum_traversal_depth"].(int))),
 	}
 
 	if v, ok := cfg["exclusions"]; ok {
-		target.Exclusions = flex.ExpandStringValueList(v.([]interface{}))
+		target.Exclusions = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := cfg["connection_name"].(string); ok {
@@ -1057,11 +1057,11 @@ func expandIcebergTarget(cfg map[string]interface{}) awstypes.IcebergTarget {
 	return target
 }
 
-func flattenS3Targets(s3Targets []awstypes.S3Target) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenS3Targets(s3Targets []awstypes.S3Target) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, s3Target := range s3Targets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["exclusions"] = flex.FlattenStringValueList(s3Target.Exclusions)
 		attrs[names.AttrPath] = aws.ToString(s3Target.Path)
 		attrs["connection_name"] = aws.ToString(s3Target.ConnectionName)
@@ -1078,11 +1078,11 @@ func flattenS3Targets(s3Targets []awstypes.S3Target) []map[string]interface{} {
 	return result
 }
 
-func flattenCatalogTargets(CatalogTargets []awstypes.CatalogTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenCatalogTargets(CatalogTargets []awstypes.CatalogTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, catalogTarget := range CatalogTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(catalogTarget.ConnectionName)
 		attrs["tables"] = flex.FlattenStringValueList(catalogTarget.Tables)
 		attrs[names.AttrDatabaseName] = aws.ToString(catalogTarget.DatabaseName)
@@ -1094,11 +1094,11 @@ func flattenCatalogTargets(CatalogTargets []awstypes.CatalogTarget) []map[string
 	return result
 }
 
-func flattenDynamoDBTargets(dynamodbTargets []awstypes.DynamoDBTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenDynamoDBTargets(dynamodbTargets []awstypes.DynamoDBTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, dynamodbTarget := range dynamodbTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs[names.AttrPath] = aws.ToString(dynamodbTarget.Path)
 		attrs["scan_all"] = aws.ToBool(dynamodbTarget.ScanAll)
 		attrs["scan_rate"] = aws.ToFloat64(dynamodbTarget.ScanRate)
@@ -1108,11 +1108,11 @@ func flattenDynamoDBTargets(dynamodbTargets []awstypes.DynamoDBTarget) []map[str
 	return result
 }
 
-func flattenJDBCTargets(jdbcTargets []awstypes.JdbcTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenJDBCTargets(jdbcTargets []awstypes.JdbcTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, jdbcTarget := range jdbcTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(jdbcTarget.ConnectionName)
 		attrs["exclusions"] = flex.FlattenStringValueList(jdbcTarget.Exclusions)
 		attrs["enable_additional_metadata"] = flex.FlattenStringyValueList(jdbcTarget.EnableAdditionalMetadata)
@@ -1123,11 +1123,11 @@ func flattenJDBCTargets(jdbcTargets []awstypes.JdbcTarget) []map[string]interfac
 	return result
 }
 
-func flattenMongoDBTargets(mongoDBTargets []awstypes.MongoDBTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenMongoDBTargets(mongoDBTargets []awstypes.MongoDBTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, mongoDBTarget := range mongoDBTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(mongoDBTarget.ConnectionName)
 		attrs[names.AttrPath] = aws.ToString(mongoDBTarget.Path)
 		attrs["scan_all"] = aws.ToBool(mongoDBTarget.ScanAll)
@@ -1137,11 +1137,11 @@ func flattenMongoDBTargets(mongoDBTargets []awstypes.MongoDBTarget) []map[string
 	return result
 }
 
-func flattenDeltaTargets(deltaTargets []awstypes.DeltaTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenDeltaTargets(deltaTargets []awstypes.DeltaTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, deltaTarget := range deltaTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(deltaTarget.ConnectionName)
 		attrs["create_native_delta_table"] = aws.ToBool(deltaTarget.CreateNativeDeltaTable)
 		attrs["delta_tables"] = flex.FlattenStringValueSet(deltaTarget.DeltaTables)
@@ -1152,11 +1152,11 @@ func flattenDeltaTargets(deltaTargets []awstypes.DeltaTarget) []map[string]inter
 	return result
 }
 
-func flattenHudiTargets(hudiTargets []awstypes.HudiTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenHudiTargets(hudiTargets []awstypes.HudiTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, hudiTarget := range hudiTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(hudiTarget.ConnectionName)
 		attrs["maximum_traversal_depth"] = aws.ToInt32(hudiTarget.MaximumTraversalDepth)
 		attrs["paths"] = flex.FlattenStringValueSet(hudiTarget.Paths)
@@ -1167,11 +1167,11 @@ func flattenHudiTargets(hudiTargets []awstypes.HudiTarget) []map[string]interfac
 	return result
 }
 
-func flattenIcebergTargets(icebergTargets []awstypes.IcebergTarget) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+func flattenIcebergTargets(icebergTargets []awstypes.IcebergTarget) []map[string]any {
+	result := make([]map[string]any, 0)
 
 	for _, icebergTarget := range icebergTargets {
-		attrs := make(map[string]interface{})
+		attrs := make(map[string]any)
 		attrs["connection_name"] = aws.ToString(icebergTarget.ConnectionName)
 		attrs["maximum_traversal_depth"] = aws.ToInt32(icebergTarget.MaximumTraversalDepth)
 		attrs["paths"] = flex.FlattenStringValueSet(icebergTarget.Paths)
@@ -1182,21 +1182,21 @@ func flattenIcebergTargets(icebergTargets []awstypes.IcebergTarget) []map[string
 	return result
 }
 
-func flattenCrawlerSchemaChangePolicy(cfg *awstypes.SchemaChangePolicy) []map[string]interface{} {
+func flattenCrawlerSchemaChangePolicy(cfg *awstypes.SchemaChangePolicy) []map[string]any {
 	if cfg == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"delete_behavior": string(cfg.DeleteBehavior),
 		"update_behavior": string(cfg.UpdateBehavior),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandCrawlerLineageConfiguration(cfg []interface{}) *awstypes.LineageConfiguration {
-	m := cfg[0].(map[string]interface{})
+func expandCrawlerLineageConfiguration(cfg []any) *awstypes.LineageConfiguration {
+	m := cfg[0].(map[string]any)
 
 	target := &awstypes.LineageConfiguration{
 		CrawlerLineageSettings: awstypes.CrawlerLineageSettings(m["crawler_lineage_settings"].(string)),
@@ -1204,20 +1204,20 @@ func expandCrawlerLineageConfiguration(cfg []interface{}) *awstypes.LineageConfi
 	return target
 }
 
-func flattenCrawlerLineageConfiguration(cfg *awstypes.LineageConfiguration) []map[string]interface{} {
+func flattenCrawlerLineageConfiguration(cfg *awstypes.LineageConfiguration) []map[string]any {
 	if cfg == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"crawler_lineage_settings": string(cfg.CrawlerLineageSettings),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandLakeFormationConfiguration(cfg []interface{}) *awstypes.LakeFormationConfiguration {
-	m := cfg[0].(map[string]interface{})
+func expandLakeFormationConfiguration(cfg []any) *awstypes.LakeFormationConfiguration {
+	m := cfg[0].(map[string]any)
 
 	target := &awstypes.LakeFormationConfiguration{}
 
@@ -1232,21 +1232,21 @@ func expandLakeFormationConfiguration(cfg []interface{}) *awstypes.LakeFormation
 	return target
 }
 
-func flattenLakeFormationConfiguration(cfg *awstypes.LakeFormationConfiguration) []map[string]interface{} {
+func flattenLakeFormationConfiguration(cfg *awstypes.LakeFormationConfiguration) []map[string]any {
 	if cfg == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrAccountID:              aws.ToString(cfg.AccountId),
 		"use_lake_formation_credentials": aws.ToBool(cfg.UseLakeFormationCredentials),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandCrawlerRecrawlPolicy(cfg []interface{}) *awstypes.RecrawlPolicy {
-	m := cfg[0].(map[string]interface{})
+func expandCrawlerRecrawlPolicy(cfg []any) *awstypes.RecrawlPolicy {
+	m := cfg[0].(map[string]any)
 
 	target := &awstypes.RecrawlPolicy{
 		RecrawlBehavior: awstypes.RecrawlBehavior(m["recrawl_behavior"].(string)),
@@ -1254,14 +1254,14 @@ func expandCrawlerRecrawlPolicy(cfg []interface{}) *awstypes.RecrawlPolicy {
 	return target
 }
 
-func flattenCrawlerRecrawlPolicy(cfg *awstypes.RecrawlPolicy) []map[string]interface{} {
+func flattenCrawlerRecrawlPolicy(cfg *awstypes.RecrawlPolicy) []map[string]any {
 	if cfg == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"recrawl_behavior": string(cfg.RecrawlBehavior),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }

--- a/internal/service/glue/data_catalog_encryption_settings.go
+++ b/internal/service/glue/data_catalog_encryption_settings.go
@@ -92,7 +92,7 @@ func ResourceDataCatalogEncryptionSettings() *schema.Resource {
 	}
 }
 
-func resourceDataCatalogEncryptionSettingsPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataCatalogEncryptionSettingsPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -101,8 +101,8 @@ func resourceDataCatalogEncryptionSettingsPut(ctx context.Context, d *schema.Res
 		CatalogId: aws.String(catalogID),
 	}
 
-	if v, ok := d.GetOk("data_catalog_encryption_settings"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DataCatalogEncryptionSettings = expandDataCatalogEncryptionSettings(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("data_catalog_encryption_settings"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DataCatalogEncryptionSettings = expandDataCatalogEncryptionSettings(v.([]any)[0].(map[string]any))
 	}
 
 	log.Printf("[DEBUG] Putting Glue Data Catalog Encryption Settings: %+v", input)
@@ -117,7 +117,7 @@ func resourceDataCatalogEncryptionSettingsPut(ctx context.Context, d *schema.Res
 	return append(diags, resourceDataCatalogEncryptionSettingsRead(ctx, d, meta)...)
 }
 
-func resourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -131,7 +131,7 @@ func resourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.Re
 
 	d.Set(names.AttrCatalogID, d.Id())
 	if output.DataCatalogEncryptionSettings != nil {
-		if err := d.Set("data_catalog_encryption_settings", []interface{}{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
+		if err := d.Set("data_catalog_encryption_settings", []any{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting data_catalog_encryption_settings: %s", err)
 		}
 	} else {
@@ -141,7 +141,7 @@ func resourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.Re
 	return diags
 }
 
-func resourceDataCatalogEncryptionSettingsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataCatalogEncryptionSettingsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -160,25 +160,25 @@ func resourceDataCatalogEncryptionSettingsDelete(ctx context.Context, d *schema.
 	return diags
 }
 
-func expandDataCatalogEncryptionSettings(tfMap map[string]interface{}) *awstypes.DataCatalogEncryptionSettings {
+func expandDataCatalogEncryptionSettings(tfMap map[string]any) *awstypes.DataCatalogEncryptionSettings {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DataCatalogEncryptionSettings{}
 
-	if v, ok := tfMap["connection_password_encryption"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ConnectionPasswordEncryption = expandConnectionPasswordEncryption(v[0].(map[string]interface{}))
+	if v, ok := tfMap["connection_password_encryption"].([]any); ok && len(v) > 0 {
+		apiObject.ConnectionPasswordEncryption = expandConnectionPasswordEncryption(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["encryption_at_rest"].([]interface{}); ok && len(v) > 0 {
-		apiObject.EncryptionAtRest = expandEncryptionAtRest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["encryption_at_rest"].([]any); ok && len(v) > 0 {
+		apiObject.EncryptionAtRest = expandEncryptionAtRest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandConnectionPasswordEncryption(tfMap map[string]interface{}) *awstypes.ConnectionPasswordEncryption {
+func expandConnectionPasswordEncryption(tfMap map[string]any) *awstypes.ConnectionPasswordEncryption {
 	if tfMap == nil {
 		return nil
 	}
@@ -196,7 +196,7 @@ func expandConnectionPasswordEncryption(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func expandEncryptionAtRest(tfMap map[string]interface{}) *awstypes.EncryptionAtRest {
+func expandEncryptionAtRest(tfMap map[string]any) *awstypes.EncryptionAtRest {
 	if tfMap == nil {
 		return nil
 	}
@@ -218,30 +218,30 @@ func expandEncryptionAtRest(tfMap map[string]interface{}) *awstypes.EncryptionAt
 	return apiObject
 }
 
-func flattenDataCatalogEncryptionSettings(apiObject *awstypes.DataCatalogEncryptionSettings) map[string]interface{} {
+func flattenDataCatalogEncryptionSettings(apiObject *awstypes.DataCatalogEncryptionSettings) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ConnectionPasswordEncryption; v != nil {
-		tfMap["connection_password_encryption"] = []interface{}{flattenConnectionPasswordEncryption(v)}
+		tfMap["connection_password_encryption"] = []any{flattenConnectionPasswordEncryption(v)}
 	}
 
 	if v := apiObject.EncryptionAtRest; v != nil {
-		tfMap["encryption_at_rest"] = []interface{}{flattenEncryptionAtRest(v)}
+		tfMap["encryption_at_rest"] = []any{flattenEncryptionAtRest(v)}
 	}
 
 	return tfMap
 }
 
-func flattenConnectionPasswordEncryption(apiObject *awstypes.ConnectionPasswordEncryption) map[string]interface{} {
+func flattenConnectionPasswordEncryption(apiObject *awstypes.ConnectionPasswordEncryption) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AwsKmsKeyId; v != nil {
 		tfMap["aws_kms_key_id"] = aws.ToString(v)
@@ -252,12 +252,12 @@ func flattenConnectionPasswordEncryption(apiObject *awstypes.ConnectionPasswordE
 	return tfMap
 }
 
-func flattenEncryptionAtRest(apiObject *awstypes.EncryptionAtRest) map[string]interface{} {
+func flattenEncryptionAtRest(apiObject *awstypes.EncryptionAtRest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["catalog_encryption_mode"] = string(apiObject.CatalogEncryptionMode)
 

--- a/internal/service/glue/data_catalog_encryption_settings_data_source.go
+++ b/internal/service/glue/data_catalog_encryption_settings_data_source.go
@@ -72,7 +72,7 @@ func DataSourceDataCatalogEncryptionSettings() *schema.Resource {
 	}
 }
 
-func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
@@ -89,7 +89,7 @@ func dataSourceDataCatalogEncryptionSettingsRead(ctx context.Context, d *schema.
 	d.SetId(catalogID)
 	d.Set(names.AttrCatalogID, d.Id())
 	if output.DataCatalogEncryptionSettings != nil {
-		if err := d.Set("data_catalog_encryption_settings", []interface{}{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
+		if err := d.Set("data_catalog_encryption_settings", []any{flattenDataCatalogEncryptionSettings(output.DataCatalogEncryptionSettings)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting data_catalog_encryption_settings: %s", err)
 		}
 	} else {

--- a/internal/service/glue/data_quality_ruleset.go
+++ b/internal/service/glue/data_quality_ruleset.go
@@ -103,7 +103,7 @@ func ResourceDataQualityRuleset() *schema.Resource {
 	}
 }
 
-func resourceDataQualityRulesetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataQualityRulesetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -119,8 +119,8 @@ func resourceDataQualityRulesetCreate(ctx context.Context, d *schema.ResourceDat
 		input.Description = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("target_table"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.TargetTable = expandTargetTable(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("target_table"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.TargetTable = expandTargetTable(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.CreateDataQualityRuleset(ctx, input)
@@ -133,7 +133,7 @@ func resourceDataQualityRulesetCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceDataQualityRulesetRead(ctx, d, meta)...)
 }
 
-func resourceDataQualityRulesetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataQualityRulesetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -173,7 +173,7 @@ func resourceDataQualityRulesetRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceDataQualityRulesetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataQualityRulesetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -200,7 +200,7 @@ func resourceDataQualityRulesetUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceDataQualityRulesetRead(ctx, d, meta)...)
 }
 
-func resourceDataQualityRulesetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataQualityRulesetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -220,7 +220,7 @@ func resourceDataQualityRulesetDelete(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func expandTargetTable(tfMap map[string]interface{}) *awstypes.DataQualityTargetTable {
+func expandTargetTable(tfMap map[string]any) *awstypes.DataQualityTargetTable {
 	if tfMap == nil {
 		return nil
 	}
@@ -237,12 +237,12 @@ func expandTargetTable(tfMap map[string]interface{}) *awstypes.DataQualityTarget
 	return apiObject
 }
 
-func flattenTargetTable(apiObject *awstypes.DataQualityTargetTable) []interface{} {
+func flattenTargetTable(apiObject *awstypes.DataQualityTargetTable) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrDatabaseName: aws.ToString(apiObject.DatabaseName),
 		names.AttrTableName:    aws.ToString(apiObject.TableName),
 	}
@@ -251,5 +251,5 @@ func flattenTargetTable(apiObject *awstypes.DataQualityTargetTable) []interface{
 		tfMap[names.AttrCatalogID] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/glue/dev_endpoint.go
+++ b/internal/service/glue/dev_endpoint.go
@@ -172,7 +172,7 @@ func ResourceDevEndpoint() *schema.Resource {
 	}
 }
 
-func resourceDevEndpointCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDevEndpointCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -184,7 +184,7 @@ func resourceDevEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("arguments"); ok {
-		input.Arguments = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.Arguments = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("extra_jars_s3_path"); ok {
@@ -271,7 +271,7 @@ func resourceDevEndpointCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceDevEndpointRead(ctx, d, meta)...)
 }
 
-func resourceDevEndpointRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDevEndpointRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -390,7 +390,7 @@ func resourceDevEndpointRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceDevEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDevEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -404,8 +404,8 @@ func resourceDevEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	if d.HasChange("arguments") {
 		oldRaw, newRaw := d.GetChange("arguments")
-		old := oldRaw.(map[string]interface{})
-		new := newRaw.(map[string]interface{})
+		old := oldRaw.(map[string]any)
+		new := newRaw.(map[string]any)
 		add, remove, _ := flex.DiffStringValueMaps(old, new)
 
 		removeKeys := make([]string, 0)
@@ -489,7 +489,7 @@ func resourceDevEndpointUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceDevEndpointRead(ctx, d, meta)...)
 }
 
-func resourceDevEndpointDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDevEndpointDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 

--- a/internal/service/glue/id.go
+++ b/internal/service/glue/id.go
@@ -29,7 +29,7 @@ func readPartitionIndexID(id string) (string, string, string, string, error) {
 	return idParts[0], idParts[1], idParts[2], idParts[3], nil
 }
 
-func createPartitionID(catalogID, dbName, tableName string, values []interface{}) string {
+func createPartitionID(catalogID, dbName, tableName string, values []any) string {
 	return fmt.Sprintf("%s:%s:%s:%s", catalogID, dbName, tableName, stringifyPartition(values))
 }
 
@@ -37,7 +37,7 @@ func createPartitionIndexID(catalogID, dbName, tableName, indexName string) stri
 	return fmt.Sprintf("%s:%s:%s:%s", catalogID, dbName, tableName, indexName)
 }
 
-func stringifyPartition(partValues []interface{}) string {
+func stringifyPartition(partValues []any) string {
 	var b bytes.Buffer
 	for _, val := range partValues {
 		b.WriteString(fmt.Sprintf("%s#", val.(string)))

--- a/internal/service/glue/job.go
+++ b/internal/service/glue/job.go
@@ -193,13 +193,13 @@ func ResourceJob() *schema.Resource {
 	}
 }
 
-func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &glue.CreateJobInput{
-		Command: expandJobCommand(d.Get("command").([]interface{})),
+		Command: expandJobCommand(d.Get("command").([]any)),
 		Name:    aws.String(name),
 		Role:    aws.String(d.Get(names.AttrRoleARN).(string)),
 		Tags:    getTagsIn(ctx),
@@ -207,12 +207,12 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	if v, ok := d.GetOk("connections"); ok {
 		input.Connections = &awstypes.ConnectionsList{
-			Connections: flex.ExpandStringValueList(v.([]interface{})),
+			Connections: flex.ExpandStringValueList(v.([]any)),
 		}
 	}
 
 	if v, ok := d.GetOk("default_arguments"); ok {
-		input.DefaultArguments = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.DefaultArguments = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -224,7 +224,7 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("execution_property"); ok {
-		input.ExecutionProperty = expandExecutionProperty(v.([]interface{}))
+		input.ExecutionProperty = expandExecutionProperty(v.([]any))
 	}
 
 	if v, ok := d.GetOk("glue_version"); ok {
@@ -248,11 +248,11 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("non_overridable_arguments"); ok {
-		input.NonOverridableArguments = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.NonOverridableArguments = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("notification_property"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NotificationProperty = expandNotificationProperty(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("notification_property"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.NotificationProperty = expandNotificationProperty(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("number_of_workers"); ok {
@@ -282,7 +282,7 @@ func resourceJobCreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceJobRead(ctx, d, meta)...)
 }
 
-func resourceJobRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -337,24 +337,24 @@ func resourceJobRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return diags
 }
 
-func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		jobUpdate := &awstypes.JobUpdate{
-			Command: expandJobCommand(d.Get("command").([]interface{})),
+			Command: expandJobCommand(d.Get("command").([]any)),
 			Role:    aws.String(d.Get(names.AttrRoleARN).(string)),
 		}
 
 		if v, ok := d.GetOk("connections"); ok {
 			jobUpdate.Connections = &awstypes.ConnectionsList{
-				Connections: flex.ExpandStringValueList(v.([]interface{})),
+				Connections: flex.ExpandStringValueList(v.([]any)),
 			}
 		}
 
 		if kv, ok := d.GetOk("default_arguments"); ok {
-			jobUpdate.DefaultArguments = flex.ExpandStringValueMap(kv.(map[string]interface{}))
+			jobUpdate.DefaultArguments = flex.ExpandStringValueMap(kv.(map[string]any))
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -366,7 +366,7 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		if v, ok := d.GetOk("execution_property"); ok {
-			jobUpdate.ExecutionProperty = expandExecutionProperty(v.([]interface{}))
+			jobUpdate.ExecutionProperty = expandExecutionProperty(v.([]any))
 		}
 
 		if v, ok := d.GetOk("glue_version"); ok {
@@ -386,11 +386,11 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		if kv, ok := d.GetOk("non_overridable_arguments"); ok {
-			jobUpdate.NonOverridableArguments = flex.ExpandStringValueMap(kv.(map[string]interface{}))
+			jobUpdate.NonOverridableArguments = flex.ExpandStringValueMap(kv.(map[string]any))
 		}
 
-		if v, ok := d.GetOk("notification_property"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			jobUpdate.NotificationProperty = expandNotificationProperty(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("notification_property"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			jobUpdate.NotificationProperty = expandNotificationProperty(v.([]any)[0].(map[string]any))
 		}
 
 		if v, ok := d.GetOk("number_of_workers"); ok {
@@ -428,7 +428,7 @@ func resourceJobUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceJobRead(ctx, d, meta)...)
 }
 
-func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -448,8 +448,8 @@ func resourceJobDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func expandExecutionProperty(l []interface{}) *awstypes.ExecutionProperty {
-	m := l[0].(map[string]interface{})
+func expandExecutionProperty(l []any) *awstypes.ExecutionProperty {
+	m := l[0].(map[string]any)
 
 	executionProperty := &awstypes.ExecutionProperty{
 		MaxConcurrentRuns: int32(m["max_concurrent_runs"].(int)),
@@ -458,8 +458,8 @@ func expandExecutionProperty(l []interface{}) *awstypes.ExecutionProperty {
 	return executionProperty
 }
 
-func expandJobCommand(l []interface{}) *awstypes.JobCommand {
-	m := l[0].(map[string]interface{})
+func expandJobCommand(l []any) *awstypes.JobCommand {
+	m := l[0].(map[string]any)
 
 	jobCommand := &awstypes.JobCommand{
 		Name:           aws.String(m[names.AttrName].(string)),
@@ -477,7 +477,7 @@ func expandJobCommand(l []interface{}) *awstypes.JobCommand {
 	return jobCommand
 }
 
-func expandNotificationProperty(tfMap map[string]interface{}) *awstypes.NotificationProperty {
+func expandNotificationProperty(tfMap map[string]any) *awstypes.NotificationProperty {
 	if tfMap == nil {
 		return nil
 	}
@@ -491,49 +491,49 @@ func expandNotificationProperty(tfMap map[string]interface{}) *awstypes.Notifica
 	return notificationProperty
 }
 
-func flattenConnectionsList(connectionsList *awstypes.ConnectionsList) []interface{} {
+func flattenConnectionsList(connectionsList *awstypes.ConnectionsList) []any {
 	if connectionsList == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
 	return flex.FlattenStringValueList(connectionsList.Connections)
 }
 
-func flattenExecutionProperty(executionProperty *awstypes.ExecutionProperty) []map[string]interface{} {
+func flattenExecutionProperty(executionProperty *awstypes.ExecutionProperty) []map[string]any {
 	if executionProperty == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"max_concurrent_runs": int(executionProperty.MaxConcurrentRuns),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenJobCommand(jobCommand *awstypes.JobCommand) []map[string]interface{} {
+func flattenJobCommand(jobCommand *awstypes.JobCommand) []map[string]any {
 	if jobCommand == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrName:    aws.ToString(jobCommand.Name),
 		"script_location": aws.ToString(jobCommand.ScriptLocation),
 		"python_version":  aws.ToString(jobCommand.PythonVersion),
 		"runtime":         aws.ToString(jobCommand.Runtime),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenNotificationProperty(notificationProperty *awstypes.NotificationProperty) []map[string]interface{} {
+func flattenNotificationProperty(notificationProperty *awstypes.NotificationProperty) []map[string]any {
 	if notificationProperty == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"notify_delay_after": int(aws.ToInt32(notificationProperty.NotifyDelayAfter)),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }

--- a/internal/service/glue/ml_transform.go
+++ b/internal/service/glue/ml_transform.go
@@ -185,7 +185,7 @@ func ResourceMLTransform() *schema.Resource {
 	}
 }
 
-func resourceMLTransformCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMLTransformCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -194,8 +194,8 @@ func resourceMLTransformCreate(ctx context.Context, d *schema.ResourceData, meta
 		Role:              aws.String(d.Get(names.AttrRoleARN).(string)),
 		Tags:              getTagsIn(ctx),
 		Timeout:           aws.Int32(int32(d.Get(names.AttrTimeout).(int))),
-		InputRecordTables: expandMLTransformInputRecordTables(d.Get("input_record_tables").([]interface{})),
-		Parameters:        expandMLTransformParameters(d.Get(names.AttrParameters).([]interface{})),
+		InputRecordTables: expandMLTransformInputRecordTables(d.Get("input_record_tables").([]any)),
+		Parameters:        expandMLTransformParameters(d.Get(names.AttrParameters).([]any)),
 	}
 
 	if v, ok := d.GetOk(names.AttrMaxCapacity); ok {
@@ -239,7 +239,7 @@ func resourceMLTransformCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceMLTransformRead(ctx, d, meta)...)
 }
 
-func resourceMLTransformRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMLTransformRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -301,7 +301,7 @@ func resourceMLTransformRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceMLTransformUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMLTransformUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -338,7 +338,7 @@ func resourceMLTransformUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if v, ok := d.GetOk(names.AttrParameters); ok {
-			input.Parameters = expandMLTransformParameters(v.([]interface{}))
+			input.Parameters = expandMLTransformParameters(v.([]any))
 		}
 
 		log.Printf("[DEBUG] Updating Glue ML Transform: %+v", input)
@@ -351,7 +351,7 @@ func resourceMLTransformUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceMLTransformRead(ctx, d, meta)...)
 }
 
-func resourceMLTransformDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMLTransformDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -379,11 +379,11 @@ func resourceMLTransformDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func expandMLTransformInputRecordTables(l []interface{}) []awstypes.GlueTable {
+func expandMLTransformInputRecordTables(l []any) []awstypes.GlueTable {
 	var tables []awstypes.GlueTable
 
 	for _, mRaw := range l {
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 
 		table := awstypes.GlueTable{}
 
@@ -409,11 +409,11 @@ func expandMLTransformInputRecordTables(l []interface{}) []awstypes.GlueTable {
 	return tables
 }
 
-func flattenMLTransformInputRecordTables(tables []awstypes.GlueTable) []interface{} {
-	l := []interface{}{}
+func flattenMLTransformInputRecordTables(tables []awstypes.GlueTable) []any {
+	l := []any{}
 
 	for _, table := range tables {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrTableName:    aws.ToString(table.TableName),
 			names.AttrDatabaseName: aws.ToString(table.DatabaseName),
 		}
@@ -432,26 +432,26 @@ func flattenMLTransformInputRecordTables(tables []awstypes.GlueTable) []interfac
 	return l
 }
 
-func expandMLTransformParameters(l []interface{}) *awstypes.TransformParameters {
-	m := l[0].(map[string]interface{})
+func expandMLTransformParameters(l []any) *awstypes.TransformParameters {
+	m := l[0].(map[string]any)
 
 	param := &awstypes.TransformParameters{
 		TransformType: awstypes.TransformType(m["transform_type"].(string)),
 	}
 
-	if v, ok := m["find_matches_parameters"]; ok && len(v.([]interface{})) > 0 {
-		param.FindMatchesParameters = expandMLTransformFindMatchesParameters(v.([]interface{}))
+	if v, ok := m["find_matches_parameters"]; ok && len(v.([]any)) > 0 {
+		param.FindMatchesParameters = expandMLTransformFindMatchesParameters(v.([]any))
 	}
 
 	return param
 }
 
-func flattenMLTransformParameters(parameters *awstypes.TransformParameters) []map[string]interface{} {
+func flattenMLTransformParameters(parameters *awstypes.TransformParameters) []map[string]any {
 	if parameters == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"transform_type": string(parameters.TransformType),
 	}
 
@@ -459,11 +459,11 @@ func flattenMLTransformParameters(parameters *awstypes.TransformParameters) []ma
 		m["find_matches_parameters"] = flattenMLTransformFindMatchesParameters(parameters.FindMatchesParameters)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandMLTransformFindMatchesParameters(l []interface{}) *awstypes.FindMatchesParameters {
-	m := l[0].(map[string]interface{})
+func expandMLTransformFindMatchesParameters(l []any) *awstypes.FindMatchesParameters {
+	m := l[0].(map[string]any)
 
 	param := &awstypes.FindMatchesParameters{}
 
@@ -486,12 +486,12 @@ func expandMLTransformFindMatchesParameters(l []interface{}) *awstypes.FindMatch
 	return param
 }
 
-func flattenMLTransformFindMatchesParameters(parameters *awstypes.FindMatchesParameters) []map[string]interface{} {
+func flattenMLTransformFindMatchesParameters(parameters *awstypes.FindMatchesParameters) []map[string]any {
 	if parameters == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if parameters.PrimaryKeyColumnName != nil {
 		m["primary_key_column_name"] = aws.ToString(parameters.PrimaryKeyColumnName)
@@ -509,14 +509,14 @@ func flattenMLTransformFindMatchesParameters(parameters *awstypes.FindMatchesPar
 		m["precision_recall_trade_off"] = aws.ToFloat64(parameters.PrecisionRecallTradeoff)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenMLTransformSchemaColumns(schemaCols []awstypes.SchemaColumn) []interface{} {
-	l := []interface{}{}
+func flattenMLTransformSchemaColumns(schemaCols []awstypes.SchemaColumn) []any {
+	l := []any{}
 
 	for _, schemaCol := range schemaCols {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrName: aws.ToString(schemaCol.Name),
 			"data_type":    aws.ToString(schemaCol.DataType),
 		}

--- a/internal/service/glue/partition.go
+++ b/internal/service/glue/partition.go
@@ -211,13 +211,13 @@ func ResourcePartition() *schema.Resource {
 	}
 }
 
-func resourcePartitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
 	dbName := d.Get(names.AttrDatabaseName).(string)
 	tableName := d.Get(names.AttrTableName).(string)
-	values := d.Get("partition_values").([]interface{})
+	values := d.Get("partition_values").([]any)
 
 	input := &glue.CreatePartitionInput{
 		CatalogId:      aws.String(catalogID),
@@ -237,7 +237,7 @@ func resourcePartitionCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourcePartitionRead(ctx, d, meta)...)
 }
 
-func resourcePartitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -280,7 +280,7 @@ func resourcePartitionRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourcePartitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -304,7 +304,7 @@ func resourcePartitionUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourcePartitionRead(ctx, d, meta)...)
 }
 
-func resourcePartitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -335,15 +335,15 @@ func expandPartitionInput(d *schema.ResourceData) *awstypes.PartitionInput {
 	tableInput := &awstypes.PartitionInput{}
 
 	if v, ok := d.GetOk("storage_descriptor"); ok {
-		tableInput.StorageDescriptor = expandStorageDescriptor(v.([]interface{}))
+		tableInput.StorageDescriptor = expandStorageDescriptor(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrParameters); ok {
-		tableInput.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		tableInput.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("partition_values"); ok && len(v.([]interface{})) > 0 {
-		tableInput.Values = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("partition_values"); ok && len(v.([]any)) > 0 {
+		tableInput.Values = flex.ExpandStringValueList(v.([]any))
 	}
 
 	return tableInput

--- a/internal/service/glue/partition_index.go
+++ b/internal/service/glue/partition_index.go
@@ -85,7 +85,7 @@ func ResourcePartitionIndex() *schema.Resource {
 	}
 }
 
-func resourcePartitionIndexCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionIndexCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
@@ -96,7 +96,7 @@ func resourcePartitionIndexCreate(ctx context.Context, d *schema.ResourceData, m
 		CatalogId:      aws.String(catalogID),
 		DatabaseName:   aws.String(dbName),
 		TableName:      aws.String(tableName),
-		PartitionIndex: expandPartitionIndex(d.Get("partition_index").([]interface{})),
+		PartitionIndex: expandPartitionIndex(d.Get("partition_index").([]any)),
 	}
 
 	log.Printf("[DEBUG] Creating Glue Partition Index: %#v", input)
@@ -114,7 +114,7 @@ func resourcePartitionIndexCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourcePartitionIndexRead(ctx, d, meta)...)
 }
 
-func resourcePartitionIndexRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionIndexRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -139,14 +139,14 @@ func resourcePartitionIndexRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set(names.AttrCatalogID, catalogID)
 	d.Set(names.AttrDatabaseName, dbName)
 
-	if err := d.Set("partition_index", []map[string]interface{}{flattenPartitionIndex(*partition)}); err != nil {
+	if err := d.Set("partition_index", []map[string]any{flattenPartitionIndex(*partition)}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting partition_index: %s", err)
 	}
 
 	return diags
 }
 
-func resourcePartitionIndexDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePartitionIndexDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -176,15 +176,15 @@ func resourcePartitionIndexDelete(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func expandPartitionIndex(l []interface{}) *awstypes.PartitionIndex {
+func expandPartitionIndex(l []any) *awstypes.PartitionIndex {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	s := l[0].(map[string]interface{})
+	s := l[0].(map[string]any)
 	parIndex := &awstypes.PartitionIndex{}
 
-	if v, ok := s["keys"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := s["keys"].([]any); ok && len(v) > 0 {
 		parIndex.Keys = flex.ExpandStringValueList(v)
 	}
 

--- a/internal/service/glue/registry.go
+++ b/internal/service/glue/registry.go
@@ -59,7 +59,7 @@ func ResourceRegistry() *schema.Resource {
 	}
 }
 
-func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -82,7 +82,7 @@ func resourceRegistryCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceRegistryRead(ctx, d, meta)...)
 }
 
-func resourceRegistryRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegistryRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -112,7 +112,7 @@ func resourceRegistryRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceRegistryUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegistryUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -135,7 +135,7 @@ func resourceRegistryUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceRegistryRead(ctx, d, meta)...)
 }
 
-func resourceRegistryDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegistryDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 

--- a/internal/service/glue/resource_policy.go
+++ b/internal/service/glue/resource_policy.go
@@ -40,7 +40,7 @@ func ResourceResourcePolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -54,8 +54,8 @@ func ResourceResourcePolicy() *schema.Resource {
 	}
 }
 
-func resourceResourcePolicyPut(condition awstypes.ExistCondition) func(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
-	return func(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourcePolicyPut(condition awstypes.ExistCondition) func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 		var diags diag.Diagnostics
 		conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -84,7 +84,7 @@ func resourceResourcePolicyPut(condition awstypes.ExistCondition) func(context.C
 	}
 }
 
-func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -113,7 +113,7 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 

--- a/internal/service/glue/schema.go
+++ b/internal/service/glue/schema.go
@@ -100,7 +100,7 @@ func ResourceSchema() *schema.Resource {
 	}
 }
 
-func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -138,7 +138,7 @@ func resourceSchemaCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceSchemaRead(ctx, d, meta)...)
 }
 
-func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -180,7 +180,7 @@ func resourceSchemaRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceSchemaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchemaUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -235,7 +235,7 @@ func resourceSchemaUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceSchemaRead(ctx, d, meta)...)
 }
 
-func resourceSchemaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchemaDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 

--- a/internal/service/glue/script_data_source.go
+++ b/internal/service/glue/script_data_source.go
@@ -102,12 +102,12 @@ func DataSourceScript() *schema.Resource {
 	}
 }
 
-func dataSourceScriptRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceScriptRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
-	dagEdge := d.Get("dag_edge").([]interface{})
-	dagNode := d.Get("dag_node").([]interface{})
+	dagEdge := d.Get("dag_edge").([]any)
+	dagNode := d.Get("dag_node").([]any)
 
 	input := &glue.CreateScriptInput{
 		DagEdges: expandCodeGenEdges(dagEdge),
@@ -135,11 +135,11 @@ func dataSourceScriptRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func expandCodeGenNodeArgs(l []interface{}) []awstypes.CodeGenNodeArg {
+func expandCodeGenNodeArgs(l []any) []awstypes.CodeGenNodeArg {
 	args := []awstypes.CodeGenNodeArg{}
 
 	for _, mRaw := range l {
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 		arg := awstypes.CodeGenNodeArg{
 			Name:  aws.String(m[names.AttrName].(string)),
 			Param: m["param"].(bool),
@@ -151,11 +151,11 @@ func expandCodeGenNodeArgs(l []interface{}) []awstypes.CodeGenNodeArg {
 	return args
 }
 
-func expandCodeGenEdges(l []interface{}) []awstypes.CodeGenEdge {
+func expandCodeGenEdges(l []any) []awstypes.CodeGenEdge {
 	edges := []awstypes.CodeGenEdge{}
 
 	for _, mRaw := range l {
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 		edge := awstypes.CodeGenEdge{
 			Source: aws.String(m[names.AttrSource].(string)),
 			Target: aws.String(m[names.AttrTarget].(string)),
@@ -169,13 +169,13 @@ func expandCodeGenEdges(l []interface{}) []awstypes.CodeGenEdge {
 	return edges
 }
 
-func expandCodeGenNodes(l []interface{}) []awstypes.CodeGenNode {
+func expandCodeGenNodes(l []any) []awstypes.CodeGenNode {
 	nodes := []awstypes.CodeGenNode{}
 
 	for _, mRaw := range l {
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 		node := awstypes.CodeGenNode{
-			Args:     expandCodeGenNodeArgs(m["args"].([]interface{})),
+			Args:     expandCodeGenNodeArgs(m["args"].([]any)),
 			Id:       aws.String(m[names.AttrID].(string)),
 			NodeType: aws.String(m["node_type"].(string)),
 		}

--- a/internal/service/glue/security_configuration.go
+++ b/internal/service/glue/security_configuration.go
@@ -117,13 +117,13 @@ func ResourceSecurityConfiguration() *schema.Resource {
 	}
 }
 
-func resourceSecurityConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	name := d.Get(names.AttrName).(string)
 
 	input := &glue.CreateSecurityConfigurationInput{
-		EncryptionConfiguration: expandEncryptionConfiguration(d.Get(names.AttrEncryptionConfiguration).([]interface{})),
+		EncryptionConfiguration: expandEncryptionConfiguration(d.Get(names.AttrEncryptionConfiguration).([]any)),
 		Name:                    aws.String(name),
 	}
 
@@ -138,7 +138,7 @@ func resourceSecurityConfigurationCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceSecurityConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceSecurityConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -175,7 +175,7 @@ func resourceSecurityConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceSecurityConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSecurityConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -202,12 +202,12 @@ func DeleteSecurityConfiguration(ctx context.Context, conn *glue.Client, name st
 	return err
 }
 
-func expandCloudWatchEncryption(l []interface{}) *awstypes.CloudWatchEncryption {
+func expandCloudWatchEncryption(l []any) *awstypes.CloudWatchEncryption {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	cloudwatchEncryption := &awstypes.CloudWatchEncryption{
 		CloudWatchEncryptionMode: awstypes.CloudWatchEncryptionMode(m["cloudwatch_encryption_mode"].(string)),
@@ -220,28 +220,28 @@ func expandCloudWatchEncryption(l []interface{}) *awstypes.CloudWatchEncryption 
 	return cloudwatchEncryption
 }
 
-func expandEncryptionConfiguration(l []interface{}) *awstypes.EncryptionConfiguration {
+func expandEncryptionConfiguration(l []any) *awstypes.EncryptionConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	encryptionConfiguration := &awstypes.EncryptionConfiguration{
-		CloudWatchEncryption:   expandCloudWatchEncryption(m["cloudwatch_encryption"].([]interface{})),
-		JobBookmarksEncryption: expandJobBookmarksEncryption(m["job_bookmarks_encryption"].([]interface{})),
-		S3Encryption:           expandS3Encryptions(m["s3_encryption"].([]interface{})),
+		CloudWatchEncryption:   expandCloudWatchEncryption(m["cloudwatch_encryption"].([]any)),
+		JobBookmarksEncryption: expandJobBookmarksEncryption(m["job_bookmarks_encryption"].([]any)),
+		S3Encryption:           expandS3Encryptions(m["s3_encryption"].([]any)),
 	}
 
 	return encryptionConfiguration
 }
 
-func expandJobBookmarksEncryption(l []interface{}) *awstypes.JobBookmarksEncryption {
+func expandJobBookmarksEncryption(l []any) *awstypes.JobBookmarksEncryption {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	jobBookmarksEncryption := &awstypes.JobBookmarksEncryption{
 		JobBookmarksEncryptionMode: awstypes.JobBookmarksEncryptionMode(m["job_bookmarks_encryption_mode"].(string)),
@@ -254,20 +254,20 @@ func expandJobBookmarksEncryption(l []interface{}) *awstypes.JobBookmarksEncrypt
 	return jobBookmarksEncryption
 }
 
-func expandS3Encryptions(l []interface{}) []awstypes.S3Encryption {
+func expandS3Encryptions(l []any) []awstypes.S3Encryption {
 	s3Encryptions := make([]awstypes.S3Encryption, 0)
 
 	for _, s3Encryption := range l {
 		if s3Encryption == nil {
 			continue
 		}
-		s3Encryptions = append(s3Encryptions, expandS3Encryption(s3Encryption.(map[string]interface{})))
+		s3Encryptions = append(s3Encryptions, expandS3Encryption(s3Encryption.(map[string]any)))
 	}
 
 	return s3Encryptions
 }
 
-func expandS3Encryption(m map[string]interface{}) awstypes.S3Encryption {
+func expandS3Encryption(m map[string]any) awstypes.S3Encryption {
 	s3Encryption := awstypes.S3Encryption{
 		S3EncryptionMode: awstypes.S3EncryptionMode(m["s3_encryption_mode"].(string)),
 	}
@@ -279,48 +279,48 @@ func expandS3Encryption(m map[string]interface{}) awstypes.S3Encryption {
 	return s3Encryption
 }
 
-func flattenCloudWatchEncryption(cloudwatchEncryption *awstypes.CloudWatchEncryption) []interface{} {
+func flattenCloudWatchEncryption(cloudwatchEncryption *awstypes.CloudWatchEncryption) []any {
 	if cloudwatchEncryption == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"cloudwatch_encryption_mode": string(cloudwatchEncryption.CloudWatchEncryptionMode),
 		names.AttrKMSKeyARN:          aws.ToString(cloudwatchEncryption.KmsKeyArn),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenEncryptionConfiguration(encryptionConfiguration *awstypes.EncryptionConfiguration) []interface{} {
+func flattenEncryptionConfiguration(encryptionConfiguration *awstypes.EncryptionConfiguration) []any {
 	if encryptionConfiguration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"cloudwatch_encryption":    flattenCloudWatchEncryption(encryptionConfiguration.CloudWatchEncryption),
 		"job_bookmarks_encryption": flattenJobBookmarksEncryption(encryptionConfiguration.JobBookmarksEncryption),
 		"s3_encryption":            flattenS3Encryptions(encryptionConfiguration.S3Encryption),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenJobBookmarksEncryption(jobBookmarksEncryption *awstypes.JobBookmarksEncryption) []interface{} {
+func flattenJobBookmarksEncryption(jobBookmarksEncryption *awstypes.JobBookmarksEncryption) []any {
 	if jobBookmarksEncryption == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"job_bookmarks_encryption_mode": string(jobBookmarksEncryption.JobBookmarksEncryptionMode),
 		names.AttrKMSKeyARN:             aws.ToString(jobBookmarksEncryption.KmsKeyArn),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenS3Encryptions(s3Encryptions []awstypes.S3Encryption) []interface{} {
-	l := make([]interface{}, 0)
+func flattenS3Encryptions(s3Encryptions []awstypes.S3Encryption) []any {
+	l := make([]any, 0)
 
 	for _, s3Encryption := range s3Encryptions {
 		l = append(l, flattenS3Encryption(s3Encryption))
@@ -329,8 +329,8 @@ func flattenS3Encryptions(s3Encryptions []awstypes.S3Encryption) []interface{} {
 	return l
 }
 
-func flattenS3Encryption(s3Encryption awstypes.S3Encryption) map[string]interface{} {
-	m := map[string]interface{}{
+func flattenS3Encryption(s3Encryption awstypes.S3Encryption) map[string]any {
+	m := map[string]any{
 		names.AttrKMSKeyARN:  aws.ToString(s3Encryption.KmsKeyArn),
 		"s3_encryption_mode": string(s3Encryption.S3EncryptionMode),
 	}

--- a/internal/service/glue/status.go
+++ b/internal/service/glue/status.go
@@ -22,7 +22,7 @@ const (
 
 // statusMLTransform fetches the MLTransform and its Status
 func statusMLTransform(ctx context.Context, conn *glue.Client, transformId string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		input := &glue.GetMLTransformInput{
 			TransformId: aws.String(transformId),
 		}
@@ -43,7 +43,7 @@ func statusMLTransform(ctx context.Context, conn *glue.Client, transformId strin
 
 // statusRegistry fetches the Registry and its Status
 func statusRegistry(ctx context.Context, conn *glue.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := FindRegistryByID(ctx, conn, id)
 		if err != nil {
 			return nil, registryStatusUnknown, err
@@ -59,7 +59,7 @@ func statusRegistry(ctx context.Context, conn *glue.Client, id string) retry.Sta
 
 // statusSchema fetches the Schema and its Status
 func statusSchema(ctx context.Context, conn *glue.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := FindSchemaByID(ctx, conn, id)
 		if err != nil {
 			return nil, schemaStatusUnknown, err
@@ -75,7 +75,7 @@ func statusSchema(ctx context.Context, conn *glue.Client, id string) retry.State
 
 // statusSchemaVersion fetches the Schema Version and its Status
 func statusSchemaVersion(ctx context.Context, conn *glue.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := FindSchemaVersionByID(ctx, conn, id)
 		if err != nil {
 			return nil, schemaVersionStatusUnknown, err
@@ -91,7 +91,7 @@ func statusSchemaVersion(ctx context.Context, conn *glue.Client, id string) retr
 
 // statusTrigger fetches the Trigger and its Status
 func statusTrigger(ctx context.Context, conn *glue.Client, triggerName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		input := &glue.GetTriggerInput{
 			Name: aws.String(triggerName),
 		}
@@ -111,7 +111,7 @@ func statusTrigger(ctx context.Context, conn *glue.Client, triggerName string) r
 }
 
 func statusDevEndpoint(ctx context.Context, conn *glue.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := FindDevEndpointByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -127,7 +127,7 @@ func statusDevEndpoint(ctx context.Context, conn *glue.Client, name string) retr
 }
 
 func statusPartitionIndex(ctx context.Context, conn *glue.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := FindPartitionIndexByName(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/glue/trigger.go
+++ b/internal/service/glue/trigger.go
@@ -207,14 +207,14 @@ func ResourceTrigger() *schema.Resource {
 	}
 }
 
-func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	triggerType := d.Get(names.AttrType).(string)
 	input := &glue.CreateTriggerInput{
-		Actions:         expandActions(d.Get(names.AttrActions).([]interface{})),
+		Actions:         expandActions(d.Get(names.AttrActions).([]any)),
 		Name:            aws.String(name),
 		Tags:            getTagsIn(ctx),
 		Type:            awstypes.TriggerType(triggerType),
@@ -226,11 +226,11 @@ func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("event_batching_condition"); ok {
-		input.EventBatchingCondition = expandEventBatchingCondition(v.([]interface{}))
+		input.EventBatchingCondition = expandEventBatchingCondition(v.([]any))
 	}
 
 	if v, ok := d.GetOk("predicate"); ok {
-		input.Predicate = expandPredicate(v.([]interface{}))
+		input.Predicate = expandPredicate(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrSchedule); ok {
@@ -308,7 +308,7 @@ func resourceTriggerCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceTriggerRead(ctx, d, meta)...)
 }
 
-func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -370,13 +370,13 @@ func resourceTriggerRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
 	if d.HasChanges(names.AttrActions, names.AttrDescription, "predicate", names.AttrSchedule, "event_batching_condition") {
 		triggerUpdate := &awstypes.TriggerUpdate{
-			Actions: expandActions(d.Get(names.AttrActions).([]interface{})),
+			Actions: expandActions(d.Get(names.AttrActions).([]any)),
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -384,7 +384,7 @@ func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if v, ok := d.GetOk("predicate"); ok {
-			triggerUpdate.Predicate = expandPredicate(v.([]interface{}))
+			triggerUpdate.Predicate = expandPredicate(v.([]any))
 		}
 
 		if v, ok := d.GetOk(names.AttrSchedule); ok {
@@ -392,7 +392,7 @@ func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if v, ok := d.GetOk("event_batching_condition"); ok {
-			triggerUpdate.EventBatchingCondition = expandEventBatchingCondition(v.([]interface{}))
+			triggerUpdate.EventBatchingCondition = expandEventBatchingCondition(v.([]any))
 		}
 
 		input := &glue.UpdateTriggerInput{
@@ -441,7 +441,7 @@ func resourceTriggerUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceTriggerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTriggerDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -478,14 +478,14 @@ func deleteTrigger(ctx context.Context, conn *glue.Client, Name string) error {
 	return nil
 }
 
-func expandActions(l []interface{}) []awstypes.Action {
+func expandActions(l []any) []awstypes.Action {
 	actions := []awstypes.Action{}
 
 	for _, mRaw := range l {
 		if mRaw == nil {
 			continue
 		}
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 
 		action := awstypes.Action{}
 
@@ -497,7 +497,7 @@ func expandActions(l []interface{}) []awstypes.Action {
 			action.JobName = aws.String(v)
 		}
 
-		if v, ok := m["arguments"].(map[string]interface{}); ok && len(v) > 0 {
+		if v, ok := m["arguments"].(map[string]any); ok && len(v) > 0 {
 			action.Arguments = flex.ExpandStringValueMap(v)
 		}
 
@@ -509,7 +509,7 @@ func expandActions(l []interface{}) []awstypes.Action {
 			action.SecurityConfiguration = aws.String(v)
 		}
 
-		if v, ok := m["notification_property"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := m["notification_property"].([]any); ok && len(v) > 0 {
 			action.NotificationProperty = expandTriggerNotificationProperty(v)
 		}
 
@@ -519,11 +519,11 @@ func expandActions(l []interface{}) []awstypes.Action {
 	return actions
 }
 
-func expandTriggerNotificationProperty(l []interface{}) *awstypes.NotificationProperty {
+func expandTriggerNotificationProperty(l []any) *awstypes.NotificationProperty {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	property := &awstypes.NotificationProperty{}
 
@@ -534,14 +534,14 @@ func expandTriggerNotificationProperty(l []interface{}) *awstypes.NotificationPr
 	return property
 }
 
-func expandConditions(l []interface{}) []awstypes.Condition {
+func expandConditions(l []any) []awstypes.Condition {
 	conditions := []awstypes.Condition{}
 
 	for _, mRaw := range l {
 		if mRaw == nil {
 			continue
 		}
-		m := mRaw.(map[string]interface{})
+		m := mRaw.(map[string]any)
 
 		condition := awstypes.Condition{
 			LogicalOperator: awstypes.LogicalOperator(m["logical_operator"].(string)),
@@ -569,14 +569,14 @@ func expandConditions(l []interface{}) []awstypes.Condition {
 	return conditions
 }
 
-func expandPredicate(l []interface{}) *awstypes.Predicate {
+func expandPredicate(l []any) *awstypes.Predicate {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	predicate := &awstypes.Predicate{
-		Conditions: expandConditions(m["conditions"].([]interface{})),
+		Conditions: expandConditions(m["conditions"].([]any)),
 	}
 
 	if v, ok := m["logical"].(string); ok && v != "" {
@@ -586,11 +586,11 @@ func expandPredicate(l []interface{}) *awstypes.Predicate {
 	return predicate
 }
 
-func flattenActions(actions []awstypes.Action) []interface{} {
-	l := []interface{}{}
+func flattenActions(actions []awstypes.Action) []any {
+	l := []any{}
 
 	for _, action := range actions {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"arguments":       action.Arguments,
 			names.AttrTimeout: int(aws.ToInt32(action.Timeout)),
 		}
@@ -617,11 +617,11 @@ func flattenActions(actions []awstypes.Action) []interface{} {
 	return l
 }
 
-func flattenConditions(conditions []awstypes.Condition) []interface{} {
-	l := []interface{}{}
+func flattenConditions(conditions []awstypes.Condition) []any {
+	l := []any{}
 
 	for _, condition := range conditions {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"logical_operator": string(condition.LogicalOperator),
 		}
 
@@ -647,36 +647,36 @@ func flattenConditions(conditions []awstypes.Condition) []interface{} {
 	return l
 }
 
-func flattenPredicate(predicate *awstypes.Predicate) []map[string]interface{} {
+func flattenPredicate(predicate *awstypes.Predicate) []map[string]any {
 	if predicate == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"conditions": flattenConditions(predicate.Conditions),
 		"logical":    string(predicate.Logical),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func flattenTriggerNotificationProperty(property *awstypes.NotificationProperty) []map[string]interface{} {
+func flattenTriggerNotificationProperty(property *awstypes.NotificationProperty) []map[string]any {
 	if property == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"notify_delay_after": aws.ToInt32(property.NotifyDelayAfter),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandEventBatchingCondition(l []interface{}) *awstypes.EventBatchingCondition {
+func expandEventBatchingCondition(l []any) *awstypes.EventBatchingCondition {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	ebc := &awstypes.EventBatchingCondition{
 		BatchSize: aws.Int32(int32(m["batch_size"].(int))),
@@ -689,15 +689,15 @@ func expandEventBatchingCondition(l []interface{}) *awstypes.EventBatchingCondit
 	return ebc
 }
 
-func flattenEventBatchingCondition(ebc *awstypes.EventBatchingCondition) []map[string]interface{} {
+func flattenEventBatchingCondition(ebc *awstypes.EventBatchingCondition) []map[string]any {
 	if ebc == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"batch_size":   aws.ToInt32(ebc.BatchSize),
 		"batch_window": aws.ToInt32(ebc.BatchWindow),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }

--- a/internal/service/glue/user_defined_function.go
+++ b/internal/service/glue/user_defined_function.go
@@ -98,7 +98,7 @@ func ResourceUserDefinedFunction() *schema.Resource {
 	}
 }
 
-func resourceUserDefinedFunctionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDefinedFunctionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID := createCatalogID(d, meta.(*conns.AWSClient).AccountID(ctx))
@@ -121,7 +121,7 @@ func resourceUserDefinedFunctionCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceUserDefinedFunctionRead(ctx, d, meta)...)
 }
 
-func resourceUserDefinedFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDefinedFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -144,7 +144,7 @@ func resourceUserDefinedFunctionUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceUserDefinedFunctionRead(ctx, d, meta)...)
 }
 
-func resourceUserDefinedFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDefinedFunctionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -197,7 +197,7 @@ func resourceUserDefinedFunctionRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceUserDefinedFunctionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDefinedFunctionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 	catalogID, dbName, funcName, err := ReadUDFID(d.Id())
@@ -249,7 +249,7 @@ func expandUserDefinedFunctionResourceURI(conf *schema.Set) []awstypes.ResourceU
 	result := make([]awstypes.ResourceUri, 0, conf.Len())
 
 	for _, r := range conf.List() {
-		uriRaw, ok := r.(map[string]interface{})
+		uriRaw, ok := r.(map[string]any)
 
 		if !ok {
 			continue
@@ -266,11 +266,11 @@ func expandUserDefinedFunctionResourceURI(conf *schema.Set) []awstypes.ResourceU
 	return result
 }
 
-func flattenUserDefinedFunctionResourceURI(uris []awstypes.ResourceUri) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(uris))
+func flattenUserDefinedFunctionResourceURI(uris []awstypes.ResourceUri) []map[string]any {
+	result := make([]map[string]any, 0, len(uris))
 
 	for _, i := range uris {
-		l := map[string]interface{}{
+		l := map[string]any{
 			names.AttrResourceType: string(i.ResourceType),
 			names.AttrURI:          aws.ToString(i.Uri),
 		}

--- a/internal/service/glue/workflow.go
+++ b/internal/service/glue/workflow.go
@@ -65,7 +65,7 @@ func ResourceWorkflow() *schema.Resource {
 	}
 }
 
-func resourceWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -76,7 +76,7 @@ func resourceWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if kv, ok := d.GetOk("default_run_properties"); ok {
-		input.DefaultRunProperties = flex.ExpandStringValueMap(kv.(map[string]interface{}))
+		input.DefaultRunProperties = flex.ExpandStringValueMap(kv.(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -97,7 +97,7 @@ func resourceWorkflowCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceWorkflowRead(ctx, d, meta)...)
 }
 
-func resourceWorkflowRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkflowRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -142,7 +142,7 @@ func resourceWorkflowRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceWorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceWorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if kv, ok := d.GetOk("default_run_properties"); ok {
-			input.DefaultRunProperties = flex.ExpandStringValueMap(kv.(map[string]interface{}))
+			input.DefaultRunProperties = flex.ExpandStringValueMap(kv.(map[string]any))
 		}
 
 		if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -173,7 +173,7 @@ func resourceWorkflowUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceWorkflowRead(ctx, d, meta)...)
 }
 
-func resourceWorkflowDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWorkflowDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GlueClient(ctx)
 


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
