### PR TITLE
ecs: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -79,6 +79,7 @@ jobs:
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check
+      - run: make TEST=./internal/service/ecs modern-check
       - run: make TEST=./internal/service/elbv2 modern-check
       - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check
@@ -86,10 +87,10 @@ jobs:
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check
       - run: make TEST=./internal/service/rds/... modern-check
-      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/s3 modern-check
+      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/sns modern-check
-      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/ssm modern-check
+      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/ecs/account_setting_default.go
+++ b/internal/service/ecs/account_setting_default.go
@@ -52,7 +52,7 @@ func resourceAccountSettingDefault() *schema.Resource {
 	}
 }
 
-func resourceAccountSettingDefaultPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSettingDefaultPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -76,7 +76,7 @@ func resourceAccountSettingDefaultPut(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceAccountSettingDefaultRead(ctx, d, meta)...)
 }
 
-func resourceAccountSettingDefaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSettingDefaultRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -102,7 +102,7 @@ func resourceAccountSettingDefaultRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceAccountSettingDefaultDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAccountSettingDefaultDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -136,7 +136,7 @@ func resourceAccountSettingDefaultDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceAccountSettingDefaultImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceAccountSettingDefaultImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set(names.AttrName, d.Id())
 	d.SetId(arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition(ctx),

--- a/internal/service/ecs/capacity_provider.go
+++ b/internal/service/ecs/capacity_provider.go
@@ -123,7 +123,7 @@ func resourceCapacityProvider() *schema.Resource {
 	}
 }
 
-func resourceCapacityProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -155,7 +155,7 @@ func resourceCapacityProviderCreate(ctx context.Context, d *schema.ResourceData,
 		err := createTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceCapacityProviderRead(ctx, d, meta)...)
 		}
 
@@ -167,7 +167,7 @@ func resourceCapacityProviderCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceCapacityProviderRead(ctx, d, meta)...)
 }
 
-func resourceCapacityProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -194,7 +194,7 @@ func resourceCapacityProviderRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceCapacityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -207,7 +207,7 @@ func resourceCapacityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 		const (
 			timeout = 10 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.UpdateInProgressException](ctx, timeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenIsA[*awstypes.UpdateInProgressException](ctx, timeout, func() (any, error) {
 			return conn.UpdateCapacityProvider(ctx, input)
 		})
 
@@ -223,7 +223,7 @@ func resourceCapacityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceCapacityProviderRead(ctx, d, meta)...)
 }
 
