### PR TITLE
batch: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -77,6 +77,7 @@ jobs:
       # Services
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/appmesh modern-check
+      - run: make TEST=./internal/service/batch modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/elbv2 modern-check

--- a/internal/service/batch/compute_environment.go
+++ b/internal/service/batch/compute_environment.go
@@ -274,7 +274,7 @@ func resourceComputeEnvironment() *schema.Resource {
 	}
 }
 
-func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -287,12 +287,12 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 		Type:                   computeEnvironmentType,
 	}
 
-	if v, ok := d.GetOk("compute_resources"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ComputeResources = expandComputeResource(ctx, v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("compute_resources"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ComputeResources = expandComputeResource(ctx, v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("eks_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.EksConfiguration = expandEKSConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("eks_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.EksConfiguration = expandEKSConfiguration(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrState); ok {
@@ -312,10 +312,10 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 	}
 
 	// UpdatePolicy is not possible to set with CreateComputeEnvironment
-	if v, ok := d.GetOk("update_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+	if v, ok := d.GetOk("update_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input := &batch.UpdateComputeEnvironmentInput{
 			ComputeEnvironment: aws.String(d.Id()),
-			UpdatePolicy:       expandComputeEnvironmentUpdatePolicy(v.([]interface{})),
+			UpdatePolicy:       expandComputeEnvironmentUpdatePolicy(v.([]any)),
 		}
 
 		_, err := conn.UpdateComputeEnvironment(ctx, input)
@@ -332,7 +332,7 @@ func resourceComputeEnvironmentCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceComputeEnvironmentRead(ctx, d, meta)...)
 }
 
-func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -352,7 +352,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	d.Set("compute_environment_name", computeEnvironment.ComputeEnvironmentName)
 	d.Set("compute_environment_name_prefix", create.NamePrefixFromName(aws.ToString(computeEnvironment.ComputeEnvironmentName)))
 	if computeEnvironment.ComputeResources != nil {
-		if err := d.Set("compute_resources", []interface{}{flattenComputeResource(ctx, computeEnvironment.ComputeResources)}); err != nil {
+		if err := d.Set("compute_resources", []any{flattenComputeResource(ctx, computeEnvironment.ComputeResources)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting compute_resources: %s", err)
 		}
 	} else {
@@ -360,7 +360,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	}
 	d.Set("ecs_cluster_arn", computeEnvironment.EcsClusterArn)
 	if computeEnvironment.EksConfiguration != nil {
-		if err := d.Set("eks_configuration", []interface{}{flattenEKSConfiguration(computeEnvironment.EksConfiguration)}); err != nil {
+		if err := d.Set("eks_configuration", []any{flattenEKSConfiguration(computeEnvironment.EksConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting eks_configuration: %s", err)
 		}
 	} else {
@@ -380,7 +380,7 @@ func resourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -398,7 +398,7 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 		}
 
 		if d.HasChange("update_policy") {
-			input.UpdatePolicy = expandComputeEnvironmentUpdatePolicy(d.Get("update_policy").([]interface{}))
+			input.UpdatePolicy = expandComputeEnvironmentUpdatePolicy(d.Get("update_policy").([]any))
 		}
 
 		if computeEnvironmentType := strings.ToUpper(d.Get(names.AttrType).(string)); computeEnvironmentType == string(awstypes.CETypeManaged) {
@@ -459,7 +459,7 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 					if _, ok := d.GetOk("eks_configuration.#"); ok {
 						defaultImageType = "EKS_AL2"
 					}
-					ec2Configuration := d.Get("compute_resources.0.ec2_configuration").([]interface{})
+					ec2Configuration := d.Get("compute_resources.0.ec2_configuration").([]any)
 					computeResourceUpdate.Ec2Configuration = expandEC2ConfigurationsUpdate(ec2Configuration, defaultImageType)
 				}
 
@@ -492,13 +492,13 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 				}
 
 				if d.HasChange("compute_resources.0.launch_template") {
-					launchTemplate := d.Get("compute_resources.0.launch_template").([]interface{})
+					launchTemplate := d.Get("compute_resources.0.launch_template").([]any)
 					computeResourceUpdate.LaunchTemplate = expandLaunchTemplateSpecificationUpdate(launchTemplate)
 				}
 
 				if d.HasChange("compute_resources.0.tags") {
 					if tags, ok := d.GetOk("compute_resources.0.tags"); ok {
-						computeResourceUpdate.Tags = Tags(tftags.New(ctx, tags.(map[string]interface{})).IgnoreAWS())
+						computeResourceUpdate.Tags = Tags(tftags.New(ctx, tags.(map[string]any)).IgnoreAWS())
 					} else {
 						computeResourceUpdate.Tags = map[string]string{}
 					}
@@ -522,7 +522,7 @@ func resourceComputeEnvironmentUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceComputeEnvironmentRead(ctx, d, meta)...)
 }
 
-func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -562,10 +562,10 @@ func resourceComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceComputeEnvironmentCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 	if computeEnvironmentType := strings.ToUpper(diff.Get(names.AttrType).(string)); computeEnvironmentType == string(awstypes.CETypeUnmanaged) {
 		// UNMANAGED compute environments can have no compute_resources configured.
-		if v, ok := diff.GetOk("compute_resources"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		if v, ok := diff.GetOk("compute_resources"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			return fmt.Errorf("no `compute_resources` can be specified when `type` is %q", computeEnvironmentType)
 		}
 	}
@@ -726,7 +726,7 @@ func findComputeEnvironmentDetails(ctx context.Context, conn *batch.Client, inpu
 }
 
 func statusComputeEnvironment(ctx context.Context, conn *batch.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findComputeEnvironmentDetailByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -859,7 +859,7 @@ func isUpdatableAllocationStrategy(allocationStrategy awstypes.CRAllocationStrat
 	return allocationStrategy == awstypes.CRAllocationStrategyBestFitProgressive || allocationStrategy == awstypes.CRAllocationStrategySpotCapacityOptimized
 }
 
-func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *awstypes.ComputeResource {
+func expandComputeResource(ctx context.Context, tfMap map[string]any) *awstypes.ComputeResource {
 	if tfMap == nil {
 		return nil
 	}
@@ -884,7 +884,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *a
 		apiObject.DesiredvCpus = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["ec2_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["ec2_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.Ec2Configuration = expandEC2Configurations(v)
 	}
 
@@ -904,8 +904,8 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *a
 		apiObject.InstanceTypes = flex.ExpandStringValueSet(v)
 	}
 
-	if v, ok := tfMap[names.AttrLaunchTemplate].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.LaunchTemplate = expandLaunchTemplateSpecification(v[0].(map[string]interface{}))
+	if v, ok := tfMap[names.AttrLaunchTemplate].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.LaunchTemplate = expandLaunchTemplateSpecification(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["max_vcpus"].(int); ok && v != 0 {
@@ -934,7 +934,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *a
 		apiObject.Subnets = flex.ExpandStringValueSet(v)
 	}
 
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok && len(v) > 0 {
 		apiObject.Tags = Tags(tftags.New(ctx, v).IgnoreAWS())
 	}
 
@@ -945,7 +945,7 @@ func expandComputeResource(ctx context.Context, tfMap map[string]interface{}) *a
 	return apiObject
 }
 
-func expandEKSConfiguration(tfMap map[string]interface{}) *awstypes.EksConfiguration {
+func expandEKSConfiguration(tfMap map[string]any) *awstypes.EksConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -963,7 +963,7 @@ func expandEKSConfiguration(tfMap map[string]interface{}) *awstypes.EksConfigura
 	return apiObject
 }
 
-func expandEC2Configuration(tfMap map[string]interface{}) *awstypes.Ec2Configuration {
+func expandEC2Configuration(tfMap map[string]any) *awstypes.Ec2Configuration {
 	if tfMap == nil {
 		return nil
 	}
@@ -981,7 +981,7 @@ func expandEC2Configuration(tfMap map[string]interface{}) *awstypes.Ec2Configura
 	return apiObject
 }
 
-func expandEC2Configurations(tfList []interface{}) []awstypes.Ec2Configuration {
+func expandEC2Configurations(tfList []any) []awstypes.Ec2Configuration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -989,7 +989,7 @@ func expandEC2Configurations(tfList []interface{}) []awstypes.Ec2Configuration {
 	var apiObjects []awstypes.Ec2Configuration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1006,7 +1006,7 @@ func expandEC2Configurations(tfList []interface{}) []awstypes.Ec2Configuration {
 	return apiObjects
 }
 
-func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *awstypes.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecification(tfMap map[string]any) *awstypes.LaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -1028,7 +1028,7 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *awstypes.L
 	return apiObject
 }
 
-func expandEC2ConfigurationsUpdate(tfList []interface{}, defaultImageType string) []awstypes.Ec2Configuration {
+func expandEC2ConfigurationsUpdate(tfList []any, defaultImageType string) []awstypes.Ec2Configuration {
 	if len(tfList) == 0 {
 		return []awstypes.Ec2Configuration{
 			{
@@ -1040,7 +1040,7 @@ func expandEC2ConfigurationsUpdate(tfList []interface{}, defaultImageType string
 	var apiObjects []awstypes.Ec2Configuration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1057,7 +1057,7 @@ func expandEC2ConfigurationsUpdate(tfList []interface{}, defaultImageType string
 	return apiObjects
 }
 
-func expandLaunchTemplateSpecificationUpdate(tfList []interface{}) *awstypes.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecificationUpdate(tfList []any) *awstypes.LaunchTemplateSpecification {
 	if len(tfList) == 0 || tfList[0] == nil {
 		// delete any existing launch template configuration
 		return &awstypes.LaunchTemplateSpecification{
@@ -1065,7 +1065,7 @@ func expandLaunchTemplateSpecificationUpdate(tfList []interface{}) *awstypes.Lau
 		}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.LaunchTemplateSpecification{}
 
 	if v, ok := tfMap["launch_template_id"].(string); ok && v != "" {
@@ -1085,12 +1085,12 @@ func expandLaunchTemplateSpecificationUpdate(tfList []interface{}) *awstypes.Lau
 	return apiObject
 }
 
-func flattenComputeResource(ctx context.Context, apiObject *awstypes.ComputeResource) map[string]interface{} {
+func flattenComputeResource(ctx context.Context, apiObject *awstypes.ComputeResource) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"allocation_strategy": apiObject.AllocationStrategy,
 		names.AttrType:        apiObject.Type,
 	}
@@ -1124,7 +1124,7 @@ func flattenComputeResource(ctx context.Context, apiObject *awstypes.ComputeReso
 	}
 
 	if v := apiObject.LaunchTemplate; v != nil {
-		tfMap[names.AttrLaunchTemplate] = []interface{}{flattenLaunchTemplateSpecification(v)}
+		tfMap[names.AttrLaunchTemplate] = []any{flattenLaunchTemplateSpecification(v)}
 	}
 
 	if v := apiObject.MaxvCpus; v != nil {
@@ -1158,12 +1158,12 @@ func flattenComputeResource(ctx context.Context, apiObject *awstypes.ComputeReso
 	return tfMap
 }
 
-func flattenEKSConfiguration(apiObject *awstypes.EksConfiguration) map[string]interface{} {
+func flattenEKSConfiguration(apiObject *awstypes.EksConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.EksClusterArn; v != nil {
 		tfMap["eks_cluster_arn"] = aws.ToString(v)
@@ -1176,12 +1176,12 @@ func flattenEKSConfiguration(apiObject *awstypes.EksConfiguration) map[string]in
 	return tfMap
 }
 
-func flattenEC2Configuration(apiObject *awstypes.Ec2Configuration) map[string]interface{} {
+func flattenEC2Configuration(apiObject *awstypes.Ec2Configuration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ImageIdOverride; v != nil {
 		tfMap["image_id_override"] = aws.ToString(v)
@@ -1194,12 +1194,12 @@ func flattenEC2Configuration(apiObject *awstypes.Ec2Configuration) map[string]in
 	return tfMap
 }
 
-func flattenEC2Configurations(apiObjects []awstypes.Ec2Configuration) []interface{} {
+func flattenEC2Configurations(apiObjects []awstypes.Ec2Configuration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenEC2Configuration(&apiObject))
@@ -1208,12 +1208,12 @@ func flattenEC2Configurations(apiObjects []awstypes.Ec2Configuration) []interfac
 	return tfList
 }
 
-func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecification) map[string]interface{} {
+func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateId; v != nil {
 		tfMap["launch_template_id"] = aws.ToString(v)
@@ -1230,12 +1230,12 @@ func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecif
 	return tfMap
 }
 
-func expandComputeEnvironmentUpdatePolicy(tfList []interface{}) *awstypes.UpdatePolicy {
+func expandComputeEnvironmentUpdatePolicy(tfList []any) *awstypes.UpdatePolicy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	apiObject := &awstypes.UpdatePolicy{
 		JobExecutionTimeoutMinutes: aws.Int64(int64(tfMap["job_execution_timeout_minutes"].(int))),
@@ -1245,15 +1245,15 @@ func expandComputeEnvironmentUpdatePolicy(tfList []interface{}) *awstypes.Update
 	return apiObject
 }
 
-func flattenComputeEnvironmentUpdatePolicy(apiObject *awstypes.UpdatePolicy) []interface{} {
+func flattenComputeEnvironmentUpdatePolicy(apiObject *awstypes.UpdatePolicy) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"job_execution_timeout_minutes": aws.ToInt64(apiObject.JobExecutionTimeoutMinutes),
 		"terminate_jobs_on_update":      aws.ToBool(apiObject.TerminateJobsOnUpdate),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/batch/compute_environment_data_source.go
+++ b/internal/service/batch/compute_environment_data_source.go
@@ -76,7 +76,7 @@ func dataSourceComputeEnvironment() *schema.Resource {
 	}
 }
 
-func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceComputeEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 

--- a/internal/service/batch/compute_environment_test.go
+++ b/internal/service/batch/compute_environment_test.go
@@ -29,11 +29,11 @@ func TestExpandEC2ConfigurationsUpdate(t *testing.T) {
 
 	//lintignore:AWSAT002
 	testCases := []struct {
-		flattened []interface{}
+		flattened []any
 		expected  []awstypes.Ec2Configuration
 	}{
 		{
-			flattened: []interface{}{},
+			flattened: []any{},
 			expected: []awstypes.Ec2Configuration{
 				{
 					ImageType: aws.String("default"),
@@ -41,8 +41,8 @@ func TestExpandEC2ConfigurationsUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"image_type": "ECS_AL1",
 				},
 			},
@@ -53,8 +53,8 @@ func TestExpandEC2ConfigurationsUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"image_id_override": "ami-deadbeef",
 				},
 			},
@@ -65,8 +65,8 @@ func TestExpandEC2ConfigurationsUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"image_id_override": "ami-deadbeef",
 					"image_type":        "ECS_AL1",
 				},
@@ -96,18 +96,18 @@ func TestExpandLaunchTemplateSpecificationUpdate(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		flattened []interface{}
+		flattened []any
 		expected  *awstypes.LaunchTemplateSpecification
 	}{
 		{
-			flattened: []interface{}{},
+			flattened: []any{},
 			expected: &awstypes.LaunchTemplateSpecification{
 				LaunchTemplateId: aws.String(""),
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"launch_template_id": "lt-123456",
 				},
 			},
@@ -117,8 +117,8 @@ func TestExpandLaunchTemplateSpecificationUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"launch_template_name": "my-launch-template",
 				},
 			},
@@ -128,8 +128,8 @@ func TestExpandLaunchTemplateSpecificationUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"launch_template_id": "lt-123456",
 					names.AttrVersion:    "$LATEST",
 				},
@@ -140,8 +140,8 @@ func TestExpandLaunchTemplateSpecificationUpdate(t *testing.T) {
 			},
 		},
 		{
-			flattened: []interface{}{
-				map[string]interface{}{
+			flattened: []any{
+				map[string]any{
 					"launch_template_name": "my-launch-template",
 					names.AttrVersion:      "$LATEST",
 				},

--- a/internal/service/batch/job_definition.go
+++ b/internal/service/batch/job_definition.go
@@ -58,7 +58,7 @@ func resourceJobDefinition() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"ecs_properties", "eks_properties", "node_properties"},
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -78,7 +78,7 @@ func resourceJobDefinition() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"container_properties", "eks_properties", "node_properties"},
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -456,7 +456,7 @@ func resourceJobDefinition() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"container_properties", "ecs_properties", "eks_properties"},
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -575,7 +575,7 @@ func resourceJobDefinition() *schema.Resource {
 	}
 }
 
-func jobDefinitionCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func jobDefinitionCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	if d.Id() != "" && needsJobDefUpdate(d) && d.Get(names.AttrARN).(string) != "" {
 		d.SetNewComputed(names.AttrARN)
 		d.SetNewComputed("revision")
@@ -635,7 +635,7 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 
 	if d.HasChange("eks_properties") {
 		o, n := d.GetChange("eks_properties")
-		if len(o.([]interface{})) == 0 && len(n.([]interface{})) == 0 {
+		if len(o.([]any)) == 0 && len(n.([]any)) == 0 {
 			return false
 		}
 
@@ -644,17 +644,17 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 		}
 
 		var oeks, neks *awstypes.EksPodProperties
-		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
-			oProps := o.([]interface{})[0].(map[string]interface{})
-			if opodProps, ok := oProps["pod_properties"].([]interface{}); ok && len(opodProps) > 0 {
-				oeks = expandEKSPodProperties(opodProps[0].(map[string]interface{}))
+		if len(o.([]any)) > 0 && o.([]any)[0] != nil {
+			oProps := o.([]any)[0].(map[string]any)
+			if opodProps, ok := oProps["pod_properties"].([]any); ok && len(opodProps) > 0 {
+				oeks = expandEKSPodProperties(opodProps[0].(map[string]any))
 			}
 		}
 
-		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
-			nProps := n.([]interface{})[0].(map[string]interface{})
-			if npodProps, ok := nProps["pod_properties"].([]interface{}); ok && len(npodProps) > 0 {
-				neks = expandEKSPodProperties(npodProps[0].(map[string]interface{}))
+		if len(n.([]any)) > 0 && n.([]any)[0] != nil {
+			nProps := n.([]any)[0].(map[string]any)
+			if npodProps, ok := nProps["pod_properties"].([]any); ok && len(npodProps) > 0 {
+				neks = expandEKSPodProperties(npodProps[0].(map[string]any))
 			}
 		}
 
@@ -663,18 +663,18 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 
 	if d.HasChange("retry_strategy") {
 		o, n := d.GetChange("retry_strategy")
-		if len(o.([]interface{})) == 0 && len(n.([]interface{})) == 0 {
+		if len(o.([]any)) == 0 && len(n.([]any)) == 0 {
 			return false
 		}
 
 		var ors, nrs *awstypes.RetryStrategy
-		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
-			oProps := o.([]interface{})[0].(map[string]interface{})
+		if len(o.([]any)) > 0 && o.([]any)[0] != nil {
+			oProps := o.([]any)[0].(map[string]any)
 			ors = expandRetryStrategy(oProps)
 		}
 
-		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
-			nProps := n.([]interface{})[0].(map[string]interface{})
+		if len(n.([]any)) > 0 && n.([]any)[0] != nil {
+			nProps := n.([]any)[0].(map[string]any)
 			nrs = expandRetryStrategy(nProps)
 		}
 
@@ -683,18 +683,18 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 
 	if d.HasChange(names.AttrTimeout) {
 		o, n := d.GetChange(names.AttrTimeout)
-		if len(o.([]interface{})) == 0 && len(n.([]interface{})) == 0 {
+		if len(o.([]any)) == 0 && len(n.([]any)) == 0 {
 			return false
 		}
 
 		var ors, nrs *awstypes.JobTimeout
-		if len(o.([]interface{})) > 0 && o.([]interface{})[0] != nil {
-			oProps := o.([]interface{})[0].(map[string]interface{})
+		if len(o.([]any)) > 0 && o.([]any)[0] != nil {
+			oProps := o.([]any)[0].(map[string]any)
 			ors = expandJobTimeout(oProps)
 		}
 
-		if len(n.([]interface{})) > 0 && n.([]interface{})[0] != nil {
-			nProps := n.([]interface{})[0].(map[string]interface{})
+		if len(n.([]any)) > 0 && n.([]any)[0] != nil {
+			nProps := n.([]any)[0].(map[string]any)
 			nrs = expandJobTimeout(nProps)
 		}
 
@@ -714,7 +714,7 @@ func needsJobDefUpdate(d *schema.ResourceDiff) bool {
 	return false
 }
 
-func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -757,10 +757,10 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 			input.EcsProperties = props
 		}
 
-		if v, ok := d.GetOk("eks_properties"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			eksProps := v.([]interface{})[0].(map[string]interface{})
-			if podProps, ok := eksProps["pod_properties"].([]interface{}); ok && len(podProps) > 0 {
-				props := expandEKSPodProperties(podProps[0].(map[string]interface{}))
+		if v, ok := d.GetOk("eks_properties"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			eksProps := v.([]any)[0].(map[string]any)
+			if podProps, ok := eksProps["pod_properties"].([]any); ok && len(podProps) > 0 {
+				props := expandEKSPodProperties(podProps[0].(map[string]any))
 				input.EksProperties = &awstypes.EksProperties{
 					PodProperties: props,
 				}
@@ -794,23 +794,23 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if v, ok := d.GetOk(names.AttrParameters); ok {
-		input.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("platform_capabilities"); ok && v.(*schema.Set).Len() > 0 {
 		input.PlatformCapabilities = flex.ExpandStringyValueSet[awstypes.PlatformCapability](v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("retry_strategy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.RetryStrategy = expandRetryStrategy(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("retry_strategy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.RetryStrategy = expandRetryStrategy(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("scheduling_priority"); ok {
 		input.SchedulingPriority = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk(names.AttrTimeout); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Timeout = expandJobTimeout(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk(names.AttrTimeout); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Timeout = expandJobTimeout(v.([]any)[0].(map[string]any))
 	}
 
 	output, err := conn.RegisterJobDefinition(ctx, input)
@@ -824,7 +824,7 @@ func resourceJobDefinitionCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceJobDefinitionRead(ctx, d, meta)...)
 }
 
-func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -868,7 +868,7 @@ func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("platform_capabilities", jobDefinition.PlatformCapabilities)
 	d.Set(names.AttrPropagateTags, jobDefinition.PropagateTags)
 	if jobDefinition.RetryStrategy != nil {
-		if err := d.Set("retry_strategy", []interface{}{flattenRetryStrategy(jobDefinition.RetryStrategy)}); err != nil {
+		if err := d.Set("retry_strategy", []any{flattenRetryStrategy(jobDefinition.RetryStrategy)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting retry_strategy: %s", err)
 		}
 	} else {
@@ -877,7 +877,7 @@ func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("revision", revision)
 	d.Set("scheduling_priority", jobDefinition.SchedulingPriority)
 	if jobDefinition.Timeout != nil {
-		if err := d.Set(names.AttrTimeout, []interface{}{flattenJobTimeout(jobDefinition.Timeout)}); err != nil {
+		if err := d.Set(names.AttrTimeout, []any{flattenJobTimeout(jobDefinition.Timeout)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting timeout: %s", err)
 		}
 	} else {
@@ -890,7 +890,7 @@ func resourceJobDefinitionRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -930,9 +930,9 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 			}
 
 			if v, ok := d.GetOk("eks_properties"); ok {
-				eksProps := v.([]interface{})[0].(map[string]interface{})
-				if podProps, ok := eksProps["pod_properties"].([]interface{}); ok && len(podProps) > 0 {
-					props := expandEKSPodProperties(podProps[0].(map[string]interface{}))
+				eksProps := v.([]any)[0].(map[string]any)
+				if podProps, ok := eksProps["pod_properties"].([]any); ok && len(podProps) > 0 {
+					props := expandEKSPodProperties(podProps[0].(map[string]any))
 					input.EksProperties = &awstypes.EksProperties{
 						PodProperties: props,
 					}
@@ -954,7 +954,7 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		if v, ok := d.GetOk(names.AttrParameters); ok {
-			input.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+			input.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 		}
 
 		if v, ok := d.GetOk("platform_capabilities"); ok && v.(*schema.Set).Len() > 0 {
@@ -965,16 +965,16 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 			input.PropagateTags = aws.Bool(v.(bool))
 		}
 
-		if v, ok := d.GetOk("retry_strategy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.RetryStrategy = expandRetryStrategy(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("retry_strategy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.RetryStrategy = expandRetryStrategy(v.([]any)[0].(map[string]any))
 		}
 
 		if v, ok := d.GetOk("scheduling_priority"); ok {
 			input.SchedulingPriority = aws.Int32(int32(v.(int)))
 		}
 
-		if v, ok := d.GetOk(names.AttrTimeout); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.Timeout = expandJobTimeout(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk(names.AttrTimeout); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.Timeout = expandJobTimeout(v.([]any)[0].(map[string]any))
 		}
 
 		jd, err := conn.RegisterJobDefinition(ctx, input)
@@ -1006,7 +1006,7 @@ func resourceJobDefinitionUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceJobDefinitionRead(ctx, d, meta)...)
 }
 
-func resourceJobDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceJobDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -1090,7 +1090,7 @@ func findJobDefinitions(ctx context.Context, conn *batch.Client, input *batch.De
 	return output, nil
 }
 
-func validJobContainerProperties(v interface{}, k string) (ws []string, errors []error) {
+func validJobContainerProperties(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := expandContainerProperties(value)
 	if err != nil {
@@ -1099,7 +1099,7 @@ func validJobContainerProperties(v interface{}, k string) (ws []string, errors [
 	return
 }
 
-func validJobECSProperties(v interface{}, k string) (ws []string, errors []error) {
+func validJobECSProperties(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := expandECSProperties(value)
 	if err != nil {
@@ -1108,7 +1108,7 @@ func validJobECSProperties(v interface{}, k string) (ws []string, errors []error
 	return
 }
 
-func validJobNodeProperties(v interface{}, k string) (ws []string, errors []error) {
+func validJobNodeProperties(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := expandJobNodeProperties(value)
 	if err != nil {
@@ -1117,7 +1117,7 @@ func validJobNodeProperties(v interface{}, k string) (ws []string, errors []erro
 	return
 }
 
-func expandRetryStrategy(tfMap map[string]interface{}) *awstypes.RetryStrategy {
+func expandRetryStrategy(tfMap map[string]any) *awstypes.RetryStrategy {
 	if tfMap == nil {
 		return nil
 	}
@@ -1128,14 +1128,14 @@ func expandRetryStrategy(tfMap map[string]interface{}) *awstypes.RetryStrategy {
 		apiObject.Attempts = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["evaluate_on_exit"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["evaluate_on_exit"].([]any); ok && len(v) > 0 {
 		apiObject.EvaluateOnExit = expandEvaluateOnExits(v)
 	}
 
 	return apiObject
 }
 
-func expandEvaluateOnExit(tfMap map[string]interface{}) *awstypes.EvaluateOnExit {
+func expandEvaluateOnExit(tfMap map[string]any) *awstypes.EvaluateOnExit {
 	if tfMap == nil {
 		return nil
 	}
@@ -1161,7 +1161,7 @@ func expandEvaluateOnExit(tfMap map[string]interface{}) *awstypes.EvaluateOnExit
 	return apiObject
 }
 
-func expandEvaluateOnExits(tfList []interface{}) []awstypes.EvaluateOnExit {
+func expandEvaluateOnExits(tfList []any) []awstypes.EvaluateOnExit {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1169,7 +1169,7 @@ func expandEvaluateOnExits(tfList []interface{}) []awstypes.EvaluateOnExit {
 	var apiObjects []awstypes.EvaluateOnExit
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1186,12 +1186,12 @@ func expandEvaluateOnExits(tfList []interface{}) []awstypes.EvaluateOnExit {
 	return apiObjects
 }
 
-func flattenRetryStrategy(apiObject *awstypes.RetryStrategy) map[string]interface{} {
+func flattenRetryStrategy(apiObject *awstypes.RetryStrategy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Attempts; v != nil {
 		tfMap["attempts"] = aws.ToInt32(v)
@@ -1204,12 +1204,12 @@ func flattenRetryStrategy(apiObject *awstypes.RetryStrategy) map[string]interfac
 	return tfMap
 }
 
-func flattenEvaluateOnExit(apiObject *awstypes.EvaluateOnExit) map[string]interface{} {
+func flattenEvaluateOnExit(apiObject *awstypes.EvaluateOnExit) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrAction: apiObject.Action,
 	}
 
@@ -1228,12 +1228,12 @@ func flattenEvaluateOnExit(apiObject *awstypes.EvaluateOnExit) map[string]interf
 	return tfMap
 }
 
-func flattenEvaluateOnExits(apiObjects []awstypes.EvaluateOnExit) []interface{} {
+func flattenEvaluateOnExits(apiObjects []awstypes.EvaluateOnExit) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenEvaluateOnExit(&apiObject))
@@ -1242,7 +1242,7 @@ func flattenEvaluateOnExits(apiObjects []awstypes.EvaluateOnExit) []interface{} 
 	return tfList
 }
 
-func expandJobTimeout(tfMap map[string]interface{}) *awstypes.JobTimeout {
+func expandJobTimeout(tfMap map[string]any) *awstypes.JobTimeout {
 	if tfMap == nil {
 		return nil
 	}
@@ -1256,12 +1256,12 @@ func expandJobTimeout(tfMap map[string]interface{}) *awstypes.JobTimeout {
 	return apiObject
 }
 
-func flattenJobTimeout(apiObject *awstypes.JobTimeout) map[string]interface{} {
+func flattenJobTimeout(apiObject *awstypes.JobTimeout) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AttemptDurationSeconds; v != nil {
 		tfMap["attempt_duration_seconds"] = aws.ToInt32(v)
@@ -1286,11 +1286,11 @@ func removeEmptyEnvironmentVariables(environment []awstypes.KeyValuePair, attrib
 	return diags
 }
 
-func expandEKSPodProperties(tfMap map[string]interface{}) *awstypes.EksPodProperties {
+func expandEKSPodProperties(tfMap map[string]any) *awstypes.EksPodProperties {
 	apiObject := &awstypes.EksPodProperties{}
 
 	if v, ok := tfMap["containers"]; ok {
-		apiObject.Containers = expandContainers(v.([]interface{}))
+		apiObject.Containers = expandContainers(v.([]any))
 	}
 
 	if v, ok := tfMap["dns_policy"].(string); ok && v != "" {
@@ -1302,17 +1302,17 @@ func expandEKSPodProperties(tfMap map[string]interface{}) *awstypes.EksPodProper
 	}
 
 	if v, ok := tfMap["image_pull_secret"]; ok {
-		apiObject.ImagePullSecrets = expandImagePullSecrets(v.([]interface{}))
+		apiObject.ImagePullSecrets = expandImagePullSecrets(v.([]any))
 	}
 
 	if v, ok := tfMap["init_containers"]; ok {
-		apiObject.InitContainers = expandContainers(v.([]interface{}))
+		apiObject.InitContainers = expandContainers(v.([]any))
 	}
 
-	if v, ok := tfMap["metadata"].([]interface{}); ok && len(v) > 0 {
-		if v, ok := v[0].(map[string]interface{})["labels"]; ok {
+	if v, ok := tfMap["metadata"].([]any); ok && len(v) > 0 {
+		if v, ok := v[0].(map[string]any)["labels"]; ok {
 			apiObject.Metadata = &awstypes.EksMetadata{
-				Labels: flex.ExpandStringValueMap(v.(map[string]interface{})),
+				Labels: flex.ExpandStringValueMap(v.(map[string]any)),
 			}
 		}
 	}
@@ -1326,25 +1326,25 @@ func expandEKSPodProperties(tfMap map[string]interface{}) *awstypes.EksPodProper
 	}
 
 	if v, ok := tfMap["volumes"]; ok {
-		apiObject.Volumes = expandVolumes(v.([]interface{}))
+		apiObject.Volumes = expandVolumes(v.([]any))
 	}
 
 	return apiObject
 }
 
-func expandContainers(tfList []interface{}) []awstypes.EksContainer {
+func expandContainers(tfList []any) []awstypes.EksContainer {
 	var apiObjects []awstypes.EksContainer
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.EksContainer{}
 
 		if v, ok := tfMap["args"]; ok {
-			apiObject.Args = flex.ExpandStringValueList(v.([]interface{}))
+			apiObject.Args = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := tfMap["command"]; ok {
-			apiObject.Command = flex.ExpandStringValueList(v.([]interface{}))
+			apiObject.Command = flex.ExpandStringValueList(v.([]any))
 		}
 
 		if v, ok := tfMap["env"].(*schema.Set); ok && v.Len() > 0 {
@@ -1352,7 +1352,7 @@ func expandContainers(tfList []interface{}) []awstypes.EksContainer {
 
 			for _, tfMapRaw := range v.List() {
 				apiObject := awstypes.EksContainerEnvironmentVariable{}
-				tfMap := tfMapRaw.(map[string]interface{})
+				tfMap := tfMapRaw.(map[string]any)
 
 				if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
 					apiObject.Name = aws.String(v)
@@ -1380,24 +1380,24 @@ func expandContainers(tfList []interface{}) []awstypes.EksContainer {
 			apiObject.Name = aws.String(v)
 		}
 
-		if v, ok := tfMap[names.AttrResources].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap[names.AttrResources].([]any); ok && len(v) > 0 {
 			resources := &awstypes.EksContainerResourceRequirements{}
-			tfMap := v[0].(map[string]interface{})
+			tfMap := v[0].(map[string]any)
 
 			if v, ok := tfMap["limits"]; ok {
-				resources.Limits = flex.ExpandStringValueMap(v.(map[string]interface{}))
+				resources.Limits = flex.ExpandStringValueMap(v.(map[string]any))
 			}
 
 			if v, ok := tfMap["requests"]; ok {
-				resources.Requests = flex.ExpandStringValueMap(v.(map[string]interface{}))
+				resources.Requests = flex.ExpandStringValueMap(v.(map[string]any))
 			}
 
 			apiObject.Resources = resources
 		}
 
-		if v, ok := tfMap["security_context"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["security_context"].([]any); ok && len(v) > 0 {
 			securityContext := &awstypes.EksContainerSecurityContext{}
-			tfMap := v[0].(map[string]interface{})
+			tfMap := v[0].(map[string]any)
 
 			if v, ok := tfMap["privileged"]; ok {
 				securityContext.Privileged = aws.Bool(v.(bool))
@@ -1423,7 +1423,7 @@ func expandContainers(tfList []interface{}) []awstypes.EksContainer {
 		}
 
 		if v, ok := tfMap["volume_mounts"]; ok {
-			apiObject.VolumeMounts = expandVolumeMounts(v.([]interface{}))
+			apiObject.VolumeMounts = expandVolumeMounts(v.([]any))
 		}
 
 		apiObjects = append(apiObjects, apiObject)
@@ -1432,12 +1432,12 @@ func expandContainers(tfList []interface{}) []awstypes.EksContainer {
 	return apiObjects
 }
 
-func expandImagePullSecrets(tfList []interface{}) []awstypes.ImagePullSecret {
+func expandImagePullSecrets(tfList []any) []awstypes.ImagePullSecret {
 	var apiObjects []awstypes.ImagePullSecret
 
 	for _, tfMapRaw := range tfList {
 		apiObject := awstypes.ImagePullSecret{}
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		if v, ok := tfMap[names.AttrName].(string); ok {
 			apiObject.Name = aws.String(v)
@@ -1448,15 +1448,15 @@ func expandImagePullSecrets(tfList []interface{}) []awstypes.ImagePullSecret {
 	return apiObjects
 }
 
-func expandVolumes(tfList []interface{}) []awstypes.EksVolume {
+func expandVolumes(tfList []any) []awstypes.EksVolume {
 	var apiObjects []awstypes.EksVolume
 
 	for _, tfMapRaw := range tfList {
 		apiObject := awstypes.EksVolume{}
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
-		if v, ok := tfMap["empty_dir"].([]interface{}); ok && len(v) > 0 {
-			if v, ok := v[0].(map[string]interface{}); ok {
+		if v, ok := tfMap["empty_dir"].([]any); ok && len(v) > 0 {
+			if v, ok := v[0].(map[string]any); ok {
 				apiObject.EmptyDir = &awstypes.EksEmptyDir{
 					Medium:    aws.String(v["medium"].(string)),
 					SizeLimit: aws.String(v["size_limit"].(string)),
@@ -1468,20 +1468,20 @@ func expandVolumes(tfList []interface{}) []awstypes.EksVolume {
 			apiObject.Name = aws.String(v)
 		}
 
-		if v, ok := tfMap["host_path"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["host_path"].([]any); ok && len(v) > 0 {
 			apiObject.HostPath = &awstypes.EksHostPath{}
 
-			if v, ok := v[0].(map[string]interface{}); ok {
+			if v, ok := v[0].(map[string]any); ok {
 				if v, ok := v[names.AttrPath]; ok {
 					apiObject.HostPath.Path = aws.String(v.(string))
 				}
 			}
 		}
 
-		if v, ok := tfMap["secret"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["secret"].([]any); ok && len(v) > 0 {
 			apiObject.Secret = &awstypes.EksSecret{}
 
-			if v := v[0].(map[string]interface{}); ok {
+			if v := v[0].(map[string]any); ok {
 				if v, ok := v["optional"]; ok {
 					apiObject.Secret.Optional = aws.Bool(v.(bool))
 				}
@@ -1498,12 +1498,12 @@ func expandVolumes(tfList []interface{}) []awstypes.EksVolume {
 	return apiObjects
 }
 
-func expandVolumeMounts(tfList []interface{}) []awstypes.EksContainerVolumeMount {
+func expandVolumeMounts(tfList []any) []awstypes.EksContainerVolumeMount {
 	var apiObjects []awstypes.EksContainerVolumeMount
 
 	for _, tfMapRaw := range tfList {
 		apiObject := awstypes.EksContainerVolumeMount{}
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		if v, ok := tfMap["mount_path"]; ok {
 			apiObject.MountPath = aws.String(v.(string))
@@ -1523,15 +1523,15 @@ func expandVolumeMounts(tfList []interface{}) []awstypes.EksContainerVolumeMount
 	return apiObjects
 }
 
-func flattenEKSProperties(apiObject *awstypes.EksProperties) []interface{} {
-	var tfList []interface{}
+func flattenEKSProperties(apiObject *awstypes.EksProperties) []any {
+	var tfList []any
 
 	if apiObject == nil {
 		return tfList
 	}
 
 	if v := apiObject.PodProperties; v != nil {
-		tfList = append(tfList, map[string]interface{}{
+		tfList = append(tfList, map[string]any{
 			"pod_properties": flattenEKSPodProperties(apiObject.PodProperties),
 		})
 	}
@@ -1539,9 +1539,9 @@ func flattenEKSProperties(apiObject *awstypes.EksProperties) []interface{} {
 	return tfList
 }
 
-func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{}, 0)
+func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []any {
+	var tfList []any
+	tfMap := make(map[string]any, 0)
 
 	if v := apiObject.Containers; v != nil {
 		tfMap["containers"] = flattenEKSContainers(v)
@@ -1564,10 +1564,10 @@ func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []interface{}
 	}
 
 	if v := apiObject.Metadata; v != nil {
-		metadata := make([]map[string]interface{}, 0)
+		metadata := make([]map[string]any, 0)
 
 		if v := v.Labels; v != nil {
-			metadata = append(metadata, map[string]interface{}{
+			metadata = append(metadata, map[string]any{
 				"labels": v,
 			})
 		}
@@ -1592,11 +1592,11 @@ func flattenEKSPodProperties(apiObject *awstypes.EksPodProperties) []interface{}
 	return tfList
 }
 
-func flattenImagePullSecrets(apiObjects []awstypes.ImagePullSecret) []interface{} {
-	var tfList []interface{}
+func flattenImagePullSecrets(apiObjects []awstypes.ImagePullSecret) []any {
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := apiObject.Name; v != nil {
 			tfMap[names.AttrName] = aws.ToString(v)
@@ -1607,11 +1607,11 @@ func flattenImagePullSecrets(apiObjects []awstypes.ImagePullSecret) []interface{
 	return tfList
 }
 
-func flattenEKSContainers(apiObjects []awstypes.EksContainer) []interface{} {
-	var tfList []interface{}
+func flattenEKSContainers(apiObjects []awstypes.EksContainer) []any {
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := apiObject.Args; v != nil {
 			tfMap["args"] = v
@@ -1638,14 +1638,14 @@ func flattenEKSContainers(apiObjects []awstypes.EksContainer) []interface{} {
 		}
 
 		if v := apiObject.Resources; v != nil {
-			tfMap[names.AttrResources] = []map[string]interface{}{{
+			tfMap[names.AttrResources] = []map[string]any{{
 				"limits":   v.Limits,
 				"requests": v.Requests,
 			}}
 		}
 
 		if v := apiObject.SecurityContext; v != nil {
-			tfMap["security_context"] = []map[string]interface{}{{
+			tfMap["security_context"] = []map[string]any{{
 				"privileged":                 aws.ToBool(v.Privileged),
 				"read_only_root_file_system": aws.ToBool(v.ReadOnlyRootFilesystem),
 				"run_as_group":               aws.ToInt64(v.RunAsGroup),
@@ -1664,11 +1664,11 @@ func flattenEKSContainers(apiObjects []awstypes.EksContainer) []interface{} {
 	return tfList
 }
 
-func flattenEKSContainerEnvironmentVariables(apiObjects []awstypes.EksContainerEnvironmentVariable) []interface{} {
-	var tfList []interface{}
+func flattenEKSContainerEnvironmentVariables(apiObjects []awstypes.EksContainerEnvironmentVariable) []any {
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := apiObject.Name; v != nil {
 			tfMap[names.AttrName] = aws.ToString(v)
@@ -1684,11 +1684,11 @@ func flattenEKSContainerEnvironmentVariables(apiObjects []awstypes.EksContainerE
 	return tfList
 }
 
-func flattenEKSContainerVolumeMounts(apiObjects []awstypes.EksContainerVolumeMount) []interface{} {
-	var tfList []interface{}
+func flattenEKSContainerVolumeMounts(apiObjects []awstypes.EksContainerVolumeMount) []any {
+	var tfList []any
 
 	for _, v := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := v.MountPath; v != nil {
 			tfMap["mount_path"] = aws.ToString(v)
@@ -1708,21 +1708,21 @@ func flattenEKSContainerVolumeMounts(apiObjects []awstypes.EksContainerVolumeMou
 	return tfList
 }
 
-func flattenEKSVolumes(apiObjects []awstypes.EksVolume) []interface{} {
-	var tfList []interface{}
+func flattenEKSVolumes(apiObjects []awstypes.EksVolume) []any {
+	var tfList []any
 
 	for _, v := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := v.EmptyDir; v != nil {
-			tfMap["empty_dir"] = []map[string]interface{}{{
+			tfMap["empty_dir"] = []map[string]any{{
 				"medium":     aws.ToString(v.Medium),
 				"size_limit": aws.ToString(v.SizeLimit),
 			}}
 		}
 
 		if v := v.HostPath; v != nil {
-			tfMap["host_path"] = []map[string]interface{}{{
+			tfMap["host_path"] = []map[string]any{{
 				names.AttrPath: aws.ToString(v.Path),
 			}}
 		}
@@ -1732,7 +1732,7 @@ func flattenEKSVolumes(apiObjects []awstypes.EksVolume) []interface{} {
 		}
 
 		if v := v.Secret; v != nil {
-			tfMap["secret"] = []map[string]interface{}{{
+			tfMap["secret"] = []map[string]any{{
 				"optional":    aws.ToBool(v.Optional),
 				"secret_name": aws.ToString(v.SecretName),
 			}}

--- a/internal/service/batch/job_queue.go
+++ b/internal/service/batch/job_queue.go
@@ -455,7 +455,7 @@ func findJobQueues(ctx context.Context, conn *batch.Client, input *batch.Describ
 }
 
 func statusJobQueue(ctx context.Context, conn *batch.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findJobQueueByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/batch/job_queue_data_source.go
+++ b/internal/service/batch/job_queue_data_source.go
@@ -97,7 +97,7 @@ func dataSourceJobQueue() *schema.Resource {
 	}
 }
 
-func dataSourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -117,9 +117,9 @@ func dataSourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta in
 	d.Set(names.AttrStatus, jobQueue.Status)
 	d.Set(names.AttrStatusReason, jobQueue.StatusReason)
 
-	tfList := make([]interface{}, 0)
+	tfList := make([]any, 0)
 	for _, apiObject := range jobQueue.ComputeEnvironmentOrder {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		tfMap["compute_environment"] = aws.ToString(apiObject.ComputeEnvironment)
 		tfMap["order"] = aws.ToInt32(apiObject.Order)
 		tfList = append(tfList, tfMap)
@@ -128,9 +128,9 @@ func dataSourceJobQueueRead(ctx context.Context, d *schema.ResourceData, meta in
 		return sdkdiag.AppendErrorf(diags, "setting compute_environment_order: %s", err)
 	}
 
-	tfList = make([]interface{}, 0)
+	tfList = make([]any, 0)
 	for _, apiObject := range jobQueue.JobStateTimeLimitActions {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		tfMap[names.AttrAction] = apiObject.Action
 		tfMap["max_time_seconds"] = aws.ToInt32(apiObject.MaxTimeSeconds)
 		tfMap["reason"] = aws.ToString(apiObject.Reason)

--- a/internal/service/batch/scheduling_policy.go
+++ b/internal/service/batch/scheduling_policy.go
@@ -91,13 +91,13 @@ func resourceSchedulingPolicy() *schema.Resource {
 	}
 }
 
-func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &batch.CreateSchedulingPolicyInput{
-		FairsharePolicy: expandFairsharePolicy(d.Get("fair_share_policy").([]interface{})),
+		FairsharePolicy: expandFairsharePolicy(d.Get("fair_share_policy").([]any)),
 		Name:            aws.String(name),
 		Tags:            getTagsIn(ctx),
 	}
@@ -113,7 +113,7 @@ func resourceSchedulingPolicyCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceSchedulingPolicyRead(ctx, d, meta)...)
 }
 
-func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -140,14 +140,14 @@ func resourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
 	if d.HasChange("fair_share_policy") {
 		input := &batch.UpdateSchedulingPolicyInput{
 			Arn:             aws.String(d.Id()),
-			FairsharePolicy: expandFairsharePolicy(d.Get("fair_share_policy").([]interface{})),
+			FairsharePolicy: expandFairsharePolicy(d.Get("fair_share_policy").([]any)),
 		}
 
 		_, err := conn.UpdateSchedulingPolicy(ctx, input)
@@ -160,7 +160,7 @@ func resourceSchedulingPolicyUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceSchedulingPolicyRead(ctx, d, meta)...)
 }
 
-func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchedulingPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 
@@ -209,12 +209,12 @@ func findSchedulingPolicies(ctx context.Context, conn *batch.Client, input *batc
 	return output.SchedulingPolicies, nil
 }
 
-func expandFairsharePolicy(tfList []interface{}) *awstypes.FairsharePolicy {
+func expandFairsharePolicy(tfList []any) *awstypes.FairsharePolicy {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -225,7 +225,7 @@ func expandFairsharePolicy(tfList []interface{}) *awstypes.FairsharePolicy {
 	}
 
 	for _, tfMapRaw := range tfMap["share_distribution"].(*schema.Set).List() {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject.ShareDistribution = append(apiObject.ShareDistribution, awstypes.ShareAttributes{
 			ShareIdentifier: aws.String(tfMap["share_identifier"].(string)),
 			WeightFactor:    flex.Float64ValueToFloat32(tfMap["weight_factor"].(float64)),
@@ -235,19 +235,19 @@ func expandFairsharePolicy(tfList []interface{}) *awstypes.FairsharePolicy {
 	return apiObject
 }
 
-func flattenFairsharePolicy(apiObject *awstypes.FairsharePolicy) []interface{} {
+func flattenFairsharePolicy(apiObject *awstypes.FairsharePolicy) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"compute_reservation": aws.ToInt32(apiObject.ComputeReservation),
 		"share_decay_seconds": aws.ToInt32(apiObject.ShareDecaySeconds),
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 	for _, apiObject := range apiObject.ShareDistribution {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"share_identifier": aws.ToString(apiObject.ShareIdentifier),
 			"weight_factor":    flex.Float32ToFloat64Value(apiObject.WeightFactor),
 		}
@@ -255,5 +255,5 @@ func flattenFairsharePolicy(apiObject *awstypes.FairsharePolicy) []interface{} {
 	}
 	tfMap["share_distribution"] = tfList
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/batch/scheduling_policy_data_source.go
+++ b/internal/service/batch/scheduling_policy_data_source.go
@@ -69,7 +69,7 @@ func dataSourceSchedulingPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSchedulingPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BatchClient(ctx)
 

--- a/internal/service/batch/validate.go
+++ b/internal/service/batch/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validName(v interface{}, k string) (ws []string, errors []error) {
+func validName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z]{1}[0-9A-Za-z_-]{0,127}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be up to 128 letters (uppercase and lowercase), numbers, underscores and dashes, and must start with an alphanumeric.", k, v))
@@ -17,7 +17,7 @@ func validName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validPrefix(v interface{}, k string) (ws []string, errors []error) {
+func validPrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z]{1}[0-9A-Za-z_-]{0,101}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be up to 102 letters (uppercase and lowercase), numbers, underscores and dashes, and must start with an alphanumeric.", k, v))
@@ -25,7 +25,7 @@ func validPrefix(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validShareIdentifier(v interface{}, k string) (ws []string, errors []error) {
+func validShareIdentifier(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z]{0,254}[0-9A-Za-z*]?$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be limited to 255 alphanumeric characters, where the last character can be an asterisk (*).", k, v))


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
