### PR TITLE
apigatewayv2: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -76,6 +76,7 @@ jobs:
 
       # Services
       - run: make TEST=./internal/service/apigateway modern-check
+      - run: make TEST=./internal/service/apigatewayv2 modern-check
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check

--- a/internal/service/apigatewayv2/api.go
+++ b/internal/service/apigatewayv2/api.go
@@ -169,7 +169,7 @@ func resourceAPI() *schema.Resource {
 	}
 }
 
-func resourceAPICreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPICreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -185,7 +185,7 @@ func resourceAPICreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	if v, ok := d.GetOk("cors_configuration"); ok {
-		input.CorsConfiguration = expandCORSConfiguration(v.([]interface{}))
+		input.CorsConfiguration = expandCORSConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("credentials_arn"); ok {
@@ -233,7 +233,7 @@ func resourceAPICreate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceAPIRead(ctx, d, meta)...)
 }
 
-func resourceAPIRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -268,13 +268,13 @@ func resourceAPIRead(ctx context.Context, d *schema.ResourceData, meta interface
 	return diags
 }
 
-func resourceAPIUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	corsConfigurationDeleted := false
 	if d.HasChange("cors_configuration") {
-		if v := d.Get("cors_configuration"); len(v.([]interface{})) == 0 {
+		if v := d.Get("cors_configuration"); len(v.([]any)) == 0 {
 			corsConfigurationDeleted = true
 			input := &apigatewayv2.DeleteCorsConfigurationInput{
 				ApiId: aws.String(d.Id()),
@@ -299,7 +299,7 @@ func resourceAPIUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 		}
 
 		if d.HasChange("cors_configuration") {
-			input.CorsConfiguration = expandCORSConfiguration(d.Get("cors_configuration").([]interface{}))
+			input.CorsConfiguration = expandCORSConfiguration(d.Get("cors_configuration").([]any))
 		}
 
 		if d.HasChange(names.AttrDescription) {
@@ -340,7 +340,7 @@ func resourceAPIUpdate(ctx context.Context, d *schema.ResourceData, meta interfa
 	return append(diags, resourceAPIRead(ctx, d, meta)...)
 }
 
-func resourceAPIDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -361,7 +361,7 @@ func resourceAPIDelete(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func reimportOpenAPIDefinition(ctx context.Context, d *schema.ResourceData, meta interface{}) error {
+func reimportOpenAPIDefinition(ctx context.Context, d *schema.ResourceData, meta any) error {
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	if body, ok := d.GetOk("body"); ok {
@@ -420,7 +420,7 @@ func reimportOpenAPIDefinition(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if !reflect.DeepEqual(configuredCORSConfiguration, d.Get("cors_configuration")) {
-			if len(configuredCORSConfiguration.([]interface{})) == 0 {
+			if len(configuredCORSConfiguration.([]any)) == 0 {
 				input := &apigatewayv2.DeleteCorsConfigurationInput{
 					ApiId: aws.String(d.Id()),
 				}
@@ -431,7 +431,7 @@ func reimportOpenAPIDefinition(ctx context.Context, d *schema.ResourceData, meta
 					return fmt.Errorf("deleting API Gateway v2 API (%s) CORS configuration: %w", d.Id(), err)
 				}
 			} else {
-				inputUA.CorsConfiguration = expandCORSConfiguration(configuredCORSConfiguration.([]interface{}))
+				inputUA.CorsConfiguration = expandCORSConfiguration(configuredCORSConfiguration.([]any))
 			}
 		}
 
@@ -473,13 +473,13 @@ func findAPI(ctx context.Context, conn *apigatewayv2.Client, input *apigatewayv2
 	return output, nil
 }
 
-func expandCORSConfiguration(vConfiguration []interface{}) *awstypes.Cors {
+func expandCORSConfiguration(vConfiguration []any) *awstypes.Cors {
 	configuration := &awstypes.Cors{}
 
 	if len(vConfiguration) == 0 || vConfiguration[0] == nil {
 		return configuration
 	}
-	mConfiguration := vConfiguration[0].(map[string]interface{})
+	mConfiguration := vConfiguration[0].(map[string]any)
 
 	if vAllowCredentials, ok := mConfiguration["allow_credentials"].(bool); ok {
 		configuration.AllowCredentials = aws.Bool(vAllowCredentials)
@@ -503,12 +503,12 @@ func expandCORSConfiguration(vConfiguration []interface{}) *awstypes.Cors {
 	return configuration
 }
 
-func flattenCORSConfiguration(configuration *awstypes.Cors) []interface{} {
+func flattenCORSConfiguration(configuration *awstypes.Cors) []any {
 	if configuration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"allow_credentials": aws.ToBool(configuration.AllowCredentials),
 		"allow_headers":     flex.FlattenStringValueSetCaseInsensitive(configuration.AllowHeaders),
 		"allow_methods":     flex.FlattenStringValueSetCaseInsensitive(configuration.AllowMethods),

--- a/internal/service/apigatewayv2/api_data_source.go
+++ b/internal/service/apigatewayv2/api_data_source.go
@@ -108,7 +108,7 @@ func dataSourceAPI() *schema.Resource {
 	}
 }
 
-func dataSourceAPIRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAPIRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 

--- a/internal/service/apigatewayv2/api_mapping.go
+++ b/internal/service/apigatewayv2/api_mapping.go
@@ -57,7 +57,7 @@ func resourceAPIMapping() *schema.Resource {
 	}
 }
 
-func resourceAPIMappingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIMappingCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -82,7 +82,7 @@ func resourceAPIMappingCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceAPIMappingRead(ctx, d, meta)...)
 }
 
-func resourceAPIMappingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIMappingRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -105,7 +105,7 @@ func resourceAPIMappingRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceAPIMappingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIMappingUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -132,7 +132,7 @@ func resourceAPIMappingUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceAPIMappingRead(ctx, d, meta)...)
 }
 
-func resourceAPIMappingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAPIMappingDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -154,7 +154,7 @@ func resourceAPIMappingDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceAPIMappingImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceAPIMappingImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-mapping-id/domain-name'", d.Id())

--- a/internal/service/apigatewayv2/api_mapping_test.go
+++ b/internal/service/apigatewayv2/api_mapping_test.go
@@ -176,7 +176,7 @@ func testAccCheckAPIMappingCreateCertificate(ctx context.Context, t *testing.T, 
 		input := acm.ImportCertificateInput{
 			Certificate: []byte(certificate),
 			PrivateKey:  []byte(privateKey),
-			Tags: tfacm.Tags(tftags.New(ctx, map[string]interface{}{
+			Tags: tfacm.Tags(tftags.New(ctx, map[string]any{
 				"Name": rName,
 			}).IgnoreAWS()),
 		}

--- a/internal/service/apigatewayv2/apis_data_source.go
+++ b/internal/service/apigatewayv2/apis_data_source.go
@@ -43,12 +43,12 @@ func dataSourceAPIs() *schema.Resource {
 	}
 }
 
-func dataSourceAPIsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceAPIsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
 
-	tagsToMatch := tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+	tagsToMatch := tftags.New(ctx, d.Get(names.AttrTags).(map[string]any)).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
 	apis, err := findAPIs(ctx, conn, &apigatewayv2.GetApisInput{})
 

--- a/internal/service/apigatewayv2/authorizer.go
+++ b/internal/service/apigatewayv2/authorizer.go
@@ -112,7 +112,7 @@ func resourceAuthorizer() *schema.Resource {
 	}
 }
 
-func resourceAuthorizerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAuthorizerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -159,7 +159,7 @@ func resourceAuthorizerCreate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if v, ok := d.GetOk("jwt_configuration"); ok {
-		input.JwtConfiguration = expandJWTConfiguration(v.([]interface{}))
+		input.JwtConfiguration = expandJWTConfiguration(v.([]any))
 	}
 
 	outputCA, err := conn.CreateAuthorizer(ctx, input)
@@ -173,7 +173,7 @@ func resourceAuthorizerCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceAuthorizerRead(ctx, d, meta)...)
 }
 
-func resourceAuthorizerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAuthorizerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -204,7 +204,7 @@ func resourceAuthorizerRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceAuthorizerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAuthorizerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -246,7 +246,7 @@ func resourceAuthorizerUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	if d.HasChange("jwt_configuration") {
-		input.JwtConfiguration = expandJWTConfiguration(d.Get("jwt_configuration").([]interface{}))
+		input.JwtConfiguration = expandJWTConfiguration(d.Get("jwt_configuration").([]any))
 	}
 
 	_, err := conn.UpdateAuthorizer(ctx, input)
@@ -258,12 +258,12 @@ func resourceAuthorizerUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceAuthorizerRead(ctx, d, meta)...)
 }
 
-func resourceAuthorizerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAuthorizerDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	log.Printf("[DEBUG] Deleting API Gateway v2 Authorizer: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteAuthorizer(ctx, &apigatewayv2.DeleteAuthorizerInput{
 			ApiId:        aws.String(d.Get("api_id").(string)),
 			AuthorizerId: aws.String(d.Id()),
@@ -281,7 +281,7 @@ func resourceAuthorizerDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceAuthorizerImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceAuthorizerImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/authorizer-id'", d.Id())
@@ -323,13 +323,13 @@ func findAuthorizer(ctx context.Context, conn *apigatewayv2.Client, input *apiga
 	return output, nil
 }
 
-func expandJWTConfiguration(vConfiguration []interface{}) *awstypes.JWTConfiguration {
+func expandJWTConfiguration(vConfiguration []any) *awstypes.JWTConfiguration {
 	configuration := &awstypes.JWTConfiguration{}
 
 	if len(vConfiguration) == 0 || vConfiguration[0] == nil {
 		return configuration
 	}
-	mConfiguration := vConfiguration[0].(map[string]interface{})
+	mConfiguration := vConfiguration[0].(map[string]any)
 
 	if vAudience, ok := mConfiguration["audience"].(*schema.Set); ok && vAudience.Len() > 0 {
 		configuration.Audience = flex.ExpandStringValueSet(vAudience)
@@ -341,12 +341,12 @@ func expandJWTConfiguration(vConfiguration []interface{}) *awstypes.JWTConfigura
 	return configuration
 }
 
-func flattenJWTConfiguration(configuration *awstypes.JWTConfiguration) []interface{} {
+func flattenJWTConfiguration(configuration *awstypes.JWTConfiguration) []any {
 	if configuration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"audience":       flex.FlattenStringValueSet(configuration.Audience),
 		names.AttrIssuer: aws.ToString(configuration.Issuer),
 	}}

--- a/internal/service/apigatewayv2/deployment.go
+++ b/internal/service/apigatewayv2/deployment.go
@@ -63,7 +63,7 @@ func resourceDeployment() *schema.Resource {
 	}
 }
 
-func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -91,7 +91,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDeploymentRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -113,7 +113,7 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -140,7 +140,7 @@ func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDeploymentRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -162,7 +162,7 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceDeploymentImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceDeploymentImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/deployment-id'", d.Id())
@@ -205,7 +205,7 @@ func findDeployment(ctx context.Context, conn *apigatewayv2.Client, input *apiga
 }
 
 func statusDeployment(ctx context.Context, conn *apigatewayv2.Client, apiID, deploymentID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDeploymentByTwoPartKey(ctx, conn, apiID, deploymentID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apigatewayv2/domain_name.go
+++ b/internal/service/apigatewayv2/domain_name.go
@@ -126,15 +126,15 @@ func resourceDomainName() *schema.Resource {
 	}
 }
 
-func resourceDomainNameCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainNameCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	domainName := d.Get(names.AttrDomainName).(string)
 	input := &apigatewayv2.CreateDomainNameInput{
 		DomainName:               aws.String(domainName),
-		DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]interface{})),
-		MutualTlsAuthentication:  expandMutualTLSAuthentication(d.Get("mutual_tls_authentication").([]interface{})),
+		DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]any)),
+		MutualTlsAuthentication:  expandMutualTLSAuthentication(d.Get("mutual_tls_authentication").([]any)),
 		Tags:                     getTagsIn(ctx),
 	}
 
@@ -153,7 +153,7 @@ func resourceDomainNameCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDomainNameRead(ctx, d, meta)...)
 }
 
-func resourceDomainNameRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainNameRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -190,19 +190,19 @@ func resourceDomainNameRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
 	if d.HasChanges("domain_name_configuration", "mutual_tls_authentication") {
 		input := &apigatewayv2.UpdateDomainNameInput{
 			DomainName:               aws.String(d.Id()),
-			DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]interface{})),
+			DomainNameConfigurations: expandDomainNameConfigurations(d.Get("domain_name_configuration").([]any)),
 		}
 
 		if d.HasChange("mutual_tls_authentication") {
-			if v, ok := d.GetOk("mutual_tls_authentication"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				tfMap := v.([]interface{})[0].(map[string]interface{})
+			if v, ok := d.GetOk("mutual_tls_authentication"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				tfMap := v.([]any)[0].(map[string]any)
 
 				input.MutualTlsAuthentication = &awstypes.MutualTlsAuthenticationInput{}
 
@@ -235,7 +235,7 @@ func resourceDomainNameUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDomainNameRead(ctx, d, meta)...)
 }
 
-func resourceDomainNameDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDomainNameDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -282,7 +282,7 @@ func findDomainName(ctx context.Context, conn *apigatewayv2.Client, name string)
 }
 
 func statusDomainName(ctx context.Context, conn *apigatewayv2.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDomainName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -316,7 +316,7 @@ func waitDomainNameAvailable(ctx context.Context, conn *apigatewayv2.Client, nam
 	return nil, err
 }
 
-func expandDomainNameConfiguration(tfMap map[string]interface{}) awstypes.DomainNameConfiguration {
+func expandDomainNameConfiguration(tfMap map[string]any) awstypes.DomainNameConfiguration {
 	apiObject := awstypes.DomainNameConfiguration{}
 
 	if v, ok := tfMap[names.AttrCertificateARN].(string); ok && v != "" {
@@ -338,7 +338,7 @@ func expandDomainNameConfiguration(tfMap map[string]interface{}) awstypes.Domain
 	return apiObject
 }
 
-func expandDomainNameConfigurations(tfList []interface{}) []awstypes.DomainNameConfiguration {
+func expandDomainNameConfigurations(tfList []any) []awstypes.DomainNameConfiguration {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -346,7 +346,7 @@ func expandDomainNameConfigurations(tfList []interface{}) []awstypes.DomainNameC
 	var apiObjects []awstypes.DomainNameConfiguration
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -359,8 +359,8 @@ func expandDomainNameConfigurations(tfList []interface{}) []awstypes.DomainNameC
 	return apiObjects
 }
 
-func flattenDomainNameConfiguration(apiObject awstypes.DomainNameConfiguration) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenDomainNameConfiguration(apiObject awstypes.DomainNameConfiguration) []any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.CertificateArn; v != nil {
 		tfMap[names.AttrCertificateARN] = aws.ToString(v)
@@ -382,15 +382,15 @@ func flattenDomainNameConfiguration(apiObject awstypes.DomainNameConfiguration) 
 		tfMap["ownership_verification_certificate_arn"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandMutualTLSAuthentication(tfList []interface{}) *awstypes.MutualTlsAuthenticationInput {
+func expandMutualTLSAuthentication(tfList []any) *awstypes.MutualTlsAuthenticationInput {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	apiObject := &awstypes.MutualTlsAuthenticationInput{}
 
@@ -405,12 +405,12 @@ func expandMutualTLSAuthentication(tfList []interface{}) *awstypes.MutualTlsAuth
 	return apiObject
 }
 
-func flattenMutualTLSAuthentication(apiObject *awstypes.MutualTlsAuthentication) []interface{} {
+func flattenMutualTLSAuthentication(apiObject *awstypes.MutualTlsAuthentication) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.TruststoreUri; v != nil {
 		tfMap["truststore_uri"] = aws.ToString(v)
@@ -420,5 +420,5 @@ func flattenMutualTLSAuthentication(apiObject *awstypes.MutualTlsAuthentication)
 		tfMap["truststore_version"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/apigatewayv2/export_data_source.go
+++ b/internal/service/apigatewayv2/export_data_source.go
@@ -57,7 +57,7 @@ func dataSourceExport() *schema.Resource {
 	}
 }
 
-func dataSourceExportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceExportRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 

--- a/internal/service/apigatewayv2/integration.go
+++ b/internal/service/apigatewayv2/integration.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -182,7 +183,7 @@ func resourceIntegration() *schema.Resource {
 	}
 }
 
-func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -232,11 +233,11 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("request_parameters"); ok {
-		input.RequestParameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.RequestParameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("request_templates"); ok {
-		input.RequestTemplates = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.RequestTemplates = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("response_parameters"); ok && v.(*schema.Set).Len() > 0 {
@@ -252,7 +253,7 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("tls_config"); ok {
-		input.TlsConfig = expandTLSConfig(v.([]interface{}))
+		input.TlsConfig = expandTLSConfig(v.([]any))
 	}
 
 	output, err := conn.CreateIntegration(ctx, input)
@@ -266,7 +267,7 @@ func resourceIntegrationCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceIntegrationRead(ctx, d, meta)...)
 }
 
-func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -308,7 +309,7 @@ func resourceIntegrationRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -362,27 +363,23 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 	if d.HasChange("request_parameters") {
 		o, n := d.GetChange("request_parameters")
-		add, del, nop := flex.DiffStringValueMaps(o.(map[string]interface{}), n.(map[string]interface{}))
+		add, del, nop := flex.DiffStringValueMaps(o.(map[string]any), n.(map[string]any))
 
 		// Parameters are removed by setting the associated value to "".
 		for k := range del {
 			del[k] = ""
 		}
 		variables := del
-		for k, v := range add {
-			variables[k] = v
-		}
+		maps.Copy(variables, add)
 		// Also specify any request parameters that are unchanged as for AWS service integrations some parameters are always required:
 		// https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html
-		for k, v := range nop {
-			variables[k] = v
-		}
+		maps.Copy(variables, nop)
 
 		input.RequestParameters = variables
 	}
 
 	if d.HasChange("request_templates") {
-		input.RequestTemplates = flex.ExpandStringValueMap(d.Get("request_templates").(map[string]interface{}))
+		input.RequestTemplates = flex.ExpandStringValueMap(d.Get("request_templates").(map[string]any))
 	}
 
 	if d.HasChange("response_parameters") {
@@ -395,7 +392,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		// Parameters are removed by setting the associated value to {}.
 		for _, tfMapRaw := range del {
-			tfMap, ok := tfMapRaw.(map[string]interface{})
+			tfMap, ok := tfMapRaw.(map[string]any)
 
 			if !ok {
 				continue
@@ -419,7 +416,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("tls_config") {
-		input.TlsConfig = expandTLSConfig(d.Get("tls_config").([]interface{}))
+		input.TlsConfig = expandTLSConfig(d.Get("tls_config").([]any))
 	}
 
 	_, err := conn.UpdateIntegration(ctx, input)
@@ -431,7 +428,7 @@ func resourceIntegrationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceIntegrationRead(ctx, d, meta)...)
 }
 
-func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -453,7 +450,7 @@ func resourceIntegrationDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceIntegrationImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceIntegrationImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/integration-id'", d.Id())
@@ -537,13 +534,13 @@ func findIntegrations(ctx context.Context, conn *apigatewayv2.Client, input *api
 	return output, nil
 }
 
-func expandTLSConfig(vConfig []interface{}) *awstypes.TlsConfigInput {
+func expandTLSConfig(vConfig []any) *awstypes.TlsConfigInput {
 	config := &awstypes.TlsConfigInput{}
 
 	if len(vConfig) == 0 || vConfig[0] == nil {
 		return config
 	}
-	mConfig := vConfig[0].(map[string]interface{})
+	mConfig := vConfig[0].(map[string]any)
 
 	if vServerNameToVerify, ok := mConfig["server_name_to_verify"].(string); ok && vServerNameToVerify != "" {
 		config.ServerNameToVerify = aws.String(vServerNameToVerify)
@@ -552,17 +549,17 @@ func expandTLSConfig(vConfig []interface{}) *awstypes.TlsConfigInput {
 	return config
 }
 
-func flattenTLSConfig(config *awstypes.TlsConfig) []interface{} {
+func flattenTLSConfig(config *awstypes.TlsConfig) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"server_name_to_verify": aws.ToString(config.ServerNameToVerify),
 	}}
 }
 
-func expandIntegrationResponseParameters(tfList []interface{}) map[string]map[string]string {
+func expandIntegrationResponseParameters(tfList []any) map[string]map[string]string {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -570,14 +567,14 @@ func expandIntegrationResponseParameters(tfList []interface{}) map[string]map[st
 	responseParameters := map[string]map[string]string{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
 		}
 
 		if vStatusCode, ok := tfMap[names.AttrStatusCode].(string); ok && vStatusCode != "" {
-			if v, ok := tfMap["mappings"].(map[string]interface{}); ok && len(v) > 0 {
+			if v, ok := tfMap["mappings"].(map[string]any); ok && len(v) > 0 {
 				responseParameters[vStatusCode] = flex.ExpandStringValueMap(v)
 			}
 		}
@@ -586,19 +583,19 @@ func expandIntegrationResponseParameters(tfList []interface{}) map[string]map[st
 	return responseParameters
 }
 
-func flattenIntegrationResponseParameters(responseParameters map[string]map[string]string) []interface{} {
+func flattenIntegrationResponseParameters(responseParameters map[string]map[string]string) []any {
 	if len(responseParameters) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for statusCode, mappings := range responseParameters {
 		if len(mappings) == 0 {
 			continue
 		}
 
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		tfMap[names.AttrStatusCode] = statusCode
 		tfMap["mappings"] = mappings

--- a/internal/service/apigatewayv2/integration_response.go
+++ b/internal/service/apigatewayv2/integration_response.go
@@ -68,7 +68,7 @@ func resourceIntegrationResponse() *schema.Resource {
 	}
 }
 
-func resourceIntegrationResponseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationResponseCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -83,7 +83,7 @@ func resourceIntegrationResponseCreate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if v, ok := d.GetOk("response_templates"); ok {
-		input.ResponseTemplates = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.ResponseTemplates = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("template_selection_expression"); ok {
@@ -101,7 +101,7 @@ func resourceIntegrationResponseCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceIntegrationResponseRead(ctx, d, meta)...)
 }
 
-func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -128,7 +128,7 @@ func resourceIntegrationResponseRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceIntegrationResponseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationResponseUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -147,7 +147,7 @@ func resourceIntegrationResponseUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if d.HasChange("response_templates") {
-		input.ResponseTemplates = flex.ExpandStringValueMap(d.Get("response_templates").(map[string]interface{}))
+		input.ResponseTemplates = flex.ExpandStringValueMap(d.Get("response_templates").(map[string]any))
 	}
 
 	if d.HasChange("template_selection_expression") {
@@ -163,7 +163,7 @@ func resourceIntegrationResponseUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceIntegrationResponseRead(ctx, d, meta)...)
 }
 
-func resourceIntegrationResponseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIntegrationResponseDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -186,7 +186,7 @@ func resourceIntegrationResponseDelete(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceIntegrationResponseImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceIntegrationResponseImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/integration-id/integration-response-id'", d.Id())

--- a/internal/service/apigatewayv2/model.go
+++ b/internal/service/apigatewayv2/model.go
@@ -71,7 +71,7 @@ func resourceModel() *schema.Resource {
 				),
 				DiffSuppressFunc:      verify.SuppressEquivalentJSONDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -80,7 +80,7 @@ func resourceModel() *schema.Resource {
 	}
 }
 
-func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -107,7 +107,7 @@ func resourceModelCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceModelRead(ctx, d, meta)...)
 }
 
-func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -131,7 +131,7 @@ func resourceModelRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -165,7 +165,7 @@ func resourceModelUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceModelRead(ctx, d, meta)...)
 }
 
-func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -187,7 +187,7 @@ func resourceModelDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceModelImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceModelImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/model-id'", d.Id())

--- a/internal/service/apigatewayv2/route.go
+++ b/internal/service/apigatewayv2/route.go
@@ -111,7 +111,7 @@ func resourceRoute() *schema.Resource {
 	}
 }
 
-func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -139,7 +139,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("request_models"); ok {
-		input.RequestModels = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.RequestModels = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("request_parameter"); ok && v.(*schema.Set).Len() > 0 {
@@ -165,7 +165,7 @@ func resourceRouteCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -198,7 +198,7 @@ func resourceRouteRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -210,7 +210,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		ns := n.(*schema.Set)
 
 		for _, tfMapRaw := range os.Difference(ns).List() {
-			tfMap, ok := tfMapRaw.(map[string]interface{})
+			tfMap, ok := tfMapRaw.(map[string]any)
 
 			if !ok {
 				continue
@@ -270,7 +270,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("request_models") {
-			input.RequestModels = flex.ExpandStringValueMap(d.Get("request_models").(map[string]interface{}))
+			input.RequestModels = flex.ExpandStringValueMap(d.Get("request_models").(map[string]any))
 		}
 
 		if d.HasChange("request_parameter") {
@@ -299,7 +299,7 @@ func resourceRouteUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceRouteRead(ctx, d, meta)...)
 }
 
-func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -321,7 +321,7 @@ func resourceRouteDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRouteImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/route-id'", d.Id())
@@ -405,7 +405,7 @@ func findRoutes(ctx context.Context, conn *apigatewayv2.Client, input *apigatewa
 	return output, nil
 }
 
-func expandRouteRequestParameters(tfList []interface{}) map[string]awstypes.ParameterConstraints {
+func expandRouteRequestParameters(tfList []any) map[string]awstypes.ParameterConstraints {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -413,7 +413,7 @@ func expandRouteRequestParameters(tfList []interface{}) map[string]awstypes.Para
 	apiObjects := map[string]awstypes.ParameterConstraints{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -433,15 +433,15 @@ func expandRouteRequestParameters(tfList []interface{}) map[string]awstypes.Para
 	return apiObjects
 }
 
-func flattenRouteRequestParameters(apiObjects map[string]awstypes.ParameterConstraints) []interface{} {
+func flattenRouteRequestParameters(apiObjects map[string]awstypes.ParameterConstraints) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for k, apiObject := range apiObjects {
-		tfList = append(tfList, map[string]interface{}{
+		tfList = append(tfList, map[string]any{
 			"request_parameter_key": k,
 			"required":              aws.ToBool(apiObject.Required),
 		})

--- a/internal/service/apigatewayv2/route_response.go
+++ b/internal/service/apigatewayv2/route_response.go
@@ -62,7 +62,7 @@ func resourceRouteResponse() *schema.Resource {
 	}
 }
 
-func resourceRouteResponseCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteResponseCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -77,7 +77,7 @@ func resourceRouteResponseCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if v, ok := d.GetOk("response_models"); ok {
-		input.ResponseModels = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.ResponseModels = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	output, err := conn.CreateRouteResponse(ctx, input)
@@ -91,7 +91,7 @@ func resourceRouteResponseCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRouteResponseRead(ctx, d, meta)...)
 }
 
-func resourceRouteResponseRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteResponseRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -114,7 +114,7 @@ func resourceRouteResponseRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceRouteResponseUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteResponseUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -129,7 +129,7 @@ func resourceRouteResponseUpdate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if d.HasChange("response_models") {
-		input.ResponseModels = flex.ExpandStringValueMap(d.Get("response_models").(map[string]interface{}))
+		input.ResponseModels = flex.ExpandStringValueMap(d.Get("response_models").(map[string]any))
 	}
 
 	if d.HasChange("route_response_key") {
@@ -145,7 +145,7 @@ func resourceRouteResponseUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceRouteResponseRead(ctx, d, meta)...)
 }
 
-func resourceRouteResponseDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRouteResponseDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -168,7 +168,7 @@ func resourceRouteResponseDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceRouteResponseImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceRouteResponseImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 3 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/route-id/route-response-id'", d.Id())

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -187,7 +188,7 @@ func resourceStage() *schema.Resource {
 	}
 }
 
-func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -208,7 +209,7 @@ func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("access_log_settings"); ok {
-		input.AccessLogSettings = expandAccessLogSettings(v.([]interface{}))
+		input.AccessLogSettings = expandAccessLogSettings(v.([]any))
 	}
 
 	if v, ok := d.GetOk("client_certificate_id"); ok {
@@ -216,7 +217,7 @@ func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("default_route_settings"); ok {
-		input.DefaultRouteSettings = expandDefaultRouteSettings(v.([]interface{}), protocolType)
+		input.DefaultRouteSettings = expandDefaultRouteSettings(v.([]any), protocolType)
 	}
 
 	if v, ok := d.GetOk("deployment_id"); ok {
@@ -232,7 +233,7 @@ func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("stage_variables"); ok {
-		input.StageVariables = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.StageVariables = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	output, err := conn.CreateStage(ctx, input)
@@ -246,7 +247,7 @@ func resourceStageCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceStageRead(ctx, d, meta)...)
 }
 
-func resourceStageRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceStageRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -295,7 +296,7 @@ func resourceStageRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -316,7 +317,7 @@ func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("access_log_settings") {
-			input.AccessLogSettings = expandAccessLogSettings(d.Get("access_log_settings").([]interface{}))
+			input.AccessLogSettings = expandAccessLogSettings(d.Get("access_log_settings").([]any))
 		}
 
 		if d.HasChange("auto_deploy") {
@@ -328,7 +329,7 @@ func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("default_route_settings") {
-			input.DefaultRouteSettings = expandDefaultRouteSettings(d.Get("default_route_settings").([]interface{}), protocolType)
+			input.DefaultRouteSettings = expandDefaultRouteSettings(d.Get("default_route_settings").([]any), protocolType)
 		}
 
 		if d.HasChange("deployment_id") {
@@ -345,7 +346,7 @@ func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 			ns := n.(*schema.Set)
 
 			for _, vRouteSetting := range os.Difference(ns).List() {
-				routeKey := vRouteSetting.(map[string]interface{})["route_key"].(string)
+				routeKey := vRouteSetting.(map[string]any)["route_key"].(string)
 				input := &apigatewayv2.DeleteRouteSettingsInput{
 					ApiId:     aws.String(d.Get("api_id").(string)),
 					RouteKey:  aws.String(routeKey),
@@ -368,15 +369,13 @@ func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if d.HasChange("stage_variables") {
 			o, n := d.GetChange("stage_variables")
-			add, del, _ := flex.DiffStringValueMaps(o.(map[string]interface{}), n.(map[string]interface{}))
+			add, del, _ := flex.DiffStringValueMaps(o.(map[string]any), n.(map[string]any))
 			// Variables are removed by setting the associated value to "".
 			for k := range del {
 				del[k] = ""
 			}
 			variables := del
-			for k, v := range add {
-				variables[k] = v
-			}
+			maps.Copy(variables, add)
 			input.StageVariables = variables
 		}
 
@@ -390,7 +389,7 @@ func resourceStageUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceStageRead(ctx, d, meta)...)
 }
 
-func resourceStageDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceStageDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -412,7 +411,7 @@ func resourceStageDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceStageImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceStageImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'api-id/stage-name'", d.Id())
@@ -496,13 +495,13 @@ func findStages(ctx context.Context, conn *apigatewayv2.Client, input *apigatewa
 	return output, nil
 }
 
-func expandAccessLogSettings(vSettings []interface{}) *awstypes.AccessLogSettings {
+func expandAccessLogSettings(vSettings []any) *awstypes.AccessLogSettings {
 	settings := &awstypes.AccessLogSettings{}
 
 	if len(vSettings) == 0 || vSettings[0] == nil {
 		return settings
 	}
-	mSettings := vSettings[0].(map[string]interface{})
+	mSettings := vSettings[0].(map[string]any)
 
 	if vDestinationArn, ok := mSettings[names.AttrDestinationARN].(string); ok && vDestinationArn != "" {
 		settings.DestinationArn = aws.String(vDestinationArn)
@@ -514,24 +513,24 @@ func expandAccessLogSettings(vSettings []interface{}) *awstypes.AccessLogSetting
 	return settings
 }
 
-func flattenAccessLogSettings(settings *awstypes.AccessLogSettings) []interface{} {
+func flattenAccessLogSettings(settings *awstypes.AccessLogSettings) []any {
 	if settings == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		names.AttrDestinationARN: aws.ToString(settings.DestinationArn),
 		names.AttrFormat:         aws.ToString(settings.Format),
 	}}
 }
 
-func expandDefaultRouteSettings(vSettings []interface{}, protocolType awstypes.ProtocolType) *awstypes.RouteSettings {
+func expandDefaultRouteSettings(vSettings []any, protocolType awstypes.ProtocolType) *awstypes.RouteSettings {
 	routeSettings := &awstypes.RouteSettings{}
 
 	if len(vSettings) == 0 || vSettings[0] == nil {
 		return routeSettings
 	}
-	mSettings := vSettings[0].(map[string]interface{})
+	mSettings := vSettings[0].(map[string]any)
 
 	if vDataTraceEnabled, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == awstypes.ProtocolTypeWebsocket {
 		routeSettings.DataTraceEnabled = aws.Bool(vDataTraceEnabled)
@@ -552,12 +551,12 @@ func expandDefaultRouteSettings(vSettings []interface{}, protocolType awstypes.P
 	return routeSettings
 }
 
-func flattenDefaultRouteSettings(routeSettings *awstypes.RouteSettings) []interface{} {
+func flattenDefaultRouteSettings(routeSettings *awstypes.RouteSettings) []any {
 	if routeSettings == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	return []interface{}{map[string]interface{}{
+	return []any{map[string]any{
 		"data_trace_enabled":       aws.ToBool(routeSettings.DataTraceEnabled),
 		"detailed_metrics_enabled": aws.ToBool(routeSettings.DetailedMetricsEnabled),
 		"logging_level":            string(routeSettings.LoggingLevel),
@@ -566,13 +565,13 @@ func flattenDefaultRouteSettings(routeSettings *awstypes.RouteSettings) []interf
 	}}
 }
 
-func expandRouteSettings(vSettings []interface{}, protocolType awstypes.ProtocolType) map[string]awstypes.RouteSettings {
+func expandRouteSettings(vSettings []any, protocolType awstypes.ProtocolType) map[string]awstypes.RouteSettings {
 	settings := map[string]awstypes.RouteSettings{}
 
 	for _, v := range vSettings {
 		routeSettings := awstypes.RouteSettings{}
 
-		mSettings := v.(map[string]interface{})
+		mSettings := v.(map[string]any)
 
 		if v, ok := mSettings["data_trace_enabled"].(bool); ok && protocolType == awstypes.ProtocolTypeWebsocket {
 			routeSettings.DataTraceEnabled = aws.Bool(v)
@@ -596,11 +595,11 @@ func expandRouteSettings(vSettings []interface{}, protocolType awstypes.Protocol
 	return settings
 }
 
-func flattenRouteSettings(settings map[string]awstypes.RouteSettings) []interface{} {
-	vSettings := []interface{}{}
+func flattenRouteSettings(settings map[string]awstypes.RouteSettings) []any {
+	vSettings := []any{}
 
 	for k, routeSetting := range settings {
-		vSettings = append(vSettings, map[string]interface{}{
+		vSettings = append(vSettings, map[string]any{
 			"data_trace_enabled":       aws.ToBool(routeSetting.DataTraceEnabled),
 			"detailed_metrics_enabled": aws.ToBool(routeSetting.DetailedMetricsEnabled),
 			"logging_level":            routeSetting.LoggingLevel,

--- a/internal/service/apigatewayv2/vpc_link.go
+++ b/internal/service/apigatewayv2/vpc_link.go
@@ -68,7 +68,7 @@ func resourceVPCLink() *schema.Resource {
 	}
 }
 
-func resourceVPCLinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLinkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -95,7 +95,7 @@ func resourceVPCLinkCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceVPCLinkRead(ctx, d, meta)...)
 }
 
-func resourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -121,7 +121,7 @@ func resourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceVPCLinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLinkUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -141,7 +141,7 @@ func resourceVPCLinkUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceVPCLinkRead(ctx, d, meta)...)
 }
 
-func resourceVPCLinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCLinkDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 
@@ -196,7 +196,7 @@ func findVPCLink(ctx context.Context, conn *apigatewayv2.Client, input *apigatew
 }
 
 func statusVPCLink(ctx context.Context, conn *apigatewayv2.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCLinkByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apigatewayv2/vpc_link_data_source.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source.go
@@ -49,7 +49,7 @@ func dataSourceVPCLink() *schema.Resource {
 	}
 }
 
-func dataSourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVPCLinkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayV2Client(ctx)
 


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
