### PR TITLE
lambda: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -79,6 +79,7 @@ jobs:
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check
+      - run: make TEST=./internal/service/lambda/... modern-check
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check
       - run: make TEST=./internal/service/rds/... modern-check

--- a/internal/service/lambda/alias.go
+++ b/internal/service/lambda/alias.go
@@ -81,7 +81,7 @@ func resourceAlias() *schema.Resource {
 	}
 }
 
-func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -91,7 +91,7 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		FunctionName:    aws.String(d.Get("function_name").(string)),
 		FunctionVersion: aws.String(d.Get("function_version").(string)),
 		Name:            aws.String(name),
-		RoutingConfig:   expandAliasRoutingConfiguration(d.Get("routing_config").([]interface{})),
+		RoutingConfig:   expandAliasRoutingConfiguration(d.Get("routing_config").([]any)),
 	}
 
 	output, err := conn.CreateAlias(ctx, input)
@@ -105,7 +105,7 @@ func resourceAliasCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceAliasRead(ctx, d, meta)...)
 }
 
-func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -135,7 +135,7 @@ func resourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -144,7 +144,7 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		FunctionName:    aws.String(d.Get("function_name").(string)),
 		FunctionVersion: aws.String(d.Get("function_version").(string)),
 		Name:            aws.String(d.Get(names.AttrName).(string)),
-		RoutingConfig:   expandAliasRoutingConfiguration(d.Get("routing_config").([]interface{})),
+		RoutingConfig:   expandAliasRoutingConfiguration(d.Get("routing_config").([]any)),
 	}
 
 	_, err := conn.UpdateAlias(ctx, input)
@@ -156,7 +156,7 @@ func resourceAliasUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceAliasRead(ctx, d, meta)...)
 }
 
-func resourceAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAliasDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -177,7 +177,7 @@ func resourceAliasDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceAliasImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceAliasImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), "/")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("Unexpected format of ID (%q), expected FUNCTION_NAME/ALIAS", d.Id())
@@ -221,32 +221,32 @@ func findAlias(ctx context.Context, conn *lambda.Client, input *lambda.GetAliasI
 	return output, nil
 }
 