-func resourceCapacityProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCapacityProviderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -251,7 +251,7 @@ func resourceCapacityProviderDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceCapacityProviderImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceCapacityProviderImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set(names.AttrName, d.Id())
 	d.SetId(arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition(ctx),
@@ -328,7 +328,7 @@ func findCapacityProviderByARN(ctx context.Context, conn *ecs.Client, arn string
 }
 
 func statusCapacityProvider(ctx context.Context, conn *ecs.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCapacityProviderByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -344,7 +344,7 @@ func statusCapacityProvider(ctx context.Context, conn *ecs.Client, arn string) r
 }
 
 func statusCapacityProviderUpdate(ctx context.Context, conn *ecs.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCapacityProviderByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -395,17 +395,17 @@ func waitCapacityProviderDeleted(ctx context.Context, conn *ecs.Client, arn stri
 	return nil, err
 }
 
-func expandAutoScalingGroupProviderCreate(configured interface{}) *awstypes.AutoScalingGroupProvider {
+func expandAutoScalingGroupProviderCreate(configured any) *awstypes.AutoScalingGroupProvider {
 	if configured == nil {
 		return nil
 	}
 
-	if configured.([]interface{}) == nil || len(configured.([]interface{})) == 0 {
+	if configured.([]any) == nil || len(configured.([]any)) == 0 {
 		return nil
 	}
 
 	prov := awstypes.AutoScalingGroupProvider{}
-	p := configured.([]interface{})[0].(map[string]interface{})
+	p := configured.([]any)[0].(map[string]any)
 	arn := p["auto_scaling_group_arn"].(string)
 	prov.AutoScalingGroupArn = aws.String(arn)
 
@@ -422,17 +422,17 @@ func expandAutoScalingGroupProviderCreate(configured interface{}) *awstypes.Auto
 	return &prov
 }
 
-func expandAutoScalingGroupProviderUpdate(configured interface{}) *awstypes.AutoScalingGroupProviderUpdate {
+func expandAutoScalingGroupProviderUpdate(configured any) *awstypes.AutoScalingGroupProviderUpdate {
 	if configured == nil {
 		return nil
 	}
 
-	if configured.([]interface{}) == nil || len(configured.([]interface{})) == 0 {
+	if configured.([]any) == nil || len(configured.([]any)) == 0 {
 		return nil
 	}
 
 	prov := awstypes.AutoScalingGroupProviderUpdate{}
-	p := configured.([]interface{})[0].(map[string]interface{})
+	p := configured.([]any)[0].(map[string]any)
 
 	if mtp := p["managed_draining"].(string); len(mtp) > 0 {
 		prov.ManagedDraining = awstypes.ManagedDraining(mtp)
@@ -447,16 +447,16 @@ func expandAutoScalingGroupProviderUpdate(configured interface{}) *awstypes.Auto
 	return &prov
 }
 
-func expandManagedScaling(configured interface{}) *awstypes.ManagedScaling {
+func expandManagedScaling(configured any) *awstypes.ManagedScaling {
 	if configured == nil {
 		return nil
 	}
 
-	if configured.([]interface{}) == nil || len(configured.([]interface{})) == 0 {
+	if configured.([]any) == nil || len(configured.([]any)) == 0 {
 		return nil
 	}
 
-	tfMap := configured.([]interface{})[0].(map[string]interface{})
+	tfMap := configured.([]any)[0].(map[string]any)
 
 	managedScaling := awstypes.ManagedScaling{}
 
@@ -479,20 +479,20 @@ func expandManagedScaling(configured interface{}) *awstypes.ManagedScaling {
 	return &managedScaling
 }
 
-func flattenAutoScalingGroupProvider(provider *awstypes.AutoScalingGroupProvider) []map[string]interface{} {
+func flattenAutoScalingGroupProvider(provider *awstypes.AutoScalingGroupProvider) []map[string]any {
 	if provider == nil {
 		return nil
 	}
 
-	p := map[string]interface{}{
+	p := map[string]any{
 		"auto_scaling_group_arn":         aws.ToString(provider.AutoScalingGroupArn),
 		"managed_draining":               string(provider.ManagedDraining),
-		"managed_scaling":                []map[string]interface{}{},
+		"managed_scaling":                []map[string]any{},
 		"managed_termination_protection": string(provider.ManagedTerminationProtection),
 	}
 
 	if provider.ManagedScaling != nil {
-		m := map[string]interface{}{
+		m := map[string]any{
 			"instance_warmup_period":    aws.ToInt32(provider.ManagedScaling.InstanceWarmupPeriod),
 			"maximum_scaling_step_size": aws.ToInt32(provider.ManagedScaling.MaximumScalingStepSize),
 			"minimum_scaling_step_size": aws.ToInt32(provider.ManagedScaling.MinimumScalingStepSize),
@@ -500,9 +500,9 @@ func flattenAutoScalingGroupProvider(provider *awstypes.AutoScalingGroupProvider
 			"target_capacity":           aws.ToInt32(provider.ManagedScaling.TargetCapacity),
 		}
 
-		p["managed_scaling"] = []map[string]interface{}{m}
+		p["managed_scaling"] = []map[string]any{m}
 	}
 
-	result := []map[string]interface{}{p}
+	result := []map[string]any{p}
 	return result
 }

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -161,7 +161,7 @@ func resourceCluster() *schema.Resource {
 	}
 }
 
-func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -172,12 +172,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		Tags:        getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]interface{})) > 0 {
-		input.Configuration = expandClusterConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]any)) > 0 {
+		input.Configuration = expandClusterConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk("service_connect_defaults"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ServiceConnectDefaults = expandClusterServiceConnectDefaultsRequest(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("service_connect_defaults"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ServiceConnectDefaults = expandClusterServiceConnectDefaultsRequest(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("setting"); ok {
@@ -210,7 +210,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		err := createTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceClusterRead(ctx, d, meta)...)
 		}
 
@@ -222,14 +222,14 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
-func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
 	const (
 		timeout = 2 * time.Second
 	)
-	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenNewResourceNotFound(ctx, timeout, func() (any, error) {
 		return findClusterByNameOrARN(ctx, conn, d.Id())
 	}, d.IsNewResource())
 
@@ -252,7 +252,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set(names.AttrName, cluster.ClusterName)
 	if cluster.ServiceConnectDefaults != nil {
-		if err := d.Set("service_connect_defaults", []interface{}{flattenClusterServiceConnectDefaults(cluster.ServiceConnectDefaults)}); err != nil {
+		if err := d.Set("service_connect_defaults", []any{flattenClusterServiceConnectDefaults(cluster.ServiceConnectDefaults)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting service_connect_defaults: %s", err)
 		}
 	} else {
@@ -267,7 +267,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -276,12 +276,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			Cluster: aws.String(d.Id()),
 		}
 
-		if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]interface{})) > 0 {
-			input.Configuration = expandClusterConfiguration(v.([]interface{}))
+		if v, ok := d.GetOk(names.AttrConfiguration); ok && len(v.([]any)) > 0 {
+			input.Configuration = expandClusterConfiguration(v.([]any))
 		}
 
-		if v, ok := d.GetOk("service_connect_defaults"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.ServiceConnectDefaults = expandClusterServiceConnectDefaultsRequest(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("service_connect_defaults"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.ServiceConnectDefaults = expandClusterServiceConnectDefaultsRequest(v.([]any)[0].(map[string]any))
 		}
 
 		if v, ok := d.GetOk("setting"); ok {
@@ -302,7 +302,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -310,7 +310,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	const (
 		timeout = 10 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsOneOf4[*awstypes.ClusterContainsContainerInstancesException, *awstypes.ClusterContainsServicesException, *awstypes.ClusterContainsTasksException, *awstypes.UpdateInProgressException](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsOneOf4[*awstypes.ClusterContainsContainerInstancesException, *awstypes.ClusterContainsServicesException, *awstypes.ClusterContainsTasksException, *awstypes.UpdateInProgressException](ctx, timeout, func() (any, error) {
 		return conn.DeleteCluster(ctx, &ecs.DeleteClusterInput{
 			Cluster: aws.String(d.Id()),
 		})
@@ -327,7 +327,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceClusterImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceClusterImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set(names.AttrName, d.Id())
 	d.SetId(arn.ARN{
 		Partition: meta.(*conns.AWSClient).Partition(ctx),
@@ -341,7 +341,7 @@ func resourceClusterImport(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func retryClusterCreate(ctx context.Context, conn *ecs.Client, input *ecs.CreateClusterInput) (*ecs.CreateClusterOutput, error) {
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidParameterException](ctx, propagationTimeout, func() (any, error) {
 		return conn.CreateCluster(ctx, input)
 	}, "Unable to assume the service linked role")
 
@@ -421,7 +421,7 @@ func findClusterByNameOrARN(ctx context.Context, conn *ecs.Client, nameOrARN str
 }
 
 func statusCluster(ctx context.Context, conn *ecs.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		cluster, err := findClusterByNameOrARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -483,7 +483,7 @@ func expandClusterSettings(tfSet *schema.Set) []awstypes.ClusterSetting {
 	apiObjects := make([]awstypes.ClusterSetting, 0)
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.ClusterSetting{
 			Name:  awstypes.ClusterSettingName(tfMap[names.AttrName].(string)),
@@ -496,7 +496,7 @@ func expandClusterSettings(tfSet *schema.Set) []awstypes.ClusterSetting {
 	return apiObjects
 }
 
-func expandClusterServiceConnectDefaultsRequest(tfMap map[string]interface{}) *awstypes.ClusterServiceConnectDefaultsRequest {
+func expandClusterServiceConnectDefaultsRequest(tfMap map[string]any) *awstypes.ClusterServiceConnectDefaultsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -510,12 +510,12 @@ func expandClusterServiceConnectDefaultsRequest(tfMap map[string]interface{}) *a
 	return apiObject
 }
 
-func flattenClusterServiceConnectDefaults(apiObject *awstypes.ClusterServiceConnectDefaults) map[string]interface{} {
+func flattenClusterServiceConnectDefaults(apiObject *awstypes.ClusterServiceConnectDefaults) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Namespace; v != nil {
 		tfMap[names.AttrNamespace] = aws.ToString(v)
@@ -524,15 +524,15 @@ func flattenClusterServiceConnectDefaults(apiObject *awstypes.ClusterServiceConn
 	return tfMap
 }
 
-func flattenClusterSettings(apiObjects []awstypes.ClusterSetting) []interface{} {
+func flattenClusterSettings(apiObjects []awstypes.ClusterSetting) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	tfList := make([]interface{}, 0, len(apiObjects))
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrName:  string(apiObject.Name),
 			names.AttrValue: aws.ToString(apiObject.Value),
 		}
@@ -543,12 +543,12 @@ func flattenClusterSettings(apiObjects []awstypes.ClusterSetting) []interface{} 
 	return tfList
 }
 
-func flattenClusterConfiguration(apiObject *awstypes.ClusterConfiguration) []interface{} {
+func flattenClusterConfiguration(apiObject *awstypes.ClusterConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.ExecuteCommandConfiguration != nil {
 		tfMap["execute_command_configuration"] = flattenClusterConfigurationExecuteCommandConfiguration(apiObject.ExecuteCommandConfiguration)
@@ -558,15 +558,15 @@ func flattenClusterConfiguration(apiObject *awstypes.ClusterConfiguration) []int
 		tfMap["managed_storage_configuration"] = flattenManagedStorageConfiguration(apiObject.ManagedStorageConfiguration)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenClusterConfigurationExecuteCommandConfiguration(apiObject *awstypes.ExecuteCommandConfiguration) []interface{} {
+func flattenClusterConfigurationExecuteCommandConfiguration(apiObject *awstypes.ExecuteCommandConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.KmsKeyId != nil {
 		tfMap[names.AttrKMSKeyID] = aws.ToString(apiObject.KmsKeyId)
@@ -578,15 +578,15 @@ func flattenClusterConfigurationExecuteCommandConfiguration(apiObject *awstypes.
 
 	tfMap["logging"] = string(apiObject.Logging)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject *awstypes.ExecuteCommandLogConfiguration) []interface{} {
+func flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiObject *awstypes.ExecuteCommandLogConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["cloud_watch_encryption_enabled"] = apiObject.CloudWatchEncryptionEnabled
 	tfMap["s3_bucket_encryption_enabled"] = apiObject.S3EncryptionEnabled
@@ -603,15 +603,15 @@ func flattenClusterConfigurationExecuteCommandConfigurationLogConfiguration(apiO
 		tfMap[names.AttrS3KeyPrefix] = aws.ToString(apiObject.S3KeyPrefix)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenManagedStorageConfiguration(apiObject *awstypes.ManagedStorageConfiguration) []interface{} {
+func flattenManagedStorageConfiguration(apiObject *awstypes.ManagedStorageConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.FargateEphemeralStorageKmsKeyId != nil {
 		tfMap["fargate_ephemeral_storage_kms_key_id"] = aws.ToString(apiObject.FargateEphemeralStorageKmsKeyId)
@@ -621,37 +621,37 @@ func flattenManagedStorageConfiguration(apiObject *awstypes.ManagedStorageConfig
 		tfMap[names.AttrKMSKeyID] = aws.ToString(apiObject.KmsKeyId)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandClusterConfiguration(tfList []interface{}) *awstypes.ClusterConfiguration {
+func expandClusterConfiguration(tfList []any) *awstypes.ClusterConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return &awstypes.ClusterConfiguration{}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.ClusterConfiguration{}
 
-	if v, ok := tfMap["execute_command_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["execute_command_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ExecuteCommandConfiguration = expandClusterConfigurationExecuteCommandConfiguration(v)
 	}
 
-	if v, ok := tfMap["managed_storage_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["managed_storage_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.ManagedStorageConfiguration = expandManagedStorageConfiguration(v)
 	}
 
 	return apiObject
 }
 
-func expandClusterConfigurationExecuteCommandConfiguration(tfList []interface{}) *awstypes.ExecuteCommandConfiguration {
+func expandClusterConfigurationExecuteCommandConfiguration(tfList []any) *awstypes.ExecuteCommandConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return &awstypes.ExecuteCommandConfiguration{}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.ExecuteCommandConfiguration{}
 
-	if v, ok := tfMap["log_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["log_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.LogConfiguration = expandClusterConfigurationExecuteCommandLogConfiguration(v)
 	}
 
@@ -666,12 +666,12 @@ func expandClusterConfigurationExecuteCommandConfiguration(tfList []interface{})
 	return apiObject
 }
 
-func expandClusterConfigurationExecuteCommandLogConfiguration(tfList []interface{}) *awstypes.ExecuteCommandLogConfiguration {
+func expandClusterConfigurationExecuteCommandLogConfiguration(tfList []any) *awstypes.ExecuteCommandLogConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return &awstypes.ExecuteCommandLogConfiguration{}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.ExecuteCommandLogConfiguration{}
 
 	if v, ok := tfMap["cloud_watch_log_group_name"].(string); ok && v != "" {
@@ -697,12 +697,12 @@ func expandClusterConfigurationExecuteCommandLogConfiguration(tfList []interface
 	return apiObject
 }
 
-func expandManagedStorageConfiguration(tfList []interface{}) *awstypes.ManagedStorageConfiguration {
+func expandManagedStorageConfiguration(tfList []any) *awstypes.ManagedStorageConfiguration {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return &awstypes.ManagedStorageConfiguration{}
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.ManagedStorageConfiguration{}
 
 	if v, ok := tfMap["fargate_ephemeral_storage_kms_key_id"].(string); ok && v != "" {

--- a/internal/service/ecs/cluster_capacity_providers.go
+++ b/internal/service/ecs/cluster_capacity_providers.go
@@ -79,7 +79,7 @@ func resourceClusterCapacityProviders() *schema.Resource {
 	}
 }
 
-func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
@@ -108,7 +108,7 @@ func resourceClusterCapacityProvidersPut(ctx context.Context, d *schema.Resource
 	return append(diags, resourceClusterCapacityProvidersRead(ctx, d, meta)...)
 }
 
-func resourceClusterCapacityProvidersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCapacityProvidersRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -135,7 +135,7 @@ func resourceClusterCapacityProvidersRead(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCapacityProvidersDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -168,7 +168,7 @@ func retryClusterCapacityProvidersPut(ctx context.Context, conn *ecs.Client, inp
 		timeout = 10 * time.Minute
 	)
 	_, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.PutClusterCapacityProviders(ctx, input)
 		},
 		func(err error) (bool, error) {

--- a/internal/service/ecs/cluster_data_source.go
+++ b/internal/service/ecs/cluster_data_source.go
@@ -79,7 +79,7 @@ func dataSourceCluster() *schema.Resource {
 	}
 }
 
-func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -97,7 +97,7 @@ func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta int
 	d.Set("registered_container_instances_count", cluster.RegisteredContainerInstancesCount)
 	d.Set("running_tasks_count", cluster.RunningTasksCount)
 	if cluster.ServiceConnectDefaults != nil {
-		if err := d.Set("service_connect_defaults", []interface{}{flattenClusterServiceConnectDefaults(cluster.ServiceConnectDefaults)}); err != nil {
+		if err := d.Set("service_connect_defaults", []any{flattenClusterServiceConnectDefaults(cluster.ServiceConnectDefaults)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting service_connect_defaults: %s", err)
 		}
 	} else {

--- a/internal/service/ecs/container_definition_data_source.go
+++ b/internal/service/ecs/container_definition_data_source.go
@@ -72,7 +72,7 @@ func dataSourceContainerDefinition() *schema.Resource {
 	}
 }
 
-func dataSourceContainerDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceContainerDefinitionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 

--- a/internal/service/ecs/container_definitions.go
+++ b/internal/service/ecs/container_definitions.go
@@ -239,11 +239,5 @@ func isValidVersionConsistency(cd awstypes.ContainerDefinition) bool {
 		return true
 	}
 
-	for _, v := range enum.EnumValues[awstypes.VersionConsistency]() {
-		if cd.VersionConsistency == v {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(enum.EnumValues[awstypes.VersionConsistency](), cd.VersionConsistency)
 }

--- a/internal/service/ecs/flex.go
+++ b/internal/service/ecs/flex.go
@@ -15,7 +15,7 @@ func expandCapacityProviderStrategyItems(tfSet *schema.Set) []awstypes.CapacityP
 	apiObjects := make([]awstypes.CapacityProviderStrategyItem, 0)
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.CapacityProviderStrategyItem{}
 
 		if v, ok := tfMap["base"]; ok {
@@ -36,15 +36,15 @@ func expandCapacityProviderStrategyItems(tfSet *schema.Set) []awstypes.CapacityP
 	return apiObjects
 }
 
-func flattenCapacityProviderStrategyItems(apiObjects []awstypes.CapacityProviderStrategyItem) []interface{} {
+func flattenCapacityProviderStrategyItems(apiObjects []awstypes.CapacityProviderStrategyItem) []any {
 	if apiObjects == nil {
 		return nil
 	}
 
-	tfList := make([]interface{}, 0)
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		tfMap["base"] = apiObject.Base
 		tfMap["capacity_provider"] = aws.ToString(apiObject.CapacityProvider)
@@ -56,11 +56,11 @@ func flattenCapacityProviderStrategyItems(apiObjects []awstypes.CapacityProvider
 	return tfList
 }
 
-func expandLoadBalancers(tfList []interface{}) []awstypes.LoadBalancer {
+func expandLoadBalancers(tfList []any) []awstypes.LoadBalancer {
 	apiObjects := make([]awstypes.LoadBalancer, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.LoadBalancer{
 			ContainerName: aws.String(tfMap["container_name"].(string)),
@@ -81,11 +81,11 @@ func expandLoadBalancers(tfList []interface{}) []awstypes.LoadBalancer {
 	return apiObjects
 }
 
-func flattenLoadBalancers(apiObjects []awstypes.LoadBalancer) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenLoadBalancers(apiObjects []awstypes.LoadBalancer) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"container_name": aws.ToString(apiObject.ContainerName),
 			"container_port": aws.ToInt32(apiObject.ContainerPort),
 		}
@@ -104,7 +104,7 @@ func flattenLoadBalancers(apiObjects []awstypes.LoadBalancer) []interface{} {
 	return tfList
 }
 
-func expandTaskSetLoadBalancers(tfList []interface{}) []awstypes.LoadBalancer {
+func expandTaskSetLoadBalancers(tfList []any) []awstypes.LoadBalancer {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -112,7 +112,7 @@ func expandTaskSetLoadBalancers(tfList []interface{}) []awstypes.LoadBalancer {
 	apiObjects := make([]awstypes.LoadBalancer, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.LoadBalancer{}
 
@@ -138,11 +138,11 @@ func expandTaskSetLoadBalancers(tfList []interface{}) []awstypes.LoadBalancer {
 	return apiObjects
 }
 
-func flattenTaskSetLoadBalancers(apiObjects []awstypes.LoadBalancer) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenTaskSetLoadBalancers(apiObjects []awstypes.LoadBalancer) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"container_name": aws.ToString(apiObject.ContainerName),
 			"container_port": aws.ToInt32(apiObject.ContainerPort),
 		}
@@ -160,7 +160,7 @@ func flattenTaskSetLoadBalancers(apiObjects []awstypes.LoadBalancer) []interface
 	return tfList
 }
 
-func expandServiceRegistries(tfList []interface{}) []awstypes.ServiceRegistry {
+func expandServiceRegistries(tfList []any) []awstypes.ServiceRegistry {
 	apiObjects := make([]awstypes.ServiceRegistry, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
@@ -168,7 +168,7 @@ func expandServiceRegistries(tfList []interface{}) []awstypes.ServiceRegistry {
 			continue
 		}
 
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.ServiceRegistry{
 			RegistryArn: aws.String(tfMap["registry_arn"].(string)),
 		}
@@ -191,12 +191,12 @@ func expandServiceRegistries(tfList []interface{}) []awstypes.ServiceRegistry {
 	return apiObjects
 }
 
-func expandScale(tfList []interface{}) *awstypes.Scale {
+func expandScale(tfList []any) *awstypes.Scale {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -214,14 +214,14 @@ func expandScale(tfList []interface{}) *awstypes.Scale {
 	return apiObject
 }
 
-func flattenScale(apiObject *awstypes.Scale) []interface{} {
+func flattenScale(apiObject *awstypes.Scale) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap[names.AttrUnit] = string(apiObject.Unit)
 	tfMap[names.AttrValue] = apiObject.Value
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -752,7 +752,7 @@ func resourceService() *schema.Resource {
 						names.AttrField: {
 							Type:     schema.TypeString,
 							Optional: true,
-							StateFunc: func(v interface{}) string {
+							StateFunc: func(v any) string {
 								value := v.(string)
 								if value == "host" {
 									return "instanceId"
@@ -1121,12 +1121,12 @@ func resourceService() *schema.Resource {
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Type: resourceV0.CoreConfigSchema().ImpliedType(),
-				Upgrade: func(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+				Upgrade: func(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 					// Convert volume_configuration.managed_ebs_volume.throughput from string to int.
-					if v, ok := rawState["volume_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-						tfMap := v[0].(map[string]interface{})
-						if v, ok := tfMap["managed_ebs_volume"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-							tfMap := v[0].(map[string]interface{})
+					if v, ok := rawState["volume_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
+						tfMap := v[0].(map[string]any)
+						if v, ok := tfMap["managed_ebs_volume"].([]any); ok && len(v) > 0 && v[0] != nil {
+							tfMap := v[0].(map[string]any)
 							if v, ok := tfMap[names.AttrThroughput]; ok {
 								if v, ok := v.(string); ok {
 									if v == "" {
@@ -1156,12 +1156,12 @@ func resourceService() *schema.Resource {
 	}
 }
 
-func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
 
-	deploymentController := expandDeploymentController(d.Get("deployment_controller").([]interface{}))
+	deploymentController := expandDeploymentController(d.Get("deployment_controller").([]any))
 	deploymentMinimumHealthyPercent := d.Get("deployment_minimum_healthy_percent").(int)
 	name := d.Get(names.AttrName).(string)
 	schedulingStrategy := awstypes.SchedulingStrategy(d.Get("scheduling_strategy").(string))
@@ -1172,15 +1172,15 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		DeploymentController:     deploymentController,
 		EnableECSManagedTags:     d.Get("enable_ecs_managed_tags").(bool),
 		EnableExecuteCommand:     d.Get("enable_execute_command").(bool),
-		NetworkConfiguration:     expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]interface{})),
+		NetworkConfiguration:     expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]any)),
 		SchedulingStrategy:       schedulingStrategy,
 		ServiceName:              aws.String(name),
 		Tags:                     getTagsIn(ctx),
 		VpcLatticeConfigurations: expandVPCLatticeConfiguration(d.Get("vpc_lattice_configurations").(*schema.Set)),
 	}
 
-	if v, ok := d.GetOk("alarms"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DeploymentConfiguration.Alarms = expandAlarms(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("alarms"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DeploymentConfiguration.Alarms = expandAlarms(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("availability_zone_rebalancing"); ok {
@@ -1199,8 +1199,8 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.DesiredCount = aws.Int32(int32(d.Get("desired_count").(int)))
 	}
 
-	if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("health_check_grace_period_seconds"); ok {
@@ -1227,7 +1227,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	}
 
 	if v, ok := d.GetOk("ordered_placement_strategy"); ok {
-		apiObject, err := expandPlacementStrategy(v.([]interface{}))
+		apiObject, err := expandPlacementStrategy(v.([]any))
 		if err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
@@ -1252,11 +1252,11 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.PropagateTags = awstypes.PropagateTags(v.(string))
 	}
 
-	if v, ok := d.GetOk("service_connect_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.ServiceConnectConfiguration = expandServiceConnectConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("service_connect_configuration"); ok && len(v.([]any)) > 0 {
+		input.ServiceConnectConfiguration = expandServiceConnectConfiguration(v.([]any))
 	}
 
-	if v := d.Get("service_registries").([]interface{}); len(v) > 0 {
+	if v := d.Get("service_registries").([]any); len(v) > 0 {
 		input.ServiceRegistries = expandServiceRegistries(v)
 	}
 
@@ -1264,8 +1264,8 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.TaskDefinition = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("volume_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.VolumeConfigurations = expandVolumeConfigurations(ctx, v.([]interface{}))
+	if v, ok := d.GetOk("volume_configuration"); ok && len(v.([]any)) > 0 {
+		input.VolumeConfigurations = expandVolumeConfigurations(ctx, v.([]any))
 	}
 
 	output, err := retryServiceCreate(ctx, conn, input)
@@ -1296,7 +1296,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		err := createTags(ctx, conn, d.Id(), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceServiceRead(ctx, d, meta)...)
 		}
 
@@ -1308,7 +1308,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
-func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -1341,7 +1341,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		d.Set("deployment_minimum_healthy_percent", service.DeploymentConfiguration.MinimumHealthyPercent)
 
 		if service.DeploymentConfiguration.Alarms != nil {
-			if err := d.Set("alarms", []interface{}{flattenAlarms(service.DeploymentConfiguration.Alarms)}); err != nil {
+			if err := d.Set("alarms", []any{flattenAlarms(service.DeploymentConfiguration.Alarms)}); err != nil {
 				return sdkdiag.AppendErrorf(diags, "setting alarms: %s", err)
 			}
 		} else {
@@ -1349,7 +1349,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if service.DeploymentConfiguration.DeploymentCircuitBreaker != nil {
-			if err := d.Set("deployment_circuit_breaker", []interface{}{flattenDeploymentCircuitBreaker(service.DeploymentConfiguration.DeploymentCircuitBreaker)}); err != nil {
+			if err := d.Set("deployment_circuit_breaker", []any{flattenDeploymentCircuitBreaker(service.DeploymentConfiguration.DeploymentCircuitBreaker)}); err != nil {
 				return sdkdiag.AppendErrorf(diags, "setting deployment_circuit_breaker: %s", err)
 			}
 		} else {
@@ -1423,7 +1423,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -1440,8 +1440,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				input.DeploymentConfiguration = &awstypes.DeploymentConfiguration{}
 			}
 
-			if v, ok := d.GetOk("alarms"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.DeploymentConfiguration.Alarms = expandAlarms(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("alarms"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.DeploymentConfiguration.Alarms = expandAlarms(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -1463,8 +1463,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			// To remove an existing deployment circuit breaker, specify an empty object.
 			input.DeploymentConfiguration.DeploymentCircuitBreaker = &awstypes.DeploymentCircuitBreaker{}
 
-			if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("deployment_circuit_breaker"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.DeploymentConfiguration.DeploymentCircuitBreaker = expandDeploymentCircuitBreaker(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -1511,7 +1511,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange(names.AttrNetworkConfiguration) {
-			input.NetworkConfiguration = expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]interface{}))
+			input.NetworkConfiguration = expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]any))
 		}
 
 		if d.HasChange("ordered_placement_strategy") {
@@ -1519,8 +1519,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			// To remove an existing placement strategy, specify an empty object.
 			input.PlacementStrategy = []awstypes.PlacementStrategy{}
 
-			if v, ok := d.GetOk("ordered_placement_strategy"); ok && len(v.([]interface{})) > 0 {
-				apiObject, err := expandPlacementStrategy(v.([]interface{}))
+			if v, ok := d.GetOk("ordered_placement_strategy"); ok && len(v.([]any)) > 0 {
+				apiObject, err := expandPlacementStrategy(v.([]any))
 				if err != nil {
 					return sdkdiag.AppendFromErr(diags, err)
 				}
@@ -1553,11 +1553,11 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange("service_connect_configuration") {
-			input.ServiceConnectConfiguration = expandServiceConnectConfiguration(d.Get("service_connect_configuration").([]interface{}))
+			input.ServiceConnectConfiguration = expandServiceConnectConfiguration(d.Get("service_connect_configuration").([]any))
 		}
 
 		if d.HasChange("service_registries") {
-			input.ServiceRegistries = expandServiceRegistries(d.Get("service_registries").([]interface{}))
+			input.ServiceRegistries = expandServiceRegistries(d.Get("service_registries").([]any))
 		}
 
 		if d.HasChange("task_definition") {
@@ -1565,7 +1565,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange("volume_configuration") {
-			input.VolumeConfigurations = expandVolumeConfigurations(ctx, d.Get("volume_configuration").([]interface{}))
+			input.VolumeConfigurations = expandVolumeConfigurations(ctx, d.Get("volume_configuration").([]any))
 		}
 
 		if d.HasChange("vpc_lattice_configurations") {
@@ -1578,7 +1578,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 			timeout              = propagationTimeout + serviceUpdateTimeout
 		)
 		_, err := tfresource.RetryWhen(ctx, timeout,
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.UpdateService(ctx, input)
 			},
 			func(err error) (bool, error) {
@@ -1610,7 +1610,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
-func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -1649,7 +1649,7 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 
 	log.Printf("[DEBUG] Deleting ECS Service: %s", d.Id())
 	_, err = tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteService(ctx, &ecs.DeleteServiceInput{
 				Cluster: aws.String(cluster),
 				Force:   aws.Bool(forceDelete),
@@ -1680,7 +1680,7 @@ func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceServiceImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceServiceImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	if len(strings.Split(d.Id(), "/")) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of resource: %s, expecting 'cluster-name/service-name'", d.Id())
 	}
@@ -1706,7 +1706,7 @@ func retryServiceCreate(ctx context.Context, conn *ecs.Client, input *ecs.Create
 		timeout              = propagationTimeout + serviceCreateTimeout
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateService(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -1877,7 +1877,7 @@ const (
 )
 
 func statusService(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findServiceNoTagsByTwoPartKey(ctx, conn, serviceName, clusterNameOrARN)
 
 		if tfresource.NotFound(err) {
@@ -1893,7 +1893,7 @@ func statusService(ctx context.Context, conn *ecs.Client, serviceName, clusterNa
 }
 
 func statusServiceWaitForStable(ctx context.Context, conn *ecs.Client, serviceName, clusterNameOrARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		outputRaw, status, err := statusService(ctx, conn, serviceName, clusterNameOrARN)()
 
 		if err != nil {
@@ -1972,7 +1972,7 @@ func waitServiceInactive(ctx context.Context, conn *ecs.Client, serviceName, clu
 	return nil, err
 }
 
-func triggersCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func triggersCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	// clears diff to avoid extraneous diffs but lets it pass for triggering update
 	fnd := false
 	if v, ok := d.GetOk("force_new_deployment"); ok {
@@ -1985,7 +1985,7 @@ func triggersCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 
 	if d.HasChange(names.AttrTriggers) && fnd {
 		o, n := d.GetChange(names.AttrTriggers)
-		if len(o.(map[string]interface{})) > 0 && len(n.(map[string]interface{})) == 0 {
+		if len(o.(map[string]any)) > 0 && len(n.(map[string]any)) == 0 {
 			return d.Clear(names.AttrTriggers)
 		}
 
@@ -1995,7 +1995,7 @@ func triggersCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta inter
 	return nil
 }
 
-func capacityProviderStrategyCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func capacityProviderStrategyCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	// to be backward compatible, should ForceNew almost always (previous behavior), unless:
 	//   force_new_deployment is true and
 	//   neither the old set nor new set is 0 length
@@ -2026,7 +2026,7 @@ func capacityProviderStrategyForceNew(d *schema.ResourceDiff) error {
 	return nil
 }
 
-func expandAlarms(tfMap map[string]interface{}) *awstypes.DeploymentAlarms {
+func expandAlarms(tfMap map[string]any) *awstypes.DeploymentAlarms {
 	if tfMap == nil {
 		return nil
 	}
@@ -2048,12 +2048,12 @@ func expandAlarms(tfMap map[string]interface{}) *awstypes.DeploymentAlarms {
 	return apiObject
 }
 
-func flattenAlarms(apiObject *awstypes.DeploymentAlarms) map[string]interface{} {
+func flattenAlarms(apiObject *awstypes.DeploymentAlarms) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AlarmNames; v != nil {
 		tfMap["alarm_names"] = v
@@ -2066,12 +2066,12 @@ func flattenAlarms(apiObject *awstypes.DeploymentAlarms) map[string]interface{} 
 	return tfMap
 }
 
-func expandDeploymentController(l []interface{}) *awstypes.DeploymentController {
+func expandDeploymentController(l []any) *awstypes.DeploymentController {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	deploymentController := &awstypes.DeploymentController{
 		Type: awstypes.DeploymentControllerType(m[names.AttrType].(string)),
@@ -2080,21 +2080,21 @@ func expandDeploymentController(l []interface{}) *awstypes.DeploymentController 
 	return deploymentController
 }
 
-func flattenDeploymentController(deploymentController *awstypes.DeploymentController) []interface{} {
-	m := map[string]interface{}{
+func flattenDeploymentController(deploymentController *awstypes.DeploymentController) []any {
+	m := map[string]any{
 		names.AttrType: awstypes.DeploymentControllerTypeEcs,
 	}
 
 	if deploymentController == nil {
-		return []interface{}{m}
+		return []any{m}
 	}
 
 	m[names.AttrType] = string(deploymentController.Type)
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func expandDeploymentCircuitBreaker(tfMap map[string]interface{}) *awstypes.DeploymentCircuitBreaker {
+func expandDeploymentCircuitBreaker(tfMap map[string]any) *awstypes.DeploymentCircuitBreaker {
 	if tfMap == nil {
 		return nil
 	}
@@ -2107,12 +2107,12 @@ func expandDeploymentCircuitBreaker(tfMap map[string]interface{}) *awstypes.Depl
 	return apiObject
 }
 
-func flattenDeploymentCircuitBreaker(apiObject *awstypes.DeploymentCircuitBreaker) map[string]interface{} {
+func flattenDeploymentCircuitBreaker(apiObject *awstypes.DeploymentCircuitBreaker) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["enable"] = apiObject.Enable
 	tfMap["rollback"] = apiObject.Rollback
@@ -2120,26 +2120,26 @@ func flattenDeploymentCircuitBreaker(apiObject *awstypes.DeploymentCircuitBreake
 	return tfMap
 }
 
-func flattenNetworkConfiguration(nc *awstypes.NetworkConfiguration) []interface{} {
+func flattenNetworkConfiguration(nc *awstypes.NetworkConfiguration) []any {
 	if nc == nil {
 		return nil
 	}
 
-	result := make(map[string]interface{})
+	result := make(map[string]any)
 	result[names.AttrSecurityGroups] = flex.FlattenStringValueSet(nc.AwsvpcConfiguration.SecurityGroups)
 	result[names.AttrSubnets] = flex.FlattenStringValueSet(nc.AwsvpcConfiguration.Subnets)
 
 	result["assign_public_ip"] = nc.AwsvpcConfiguration.AssignPublicIp == awstypes.AssignPublicIpEnabled
 
-	return []interface{}{result}
+	return []any{result}
 }
 
-func expandNetworkConfiguration(nc []interface{}) *awstypes.NetworkConfiguration {
+func expandNetworkConfiguration(nc []any) *awstypes.NetworkConfiguration {
 	if len(nc) == 0 {
 		return nil
 	}
 	awsVpcConfig := &awstypes.AwsVpcConfiguration{}
-	raw := nc[0].(map[string]interface{})
+	raw := nc[0].(map[string]any)
 	if val, ok := raw[names.AttrSecurityGroups]; ok {
 		awsVpcConfig.SecurityGroups = flex.ExpandStringValueSet(val.(*schema.Set))
 	}
@@ -2158,7 +2158,7 @@ func expandVPCLatticeConfiguration(tfSet *schema.Set) []awstypes.VpcLatticeConfi
 	apiObjects := make([]awstypes.VpcLatticeConfiguration, 0)
 
 	for _, tfMapRaw := range tfSet.List() {
-		config := tfMapRaw.(map[string]interface{})
+		config := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.VpcLatticeConfiguration{
 			RoleArn:        aws.String(config[names.AttrRoleARN].(string)),
@@ -2172,15 +2172,15 @@ func expandVPCLatticeConfiguration(tfSet *schema.Set) []awstypes.VpcLatticeConfi
 	return apiObjects
 }
 
-func flattenVPCLatticeConfigurations(apiObjects []awstypes.VpcLatticeConfiguration) []interface{} {
+func flattenVPCLatticeConfigurations(apiObjects []awstypes.VpcLatticeConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	tfList := make([]interface{}, 0, len(apiObjects))
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrRoleARN:  aws.ToString(apiObject.RoleArn),
 			"target_group_arn": aws.ToString(apiObject.TargetGroupArn),
 			"port_name":        aws.ToString(apiObject.PortName),
@@ -2191,7 +2191,7 @@ func flattenVPCLatticeConfigurations(apiObjects []awstypes.VpcLatticeConfigurati
 	return tfList
 }
 
-func expandPlacementConstraints(tfList []interface{}) ([]awstypes.PlacementConstraint, error) {
+func expandPlacementConstraints(tfList []any) ([]awstypes.PlacementConstraint, error) {
 	if len(tfList) == 0 {
 		return nil, nil
 	}
@@ -2203,7 +2203,7 @@ func expandPlacementConstraints(tfList []interface{}) ([]awstypes.PlacementConst
 			continue
 		}
 
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.PlacementConstraint{}
 
@@ -2225,13 +2225,13 @@ func expandPlacementConstraints(tfList []interface{}) ([]awstypes.PlacementConst
 	return result, nil
 }
 
-func flattenServicePlacementConstraints(pcs []awstypes.PlacementConstraint) []map[string]interface{} {
+func flattenServicePlacementConstraints(pcs []awstypes.PlacementConstraint) []map[string]any {
 	if len(pcs) == 0 {
 		return nil
 	}
-	results := make([]map[string]interface{}, 0)
+	results := make([]map[string]any, 0)
 	for _, pc := range pcs {
-		c := make(map[string]interface{})
+		c := make(map[string]any)
 		c[names.AttrType] = string(pc.Type)
 		if pc.Expression != nil {
 			c[names.AttrExpression] = aws.ToString(pc.Expression)
@@ -2242,13 +2242,13 @@ func flattenServicePlacementConstraints(pcs []awstypes.PlacementConstraint) []ma
 	return results
 }
 
-func expandPlacementStrategy(s []interface{}) ([]awstypes.PlacementStrategy, error) {
+func expandPlacementStrategy(s []any) ([]awstypes.PlacementStrategy, error) {
 	if len(s) == 0 {
 		return nil, nil
 	}
 	pss := make([]awstypes.PlacementStrategy, 0)
 	for _, raw := range s {
-		p, ok := raw.(map[string]interface{})
+		p, ok := raw.(map[string]any)
 
 		if !ok {
 			continue
@@ -2281,13 +2281,13 @@ func expandPlacementStrategy(s []interface{}) ([]awstypes.PlacementStrategy, err
 	return pss, nil
 }
 
-func flattenPlacementStrategy(pss []awstypes.PlacementStrategy) []interface{} {
+func flattenPlacementStrategy(pss []awstypes.PlacementStrategy) []any {
 	if len(pss) == 0 {
 		return nil
 	}
-	results := make([]interface{}, 0, len(pss))
+	results := make([]any, 0, len(pss))
 	for _, ps := range pss {
-		c := make(map[string]interface{})
+		c := make(map[string]any)
 		c[names.AttrType] = string(ps.Type)
 
 		if ps.Field != nil {
@@ -2304,20 +2304,20 @@ func flattenPlacementStrategy(pss []awstypes.PlacementStrategy) []interface{} {
 	return results
 }
 
-func expandServiceConnectConfiguration(sc []interface{}) *awstypes.ServiceConnectConfiguration {
+func expandServiceConnectConfiguration(sc []any) *awstypes.ServiceConnectConfiguration {
 	if len(sc) == 0 {
 		return &awstypes.ServiceConnectConfiguration{
 			Enabled: false,
 		}
 	}
-	raw := sc[0].(map[string]interface{})
+	raw := sc[0].(map[string]any)
 
 	config := &awstypes.ServiceConnectConfiguration{}
 	if v, ok := raw[names.AttrEnabled].(bool); ok {
 		config.Enabled = v
 	}
 
-	if v, ok := raw["log_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["log_configuration"].([]any); ok && len(v) > 0 {
 		config.LogConfiguration = expandLogConfiguration(v)
 	}
 
@@ -2325,41 +2325,41 @@ func expandServiceConnectConfiguration(sc []interface{}) *awstypes.ServiceConnec
 		config.Namespace = aws.String(v)
 	}
 
-	if v, ok := raw["service"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["service"].([]any); ok && len(v) > 0 {
 		config.Services = expandServices(v)
 	}
 
 	return config
 }
 
-func expandLogConfiguration(lc []interface{}) *awstypes.LogConfiguration {
+func expandLogConfiguration(lc []any) *awstypes.LogConfiguration {
 	if len(lc) == 0 {
 		return &awstypes.LogConfiguration{}
 	}
-	raw := lc[0].(map[string]interface{})
+	raw := lc[0].(map[string]any)
 
 	config := &awstypes.LogConfiguration{}
 	if v, ok := raw["log_driver"].(string); ok && v != "" {
 		config.LogDriver = awstypes.LogDriver(v)
 	}
-	if v, ok := raw["options"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["options"].(map[string]any); ok && len(v) > 0 {
 		config.Options = flex.ExpandStringValueMap(v)
 	}
-	if v, ok := raw["secret_option"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["secret_option"].([]any); ok && len(v) > 0 {
 		config.SecretOptions = expandSecretOptions(v)
 	}
 
 	return config
 }
 
-func expandSecretOptions(sop []interface{}) []awstypes.Secret {
+func expandSecretOptions(sop []any) []awstypes.Secret {
 	if len(sop) == 0 {
 		return nil
 	}
 
 	var out []awstypes.Secret
 	for _, item := range sop {
-		raw, ok := item.(map[string]interface{})
+		raw, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2378,7 +2378,7 @@ func expandSecretOptions(sop []interface{}) []awstypes.Secret {
 	return out
 }
 
-func expandVolumeConfigurations(ctx context.Context, vc []interface{}) []awstypes.ServiceVolumeConfiguration {
+func expandVolumeConfigurations(ctx context.Context, vc []any) []awstypes.ServiceVolumeConfiguration {
 	if len(vc) == 0 {
 		return nil
 	}
@@ -2386,13 +2386,13 @@ func expandVolumeConfigurations(ctx context.Context, vc []interface{}) []awstype
 	vcs := make([]awstypes.ServiceVolumeConfiguration, 0)
 
 	for _, raw := range vc {
-		p := raw.(map[string]interface{})
+		p := raw.(map[string]any)
 
 		config := awstypes.ServiceVolumeConfiguration{
 			Name: aws.String(p[names.AttrName].(string)),
 		}
 
-		if v, ok := p["managed_ebs_volume"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := p["managed_ebs_volume"].([]any); ok && len(v) > 0 {
 			config.ManagedEBSVolume = expandManagedEBSVolume(ctx, v)
 		}
 		vcs = append(vcs, config)
@@ -2401,11 +2401,11 @@ func expandVolumeConfigurations(ctx context.Context, vc []interface{}) []awstype
 	return vcs
 }
 
-func expandManagedEBSVolume(ctx context.Context, ebs []interface{}) *awstypes.ServiceManagedEBSVolumeConfiguration {
+func expandManagedEBSVolume(ctx context.Context, ebs []any) *awstypes.ServiceManagedEBSVolumeConfiguration {
 	if len(ebs) == 0 {
 		return &awstypes.ServiceManagedEBSVolumeConfiguration{}
 	}
-	raw := ebs[0].(map[string]interface{})
+	raw := ebs[0].(map[string]any)
 
 	config := &awstypes.ServiceManagedEBSVolumeConfiguration{}
 	if v, ok := raw[names.AttrRoleARN].(string); ok && v != "" {
@@ -2435,21 +2435,21 @@ func expandManagedEBSVolume(ctx context.Context, ebs []interface{}) *awstypes.Se
 	if v, ok := raw[names.AttrVolumeType].(string); ok && v != "" {
 		config.VolumeType = aws.String(v)
 	}
-	if v, ok := raw["tag_specifications"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["tag_specifications"].([]any); ok && len(v) > 0 {
 		config.TagSpecifications = expandTagSpecifications(ctx, v)
 	}
 
 	return config
 }
 
-func expandTagSpecifications(ctx context.Context, ts []interface{}) []awstypes.EBSTagSpecification {
+func expandTagSpecifications(ctx context.Context, ts []any) []awstypes.EBSTagSpecification {
 	if len(ts) == 0 {
 		return []awstypes.EBSTagSpecification{}
 	}
 
 	var s []awstypes.EBSTagSpecification
 	for _, item := range ts {
-		raw, ok := item.(map[string]interface{})
+		raw, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2472,20 +2472,20 @@ func expandTagSpecifications(ctx context.Context, ts []interface{}) []awstypes.E
 	return s
 }
 
-func expandServices(srv []interface{}) []awstypes.ServiceConnectService {
+func expandServices(srv []any) []awstypes.ServiceConnectService {
 	if len(srv) == 0 {
 		return nil
 	}
 
 	var out []awstypes.ServiceConnectService
 	for _, item := range srv {
-		raw, ok := item.(map[string]interface{})
+		raw, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
 
 		var config awstypes.ServiceConnectService
-		if v, ok := raw["client_alias"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := raw["client_alias"].([]any); ok && len(v) > 0 {
 			config.ClientAliases = expandClientAliases(v)
 		}
 		if v, ok := raw["discovery_name"].(string); ok && v != "" {
@@ -2498,11 +2498,11 @@ func expandServices(srv []interface{}) []awstypes.ServiceConnectService {
 			config.PortName = aws.String(v)
 		}
 
-		if v, ok := raw[names.AttrTimeout].([]interface{}); ok && len(v) > 0 {
+		if v, ok := raw[names.AttrTimeout].([]any); ok && len(v) > 0 {
 			config.Timeout = expandTimeout(v)
 		}
 
-		if v, ok := raw["tls"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := raw["tls"].([]any); ok && len(v) > 0 {
 			config.Tls = expandTLS(v)
 		}
 
@@ -2512,12 +2512,12 @@ func expandServices(srv []interface{}) []awstypes.ServiceConnectService {
 	return out
 }
 
-func expandTimeout(timeout []interface{}) *awstypes.TimeoutConfiguration {
+func expandTimeout(timeout []any) *awstypes.TimeoutConfiguration {
 	if len(timeout) == 0 {
 		return nil
 	}
 
-	raw, ok := timeout[0].(map[string]interface{})
+	raw, ok := timeout[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2531,17 +2531,17 @@ func expandTimeout(timeout []interface{}) *awstypes.TimeoutConfiguration {
 	return timeoutConfig
 }
 
-func expandTLS(tls []interface{}) *awstypes.ServiceConnectTlsConfiguration {
+func expandTLS(tls []any) *awstypes.ServiceConnectTlsConfiguration {
 	if len(tls) == 0 {
 		return nil
 	}
 
-	raw, ok := tls[0].(map[string]interface{})
+	raw, ok := tls[0].(map[string]any)
 	if !ok {
 		return nil
 	}
 	tlsConfig := &awstypes.ServiceConnectTlsConfiguration{}
-	if v, ok := raw["issuer_cert_authority"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := raw["issuer_cert_authority"].([]any); ok && len(v) > 0 {
 		tlsConfig.IssuerCertificateAuthority = expandIssuerCertAuthority(v)
 	}
 	if v, ok := raw[names.AttrKMSKey].(string); ok && v != "" {
@@ -2553,12 +2553,12 @@ func expandTLS(tls []interface{}) *awstypes.ServiceConnectTlsConfiguration {
 	return tlsConfig
 }
 
-func expandIssuerCertAuthority(pca []interface{}) *awstypes.ServiceConnectTlsCertificateAuthority {
+func expandIssuerCertAuthority(pca []any) *awstypes.ServiceConnectTlsCertificateAuthority {
 	if len(pca) == 0 {
 		return nil
 	}
 
-	raw, ok := pca[0].(map[string]interface{})
+	raw, ok := pca[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -2570,14 +2570,14 @@ func expandIssuerCertAuthority(pca []interface{}) *awstypes.ServiceConnectTlsCer
 	return config
 }
 
-func expandClientAliases(srv []interface{}) []awstypes.ServiceConnectClientAlias {
+func expandClientAliases(srv []any) []awstypes.ServiceConnectClientAlias {
 	if len(srv) == 0 {
 		return nil
 	}
 
 	var out []awstypes.ServiceConnectClientAlias
 	for _, item := range srv {
-		raw, ok := item.(map[string]interface{})
+		raw, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2596,13 +2596,13 @@ func expandClientAliases(srv []interface{}) []awstypes.ServiceConnectClientAlias
 	return out
 }
 
-func flattenServiceRegistries(srs []awstypes.ServiceRegistry) []map[string]interface{} {
+func flattenServiceRegistries(srs []awstypes.ServiceRegistry) []map[string]any {
 	if len(srs) == 0 {
 		return nil
 	}
-	results := make([]map[string]interface{}, 0)
+	results := make([]map[string]any, 0)
 	for _, sr := range srs {
-		c := map[string]interface{}{
+		c := map[string]any{
 			"registry_arn": aws.ToString(sr.RegistryArn),
 		}
 		if sr.Port != nil {

--- a/internal/service/ecs/service_data_source.go
+++ b/internal/service/ecs/service_data_source.go
@@ -60,7 +60,7 @@ func dataSourceService() *schema.Resource {
 	}
 }
 
-func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 

--- a/internal/service/ecs/task_definition.go
+++ b/internal/service/ecs/task_definition.go
@@ -46,7 +46,7 @@ func resourceTaskDefinition() *schema.Resource {
 		DeleteWithoutTimeout: resourceTaskDefinitionDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set(names.AttrARN, d.Id())
 
 				idErr := fmt.Errorf("Expected ID in format of arn:PARTITION:ecs:REGION:ACCOUNTID:task-definition/FAMILY:REVISION and provided: %s", d.Id())
@@ -81,7 +81,7 @@ func resourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					// Sort the lists of environment variables as they are serialized to state, so we won't get
 					// spurious reorderings in plans (diff is suppressed if the environment variables haven't changed,
 					// but they still show in the plan if some other property changes).
@@ -460,15 +460,15 @@ func resourceTaskDefinition() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
+				Set: func(v any) int {
 					var str strings.Builder
-					tfMap := v.(map[string]interface{})
+					tfMap := v.(map[string]any)
 
 					if v, ok := tfMap["configure_at_launch"].(bool); ok {
 						str.WriteString(strconv.FormatBool(v))
 					}
-					if v, ok := tfMap["docker_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-						tfMap := v.([]interface{})[0].(map[string]interface{})
+					if v, ok := tfMap["docker_volume_configuration"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+						tfMap := v.([]any)[0].(map[string]any)
 
 						if v, ok := tfMap["autoprovision"].(bool); ok {
 							str.WriteString(strconv.FormatBool(v))
@@ -479,10 +479,10 @@ func resourceTaskDefinition() *schema.Resource {
 							}
 							str.WriteString(v)
 						}
-						if v, ok := tfMap["driver_opts"].(map[string]interface{}); ok && len(v) > 0 {
+						if v, ok := tfMap["driver_opts"].(map[string]any); ok && len(v) > 0 {
 							str.WriteString(strconv.Itoa(sdkv2.HashStringValueMap(flex.ExpandStringValueMap(v))))
 						}
-						if v, ok := tfMap["labels"].(map[string]interface{}); ok && len(v) > 0 {
+						if v, ok := tfMap["labels"].(map[string]any); ok && len(v) > 0 {
 							str.WriteString(strconv.Itoa(sdkv2.HashStringValueMap(flex.ExpandStringValueMap(v))))
 						}
 						if v, ok := tfMap[names.AttrScope].(string); ok {
@@ -492,11 +492,11 @@ func resourceTaskDefinition() *schema.Resource {
 							str.WriteString(v)
 						}
 					}
-					if v, ok := tfMap["efs_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-						tfMap := v.([]interface{})[0].(map[string]interface{})
+					if v, ok := tfMap["efs_volume_configuration"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+						tfMap := v.([]any)[0].(map[string]any)
 
-						if v, ok := tfMap["authorization_config"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-							tfMap := v.([]interface{})[0].(map[string]interface{})
+						if v, ok := tfMap["authorization_config"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+							tfMap := v.([]any)[0].(map[string]any)
 
 							if v, ok := tfMap["access_point_id"].(string); ok && v != "" {
 								str.WriteString(v)
@@ -518,11 +518,11 @@ func resourceTaskDefinition() *schema.Resource {
 							str.WriteString(strconv.Itoa(v))
 						}
 					}
-					if v, ok := tfMap["fsx_windows_file_server_volume_configuration"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-						tfMap := v.([]interface{})[0].(map[string]interface{})
+					if v, ok := tfMap["fsx_windows_file_server_volume_configuration"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+						tfMap := v.([]any)[0].(map[string]any)
 
-						if v, ok := tfMap["authorization_config"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-							tfMap := v.([]interface{})[0].(map[string]interface{})
+						if v, ok := tfMap["authorization_config"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+							tfMap := v.([]any)[0].(map[string]any)
 
 							if v, ok := tfMap["credentials_parameter"].(string); ok && v != "" {
 								str.WriteString(v)
@@ -548,7 +548,7 @@ func resourceTaskDefinition() *schema.Resource {
 	}
 }
 
-func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -572,8 +572,8 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 		input.EnableFaultInjection = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]interface{})) > 0 {
-		input.EphemeralStorage = expandEphemeralStorage(v.([]interface{}))
+	if v, ok := d.GetOk("ephemeral_storage"); ok && len(v.([]any)) > 0 {
+		input.EphemeralStorage = expandEphemeralStorage(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrExecutionRoleARN); ok {
@@ -609,7 +609,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 		input.PlacementConstraints = apiObject
 	}
 
-	if proxyConfigs := d.Get("proxy_configuration").([]interface{}); len(proxyConfigs) > 0 {
+	if proxyConfigs := d.Get("proxy_configuration").([]any); len(proxyConfigs) > 0 {
 		input.ProxyConfiguration = expandProxyConfiguration(proxyConfigs)
 	}
 
@@ -617,7 +617,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 		input.RequiresCompatibilities = flex.ExpandStringyValueSet[awstypes.Compatibility](v.(*schema.Set))
 	}
 
-	if runtimePlatformConfigs := d.Get("runtime_platform").([]interface{}); len(runtimePlatformConfigs) > 0 && runtimePlatformConfigs[0] != nil {
+	if runtimePlatformConfigs := d.Get("runtime_platform").([]any); len(runtimePlatformConfigs) > 0 && runtimePlatformConfigs[0] != nil {
 		input.RuntimePlatform = expandRuntimePlatform(runtimePlatformConfigs)
 	}
 
@@ -652,7 +652,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 		err := createTags(ctx, conn, d.Get(names.AttrARN).(string), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceTaskDefinitionRead(ctx, d, meta)...)
 		}
 
@@ -664,7 +664,7 @@ func resourceTaskDefinitionCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceTaskDefinitionRead(ctx, d, meta)...)
 }
 
-func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -736,7 +736,7 @@ func resourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceTaskDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskDefinitionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -744,7 +744,7 @@ func resourceTaskDefinitionUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceTaskDefinitionRead(ctx, d, meta)...)
 }
 
-func resourceTaskDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskDefinitionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	if v, ok := d.GetOk(names.AttrSkipDestroy); ok && v.(bool) {
 		log.Printf("[DEBUG] Retaining ECS Task Definition Revision: %s", d.Id())
@@ -819,7 +819,7 @@ func findTaskDefinitionByFamilyOrARN(ctx context.Context, conn *ecs.Client, fami
 	return taskDefinition, tags, nil
 }
 
-func validTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []string, errors []error) {
+func validTaskDefinitionContainerDefinitions(v any, k string) (ws []string, errors []error) {
 	_, err := expandContainerDefinitions(v.(string))
 	if err != nil {
 		errors = append(errors, fmt.Errorf("ECS Task Definition container_definitions is invalid: %s", err))
@@ -827,15 +827,15 @@ func validTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []stri
 	return
 }
 
-func flattenTaskDefinitionPlacementConstraints(apiObjects []awstypes.TaskDefinitionPlacementConstraint) []interface{} {
+func flattenTaskDefinitionPlacementConstraints(apiObjects []awstypes.TaskDefinitionPlacementConstraint) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	tfList := make([]interface{}, 0)
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		tfMap[names.AttrExpression] = aws.ToString(apiObject.Expression)
 		tfMap[names.AttrType] = apiObject.Type
@@ -846,7 +846,7 @@ func flattenTaskDefinitionPlacementConstraints(apiObjects []awstypes.TaskDefinit
 	return tfList
 }
 
-func flattenRuntimePlatform(apiObject *awstypes.RuntimePlatform) []interface{} {
+func flattenRuntimePlatform(apiObject *awstypes.RuntimePlatform) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -857,7 +857,7 @@ func flattenRuntimePlatform(apiObject *awstypes.RuntimePlatform) []interface{} {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if cpu != "" {
 		tfMap["cpu_architecture"] = cpu
@@ -866,12 +866,12 @@ func flattenRuntimePlatform(apiObject *awstypes.RuntimePlatform) []interface{} {
 		tfMap["operating_system_family"] = os
 	}
 
-	return []interface{}{
+	return []any{
 		tfMap,
 	}
 }
 
-func flattenProxyConfiguration(apiObject *awstypes.ProxyConfiguration) []interface{} {
+func flattenProxyConfiguration(apiObject *awstypes.ProxyConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -881,21 +881,21 @@ func flattenProxyConfiguration(apiObject *awstypes.ProxyConfiguration) []interfa
 		meshProperties[aws.ToString(property.Name)] = aws.ToString(property.Value)
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap["container_name"] = aws.ToString(apiObject.ContainerName)
 	tfMap[names.AttrProperties] = meshProperties
 	tfMap[names.AttrType] = apiObject.Type
 
-	return []interface{}{
+	return []any{
 		tfMap,
 	}
 }
 
-func flattenInferenceAccelerators(apiObjects []awstypes.InferenceAccelerator) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenInferenceAccelerators(apiObjects []awstypes.InferenceAccelerator) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrDeviceName: aws.ToString(apiObject.DeviceName),
 			"device_type":        aws.ToString(apiObject.DeviceType),
 		}
@@ -906,11 +906,11 @@ func flattenInferenceAccelerators(apiObjects []awstypes.InferenceAccelerator) []
 	return tfList
 }
 
-func expandInferenceAccelerators(tfList []interface{}) []awstypes.InferenceAccelerator {
+func expandInferenceAccelerators(tfList []any) []awstypes.InferenceAccelerator {
 	apiObjects := make([]awstypes.InferenceAccelerator, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.InferenceAccelerator{
 			DeviceName: aws.String(tfMap[names.AttrDeviceName].(string)),
 			DeviceType: aws.String(tfMap["device_type"].(string)),
@@ -921,11 +921,11 @@ func expandInferenceAccelerators(tfList []interface{}) []awstypes.InferenceAccel
 	return apiObjects
 }
 
-func expandTaskDefinitionPlacementConstraints(tfList []interface{}) ([]awstypes.TaskDefinitionPlacementConstraint, error) {
+func expandTaskDefinitionPlacementConstraints(tfList []any) ([]awstypes.TaskDefinitionPlacementConstraint, error) {
 	var apiObjects []awstypes.TaskDefinitionPlacementConstraint
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		t := tfMap[names.AttrType].(string)
 		e := tfMap[names.AttrExpression].(string)
 		if err := validPlacementConstraint(t, e); err != nil {
@@ -940,9 +940,9 @@ func expandTaskDefinitionPlacementConstraints(tfList []interface{}) ([]awstypes.
 	return apiObjects, nil
 }
 
-func expandRuntimePlatform(tfList []interface{}) *awstypes.RuntimePlatform {
+func expandRuntimePlatform(tfList []any) *awstypes.RuntimePlatform {
 	tfMapRaw := tfList[0]
-	tfMap := tfMapRaw.(map[string]interface{})
+	tfMap := tfMapRaw.(map[string]any)
 	apiObject := &awstypes.RuntimePlatform{}
 
 	if v := tfMap["cpu_architecture"].(string); v != "" {
@@ -955,12 +955,12 @@ func expandRuntimePlatform(tfList []interface{}) *awstypes.RuntimePlatform {
 	return apiObject
 }
 
-func expandProxyConfiguration(tfList []interface{}) *awstypes.ProxyConfiguration {
+func expandProxyConfiguration(tfList []any) *awstypes.ProxyConfiguration {
 	tfMapRaw := tfList[0]
-	tfMap := tfMapRaw.(map[string]interface{})
+	tfMap := tfMapRaw.(map[string]any)
 
 	properties := make([]awstypes.KeyValuePair, 0)
-	for k, v := range flex.ExpandStringValueMap(tfMap[names.AttrProperties].(map[string]interface{})) {
+	for k, v := range flex.ExpandStringValueMap(tfMap[names.AttrProperties].(map[string]any)) {
 		properties = append(properties, awstypes.KeyValuePair{
 			Name:  aws.String(k),
 			Value: aws.String(v),
@@ -976,11 +976,11 @@ func expandProxyConfiguration(tfList []interface{}) *awstypes.ProxyConfiguration
 	return apiObject
 }
 
-func expandVolumes(tfList []interface{}) []awstypes.Volume {
+func expandVolumes(tfList []any) []awstypes.Volume {
 	apiObjects := make([]awstypes.Volume, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.Volume{
 			Name: aws.String(tfMap[names.AttrName].(string)),
@@ -990,15 +990,15 @@ func expandVolumes(tfList []interface{}) []awstypes.Volume {
 			apiObject.ConfiguredAtLaunch = aws.Bool(v)
 		}
 
-		if v, ok := tfMap["docker_volume_configuration"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["docker_volume_configuration"].([]any); ok && len(v) > 0 {
 			apiObject.DockerVolumeConfiguration = expandDockerVolumeConfiguration(v)
 		}
 
-		if v, ok := tfMap["efs_volume_configuration"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["efs_volume_configuration"].([]any); ok && len(v) > 0 {
 			apiObject.EfsVolumeConfiguration = expandEFSVolumeConfiguration(v)
 		}
 
-		if v, ok := tfMap["fsx_windows_file_server_volume_configuration"].([]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["fsx_windows_file_server_volume_configuration"].([]any); ok && len(v) > 0 {
 			apiObject.FsxWindowsFileServerVolumeConfiguration = expandFSxWindowsFileServerVolumeConfiguration(v)
 		}
 
@@ -1014,8 +1014,8 @@ func expandVolumes(tfList []interface{}) []awstypes.Volume {
 	return apiObjects
 }
 
-func expandDockerVolumeConfiguration(tfList []interface{}) *awstypes.DockerVolumeConfiguration {
-	tfMap := tfList[0].(map[string]interface{})
+func expandDockerVolumeConfiguration(tfList []any) *awstypes.DockerVolumeConfiguration {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.DockerVolumeConfiguration{}
 
 	if v, ok := tfMap[names.AttrScope].(string); ok && v != "" {
@@ -1032,22 +1032,22 @@ func expandDockerVolumeConfiguration(tfList []interface{}) *awstypes.DockerVolum
 		apiObject.Driver = aws.String(v)
 	}
 
-	if v, ok := tfMap["driver_opts"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["driver_opts"].(map[string]any); ok && len(v) > 0 {
 		apiObject.DriverOpts = flex.ExpandStringValueMap(v)
 	}
 
-	if v, ok := tfMap["labels"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["labels"].(map[string]any); ok && len(v) > 0 {
 		apiObject.Labels = flex.ExpandStringValueMap(v)
 	}
 
 	return apiObject
 }
 
-func expandEFSVolumeConfiguration(tfList []interface{}) *awstypes.EFSVolumeConfiguration {
-	tfMap := tfList[0].(map[string]interface{})
+func expandEFSVolumeConfiguration(tfList []any) *awstypes.EFSVolumeConfiguration {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.EFSVolumeConfiguration{}
 
-	if v, ok := tfMap["authorization_config"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["authorization_config"].([]any); ok && len(v) > 0 {
 		apiObject.AuthorizationConfig = expandEFSAuthorizationConfig(v)
 	}
 
@@ -1070,8 +1070,8 @@ func expandEFSVolumeConfiguration(tfList []interface{}) *awstypes.EFSVolumeConfi
 	return apiObject
 }
 
-func expandEFSAuthorizationConfig(tfList []interface{}) *awstypes.EFSAuthorizationConfig {
-	tfMap := tfList[0].(map[string]interface{})
+func expandEFSAuthorizationConfig(tfList []any) *awstypes.EFSAuthorizationConfig {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.EFSAuthorizationConfig{}
 
 	if v, ok := tfMap["access_point_id"].(string); ok && v != "" {
@@ -1085,11 +1085,11 @@ func expandEFSAuthorizationConfig(tfList []interface{}) *awstypes.EFSAuthorizati
 	return apiObject
 }
 
-func expandFSxWindowsFileServerVolumeConfiguration(tfList []interface{}) *awstypes.FSxWindowsFileServerVolumeConfiguration {
-	tfMap := tfList[0].(map[string]interface{})
+func expandFSxWindowsFileServerVolumeConfiguration(tfList []any) *awstypes.FSxWindowsFileServerVolumeConfiguration {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.FSxWindowsFileServerVolumeConfiguration{}
 
-	if v, ok := tfMap["authorization_config"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["authorization_config"].([]any); ok && len(v) > 0 {
 		apiObject.AuthorizationConfig = expandFSxWindowsFileServerAuthorizationConfig(v)
 	}
 
@@ -1104,8 +1104,8 @@ func expandFSxWindowsFileServerVolumeConfiguration(tfList []interface{}) *awstyp
 	return apiObject
 }
 
-func expandFSxWindowsFileServerAuthorizationConfig(tfList []interface{}) *awstypes.FSxWindowsFileServerAuthorizationConfig {
-	tfMap := tfList[0].(map[string]interface{})
+func expandFSxWindowsFileServerAuthorizationConfig(tfList []any) *awstypes.FSxWindowsFileServerAuthorizationConfig {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.FSxWindowsFileServerAuthorizationConfig{}
 
 	if v, ok := tfMap["credentials_parameter"].(string); ok && v != "" {
@@ -1119,11 +1119,11 @@ func expandFSxWindowsFileServerAuthorizationConfig(tfList []interface{}) *awstyp
 	return apiObject
 }
 
-func flattenVolumes(apiObjects []awstypes.Volume) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenVolumes(apiObjects []awstypes.Volume) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrName: aws.ToString(apiObject.Name),
 		}
 
@@ -1153,9 +1153,9 @@ func flattenVolumes(apiObjects []awstypes.Volume) []interface{} {
 	return tfList
 }
 
-func flattenDockerVolumeConfiguration(apiObject *awstypes.DockerVolumeConfiguration) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{})
+func flattenDockerVolumeConfiguration(apiObject *awstypes.DockerVolumeConfiguration) []any {
+	var tfList []any
+	tfMap := make(map[string]any)
 
 	if v := apiObject.Autoprovision; v != nil {
 		tfMap["autoprovision"] = aws.ToBool(v)
@@ -1180,9 +1180,9 @@ func flattenDockerVolumeConfiguration(apiObject *awstypes.DockerVolumeConfigurat
 	return tfList
 }
 
-func flattenEFSVolumeConfiguration(apiObject *awstypes.EFSVolumeConfiguration) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{})
+func flattenEFSVolumeConfiguration(apiObject *awstypes.EFSVolumeConfiguration) []any {
+	var tfList []any
+	tfMap := make(map[string]any)
 
 	if apiObject != nil {
 		if v := apiObject.AuthorizationConfig; v != nil {
@@ -1209,9 +1209,9 @@ func flattenEFSVolumeConfiguration(apiObject *awstypes.EFSVolumeConfiguration) [
 	return tfList
 }
 
-func flattenEFSAuthorizationConfig(apiObject *awstypes.EFSAuthorizationConfig) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{})
+func flattenEFSAuthorizationConfig(apiObject *awstypes.EFSAuthorizationConfig) []any {
+	var tfList []any
+	tfMap := make(map[string]any)
 
 	if apiObject != nil {
 		if v := apiObject.AccessPointId; v != nil {
@@ -1226,9 +1226,9 @@ func flattenEFSAuthorizationConfig(apiObject *awstypes.EFSAuthorizationConfig) [
 	return tfList
 }
 
-func flattenFSxWindowsFileServerVolumeConfiguration(apiObject *awstypes.FSxWindowsFileServerVolumeConfiguration) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{})
+func flattenFSxWindowsFileServerVolumeConfiguration(apiObject *awstypes.FSxWindowsFileServerVolumeConfiguration) []any {
+	var tfList []any
+	tfMap := make(map[string]any)
 
 	if apiObject != nil {
 		if v := apiObject.AuthorizationConfig; v != nil {
@@ -1249,9 +1249,9 @@ func flattenFSxWindowsFileServerVolumeConfiguration(apiObject *awstypes.FSxWindo
 	return tfList
 }
 
-func flattenFSxWindowsFileServerAuthorizationConfig(apiObject *awstypes.FSxWindowsFileServerAuthorizationConfig) []interface{} {
-	var tfList []interface{}
-	tfMap := make(map[string]interface{})
+func flattenFSxWindowsFileServerAuthorizationConfig(apiObject *awstypes.FSxWindowsFileServerAuthorizationConfig) []any {
+	var tfList []any
+	tfMap := make(map[string]any)
 
 	if apiObject != nil {
 		if v := apiObject.CredentialsParameter; v != nil {
@@ -1268,8 +1268,8 @@ func flattenFSxWindowsFileServerAuthorizationConfig(apiObject *awstypes.FSxWindo
 	return tfList
 }
 
-func expandEphemeralStorage(tfList []interface{}) *awstypes.EphemeralStorage {
-	tfMap := tfList[0].(map[string]interface{})
+func expandEphemeralStorage(tfList []any) *awstypes.EphemeralStorage {
+	tfMap := tfList[0].(map[string]any)
 
 	apiObject := &awstypes.EphemeralStorage{
 		SizeInGiB: int32(tfMap["size_in_gib"].(int)),
@@ -1278,15 +1278,15 @@ func expandEphemeralStorage(tfList []interface{}) *awstypes.EphemeralStorage {
 	return apiObject
 }
 
-func flattenEphemeralStorage(apiObject *awstypes.EphemeralStorage) []interface{} {
+func flattenEphemeralStorage(apiObject *awstypes.EphemeralStorage) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap["size_in_gib"] = apiObject.SizeInGiB
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 // taskDefinitionARNStripRevision strips the trailing revision number from a task definition ARN

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -295,7 +295,7 @@ func dataSourceTaskDefinition() *schema.Resource {
 	}
 }
 
-func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 

--- a/internal/service/ecs/task_definition_migrate.go
+++ b/internal/service/ecs/task_definition_migrate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func resourceTaskDefinitionMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceTaskDefinitionMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	ctx := context.Background()
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -274,7 +274,7 @@ func dataSourceTaskExecution() *schema.Resource {
 	}
 }
 
-func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -287,7 +287,7 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	defaultTagsConfig := meta.(*conns.AWSClient).DefaultTagsConfig(ctx)
-	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]interface{})))
+	tags := defaultTagsConfig.MergeTags(tftags.New(ctx, d.Get(names.AttrTags).(map[string]any)))
 	if len(tags) > 0 {
 		input.Tags = Tags(tags.IgnoreAWS())
 	}
@@ -314,10 +314,10 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 		input.LaunchType = awstypes.LaunchType(v.(string))
 	}
 	if v, ok := d.GetOk(names.AttrNetworkConfiguration); ok {
-		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
+		input.NetworkConfiguration = expandNetworkConfiguration(v.([]any))
 	}
 	if v, ok := d.GetOk("overrides"); ok {
-		input.Overrides = expandTaskOverride(v.([]interface{}))
+		input.Overrides = expandTaskOverride(v.([]any))
 	}
 	if v, ok := d.GetOk("placement_constraints"); ok {
 		apiObject, err := expandPlacementConstraints(v.(*schema.Set).List())
@@ -328,7 +328,7 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 		input.PlacementConstraints = apiObject
 	}
 	if v, ok := d.GetOk("placement_strategy"); ok {
-		apiObject, err := expandPlacementStrategy(v.([]interface{}))
+		apiObject, err := expandPlacementStrategy(v.([]any))
 		if err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
@@ -362,13 +362,13 @@ func dataSourceTaskExecutionRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func expandTaskOverride(tfList []interface{}) *awstypes.TaskOverride {
+func expandTaskOverride(tfList []any) *awstypes.TaskOverride {
 	if len(tfList) == 0 {
 		return nil
 	}
 
 	apiObject := &awstypes.TaskOverride{}
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	if v, ok := tfMap["cpu"]; ok {
 		apiObject.Cpu = aws.String(v.(string))
@@ -386,7 +386,7 @@ func expandTaskOverride(tfList []interface{}) *awstypes.TaskOverride {
 		apiObject.InferenceAcceleratorOverrides = expandInferenceAcceleratorOverrides(v.(*schema.Set))
 	}
 	if v, ok := tfMap["container_overrides"]; ok {
-		apiObject.ContainerOverrides = expandContainerOverride(v.([]interface{}))
+		apiObject.ContainerOverrides = expandContainerOverride(v.([]any))
 	}
 
 	return apiObject
@@ -399,7 +399,7 @@ func expandInferenceAcceleratorOverrides(tfSet *schema.Set) []awstypes.Inference
 	apiObject := make([]awstypes.InferenceAcceleratorOverride, 0)
 
 	for _, item := range tfSet.List() {
-		tfMap := item.(map[string]interface{})
+		tfMap := item.(map[string]any)
 		iao := awstypes.InferenceAcceleratorOverride{
 			DeviceName: aws.String(tfMap[names.AttrDeviceName].(string)),
 			DeviceType: aws.String(tfMap["device_type"].(string)),
@@ -410,19 +410,19 @@ func expandInferenceAcceleratorOverrides(tfSet *schema.Set) []awstypes.Inference
 	return apiObject
 }
 
-func expandContainerOverride(tfList []interface{}) []awstypes.ContainerOverride {
+func expandContainerOverride(tfList []any) []awstypes.ContainerOverride {
 	if len(tfList) == 0 {
 		return nil
 	}
 	apiObject := make([]awstypes.ContainerOverride, 0)
 
 	for _, item := range tfList {
-		tfMap := item.(map[string]interface{})
+		tfMap := item.(map[string]any)
 		co := awstypes.ContainerOverride{
 			Name: aws.String(tfMap[names.AttrName].(string)),
 		}
 		if v, ok := tfMap["command"]; ok {
-			commandStrings := v.([]interface{})
+			commandStrings := v.([]any)
 			co.Command = flex.ExpandStringValueList(commandStrings)
 		}
 		if v, ok := tfMap["cpu"]; ok {
@@ -453,7 +453,7 @@ func expandTaskEnvironment(tfSet *schema.Set) []awstypes.KeyValuePair {
 	apiObject := make([]awstypes.KeyValuePair, 0)
 
 	for _, item := range tfSet.List() {
-		tfMap := item.(map[string]interface{})
+		tfMap := item.(map[string]any)
 		te := awstypes.KeyValuePair{
 			Name:  aws.String(tfMap[names.AttrKey].(string)),
 			Value: aws.String(tfMap[names.AttrValue].(string)),
@@ -471,7 +471,7 @@ func expandResourceRequirements(tfSet *schema.Set) []awstypes.ResourceRequiremen
 
 	apiObject := make([]awstypes.ResourceRequirement, 0)
 	for _, item := range tfSet.List() {
-		tfMap := item.(map[string]interface{})
+		tfMap := item.(map[string]any)
 		rr := awstypes.ResourceRequirement{
 			Type:  awstypes.ResourceType(tfMap[names.AttrType].(string)),
 			Value: aws.String(tfMap[names.AttrValue].(string)),

--- a/internal/service/ecs/task_set.go
+++ b/internal/service/ecs/task_set.go
@@ -253,7 +253,7 @@ func resourceTaskSet() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "10m",
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+				ValidateFunc: func(v any, k string) (ws []string, errors []error) {
 					value := v.(string)
 					duration, err := time.ParseDuration(value)
 					if err != nil {
@@ -271,7 +271,7 @@ func resourceTaskSet() *schema.Resource {
 	}
 }
 
-func resourceTaskSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskSetCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -302,20 +302,20 @@ func resourceTaskSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.LoadBalancers = expandTaskSetLoadBalancers(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk(names.AttrNetworkConfiguration); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrNetworkConfiguration); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.NetworkConfiguration = expandNetworkConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("platform_version"); ok {
 		input.PlatformVersion = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("scale"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.Scale = expandScale(v.([]interface{}))
+	if v, ok := d.GetOk("scale"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.Scale = expandScale(v.([]any))
 	}
 
-	if v, ok := d.GetOk("service_registries"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ServiceRegistries = expandServiceRegistries(v.([]interface{}))
+	if v, ok := d.GetOk("service_registries"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ServiceRegistries = expandServiceRegistries(v.([]any))
 	}
 
 	output, err := retryTaskSetCreate(ctx, conn, input)
@@ -346,7 +346,7 @@ func resourceTaskSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 		err := createTags(ctx, conn, aws.ToString(output.TaskSet.TaskSetArn), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceTaskSetRead(ctx, d, meta)...)
 		}
 
@@ -358,7 +358,7 @@ func resourceTaskSetCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceTaskSetRead(ctx, d, meta)...)
 }
 
-func resourceTaskSetRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskSetRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -410,7 +410,7 @@ func resourceTaskSetRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceTaskSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskSetUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -422,7 +422,7 @@ func resourceTaskSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 		input := &ecs.UpdateTaskSetInput{
 			Cluster: aws.String(cluster),
-			Scale:   expandScale(d.Get("scale").([]interface{})),
+			Scale:   expandScale(d.Get("scale").([]any)),
 			Service: aws.String(service),
 			TaskSet: aws.String(taskSetID),
 		}
@@ -444,7 +444,7 @@ func resourceTaskSetUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceTaskSetRead(ctx, d, meta)...)
 }
 
-func resourceTaskSetDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTaskSetDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ECSClient(ctx)
 
@@ -501,7 +501,7 @@ func retryTaskSetCreate(ctx context.Context, conn *ecs.Client, input *ecs.Create
 		timeout              = propagationTimeout + taskSetCreateTimeout
 	)
 	outputRaw, err := tfresource.RetryWhen(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateTaskSet(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -586,7 +586,7 @@ func findTaskSetNoTagsByThreePartKey(ctx context.Context, conn *ecs.Client, task
 }
 
 func statusTaskSetStability(ctx context.Context, conn *ecs.Client, taskSetID, service, cluster string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTaskSetNoTagsByThreePartKey(ctx, conn, taskSetID, service, cluster)
 
 		if tfresource.NotFound(err) {
@@ -602,7 +602,7 @@ func statusTaskSetStability(ctx context.Context, conn *ecs.Client, taskSetID, se
 }
 
 func statusTaskSet(ctx context.Context, conn *ecs.Client, taskSetID, service, cluster string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTaskSetNoTagsByThreePartKey(ctx, conn, taskSetID, service, cluster)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/ecs/validate.go
+++ b/internal/service/ecs/validate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-func validateClusterName(v interface{}, k string) (ws []string, errors []error) {
+func validateClusterName(v any, k string) (ws []string, errors []error) {
 	return validation.All(
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