-func expandAliasRoutingConfiguration(tfList []interface{}) *awstypes.AliasRoutingConfiguration {
+func expandAliasRoutingConfiguration(tfList []any) *awstypes.AliasRoutingConfiguration {
 	apiObject := &awstypes.AliasRoutingConfiguration{}
 
 	if len(tfList) == 0 || tfList[0] == nil {
 		return apiObject
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	if v, ok := tfMap["additional_version_weights"]; ok {
-		apiObject.AdditionalVersionWeights = flex.ExpandFloat64ValueMap(v.(map[string]interface{}))
+		apiObject.AdditionalVersionWeights = flex.ExpandFloat64ValueMap(v.(map[string]any))
 	}
 
 	return apiObject
 }
 
-func flattenAliasRoutingConfiguration(apiObject *awstypes.AliasRoutingConfiguration) []interface{} {
+func flattenAliasRoutingConfiguration(apiObject *awstypes.AliasRoutingConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"additional_version_weights": apiObject.AdditionalVersionWeights,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 func suppressEquivalentFunctionNameOrARN(k, old, new string, d *schema.ResourceData) bool {

--- a/internal/service/lambda/alias_data_source.go
+++ b/internal/service/lambda/alias_data_source.go
@@ -48,7 +48,7 @@ func dataSourceAlias() *schema.Resource {
 	}
 }
 
-func dataSourceAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAliasRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/code_signing_config.go
+++ b/internal/service/lambda/code_signing_config.go
@@ -97,18 +97,18 @@ func resourceCodeSigningConfig() *schema.Resource {
 	}
 }
 
-func resourceCodeSigningConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCodeSigningConfigCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
 	input := &lambda.CreateCodeSigningConfigInput{
-		AllowedPublishers: expandAllowedPublishers(d.Get("allowed_publishers").([]interface{})),
+		AllowedPublishers: expandAllowedPublishers(d.Get("allowed_publishers").([]any)),
 		Description:       aws.String(d.Get(names.AttrDescription).(string)),
 		Tags:              getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("policies"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("policies"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 		input.CodeSigningPolicies = &awstypes.CodeSigningPolicies{
 			UntrustedArtifactOnDeployment: awstypes.CodeSigningPolicy(tfMap["untrusted_artifact_on_deployment"].(string)),
 		}
@@ -125,7 +125,7 @@ func resourceCodeSigningConfigCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceCodeSigningConfigRead(ctx, d, meta)...)
 }
 
-func resourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -155,7 +155,7 @@ func resourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceCodeSigningConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCodeSigningConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -165,7 +165,7 @@ func resourceCodeSigningConfigUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("allowed_publishers") {
-			input.AllowedPublishers = expandAllowedPublishers(d.Get("allowed_publishers").([]interface{}))
+			input.AllowedPublishers = expandAllowedPublishers(d.Get("allowed_publishers").([]any))
 		}
 
 		if d.HasChange(names.AttrDescription) {
@@ -173,8 +173,8 @@ func resourceCodeSigningConfigUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("policies") {
-			if v, ok := d.GetOk("policies"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := d.GetOk("policies"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
 				input.CodeSigningPolicies = &awstypes.CodeSigningPolicies{
 					UntrustedArtifactOnDeployment: awstypes.CodeSigningPolicy(tfMap["untrusted_artifact_on_deployment"].(string)),
 				}
@@ -191,7 +191,7 @@ func resourceCodeSigningConfigUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceCodeSigningConfigRead(ctx, d, meta)...)
 }
 
-func resourceCodeSigningConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCodeSigningConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -240,36 +240,36 @@ func findCodeSigningConfig(ctx context.Context, conn *lambda.Client, input *lamb
 	return output.CodeSigningConfig, nil
 }
 
-func expandAllowedPublishers(tfList []interface{}) *awstypes.AllowedPublishers {
+func expandAllowedPublishers(tfList []any) *awstypes.AllowedPublishers {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	return &awstypes.AllowedPublishers{
 		SigningProfileVersionArns: flex.ExpandStringValueSet(tfMap["signing_profile_version_arns"].(*schema.Set)),
 	}
 }
 
-func flattenAllowedPublishers(apiObject *awstypes.AllowedPublishers) []interface{} {
+func flattenAllowedPublishers(apiObject *awstypes.AllowedPublishers) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"signing_profile_version_arns": apiObject.SigningProfileVersionArns,
 	}}
 }
 
-func flattenCodeSigningPolicies(apiObject *awstypes.CodeSigningPolicies) []interface{} {
+func flattenCodeSigningPolicies(apiObject *awstypes.CodeSigningPolicies) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"untrusted_artifact_on_deployment": apiObject.UntrustedArtifactOnDeployment,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/lambda/code_signing_config_data_source.go
+++ b/internal/service/lambda/code_signing_config_data_source.go
@@ -69,7 +69,7 @@ func dataSourceCodeSigningConfig() *schema.Resource {
 	}
 }
 
-func dataSourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -87,7 +87,7 @@ func dataSourceCodeSigningConfigRead(ctx context.Context, d *schema.ResourceData
 	d.Set("config_id", output.CodeSigningConfigId)
 	d.Set(names.AttrDescription, output.Description)
 	d.Set("last_modified", output.LastModified)
-	if err := d.Set("policies", []interface{}{map[string]interface{}{
+	if err := d.Set("policies", []any{map[string]any{
 		"untrusted_artifact_on_deployment": output.CodeSigningPolicies.UntrustedArtifactOnDeployment,
 	}}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting policies: %s", err)

--- a/internal/service/lambda/event_source_mapping.go
+++ b/internal/service/lambda/event_source_mapping.go
@@ -417,7 +417,7 @@ func resourceEventSourceMapping() *schema.Resource {
 	}
 }
 
-func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -430,8 +430,8 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 
 	var target string
 
-	if v, ok := d.GetOk("amazon_managed_kafka_event_source_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.AmazonManagedKafkaEventSourceConfig = expandAmazonManagedKafkaEventSourceConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("amazon_managed_kafka_event_source_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.AmazonManagedKafkaEventSourceConfig = expandAmazonManagedKafkaEventSourceConfig(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("batch_size"); ok {
@@ -442,12 +442,12 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 		input.BisectBatchOnFunctionError = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("destination_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DestinationConfig = expandDestinationConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("destination_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DestinationConfig = expandDestinationConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("document_db_event_source_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DocumentDBEventSourceConfig = expandDocumentDBEventSourceConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("document_db_event_source_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DocumentDBEventSourceConfig = expandDocumentDBEventSourceConfig(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("event_source_arn"); ok {
@@ -457,8 +457,8 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 		target = v
 	}
 
-	if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.FilterCriteria = expandFilterCriteria(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.FilterCriteria = expandFilterCriteria(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("function_response_types"); ok && v.(*schema.Set).Len() > 0 {
@@ -481,34 +481,34 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 		input.MaximumRetryAttempts = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.MetricsConfig = expandEventSourceMappingMetricsConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("metrics_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.MetricsConfig = expandEventSourceMappingMetricsConfig(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("parallelization_factor"); ok {
 		input.ParallelizationFactor = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("provisioned_poller_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ProvisionedPollerConfig = expandProvisionedPollerConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("provisioned_poller_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ProvisionedPollerConfig = expandProvisionedPollerConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("queues"); ok && len(v.([]interface{})) > 0 {
-		input.Queues = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("queues"); ok && len(v.([]any)) > 0 {
+		input.Queues = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("scaling_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ScalingConfig = expandScalingConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("scaling_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ScalingConfig = expandScalingConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("self_managed_event_source"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SelfManagedEventSource = expandSelfManagedEventSource(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("self_managed_event_source"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SelfManagedEventSource = expandSelfManagedEventSource(v.([]any)[0].(map[string]any))
 
 		target = "Self-Managed Apache Kafka"
 	}
 
-	if v, ok := d.GetOk("self_managed_kafka_event_source_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.SelfManagedKafkaEventSourceConfig = expandSelfManagedKafkaEventSourceConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("self_managed_kafka_event_source_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.SelfManagedKafkaEventSourceConfig = expandSelfManagedKafkaEventSourceConfig(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("source_access_configuration"); ok && v.(*schema.Set).Len() > 0 {
@@ -565,7 +565,7 @@ func resourceEventSourceMappingCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceEventSourceMappingRead(ctx, d, meta)...)
 }
 
-func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -582,7 +582,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if output.AmazonManagedKafkaEventSourceConfig != nil {
-		if err := d.Set("amazon_managed_kafka_event_source_config", []interface{}{flattenAmazonManagedKafkaEventSourceConfig(output.AmazonManagedKafkaEventSourceConfig)}); err != nil {
+		if err := d.Set("amazon_managed_kafka_event_source_config", []any{flattenAmazonManagedKafkaEventSourceConfig(output.AmazonManagedKafkaEventSourceConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting amazon_managed_kafka_event_source_config: %s", err)
 		}
 	} else {
@@ -592,14 +592,14 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("batch_size", output.BatchSize)
 	d.Set("bisect_batch_on_function_error", output.BisectBatchOnFunctionError)
 	if output.DestinationConfig != nil {
-		if err := d.Set("destination_config", []interface{}{flattenDestinationConfig(output.DestinationConfig)}); err != nil {
+		if err := d.Set("destination_config", []any{flattenDestinationConfig(output.DestinationConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting destination_config: %s", err)
 		}
 	} else {
 		d.Set("destination_config", nil)
 	}
 	if output.DocumentDBEventSourceConfig != nil {
-		if err := d.Set("document_db_event_source_config", []interface{}{flattenDocumentDBEventSourceConfig(output.DocumentDBEventSourceConfig)}); err != nil {
+		if err := d.Set("document_db_event_source_config", []any{flattenDocumentDBEventSourceConfig(output.DocumentDBEventSourceConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting document_db_event_source_config: %s", err)
 		}
 	} else {
@@ -607,7 +607,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set("event_source_arn", output.EventSourceArn)
 	if v := output.FilterCriteria; v != nil {
-		if err := d.Set("filter_criteria", []interface{}{flattenFilterCriteria(v)}); err != nil {
+		if err := d.Set("filter_criteria", []any{flattenFilterCriteria(v)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting filter criteria: %s", err)
 		}
 	} else {
@@ -627,7 +627,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("maximum_record_age_in_seconds", output.MaximumRecordAgeInSeconds)
 	d.Set("maximum_retry_attempts", output.MaximumRetryAttempts)
 	if v := output.MetricsConfig; v != nil {
-		if err := d.Set("metrics_config", []interface{}{flattenEventSourceMappingMetricsConfig(v)}); err != nil {
+		if err := d.Set("metrics_config", []any{flattenEventSourceMappingMetricsConfig(v)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting metrics_config: %s", err)
 		}
 	} else {
@@ -635,7 +635,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set("parallelization_factor", output.ParallelizationFactor)
 	if v := output.ProvisionedPollerConfig; v != nil {
-		if err := d.Set("provisioned_poller_config", []interface{}{flattenProvisionedPollerConfig(v)}); err != nil {
+		if err := d.Set("provisioned_poller_config", []any{flattenProvisionedPollerConfig(v)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting provisioned_poller_config: %s", err)
 		}
 	} else {
@@ -643,21 +643,21 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set("queues", output.Queues)
 	if v := output.ScalingConfig; v != nil {
-		if err := d.Set("scaling_config", []interface{}{flattenScalingConfig(v)}); err != nil {
+		if err := d.Set("scaling_config", []any{flattenScalingConfig(v)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting scaling_config: %s", err)
 		}
 	} else {
 		d.Set("scaling_config", nil)
 	}
 	if output.SelfManagedEventSource != nil {
-		if err := d.Set("self_managed_event_source", []interface{}{flattenSelfManagedEventSource(output.SelfManagedEventSource)}); err != nil {
+		if err := d.Set("self_managed_event_source", []any{flattenSelfManagedEventSource(output.SelfManagedEventSource)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting self_managed_event_source: %s", err)
 		}
 	} else {
 		d.Set("self_managed_event_source", nil)
 	}
 	if output.SelfManagedKafkaEventSourceConfig != nil {
-		if err := d.Set("self_managed_kafka_event_source_config", []interface{}{flattenSelfManagedKafkaEventSourceConfig(output.SelfManagedKafkaEventSourceConfig)}); err != nil {
+		if err := d.Set("self_managed_kafka_event_source_config", []any{flattenSelfManagedKafkaEventSourceConfig(output.SelfManagedKafkaEventSourceConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting self_managed_kafka_event_source_config: %s", err)
 		}
 	} else {
@@ -691,7 +691,7 @@ func resourceEventSourceMappingRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -709,14 +709,14 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("destination_config") {
-			if v, ok := d.GetOk("destination_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.DestinationConfig = expandDestinationConfig(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("destination_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.DestinationConfig = expandDestinationConfig(v.([]any)[0].(map[string]any))
 			}
 		}
 
 		if d.HasChange("document_db_event_source_config") {
-			if v, ok := d.GetOk("document_db_event_source_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.DocumentDBEventSourceConfig = expandDocumentDBEventSourceConfig(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("document_db_event_source_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.DocumentDBEventSourceConfig = expandDocumentDBEventSourceConfig(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -725,8 +725,8 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("filter_criteria") {
-			if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.FilterCriteria = expandFilterCriteria(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("filter_criteria"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.FilterCriteria = expandFilterCriteria(v.([]any)[0].(map[string]any))
 			} else {
 				// AWS ignores the removal if this is left as nil.
 				input.FilterCriteria = &awstypes.FilterCriteria{}
@@ -758,8 +758,8 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("metrics_config") {
-			if v, ok := d.GetOk("metrics_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.MetricsConfig = expandEventSourceMappingMetricsConfig((v.([]interface{})[0].(map[string]interface{})))
+			if v, ok := d.GetOk("metrics_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.MetricsConfig = expandEventSourceMappingMetricsConfig((v.([]any)[0].(map[string]any)))
 			} else {
 				input.MetricsConfig = &awstypes.EventSourceMappingMetricsConfig{}
 			}
@@ -770,8 +770,8 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("provisioned_poller_config") {
-			if v, ok := d.GetOk("provisioned_poller_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ProvisionedPollerConfig = expandProvisionedPollerConfig(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("provisioned_poller_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ProvisionedPollerConfig = expandProvisionedPollerConfig(v.([]any)[0].(map[string]any))
 			} else {
 				// AWS ignores the removal if this is left as nil.
 				input.ProvisionedPollerConfig = &awstypes.ProvisionedPollerConfig{}
@@ -779,8 +779,8 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("scaling_config") {
-			if v, ok := d.GetOk("scaling_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.ScalingConfig = expandScalingConfig(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("scaling_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.ScalingConfig = expandScalingConfig(v.([]any)[0].(map[string]any))
 			} else {
 				// AWS ignores the removal if this is left as nil.
 				input.ScalingConfig = &awstypes.ScalingConfig{}
@@ -813,7 +813,7 @@ func resourceEventSourceMappingUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceEventSourceMappingRead(ctx, d, meta)...)
 }
 
-func resourceEventSourceMappingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceEventSourceMappingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -821,7 +821,7 @@ func resourceEventSourceMappingDelete(ctx context.Context, d *schema.ResourceDat
 	const (
 		timeout = 5 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUseException](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUseException](ctx, timeout, func() (any, error) {
 		return conn.DeleteEventSourceMapping(ctx, &lambda.DeleteEventSourceMappingInput{
 			UUID: aws.String(d.Id()),
 		})
@@ -848,7 +848,7 @@ type eventSourceMappingCU interface {
 
 func retryEventSourceMapping[T eventSourceMappingCU](ctx context.Context, f func() (*T, error)) (*T, error) {
 	outputRaw, err := tfresource.RetryWhen(ctx, lambdaPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {
@@ -905,7 +905,7 @@ func findEventSourceMappingByID(ctx context.Context, conn *lambda.Client, uuid s
 }
 
 func statusEventSourceMapping(ctx context.Context, conn *lambda.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findEventSourceMappingByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -986,21 +986,21 @@ func waitEventSourceMappingDeleted(ctx context.Context, conn *lambda.Client, id 
 	return nil, err
 }
 
-func expandDestinationConfig(tfMap map[string]interface{}) *awstypes.DestinationConfig {
+func expandDestinationConfig(tfMap map[string]any) *awstypes.DestinationConfig {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.DestinationConfig{}
 
-	if v, ok := tfMap["on_failure"].([]interface{}); ok && len(v) > 0 {
-		apiObject.OnFailure = expandOnFailure(v[0].(map[string]interface{}))
+	if v, ok := tfMap["on_failure"].([]any); ok && len(v) > 0 {
+		apiObject.OnFailure = expandOnFailure(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandDocumentDBEventSourceConfig(tfMap map[string]interface{}) *awstypes.DocumentDBEventSourceConfig {
+func expandDocumentDBEventSourceConfig(tfMap map[string]any) *awstypes.DocumentDBEventSourceConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1022,7 +1022,7 @@ func expandDocumentDBEventSourceConfig(tfMap map[string]interface{}) *awstypes.D
 	return apiObject
 }
 
-func expandOnFailure(tfMap map[string]interface{}) *awstypes.OnFailure {
+func expandOnFailure(tfMap map[string]any) *awstypes.OnFailure {
 	if tfMap == nil {
 		return nil
 	}
@@ -1036,26 +1036,26 @@ func expandOnFailure(tfMap map[string]interface{}) *awstypes.OnFailure {
 	return apiObject
 }
 
-func flattenDestinationConfig(apiObject *awstypes.DestinationConfig) map[string]interface{} {
+func flattenDestinationConfig(apiObject *awstypes.DestinationConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.OnFailure; v != nil {
-		tfMap["on_failure"] = []interface{}{flattenOnFailure(v)}
+		tfMap["on_failure"] = []any{flattenOnFailure(v)}
 	}
 
 	return tfMap
 }
 
-func flattenDocumentDBEventSourceConfig(apiObject *awstypes.DocumentDBEventSourceConfig) map[string]interface{} {
+func flattenDocumentDBEventSourceConfig(apiObject *awstypes.DocumentDBEventSourceConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"full_document": apiObject.FullDocument,
 	}
 
@@ -1070,12 +1070,12 @@ func flattenDocumentDBEventSourceConfig(apiObject *awstypes.DocumentDBEventSourc
 	return tfMap
 }
 
-func flattenOnFailure(apiObject *awstypes.OnFailure) map[string]interface{} {
+func flattenOnFailure(apiObject *awstypes.OnFailure) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Destination; v != nil {
 		tfMap[names.AttrDestinationARN] = aws.ToString(v)
@@ -1084,14 +1084,14 @@ func flattenOnFailure(apiObject *awstypes.OnFailure) map[string]interface{} {
 	return tfMap
 }
 
-func expandSelfManagedEventSource(tfMap map[string]interface{}) *awstypes.SelfManagedEventSource {
+func expandSelfManagedEventSource(tfMap map[string]any) *awstypes.SelfManagedEventSource {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.SelfManagedEventSource{}
 
-	if v, ok := tfMap[names.AttrEndpoints].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrEndpoints].(map[string]any); ok && len(v) > 0 {
 		m := map[string][]string{}
 
 		for k, v := range v {
@@ -1104,12 +1104,12 @@ func expandSelfManagedEventSource(tfMap map[string]interface{}) *awstypes.SelfMa
 	return apiObject
 }
 
-func flattenSelfManagedEventSource(apiObject *awstypes.SelfManagedEventSource) map[string]interface{} {
+func flattenSelfManagedEventSource(apiObject *awstypes.SelfManagedEventSource) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Endpoints; v != nil {
 		m := map[string]string{}
@@ -1124,7 +1124,7 @@ func flattenSelfManagedEventSource(apiObject *awstypes.SelfManagedEventSource) m
 	return tfMap
 }
 
-func expandAmazonManagedKafkaEventSourceConfig(tfMap map[string]interface{}) *awstypes.AmazonManagedKafkaEventSourceConfig {
+func expandAmazonManagedKafkaEventSourceConfig(tfMap map[string]any) *awstypes.AmazonManagedKafkaEventSourceConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1138,12 +1138,12 @@ func expandAmazonManagedKafkaEventSourceConfig(tfMap map[string]interface{}) *aw
 	return apiObject
 }
 
-func flattenAmazonManagedKafkaEventSourceConfig(apiObject *awstypes.AmazonManagedKafkaEventSourceConfig) map[string]interface{} {
+func flattenAmazonManagedKafkaEventSourceConfig(apiObject *awstypes.AmazonManagedKafkaEventSourceConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ConsumerGroupId; v != nil {
 		tfMap["consumer_group_id"] = aws.ToString(v)
@@ -1152,7 +1152,7 @@ func flattenAmazonManagedKafkaEventSourceConfig(apiObject *awstypes.AmazonManage
 	return tfMap
 }
 
-func expandSelfManagedKafkaEventSourceConfig(tfMap map[string]interface{}) *awstypes.SelfManagedKafkaEventSourceConfig {
+func expandSelfManagedKafkaEventSourceConfig(tfMap map[string]any) *awstypes.SelfManagedKafkaEventSourceConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1166,12 +1166,12 @@ func expandSelfManagedKafkaEventSourceConfig(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func flattenSelfManagedKafkaEventSourceConfig(apiObject *awstypes.SelfManagedKafkaEventSourceConfig) map[string]interface{} {
+func flattenSelfManagedKafkaEventSourceConfig(apiObject *awstypes.SelfManagedKafkaEventSourceConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ConsumerGroupId; v != nil {
 		tfMap["consumer_group_id"] = aws.ToString(v)
@@ -1180,7 +1180,7 @@ func flattenSelfManagedKafkaEventSourceConfig(apiObject *awstypes.SelfManagedKaf
 	return tfMap
 }
 
-func expandProvisionedPollerConfig(tfMap map[string]interface{}) *awstypes.ProvisionedPollerConfig {
+func expandProvisionedPollerConfig(tfMap map[string]any) *awstypes.ProvisionedPollerConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1198,12 +1198,12 @@ func expandProvisionedPollerConfig(tfMap map[string]interface{}) *awstypes.Provi
 	return apiObject
 }
 
-func flattenProvisionedPollerConfig(apiObject *awstypes.ProvisionedPollerConfig) map[string]interface{} {
+func flattenProvisionedPollerConfig(apiObject *awstypes.ProvisionedPollerConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.MaximumPollers; v != nil {
 		tfMap["maximum_pollers"] = aws.ToInt32(v)
@@ -1216,7 +1216,7 @@ func flattenProvisionedPollerConfig(apiObject *awstypes.ProvisionedPollerConfig)
 	return tfMap
 }
 
-func expandSourceAccessConfiguration(tfMap map[string]interface{}) *awstypes.SourceAccessConfiguration {
+func expandSourceAccessConfiguration(tfMap map[string]any) *awstypes.SourceAccessConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -1234,7 +1234,7 @@ func expandSourceAccessConfiguration(tfMap map[string]interface{}) *awstypes.Sou
 	return apiObject
 }
 
-func expandSourceAccessConfigurations(tfList []interface{}) []awstypes.SourceAccessConfiguration {
+func expandSourceAccessConfigurations(tfList []any) []awstypes.SourceAccessConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1242,7 +1242,7 @@ func expandSourceAccessConfigurations(tfList []interface{}) []awstypes.SourceAcc
 	var apiObjects []awstypes.SourceAccessConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1260,12 +1260,12 @@ func expandSourceAccessConfigurations(tfList []interface{}) []awstypes.SourceAcc
 	return apiObjects
 }
 
-func flattenSourceAccessConfiguration(apiObject *awstypes.SourceAccessConfiguration) map[string]interface{} {
+func flattenSourceAccessConfiguration(apiObject *awstypes.SourceAccessConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrType: apiObject.Type,
 	}
 
@@ -1276,12 +1276,12 @@ func flattenSourceAccessConfiguration(apiObject *awstypes.SourceAccessConfigurat
 	return tfMap
 }
 
-func flattenSourceAccessConfigurations(apiObjects []awstypes.SourceAccessConfiguration) []interface{} {
+func flattenSourceAccessConfigurations(apiObjects []awstypes.SourceAccessConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenSourceAccessConfiguration(&apiObject))
@@ -1290,7 +1290,7 @@ func flattenSourceAccessConfigurations(apiObjects []awstypes.SourceAccessConfigu
 	return tfList
 }
 
-func expandFilterCriteria(tfMap map[string]interface{}) *awstypes.FilterCriteria {
+func expandFilterCriteria(tfMap map[string]any) *awstypes.FilterCriteria {
 	if tfMap == nil {
 		return nil
 	}
@@ -1304,12 +1304,12 @@ func expandFilterCriteria(tfMap map[string]interface{}) *awstypes.FilterCriteria
 	return apiObject
 }
 
-func flattenFilterCriteria(apiObject *awstypes.FilterCriteria) map[string]interface{} {
+func flattenFilterCriteria(apiObject *awstypes.FilterCriteria) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Filters; len(v) > 0 {
 		tfMap[names.AttrFilter] = flattenFilters(v)
@@ -1318,7 +1318,7 @@ func flattenFilterCriteria(apiObject *awstypes.FilterCriteria) map[string]interf
 	return tfMap
 }
 
-func expandFilters(tfList []interface{}) []awstypes.Filter {
+func expandFilters(tfList []any) []awstypes.Filter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1326,7 +1326,7 @@ func expandFilters(tfList []interface{}) []awstypes.Filter {
 	var apiObjects []awstypes.Filter
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1344,12 +1344,12 @@ func expandFilters(tfList []interface{}) []awstypes.Filter {
 	return apiObjects
 }
 
-func flattenFilters(apiObjects []awstypes.Filter) []interface{} {
+func flattenFilters(apiObjects []awstypes.Filter) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenFilter(&apiObject))
@@ -1358,7 +1358,7 @@ func flattenFilters(apiObjects []awstypes.Filter) []interface{} {
 	return tfList
 }
 
-func expandFilter(tfMap map[string]interface{}) *awstypes.Filter {
+func expandFilter(tfMap map[string]any) *awstypes.Filter {
 	if tfMap == nil {
 		return nil
 	}
@@ -1373,12 +1373,12 @@ func expandFilter(tfMap map[string]interface{}) *awstypes.Filter {
 	return apiObject
 }
 
-func flattenFilter(apiObject *awstypes.Filter) map[string]interface{} {
+func flattenFilter(apiObject *awstypes.Filter) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Pattern; v != nil {
 		tfMap["pattern"] = aws.ToString(v)
@@ -1387,7 +1387,7 @@ func flattenFilter(apiObject *awstypes.Filter) map[string]interface{} {
 	return tfMap
 }
 
-func expandScalingConfig(tfMap map[string]interface{}) *awstypes.ScalingConfig {
+func expandScalingConfig(tfMap map[string]any) *awstypes.ScalingConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1401,12 +1401,12 @@ func expandScalingConfig(tfMap map[string]interface{}) *awstypes.ScalingConfig {
 	return apiObject
 }
 
-func flattenScalingConfig(apiObject *awstypes.ScalingConfig) map[string]interface{} {
+func flattenScalingConfig(apiObject *awstypes.ScalingConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.MaximumConcurrency; v != nil {
 		tfMap["maximum_concurrency"] = aws.ToInt32(v)
@@ -1415,7 +1415,7 @@ func flattenScalingConfig(apiObject *awstypes.ScalingConfig) map[string]interfac
 	return tfMap
 }
 
-func expandEventSourceMappingMetricsConfig(tfMap map[string]interface{}) *awstypes.EventSourceMappingMetricsConfig {
+func expandEventSourceMappingMetricsConfig(tfMap map[string]any) *awstypes.EventSourceMappingMetricsConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1429,12 +1429,12 @@ func expandEventSourceMappingMetricsConfig(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func flattenEventSourceMappingMetricsConfig(apiObject *awstypes.EventSourceMappingMetricsConfig) map[string]interface{} {
+func flattenEventSourceMappingMetricsConfig(apiObject *awstypes.EventSourceMappingMetricsConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Metrics; v != nil {
 		tfMap["metrics"] = flex.FlattenStringyValueSet(v)

--- a/internal/service/lambda/flex.go
+++ b/internal/service/lambda/flex.go
@@ -11,14 +11,14 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func flattenLayers(apiObjects []awstypes.Layer) []interface{} {
+func flattenLayers(apiObjects []awstypes.Layer) []any {
 	return flex.FlattenStringValueList(tfslices.ApplyToAll(apiObjects, func(v awstypes.Layer) string {
 		return aws.ToString(v.Arn)
 	}))
 }
 
-func flattenVPCConfigResponse(apiObject *awstypes.VpcConfigResponse) []interface{} {
-	tfMap := make(map[string]interface{})
+func flattenVPCConfigResponse(apiObject *awstypes.VpcConfigResponse) []any {
+	tfMap := make(map[string]any)
 
 	if apiObject == nil {
 		return nil
@@ -35,5 +35,5 @@ func flattenVPCConfigResponse(apiObject *awstypes.VpcConfigResponse) []interface
 		tfMap[names.AttrVPCID] = aws.ToString(apiObject.VpcId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -58,7 +58,7 @@ func resourceFunction() *schema.Resource {
 		},
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("function_name", d.Id())
 				return []*schema.ResourceData{d}, nil
 			},
@@ -124,7 +124,7 @@ func resourceFunction() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					if old == "0" && new == "1" {
 						_, n := d.GetChange("environment.0.variables")
-						newn, ok := n.(map[string]interface{})
+						newn, ok := n.(map[string]any)
 						if ok && len(newn) == 0 {
 							return true
 						}
@@ -464,7 +464,7 @@ func resourceFunction() *schema.Resource {
 	}
 }
 
-func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -505,40 +505,40 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
-	if v, ok := d.GetOk("architectures"); ok && len(v.([]interface{})) > 0 {
-		input.Architectures = flex.ExpandStringyValueList[awstypes.Architecture](v.([]interface{}))
+	if v, ok := d.GetOk("architectures"); ok && len(v.([]any)) > 0 {
+		input.Architectures = flex.ExpandStringyValueList[awstypes.Architecture](v.([]any))
 	}
 
 	if v, ok := d.GetOk("code_signing_config_arn"); ok {
 		input.CodeSigningConfigArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]interface{})) > 0 {
-		if v.([]interface{})[0] == nil {
+	if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]any)) > 0 {
+		if v.([]any)[0] == nil {
 			return sdkdiag.AppendErrorf(diags, "nil dead_letter_config supplied for function: %s", functionName)
 		}
 
 		input.DeadLetterConfig = &awstypes.DeadLetterConfig{
-			TargetArn: aws.String(v.([]interface{})[0].(map[string]interface{})[names.AttrTargetARN].(string)),
+			TargetArn: aws.String(v.([]any)[0].(map[string]any)[names.AttrTargetARN].(string)),
 		}
 	}
 
-	if v, ok := d.GetOk(names.AttrEnvironment); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		if v, ok := v.([]interface{})[0].(map[string]interface{})["variables"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := d.GetOk(names.AttrEnvironment); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		if v, ok := v.([]any)[0].(map[string]any)["variables"].(map[string]any); ok && len(v) > 0 {
 			input.Environment = &awstypes.Environment{
 				Variables: flex.ExpandStringValueMap(v),
 			}
 		}
 	}
 
-	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.EphemeralStorage = &awstypes.EphemeralStorage{
-			Size: aws.Int32(int32(v.([]interface{})[0].(map[string]interface{})[names.AttrSize].(int))),
+			Size: aws.Int32(int32(v.([]any)[0].(map[string]any)[names.AttrSize].(int))),
 		}
 	}
 
-	if v, ok := d.GetOk("file_system_config"); ok && len(v.([]interface{})) > 0 {
-		input.FileSystemConfigs = expandFileSystemConfigs(v.([]interface{}))
+	if v, ok := d.GetOk("file_system_config"); ok && len(v.([]any)) > 0 {
+		input.FileSystemConfigs = expandFileSystemConfigs(v.([]any))
 	}
 
 	if packageType == awstypes.PackageTypeZip {
@@ -546,34 +546,34 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 		input.Runtime = awstypes.Runtime(d.Get("runtime").(string))
 	}
 
-	if v, ok := d.GetOk("image_config"); ok && len(v.([]interface{})) > 0 {
-		input.ImageConfig = expandImageConfigs(v.([]interface{}))
+	if v, ok := d.GetOk("image_config"); ok && len(v.([]any)) > 0 {
+		input.ImageConfig = expandImageConfigs(v.([]any))
 	}
 
-	if v, ok := d.GetOk("logging_config"); ok && len(v.([]interface{})) > 0 {
-		input.LoggingConfig = expandLoggingConfig(v.([]interface{}))
+	if v, ok := d.GetOk("logging_config"); ok && len(v.([]any)) > 0 {
+		input.LoggingConfig = expandLoggingConfig(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrKMSKeyARN); ok {
 		input.KMSKeyArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("layers"); ok && len(v.([]interface{})) > 0 {
-		input.Layers = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("layers"); ok && len(v.([]any)) > 0 {
+		input.Layers = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk("snap_start"); ok {
-		input.SnapStart = expandSnapStart(v.([]interface{}))
+		input.SnapStart = expandSnapStart(v.([]any))
 	}
 
-	if v, ok := d.GetOk("tracing_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("tracing_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.TracingConfig = &awstypes.TracingConfig{
-			Mode: awstypes.TracingMode(v.([]interface{})[0].(map[string]interface{})[names.AttrMode].(string)),
+			Mode: awstypes.TracingMode(v.([]any)[0].(map[string]any)[names.AttrMode].(string)),
 		}
 	}
 
-	if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 		input.VpcConfig = &awstypes.VpcConfig{
 			Ipv6AllowedForDualStack: aws.Bool(tfMap["ipv6_allowed_for_dual_stack"].(bool)),
 			SecurityGroupIds:        flex.ExpandStringValueSet(tfMap[names.AttrSecurityGroupIDs].(*schema.Set)),
@@ -591,7 +591,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(functionName)
 
-	_, err = tfresource.RetryWhenNotFound(ctx, lambdaPropagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, lambdaPropagationTimeout, func() (any, error) {
 		return findFunctionByName(ctx, conn, d.Id())
 	})
 
@@ -617,7 +617,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceFunctionRead(ctx, d, meta)...)
 }
 
-func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -649,15 +649,15 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	d.Set(names.AttrARN, functionARN)
 	d.Set("code_sha256", function.CodeSha256)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
-		if err := d.Set("dead_letter_config", []interface{}{
-			map[string]interface{}{
+		if err := d.Set("dead_letter_config", []any{
+			map[string]any{
 				names.AttrTargetARN: aws.ToString(function.DeadLetterConfig.TargetArn),
 			},
 		}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dead_letter_config: %s", err)
 		}
 	} else {
-		d.Set("dead_letter_config", []interface{}{})
+		d.Set("dead_letter_config", []any{})
 	}
 	d.Set(names.AttrDescription, function.Description)
 	if err := d.Set(names.AttrEnvironment, flattenEnvironment(function.Environment)); err != nil {
@@ -708,8 +708,8 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if function.TracingConfig != nil {
 		tracingConfigMode = function.TracingConfig.Mode
 	}
-	if err := d.Set("tracing_config", []interface{}{
-		map[string]interface{}{
+	if err := d.Set("tracing_config", []any{
+		map[string]any{
 			names.AttrMode: string(tracingConfigMode),
 		},
 	}); err != nil {
@@ -767,7 +767,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -801,13 +801,13 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("dead_letter_config") {
-			if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]interface{})) > 0 {
-				if v.([]interface{})[0] == nil {
+			if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]any)) > 0 {
+				if v.([]any)[0] == nil {
 					return sdkdiag.AppendErrorf(diags, "nil dead_letter_config supplied for function: %s", d.Id())
 				}
 
 				input.DeadLetterConfig = &awstypes.DeadLetterConfig{
-					TargetArn: aws.String(v.([]interface{})[0].(map[string]interface{})[names.AttrTargetARN].(string)),
+					TargetArn: aws.String(v.([]any)[0].(map[string]any)[names.AttrTargetARN].(string)),
 				}
 			} else {
 				input.DeadLetterConfig = &awstypes.DeadLetterConfig{
@@ -825,8 +825,8 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 				Variables: map[string]string{},
 			}
 
-			if v, ok := d.GetOk(names.AttrEnvironment); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				if v, ok := v.([]interface{})[0].(map[string]interface{})["variables"].(map[string]interface{}); ok && len(v) > 0 {
+			if v, ok := d.GetOk(names.AttrEnvironment); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				if v, ok := v.([]any)[0].(map[string]any)["variables"].(map[string]any); ok && len(v) > 0 {
 					input.Environment = &awstypes.Environment{
 						Variables: flex.ExpandStringValueMap(v),
 					}
@@ -835,16 +835,16 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("ephemeral_storage") {
-			if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 				input.EphemeralStorage = &awstypes.EphemeralStorage{
-					Size: aws.Int32(int32(v.([]interface{})[0].(map[string]interface{})[names.AttrSize].(int))),
+					Size: aws.Int32(int32(v.([]any)[0].(map[string]any)[names.AttrSize].(int))),
 				}
 			}
 		}
 
 		if d.HasChange("file_system_config") {
-			if v, ok := d.GetOk("file_system_config"); ok && len(v.([]interface{})) > 0 {
-				input.FileSystemConfigs = expandFileSystemConfigs(v.([]interface{}))
+			if v, ok := d.GetOk("file_system_config"); ok && len(v.([]any)) > 0 {
+				input.FileSystemConfigs = expandFileSystemConfigs(v.([]any))
 			} else {
 				input.FileSystemConfigs = []awstypes.FileSystemConfig{}
 			}
@@ -855,8 +855,8 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("image_config") {
-			if v, ok := d.GetOk("image_config"); ok && len(v.([]interface{})) > 0 {
-				input.ImageConfig = expandImageConfigs(v.([]interface{}))
+			if v, ok := d.GetOk("image_config"); ok && len(v.([]any)) > 0 {
+				input.ImageConfig = expandImageConfigs(v.([]any))
 			} else {
 				input.ImageConfig = &awstypes.ImageConfig{}
 			}
@@ -867,11 +867,11 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("layers") {
-			input.Layers = flex.ExpandStringValueList(d.Get("layers").([]interface{}))
+			input.Layers = flex.ExpandStringValueList(d.Get("layers").([]any))
 		}
 
 		if d.HasChange("logging_config") {
-			input.LoggingConfig = expandLoggingConfig(d.Get("logging_config").([]interface{}))
+			input.LoggingConfig = expandLoggingConfig(d.Get("logging_config").([]any))
 		}
 
 		if d.HasChange("memory_size") {
@@ -887,7 +887,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("snap_start") {
-			input.SnapStart = expandSnapStart(d.Get("snap_start").([]interface{}))
+			input.SnapStart = expandSnapStart(d.Get("snap_start").([]any))
 		}
 
 		if d.HasChange(names.AttrTimeout) {
@@ -895,16 +895,16 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("tracing_config") {
-			if v, ok := d.GetOk("tracing_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+			if v, ok := d.GetOk("tracing_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 				input.TracingConfig = &awstypes.TracingConfig{
-					Mode: awstypes.TracingMode(v.([]interface{})[0].(map[string]interface{})[names.AttrMode].(string)),
+					Mode: awstypes.TracingMode(v.([]any)[0].(map[string]any)[names.AttrMode].(string)),
 				}
 			}
 		}
 
 		if d.HasChanges("vpc_config.0.security_group_ids", "vpc_config.0.subnet_ids", "vpc_config.0.ipv6_allowed_for_dual_stack") {
-			if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
 				input.VpcConfig = &awstypes.VpcConfig{
 					Ipv6AllowedForDualStack: aws.Bool(tfMap["ipv6_allowed_for_dual_stack"].(bool)),
 					SecurityGroupIds:        flex.ExpandStringValueSet(tfMap[names.AttrSecurityGroupIDs].(*schema.Set)),
@@ -939,8 +939,8 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if d.HasChange("architectures") {
-			if v, ok := d.GetOk("architectures"); ok && len(v.([]interface{})) > 0 {
-				input.Architectures = flex.ExpandStringyValueList[awstypes.Architecture](v.([]interface{}))
+			if v, ok := d.GetOk("architectures"); ok && len(v.([]any)) > 0 {
+				input.Architectures = flex.ExpandStringyValueList[awstypes.Architecture](v.([]any))
 			}
 		}
 
@@ -1016,7 +1016,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			FunctionName: aws.String(d.Id()),
 		}
 
-		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ResourceConflictException](ctx, lambdaPropagationTimeout, func() (interface{}, error) {
+		outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.ResourceConflictException](ctx, lambdaPropagationTimeout, func() (any, error) {
 			return conn.PublishVersion(ctx, input)
 		}, "in progress")
 
@@ -1039,7 +1039,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceFunctionRead(ctx, d, meta)...)
 }
 
-func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -1055,7 +1055,7 @@ func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	log.Printf("[INFO] Deleting Lambda Function: %s", d.Id())
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterValueException](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterValueException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteFunction(ctx, &lambda.DeleteFunctionInput{
 			FunctionName: aws.String(d.Id()),
 		})
@@ -1141,14 +1141,14 @@ func findLatestFunctionVersionByName(ctx context.Context, conn *lambda.Client, n
 // groups included in the VPC configuration block during normal operation
 // by freeing them from association with ENI's left behind after destruction
 // of the function.
-func replaceSecurityGroupsOnDestroy(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func replaceSecurityGroupsOnDestroy(ctx context.Context, d *schema.ResourceData, meta any) error {
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 	ec2Conn := meta.(*conns.AWSClient).EC2Client(ctx)
 
 	var sgIDs []string
 	var vpcID string
-	if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk(names.AttrVPCConfig); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 		sgIDs = flex.ExpandStringValueSet(tfMap[names.AttrSecurityGroupIDs].(*schema.Set))
 		vpcID = tfMap[names.AttrVPCID].(string)
 	} else { // empty VPC config, nothing to do
@@ -1191,7 +1191,7 @@ func replaceSecurityGroupsOnDestroy(ctx context.Context, d *schema.ResourceData,
 }
 
 func statusFunctionLastUpdateStatus(ctx context.Context, conn *lambda.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFunctionByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -1207,7 +1207,7 @@ func statusFunctionLastUpdateStatus(ctx context.Context, conn *lambda.Client, na
 }
 
 func statusFunctionState(ctx context.Context, conn *lambda.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFunctionByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -1270,7 +1270,7 @@ type functionCU interface {
 
 func retryFunctionOp[T functionCU](ctx context.Context, f func() (*T, error)) (*T, error) {
 	output, err := tfresource.RetryWhen(ctx, lambdaPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return f()
 		},
 		func(err error) (bool, error) {
@@ -1302,7 +1302,7 @@ func retryFunctionOp[T functionCU](ctx context.Context, f func() (*T, error)) (*
 			functionExtraThrottlingTimeout = 9 * time.Minute
 		)
 		output, err = tfresource.RetryWhen(ctx, functionExtraThrottlingTimeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return f()
 			},
 			func(err error) (bool, error) {
@@ -1322,7 +1322,7 @@ func retryFunctionOp[T functionCU](ctx context.Context, f func() (*T, error)) (*
 	return output.(*T), err
 }
 
-func checkHandlerRuntimeForZipFunction(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func checkHandlerRuntimeForZipFunction(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	packageType := d.Get("package_type").(string)
 	_, handlerOk := d.GetOk("handler")
 	_, runtimeOk := d.GetOk("runtime")
@@ -1333,7 +1333,7 @@ func checkHandlerRuntimeForZipFunction(_ context.Context, d *schema.ResourceDiff
 	return nil
 }
 
-func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	configChanged := needsFunctionConfigUpdate(d)
 	codeChanged := needsFunctionCodeUpdate(d)
 	if codeChanged {
@@ -1424,25 +1424,25 @@ func signerServiceIsAvailable(region string) bool {
 	return ok
 }
 
-func flattenEnvironment(apiObject *awstypes.EnvironmentResponse) []interface{} {
+func flattenEnvironment(apiObject *awstypes.EnvironmentResponse) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Variables; v != nil {
 		tfMap["variables"] = aws.StringMap(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFileSystemConfigs(apiObjects []awstypes.FileSystemConfig) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenFileSystemConfigs(apiObjects []awstypes.FileSystemConfig) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 		tfMap[names.AttrARN] = aws.ToString(apiObject.Arn)
 		tfMap["local_mount_path"] = aws.ToString(apiObject.LocalMountPath)
 
@@ -1452,11 +1452,11 @@ func flattenFileSystemConfigs(apiObjects []awstypes.FileSystemConfig) []interfac
 	return tfList
 }
 
-func expandFileSystemConfigs(tfList []interface{}) []awstypes.FileSystemConfig {
+func expandFileSystemConfigs(tfList []any) []awstypes.FileSystemConfig {
 	apiObjects := make([]awstypes.FileSystemConfig, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObjects = append(apiObjects, awstypes.FileSystemConfig{
 			Arn:            aws.String(tfMap[names.AttrARN].(string)),
 			LocalMountPath: aws.String(tfMap["local_mount_path"].(string)),
@@ -1466,8 +1466,8 @@ func expandFileSystemConfigs(tfList []interface{}) []awstypes.FileSystemConfig {
 	return apiObjects
 }
 
-func flattenImageConfig(apiObject *awstypes.ImageConfigResponse) []interface{} {
-	tfMap := make(map[string]interface{})
+func flattenImageConfig(apiObject *awstypes.ImageConfigResponse) []any {
+	tfMap := make(map[string]any)
 
 	if apiObject == nil || apiObject.Error != nil || apiObject.ImageConfig == nil {
 		return nil
@@ -1477,22 +1477,22 @@ func flattenImageConfig(apiObject *awstypes.ImageConfigResponse) []interface{} {
 	tfMap["entry_point"] = apiObject.ImageConfig.EntryPoint
 	tfMap["working_directory"] = apiObject.ImageConfig.WorkingDirectory
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandImageConfigs(tfList []interface{}) *awstypes.ImageConfig {
+func expandImageConfigs(tfList []any) *awstypes.ImageConfig {
 	apiObject := &awstypes.ImageConfig{}
 
 	// only one image_config block is allowed
 	if len(tfList) == 1 && tfList[0] != nil {
-		tfMap := tfList[0].(map[string]interface{})
+		tfMap := tfList[0].(map[string]any)
 
-		if len(tfMap["entry_point"].([]interface{})) > 0 {
-			apiObject.EntryPoint = flex.ExpandStringValueList(tfMap["entry_point"].([]interface{}))
+		if len(tfMap["entry_point"].([]any)) > 0 {
+			apiObject.EntryPoint = flex.ExpandStringValueList(tfMap["entry_point"].([]any))
 		}
 
-		if len(tfMap["command"].([]interface{})) > 0 {
-			apiObject.Command = flex.ExpandStringValueList(tfMap["command"].([]interface{}))
+		if len(tfMap["command"].([]any)) > 0 {
+			apiObject.Command = flex.ExpandStringValueList(tfMap["command"].([]any))
 		}
 
 		apiObject.WorkingDirectory = aws.String(tfMap["working_directory"].(string))
@@ -1501,11 +1501,11 @@ func expandImageConfigs(tfList []interface{}) *awstypes.ImageConfig {
 	return apiObject
 }
 
-func expandLoggingConfig(tfList []interface{}) *awstypes.LoggingConfig {
+func expandLoggingConfig(tfList []any) *awstypes.LoggingConfig {
 	apiObject := &awstypes.LoggingConfig{}
 
 	if len(tfList) == 1 && tfList[0] != nil {
-		tfMap := tfList[0].(map[string]interface{})
+		tfMap := tfList[0].(map[string]any)
 
 		if v := tfMap["application_log_level"].(string); len(v) > 0 {
 			apiObject.ApplicationLogLevel = awstypes.ApplicationLogLevel(v)
@@ -1527,19 +1527,19 @@ func expandLoggingConfig(tfList []interface{}) *awstypes.LoggingConfig {
 	return apiObject
 }
 
-func flattenLoggingConfig(apiObject *awstypes.LoggingConfig) []map[string]interface{} {
+func flattenLoggingConfig(apiObject *awstypes.LoggingConfig) []map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"application_log_level": apiObject.ApplicationLogLevel,
 		"log_format":            apiObject.LogFormat,
 		"log_group":             aws.ToString(apiObject.LogGroup),
 		"system_log_level":      apiObject.SystemLogLevel,
 	}
 
-	return []map[string]interface{}{tfMap}
+	return []map[string]any{tfMap}
 }
 
 // Suppress diff if log levels have not been specified, unless log_format has changed
@@ -1553,31 +1553,31 @@ func suppressLoggingConfigUnspecifiedLogLevels(k, old, new string, d *schema.Res
 	return false
 }
 
-func flattenEphemeralStorage(apiObject *awstypes.EphemeralStorage) []interface{} {
+func flattenEphemeralStorage(apiObject *awstypes.EphemeralStorage) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap[names.AttrSize] = aws.ToInt32(apiObject.Size)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandSnapStart(tfList []interface{}) *awstypes.SnapStart {
+func expandSnapStart(tfList []any) *awstypes.SnapStart {
 	apiObject := &awstypes.SnapStart{
 		ApplyOn: awstypes.SnapStartApplyOnNone,
 	}
 
 	if len(tfList) == 1 && tfList[0] != nil {
-		tfMap := tfList[0].(map[string]interface{})
+		tfMap := tfList[0].(map[string]any)
 		apiObject.ApplyOn = awstypes.SnapStartApplyOn(tfMap["apply_on"].(string))
 	}
 
 	return apiObject
 }
 
-func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []interface{} {
+func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -1586,10 +1586,10 @@ func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []interface{} {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"apply_on":            apiObject.ApplyOn,
 		"optimization_status": apiObject.OptimizationStatus,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/lambda/function_data_source.go
+++ b/internal/service/lambda/function_data_source.go
@@ -251,7 +251,7 @@ func dataSourceFunction() *schema.Resource {
 	}
 }
 
-func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -297,15 +297,15 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set(names.AttrARN, unqualifiedARN)
 	d.Set("code_sha256", function.CodeSha256)
 	if function.DeadLetterConfig != nil && function.DeadLetterConfig.TargetArn != nil {
-		if err := d.Set("dead_letter_config", []interface{}{
-			map[string]interface{}{
+		if err := d.Set("dead_letter_config", []any{
+			map[string]any{
 				names.AttrTargetARN: aws.ToString(function.DeadLetterConfig.TargetArn),
 			},
 		}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dead_letter_config: %s", err)
 		}
 	} else {
-		d.Set("dead_letter_config", []interface{}{})
+		d.Set("dead_letter_config", []any{})
 	}
 	d.Set(names.AttrDescription, function.Description)
 	if err := d.Set(names.AttrEnvironment, flattenEnvironment(function.Environment)); err != nil {
@@ -349,8 +349,8 @@ func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta in
 	if function.TracingConfig != nil {
 		tracingConfigMode = function.TracingConfig.Mode
 	}
-	if err := d.Set("tracing_config", []interface{}{
-		map[string]interface{}{
+	if err := d.Set("tracing_config", []any{
+		map[string]any{
 			names.AttrMode: string(tracingConfigMode),
 		},
 	}); err != nil {

--- a/internal/service/lambda/function_event_invoke_config.go
+++ b/internal/service/lambda/function_event_invoke_config.go
@@ -102,7 +102,7 @@ func resourceFunctionEventInvokeConfig() *schema.Resource {
 	}
 }
 
-func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -113,7 +113,7 @@ func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.Reso
 		id = fmt.Sprintf("%s:%s", functionName, qualifier)
 	}
 	input := &lambda.PutFunctionEventInvokeConfigInput{
-		DestinationConfig:    expandFunctionEventInvokeConfigDestinationConfig(d.Get("destination_config").([]interface{})),
+		DestinationConfig:    expandFunctionEventInvokeConfigDestinationConfig(d.Get("destination_config").([]any)),
 		FunctionName:         aws.String(functionName),
 		MaximumRetryAttempts: aws.Int32(int32(d.Get("maximum_retry_attempts").(int))),
 	}
@@ -128,7 +128,7 @@ func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.Reso
 
 	// Retry for destination validation eventual consistency errors.
 	_, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.PutFunctionEventInvokeConfig(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -155,7 +155,7 @@ func resourceFunctionEventInvokeConfigCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceFunctionEventInvokeConfigRead(ctx, d, meta)...)
 }
 
-func resourceFunctionEventInvokeConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionEventInvokeConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -187,7 +187,7 @@ func resourceFunctionEventInvokeConfigRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -197,7 +197,7 @@ func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.Reso
 	}
 
 	input := &lambda.PutFunctionEventInvokeConfigInput{
-		DestinationConfig:    expandFunctionEventInvokeConfigDestinationConfig(d.Get("destination_config").([]interface{})),
+		DestinationConfig:    expandFunctionEventInvokeConfigDestinationConfig(d.Get("destination_config").([]any)),
 		FunctionName:         aws.String(functionName),
 		MaximumRetryAttempts: aws.Int32(int32(d.Get("maximum_retry_attempts").(int))),
 	}
@@ -212,7 +212,7 @@ func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.Reso
 
 	// Retry for destination validation eventual consistency errors.
 	_, err = tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.PutFunctionEventInvokeConfig(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -237,7 +237,7 @@ func resourceFunctionEventInvokeConfigUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceFunctionEventInvokeConfigRead(ctx, d, meta)...)
 }
 
-func resourceFunctionEventInvokeConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionEventInvokeConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -341,32 +341,32 @@ func findFunctionEventInvokeConfigByTwoPartKey(ctx context.Context, conn *lambda
 	return findFunctionEventInvokeConfig(ctx, conn, input)
 }
 
-func expandFunctionEventInvokeConfigDestinationConfig(tfList []interface{}) *awstypes.DestinationConfig {
+func expandFunctionEventInvokeConfigDestinationConfig(tfList []any) *awstypes.DestinationConfig {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	destinationConfig := &awstypes.DestinationConfig{}
 
-	if v, ok := tfMap["on_failure"].([]interface{}); ok {
+	if v, ok := tfMap["on_failure"].([]any); ok {
 		destinationConfig.OnFailure = expandFunctionEventInvokeConfigDestinationConfigOnFailure(v)
 	}
 
-	if v, ok := tfMap["on_success"].([]interface{}); ok {
+	if v, ok := tfMap["on_success"].([]any); ok {
 		destinationConfig.OnSuccess = expandFunctionEventInvokeConfigDestinationConfigOnSuccess(v)
 	}
 
 	return destinationConfig
 }
 
-func expandFunctionEventInvokeConfigDestinationConfigOnFailure(tfList []interface{}) *awstypes.OnFailure {
+func expandFunctionEventInvokeConfigDestinationConfigOnFailure(tfList []any) *awstypes.OnFailure {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	onFailure := &awstypes.OnFailure{}
 
@@ -377,12 +377,12 @@ func expandFunctionEventInvokeConfigDestinationConfigOnFailure(tfList []interfac
 	return onFailure
 }
 
-func expandFunctionEventInvokeConfigDestinationConfigOnSuccess(tfList []interface{}) *awstypes.OnSuccess {
+func expandFunctionEventInvokeConfigDestinationConfigOnSuccess(tfList []any) *awstypes.OnSuccess {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	onSuccess := &awstypes.OnSuccess{}
 
@@ -393,59 +393,59 @@ func expandFunctionEventInvokeConfigDestinationConfigOnSuccess(tfList []interfac
 	return onSuccess
 }
 
-func flattenFunctionEventInvokeConfigDestinationConfig(apiObject *awstypes.DestinationConfig) []interface{} {
+func flattenFunctionEventInvokeConfigDestinationConfig(apiObject *awstypes.DestinationConfig) []any {
 	// The API will respond with empty OnFailure and OnSuccess destinations when unconfigured:
 	// "DestinationConfig":{"OnFailure":{"Destination":null},"OnSuccess":{"Destination":null}}
 	// Return no destination configuration to prevent Terraform state difference
 
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
 	if apiObject.OnFailure == nil && apiObject.OnSuccess == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
 	if (apiObject.OnFailure != nil && apiObject.OnFailure.Destination == nil) && (apiObject.OnSuccess != nil && apiObject.OnSuccess.Destination == nil) {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"on_failure": flattenFunctionEventInvokeConfigDestinationConfigOnFailure(apiObject.OnFailure),
 		"on_success": flattenFunctionEventInvokeConfigDestinationConfigOnSuccess(apiObject.OnSuccess),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunctionEventInvokeConfigDestinationConfigOnFailure(apiObject *awstypes.OnFailure) []interface{} {
+func flattenFunctionEventInvokeConfigDestinationConfigOnFailure(apiObject *awstypes.OnFailure) []any {
 	// The API will respond with empty OnFailure destination when unconfigured:
 	// "DestinationConfig":{"OnFailure":{"Destination":null},"OnSuccess":{"Destination":null}}
 	// Return no on failure configuration to prevent Terraform state difference
 
 	if apiObject == nil || apiObject.Destination == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrDestination: aws.ToString(apiObject.Destination),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenFunctionEventInvokeConfigDestinationConfigOnSuccess(apiObject *awstypes.OnSuccess) []interface{} {
+func flattenFunctionEventInvokeConfigDestinationConfigOnSuccess(apiObject *awstypes.OnSuccess) []any {
 	// The API will respond with empty OnSuccess destination when unconfigured:
 	// "DestinationConfig":{"OnFailure":{"Destination":null},"OnSuccess":{"Destination":null}}
 	// Return no on success configuration to prevent Terraform state difference
 
 	if apiObject == nil || apiObject.Destination == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrDestination: aws.ToString(apiObject.Destination),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/lambda/function_url.go
+++ b/internal/service/lambda/function_url.go
@@ -120,7 +120,7 @@ func resourceFunctionURL() *schema.Resource {
 	}
 }
 
-func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -138,8 +138,8 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.Qualifier = aws.String(qualifier)
 	}
 
-	if v, ok := d.GetOk("cors"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Cors = expandCors(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cors"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Cors = expandCors(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.CreateFunctionUrlConfig(ctx, input)
@@ -177,7 +177,7 @@ func resourceFunctionURLCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceFunctionURLRead(ctx, d, meta)...)
 }
 
-func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -201,7 +201,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	functionURL := aws.ToString(output.FunctionUrl)
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
-		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
+		if err := d.Set("cors", []any{flattenCors(output.Cors)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cors: %s", err)
 		}
 	} else {
@@ -226,7 +226,7 @@ func resourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -248,8 +248,8 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("cors") {
-		if v, ok := d.GetOk("cors"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Cors = expandCors(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("cors"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.Cors = expandCors(v.([]any)[0].(map[string]any))
 		} else {
 			input.Cors = &awstypes.Cors{}
 		}
@@ -268,7 +268,7 @@ func resourceFunctionURLUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceFunctionURLRead(ctx, d, meta)...)
 }
 
-func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionURLDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -357,7 +357,7 @@ func functionURLParseResourceID(id string) (string, string, error) {
 	return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected FUNCTION-NAME%[2]sQUALIFIER or FUNCTION-NAME", id, functionURLResourceIDSeparator)
 }
 
-func expandCors(tfMap map[string]interface{}) *awstypes.Cors {
+func expandCors(tfMap map[string]any) *awstypes.Cors {
 	if tfMap == nil {
 		return nil
 	}
@@ -391,12 +391,12 @@ func expandCors(tfMap map[string]interface{}) *awstypes.Cors {
 	return apiObject
 }
 
-func flattenCors(apiObject *awstypes.Cors) map[string]interface{} {
+func flattenCors(apiObject *awstypes.Cors) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AllowCredentials; v != nil {
 		tfMap["allow_credentials"] = aws.ToBool(v)

--- a/internal/service/lambda/function_url_data_source.go
+++ b/internal/service/lambda/function_url_data_source.go
@@ -98,7 +98,7 @@ func dataSourceFunctionURL() *schema.Resource {
 	}
 }
 
-func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -115,7 +115,7 @@ func dataSourceFunctionURLRead(ctx context.Context, d *schema.ResourceData, meta
 	d.SetId(id)
 	d.Set("authorization_type", output.AuthType)
 	if output.Cors != nil {
-		if err := d.Set("cors", []interface{}{flattenCors(output.Cors)}); err != nil {
+		if err := d.Set("cors", []any{flattenCors(output.Cors)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cors: %s", err)
 		}
 	} else {

--- a/internal/service/lambda/functions_data_source.go
+++ b/internal/service/lambda/functions_data_source.go
@@ -34,7 +34,7 @@ func dataSourceFunctions() *schema.Resource {
 	}
 }
 
-func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFunctionsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/invocation.go
+++ b/internal/service/lambda/invocation.go
@@ -90,21 +90,21 @@ func resourceInvocation() *schema.Resource {
 	}
 }
 
-func resourceInvocationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInvocationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
 	return append(diags, invoke(ctx, conn, d, invocationActionCreate)...)
 }
 
-func resourceInvocationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInvocationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
 	return append(diags, invoke(ctx, conn, d, invocationActionUpdate)...)
 }
 
-func resourceInvocationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceInvocationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -135,18 +135,18 @@ func buildInput(d *schema.ResourceData, action invocationAction) ([]byte, error)
 		return nil, err
 	}
 
-	newInputMap[d.Get("terraform_key").(string)] = map[string]interface{}{
+	newInputMap[d.Get("terraform_key").(string)] = map[string]any{
 		names.AttrAction: action,
 		"prev_input":     oldInputMap,
 	}
 	return json.Marshal(&newInputMap)
 }
 
-func getObjectFromJSONString(s string) (map[string]interface{}, error) {
+func getObjectFromJSONString(s string) (map[string]any, error) {
 	if len(s) == 0 {
 		return nil, nil
 	}
-	var mapObject map[string]interface{}
+	var mapObject map[string]any
 	if err := json.Unmarshal([]byte(s), &mapObject); err != nil {
 		log.Printf("[ERROR] input JSON deserialization '%s'", s)
 		return nil, err
@@ -155,7 +155,7 @@ func getObjectFromJSONString(s string) (map[string]interface{}, error) {
 }
 
 // getInputChange gets old an new input as maps
-func getInputChange(d *schema.ResourceData) (map[string]interface{}, map[string]interface{}, error) {
+func getInputChange(d *schema.ResourceData) (map[string]any, map[string]any, error) {
 	old, new := d.GetChange("input")
 	oldMap, err := getObjectFromJSONString(old.(string))
 	if err != nil {
@@ -213,7 +213,7 @@ func invoke(ctx context.Context, conn *lambda.Client, d *schema.ResourceData, ac
 
 // customizeDiffValidateInput validates that `input` is JSON object when
 // `lifecycle_scope` is not "CREATE_ONLY"
-func customizeDiffValidateInput(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func customizeDiffValidateInput(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if lifecycleScope(diff.Get("lifecycle_scope").(string)) == lifecycleScopeCreateOnly {
 		return nil
 	}
@@ -233,7 +233,7 @@ func customizeDiffValidateInput(_ context.Context, diff *schema.ResourceDiff, v 
 
 // customizeDiffInputChangeWithCreateOnlyScope forces a new resource when `input` has
 // a change and `lifecycle_scope` is set to "CREATE_ONLY"
-func customizeDiffInputChangeWithCreateOnlyScope(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func customizeDiffInputChangeWithCreateOnlyScope(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if diff.HasChange("input") && lifecycleScope(diff.Get("lifecycle_scope").(string)) == lifecycleScopeCreateOnly {
 		return diff.ForceNew("input")
 	}
@@ -242,7 +242,7 @@ func customizeDiffInputChangeWithCreateOnlyScope(_ context.Context, diff *schema
 
 // customizeDiffInputChangedWithCRUDScope invalidates the result of the previous invocation for any changes
 // to the input, causing any dependent resources to refresh their own state, when `lifecycle_scope` is set to "CRUD"
-func customizeDiffInputChangeWithCRUDScope(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func customizeDiffInputChangeWithCRUDScope(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if diff.HasChange("input") && lifecycleScope(diff.Get("lifecycle_scope").(string)) == lifecycleScopeCRUD {
 		return diff.SetNewComputed("result")
 	}

--- a/internal/service/lambda/invocation_data_source.go
+++ b/internal/service/lambda/invocation_data_source.go
@@ -46,7 +46,7 @@ func dataSourceInvocation() *schema.Resource {
 	}
 }
 
-func dataSourceInvocationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceInvocationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/invocation_migrate.go
+++ b/internal/service/lambda/invocation_migrate.go
@@ -63,9 +63,9 @@ func resourceInvocationConfigV0() *schema.Resource {
 // reasonably go back and patch the schemas for all versions in between,
 // we instead handle both pre-v5.1.0 and v5.1.0-v5.83.0 versions of the
 // previous state.
-func invocationStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func invocationStateUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
-		rawState = map[string]interface{}{}
+		rawState = map[string]any{}
 	}
 
 	// If upgrading from a version < v5.1.0, these values will be unset and

--- a/internal/service/lambda/layer_version.go
+++ b/internal/service/lambda/layer_version.go
@@ -151,7 +151,7 @@ func resourceLayerVersion() *schema.Resource {
 	}
 }
 
-func resourceLayerVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -217,7 +217,7 @@ func resourceLayerVersionCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceLayerVersionRead(ctx, d, meta)...)
 }
 
-func resourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -256,7 +256,7 @@ func resourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceLayerVersionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/layer_version_data_source.go
+++ b/internal/service/lambda/layer_version_data_source.go
@@ -105,7 +105,7 @@ func dataSourceLayerVersion() *schema.Resource {
 	}
 }
 
-func dataSourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLayerVersionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/layer_version_permission.go
+++ b/internal/service/lambda/layer_version_permission.go
@@ -96,7 +96,7 @@ func resourceLayerVersionPermission() *schema.Resource {
 	}
 }
 
-func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -127,7 +127,7 @@ func resourceLayerVersionPermissionCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceLayerVersionPermissionRead(ctx, d, meta)...)
 }
 
-func resourceLayerVersionPermissionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionPermissionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -209,7 +209,7 @@ func resourceLayerVersionPermissionRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceLayerVersionPermissionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLayerVersionPermissionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 

--- a/internal/service/lambda/permission_test.go
+++ b/internal/service/lambda/permission_test.go
@@ -47,7 +47,7 @@ func TestPermissionUnmarshalling(t *testing.T) {
 	}
 
 	expectedPrincipal := "events.amazonaws.com"
-	service := stmt.Principal.(map[string]interface{})["Service"]
+	service := stmt.Principal.(map[string]any)["Service"]
 	if service != expectedPrincipal {
 		t.Fatalf("Expected Principal to match (%q != %q)", service, expectedPrincipal)
 	}

--- a/internal/service/lambda/policy_model.go
+++ b/internal/service/lambda/policy_model.go
@@ -22,10 +22,10 @@ type IAMPolicyDoc struct {
 type IAMPolicyStatement struct {
 	Sid           string
 	Effect        string                         `json:",omitempty"`
-	Actions       interface{}                    `json:"Action,omitempty"`
-	NotActions    interface{}                    `json:"NotAction,omitempty"`
-	Resources     interface{}                    `json:"Resource,omitempty"`
-	NotResources  interface{}                    `json:"NotResource,omitempty"`
+	Actions       any                            `json:"Action,omitempty"`
+	NotActions    any                            `json:"NotAction,omitempty"`
+	Resources     any                            `json:"Resource,omitempty"`
+	NotResources  any                            `json:"NotResource,omitempty"`
 	Principals    IAMPolicyStatementPrincipalSet `json:"Principal,omitempty"`
 	NotPrincipals IAMPolicyStatementPrincipalSet `json:"NotPrincipal,omitempty"`
 	Conditions    IAMPolicyStatementConditionSet `json:"Condition,omitempty"`
@@ -33,13 +33,13 @@ type IAMPolicyStatement struct {
 
 type IAMPolicyStatementPrincipal struct {
 	Type        string
-	Identifiers interface{}
+	Identifiers any
 }
 
 type IAMPolicyStatementCondition struct {
 	Test     string
 	Variable string
-	Values   interface{}
+	Values   any
 }
 
 type IAMPolicyStatementPrincipalSet []IAMPolicyStatementPrincipal
@@ -78,7 +78,7 @@ func (s *IAMPolicyDoc) Merge(newDoc *IAMPolicyDoc) {
 }
 
 func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
-	raw := map[string]interface{}{}
+	raw := map[string]any{}
 
 	// Although IAM documentation says that "*" and {"AWS": "*"} are equivalent
 	// (https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html),
@@ -135,7 +135,7 @@ func (ps IAMPolicyStatementPrincipalSet) MarshalJSON() ([]byte, error) {
 func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 	var out IAMPolicyStatementPrincipalSet
 
-	var data interface{}
+	var data any
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
@@ -143,14 +143,14 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 	switch t := data.(type) {
 	case string:
 		out = append(out, IAMPolicyStatementPrincipal{Type: "*", Identifiers: []string{"*"}})
-	case map[string]interface{}:
-		for key, value := range data.(map[string]interface{}) {
+	case map[string]any:
+		for key, value := range data.(map[string]any) {
 			switch vt := value.(type) {
 			case string:
 				out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: value.(string)})
-			case []interface{}:
+			case []any:
 				values := []string{}
-				for _, v := range value.([]interface{}) {
+				for _, v := range value.([]any) {
 					values = append(values, v.(string))
 				}
 				out = append(out, IAMPolicyStatementPrincipal{Type: key, Identifiers: values})
@@ -167,11 +167,11 @@ func (ps *IAMPolicyStatementPrincipalSet) UnmarshalJSON(b []byte) error {
 }
 
 func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
-	raw := map[string]map[string]interface{}{}
+	raw := map[string]map[string]any{}
 
 	for _, c := range cs {
 		if _, ok := raw[c.Test]; !ok {
-			raw[c.Test] = map[string]interface{}{}
+			raw[c.Test] = map[string]any{}
 		}
 		switch i := c.Values.(type) {
 		case []string:
@@ -193,7 +193,7 @@ func (cs IAMPolicyStatementConditionSet) MarshalJSON() ([]byte, error) {
 func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 	var out IAMPolicyStatementConditionSet
 
-	var data map[string]map[string]interface{}
+	var data map[string]map[string]any
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func (cs *IAMPolicyStatementConditionSet) UnmarshalJSON(b []byte) error {
 			switch var_values := var_values.(type) {
 			case string:
 				out = append(out, IAMPolicyStatementCondition{Test: test_key, Variable: var_key, Values: []string{var_values}})
-			case []interface{}:
+			case []any:
 				values := []string{}
 				for _, v := range var_values {
 					values = append(values, v.(string))

--- a/internal/service/lambda/provisioned_concurrency_config.go
+++ b/internal/service/lambda/provisioned_concurrency_config.go
@@ -82,7 +82,7 @@ const (
 	provisionedConcurrencyConfigResourceIDPartCount = 2
 )
 
-func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -111,7 +111,7 @@ func resourceProvisionedConcurrencyConfigCreate(ctx context.Context, d *schema.R
 	return append(diags, resourceProvisionedConcurrencyConfigRead(ctx, d, meta)...)
 }
 
-func resourceProvisionedConcurrencyConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProvisionedConcurrencyConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -141,7 +141,7 @@ func resourceProvisionedConcurrencyConfigRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -171,7 +171,7 @@ func resourceProvisionedConcurrencyConfigUpdate(ctx context.Context, d *schema.R
 	return append(diags, resourceProvisionedConcurrencyConfigRead(ctx, d, meta)...)
 }
 
-func resourceProvisionedConcurrencyConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceProvisionedConcurrencyConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).LambdaClient(ctx)
 
@@ -235,7 +235,7 @@ func findProvisionedConcurrencyConfigByTwoPartKey(ctx context.Context, conn *lam
 }
 
 func statusProvisionedConcurrencyConfig(ctx context.Context, conn *lambda.Client, functionName, qualifier string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findProvisionedConcurrencyConfigByTwoPartKey(ctx, conn, functionName, qualifier)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/lambda/provisioned_concurrency_config_migrate.go
+++ b/internal/service/lambda/provisioned_concurrency_config_migrate.go
@@ -42,9 +42,9 @@ func resourceProvisionedConcurrencyConfigV0() *schema.Resource {
 	}
 }
 
-func provisionedConcurrencyConfigStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func provisionedConcurrencyConfigStateUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
-		rawState = map[string]interface{}{}
+		rawState = map[string]any{}
 	}
 
 	// Convert id separator from ":" to ","


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
