### PR TITLE
cloudfront: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -77,6 +77,7 @@ jobs:
       # Services
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/appmesh modern-check
+      - run: make TEST=./internal/service/cloudfront modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/elbv2 modern-check
@@ -86,10 +87,10 @@ jobs:
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check
       - run: make TEST=./internal/service/rds/... modern-check
-      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/s3 modern-check
+      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/sns modern-check
-      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/ssm modern-check
+      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/internal/service/cloudfront/cache_policy.go
+++ b/internal/service/cloudfront/cache_policy.go
@@ -170,7 +170,7 @@ func resourceCachePolicy() *schema.Resource {
 	}
 }
 
-func resourceCachePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCachePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -186,8 +186,8 @@ func resourceCachePolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ParametersInCacheKeyAndForwardedToOrigin = expandParametersInCacheKeyAndForwardedToOrigin(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ParametersInCacheKeyAndForwardedToOrigin = expandParametersInCacheKeyAndForwardedToOrigin(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.CreateCachePolicyInput{
@@ -205,7 +205,7 @@ func resourceCachePolicyCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceCachePolicyRead(ctx, d, meta)...)
 }
 
-func resourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -230,7 +230,7 @@ func resourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("min_ttl", apiObject.MinTTL)
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.ParametersInCacheKeyAndForwardedToOrigin != nil {
-		if err := d.Set("parameters_in_cache_key_and_forwarded_to_origin", []interface{}{flattenParametersInCacheKeyAndForwardedToOrigin(apiObject.ParametersInCacheKeyAndForwardedToOrigin)}); err != nil {
+		if err := d.Set("parameters_in_cache_key_and_forwarded_to_origin", []any{flattenParametersInCacheKeyAndForwardedToOrigin(apiObject.ParametersInCacheKeyAndForwardedToOrigin)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting parameters_in_cache_key_and_forwarded_to_origin: %s", err)
 		}
 	} else {
@@ -240,7 +240,7 @@ func resourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceCachePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCachePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -259,8 +259,8 @@ func resourceCachePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ParametersInCacheKeyAndForwardedToOrigin = expandParametersInCacheKeyAndForwardedToOrigin(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("parameters_in_cache_key_and_forwarded_to_origin"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ParametersInCacheKeyAndForwardedToOrigin = expandParametersInCacheKeyAndForwardedToOrigin(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.UpdateCachePolicyInput{
@@ -278,7 +278,7 @@ func resourceCachePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceCachePolicyRead(ctx, d, meta)...)
 }
 
-func resourceCachePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCachePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -325,15 +325,15 @@ func findCachePolicyByID(ctx context.Context, conn *cloudfront.Client, id string
 	return output, nil
 }
 
-func expandParametersInCacheKeyAndForwardedToOrigin(tfMap map[string]interface{}) *awstypes.ParametersInCacheKeyAndForwardedToOrigin {
+func expandParametersInCacheKeyAndForwardedToOrigin(tfMap map[string]any) *awstypes.ParametersInCacheKeyAndForwardedToOrigin {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ParametersInCacheKeyAndForwardedToOrigin{}
 
-	if v, ok := tfMap["cookies_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.CookiesConfig = expandCachePolicyCookiesConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["cookies_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.CookiesConfig = expandCachePolicyCookiesConfig(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["enable_accept_encoding_brotli"].(bool); ok {
@@ -344,18 +344,18 @@ func expandParametersInCacheKeyAndForwardedToOrigin(tfMap map[string]interface{}
 		apiObject.EnableAcceptEncodingGzip = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["headers_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.HeadersConfig = expandCachePolicyHeadersConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["headers_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.HeadersConfig = expandCachePolicyHeadersConfig(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["query_strings_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.QueryStringsConfig = expandCachePolicyQueryStringsConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["query_strings_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.QueryStringsConfig = expandCachePolicyQueryStringsConfig(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandCachePolicyCookiesConfig(tfMap map[string]interface{}) *awstypes.CachePolicyCookiesConfig {
+func expandCachePolicyCookiesConfig(tfMap map[string]any) *awstypes.CachePolicyCookiesConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -366,14 +366,14 @@ func expandCachePolicyCookiesConfig(tfMap map[string]interface{}) *awstypes.Cach
 		apiObject.CookieBehavior = awstypes.CachePolicyCookieBehavior(v)
 	}
 
-	if v, ok := tfMap["cookies"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Cookies = expandCookieNames(v[0].(map[string]interface{}))
+	if v, ok := tfMap["cookies"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Cookies = expandCookieNames(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandCookieNames(tfMap map[string]interface{}) *awstypes.CookieNames {
+func expandCookieNames(tfMap map[string]any) *awstypes.CookieNames {
 	if tfMap == nil {
 		return nil
 	}
@@ -389,7 +389,7 @@ func expandCookieNames(tfMap map[string]interface{}) *awstypes.CookieNames {
 	return apiObject
 }
 
-func expandCachePolicyHeadersConfig(tfMap map[string]interface{}) *awstypes.CachePolicyHeadersConfig {
+func expandCachePolicyHeadersConfig(tfMap map[string]any) *awstypes.CachePolicyHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -400,14 +400,14 @@ func expandCachePolicyHeadersConfig(tfMap map[string]interface{}) *awstypes.Cach
 		apiObject.HeaderBehavior = awstypes.CachePolicyHeaderBehavior(v)
 	}
 
-	if v, ok := tfMap["headers"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Headers = expandHeaders(v[0].(map[string]interface{}))
+	if v, ok := tfMap["headers"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Headers = expandHeaders(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandHeaders(tfMap map[string]interface{}) *awstypes.Headers {
+func expandHeaders(tfMap map[string]any) *awstypes.Headers {
 	if tfMap == nil {
 		return nil
 	}
@@ -423,7 +423,7 @@ func expandHeaders(tfMap map[string]interface{}) *awstypes.Headers {
 	return apiObject
 }
 
-func expandCachePolicyQueryStringsConfig(tfMap map[string]interface{}) *awstypes.CachePolicyQueryStringsConfig {
+func expandCachePolicyQueryStringsConfig(tfMap map[string]any) *awstypes.CachePolicyQueryStringsConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -434,14 +434,14 @@ func expandCachePolicyQueryStringsConfig(tfMap map[string]interface{}) *awstypes
 		apiObject.QueryStringBehavior = awstypes.CachePolicyQueryStringBehavior(v)
 	}
 
-	if v, ok := tfMap["query_strings"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.QueryStrings = expandQueryStringNames(v[0].(map[string]interface{}))
+	if v, ok := tfMap["query_strings"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.QueryStrings = expandQueryStringNames(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandQueryStringNames(tfMap map[string]interface{}) *awstypes.QueryStringNames {
+func expandQueryStringNames(tfMap map[string]any) *awstypes.QueryStringNames {
 	if tfMap == nil {
 		return nil
 	}
@@ -457,15 +457,15 @@ func expandQueryStringNames(tfMap map[string]interface{}) *awstypes.QueryStringN
 	return apiObject
 }
 
-func flattenParametersInCacheKeyAndForwardedToOrigin(apiObject *awstypes.ParametersInCacheKeyAndForwardedToOrigin) map[string]interface{} {
+func flattenParametersInCacheKeyAndForwardedToOrigin(apiObject *awstypes.ParametersInCacheKeyAndForwardedToOrigin) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenCachePolicyCookiesConfig(apiObject.CookiesConfig); len(v) > 0 {
-		tfMap["cookies_config"] = []interface{}{v}
+		tfMap["cookies_config"] = []any{v}
 	}
 
 	if v := apiObject.EnableAcceptEncodingBrotli; v != nil {
@@ -477,38 +477,38 @@ func flattenParametersInCacheKeyAndForwardedToOrigin(apiObject *awstypes.Paramet
 	}
 
 	if v := flattenCachePolicyHeadersConfig(apiObject.HeadersConfig); len(v) > 0 {
-		tfMap["headers_config"] = []interface{}{v}
+		tfMap["headers_config"] = []any{v}
 	}
 
 	if v := flattenCachePolicyQueryStringsConfig(apiObject.QueryStringsConfig); len(v) > 0 {
-		tfMap["query_strings_config"] = []interface{}{v}
+		tfMap["query_strings_config"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenCachePolicyCookiesConfig(apiObject *awstypes.CachePolicyCookiesConfig) map[string]interface{} {
+func flattenCachePolicyCookiesConfig(apiObject *awstypes.CachePolicyCookiesConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"cookie_behavior": apiObject.CookieBehavior,
 	}
 
 	if v := flattenCookieNames(apiObject.Cookies); len(v) > 0 {
-		tfMap["cookies"] = []interface{}{v}
+		tfMap["cookies"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenCookieNames(apiObject *awstypes.CookieNames) map[string]interface{} {
+func flattenCookieNames(apiObject *awstypes.CookieNames) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -517,28 +517,28 @@ func flattenCookieNames(apiObject *awstypes.CookieNames) map[string]interface{} 
 	return tfMap
 }
 
-func flattenCachePolicyHeadersConfig(apiObject *awstypes.CachePolicyHeadersConfig) map[string]interface{} {
+func flattenCachePolicyHeadersConfig(apiObject *awstypes.CachePolicyHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"header_behavior": apiObject.HeaderBehavior,
 	}
 
 	if v := flattenHeaders(apiObject.Headers); len(v) > 0 {
-		tfMap["headers"] = []interface{}{v}
+		tfMap["headers"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenHeaders(apiObject *awstypes.Headers) map[string]interface{} {
+func flattenHeaders(apiObject *awstypes.Headers) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -547,28 +547,28 @@ func flattenHeaders(apiObject *awstypes.Headers) map[string]interface{} {
 	return tfMap
 }
 
-func flattenCachePolicyQueryStringsConfig(apiObject *awstypes.CachePolicyQueryStringsConfig) map[string]interface{} {
+func flattenCachePolicyQueryStringsConfig(apiObject *awstypes.CachePolicyQueryStringsConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"query_string_behavior": apiObject.QueryStringBehavior,
 	}
 
 	if v := flattenQueryStringNames(apiObject.QueryStrings); len(v) > 0 {
-		tfMap["query_strings"] = []interface{}{v}
+		tfMap["query_strings"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenQueryStringNames(apiObject *awstypes.QueryStringNames) map[string]interface{} {
+func flattenQueryStringNames(apiObject *awstypes.QueryStringNames) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v

--- a/internal/service/cloudfront/cache_policy_data_source.go
+++ b/internal/service/cloudfront/cache_policy_data_source.go
@@ -149,7 +149,7 @@ func dataSourceCachePolicy() *schema.Resource {
 		},
 	}
 }
-func dataSourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -202,7 +202,7 @@ func dataSourceCachePolicyRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("min_ttl", apiObject.MinTTL)
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.ParametersInCacheKeyAndForwardedToOrigin != nil {
-		if err := d.Set("parameters_in_cache_key_and_forwarded_to_origin", []interface{}{flattenParametersInCacheKeyAndForwardedToOrigin(apiObject.ParametersInCacheKeyAndForwardedToOrigin)}); err != nil {
+		if err := d.Set("parameters_in_cache_key_and_forwarded_to_origin", []any{flattenParametersInCacheKeyAndForwardedToOrigin(apiObject.ParametersInCacheKeyAndForwardedToOrigin)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting parameters_in_cache_key_and_forwarded_to_origin: %s", err)
 		}
 	} else {

--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -39,7 +39,7 @@ func resourceDistribution() *schema.Resource {
 		DeleteWithoutTimeout: resourceDistributionDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				// Set non API attributes to their Default settings in the schema
 				d.Set("retain_on_delete", false)
 				d.Set("wait_for_deployment", true)
@@ -893,7 +893,7 @@ func resourceDistribution() *schema.Resource {
 	}
 }
 
-func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -913,7 +913,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	const (
 		timeout = 1 * time.Minute
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
 		return conn.CreateDistributionWithTags(ctx, input)
 	})
 
@@ -932,7 +932,7 @@ func resourceDistributionCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceDistributionRead(ctx, d, meta)...)
 }
 
-func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -968,7 +968,7 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 			return sdkdiag.AppendErrorf(diags, "setting custom_error_response: %s", err)
 		}
 	}
-	if err := d.Set("default_cache_behavior", []interface{}{flattenDefaultCacheBehavior(distributionConfig.DefaultCacheBehavior)}); err != nil {
+	if err := d.Set("default_cache_behavior", []any{flattenDefaultCacheBehavior(distributionConfig.DefaultCacheBehavior)}); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting default_cache_behavior: %s", err)
 	}
 	d.Set("default_root_object", distributionConfig.DefaultRootObject)
@@ -985,7 +985,7 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 			return sdkdiag.AppendErrorf(diags, "setting logging_config: %s", err)
 		}
 	} else {
-		d.Set("logging_config", []interface{}{})
+		d.Set("logging_config", []any{})
 	}
 	if distributionConfig.CacheBehaviors != nil {
 		if err := d.Set("ordered_cache_behavior", flattenCacheBehaviors(distributionConfig.CacheBehaviors)); err != nil {
@@ -1024,7 +1024,7 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -1040,7 +1040,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 1 * time.Minute
 		)
-		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhenIsA[*awstypes.InvalidViewerCertificate](ctx, timeout, func() (any, error) {
 			return conn.UpdateDistribution(ctx, input)
 		})
 
@@ -1072,7 +1072,7 @@ func resourceDistributionUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceDistributionRead(ctx, d, meta)...)
 }
 
-func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -1128,7 +1128,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 3 * time.Minute
 		)
-		_, err = tfresource.RetryWhenIsA[*awstypes.DistributionNotDisabled](ctx, timeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenIsA[*awstypes.DistributionNotDisabled](ctx, timeout, func() (any, error) {
 			return nil, deleteDistribution(ctx, conn, d.Id())
 		})
 	}
@@ -1137,7 +1137,7 @@ func resourceDistributionDelete(ctx context.Context, d *schema.ResourceData, met
 		const (
 			timeout = 1 * time.Minute
 		)
-		_, err = tfresource.RetryWhenIsOneOf2[*awstypes.PreconditionFailed, *awstypes.InvalidIfMatchVersion](ctx, timeout, func() (interface{}, error) {
+		_, err = tfresource.RetryWhenIsOneOf2[*awstypes.PreconditionFailed, *awstypes.InvalidIfMatchVersion](ctx, timeout, func() (any, error) {
 			return nil, deleteDistribution(ctx, conn, d.Id())
 		})
 	}
@@ -1265,7 +1265,7 @@ func findDistributionByID(ctx context.Context, conn *cloudfront.Client, id strin
 }
 
 func statusDistribution(ctx context.Context, conn *cloudfront.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDistributionByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -1324,12 +1324,12 @@ func waitDistributionDeleted(ctx context.Context, conn *cloudfront.Client, id st
 
 func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConfig {
 	apiObject := &awstypes.DistributionConfig{
-		CacheBehaviors:               expandCacheBehaviors(d.Get("ordered_cache_behavior").([]interface{})),
+		CacheBehaviors:               expandCacheBehaviors(d.Get("ordered_cache_behavior").([]any)),
 		CallerReference:              aws.String(id.UniqueId()),
 		Comment:                      aws.String(d.Get(names.AttrComment).(string)),
 		ContinuousDeploymentPolicyId: aws.String(d.Get("continuous_deployment_policy_id").(string)),
 		CustomErrorResponses:         expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set).List()),
-		DefaultCacheBehavior:         expandDefaultCacheBehavior(d.Get("default_cache_behavior").([]interface{})[0].(map[string]interface{})),
+		DefaultCacheBehavior:         expandDefaultCacheBehavior(d.Get("default_cache_behavior").([]any)[0].(map[string]any)),
 		DefaultRootObject:            aws.String(d.Get("default_root_object").(string)),
 		Enabled:                      aws.Bool(d.Get(names.AttrEnabled).(bool)),
 		IsIPV6Enabled:                aws.Bool(d.Get("is_ipv6_enabled").(bool)),
@@ -1343,15 +1343,15 @@ func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConf
 	if v, ok := d.GetOk("aliases"); ok {
 		apiObject.Aliases = expandAliases(v.(*schema.Set).List())
 	} else {
-		apiObject.Aliases = expandAliases([]interface{}{})
+		apiObject.Aliases = expandAliases([]any{})
 	}
 
 	if v, ok := d.GetOk("caller_reference"); ok {
 		apiObject.CallerReference = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("logging_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.Logging = expandLoggingConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("logging_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.Logging = expandLoggingConfig(v.([]any)[0].(map[string]any))
 	} else {
 		apiObject.Logging = expandLoggingConfig(nil)
 	}
@@ -1360,18 +1360,18 @@ func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConf
 		apiObject.OriginGroups = expandOriginGroups(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("restrictions"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.Restrictions = expandRestrictions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("restrictions"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.Restrictions = expandRestrictions(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("viewer_certificate"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ViewerCertificate = expandViewerCertificate(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("viewer_certificate"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ViewerCertificate = expandViewerCertificate(v.([]any)[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandCacheBehavior(tfMap map[string]interface{}) *awstypes.CacheBehavior {
+func expandCacheBehavior(tfMap map[string]any) *awstypes.CacheBehavior {
 	if tfMap == nil {
 		return nil
 	}
@@ -1400,16 +1400,16 @@ func expandCacheBehavior(tfMap map[string]interface{}) *awstypes.CacheBehavior {
 		apiObject.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set).List())
 	}
 
-	if v, ok := tfMap["forwarded_values"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.ForwardedValues = expandForwardedValues(v[0].(map[string]interface{}))
+	if v, ok := tfMap["forwarded_values"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ForwardedValues = expandForwardedValues(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["function_association"]; ok {
 		apiObject.FunctionAssociations = expandFunctionAssociations(v.(*schema.Set).List())
 	}
 
-	if v, ok := tfMap["grpc_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.GrpcConfig = expandGRPCConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["grpc_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.GrpcConfig = expandGRPCConfig(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["lambda_function_association"]; ok {
@@ -1429,25 +1429,25 @@ func expandCacheBehavior(tfMap map[string]interface{}) *awstypes.CacheBehavior {
 	}
 
 	if v, ok := tfMap["trusted_key_groups"]; ok {
-		apiObject.TrustedKeyGroups = expandTrustedKeyGroups(v.([]interface{}))
+		apiObject.TrustedKeyGroups = expandTrustedKeyGroups(v.([]any))
 	} else {
-		apiObject.TrustedKeyGroups = expandTrustedKeyGroups([]interface{}{})
+		apiObject.TrustedKeyGroups = expandTrustedKeyGroups([]any{})
 	}
 
 	if v, ok := tfMap["trusted_signers"]; ok {
-		apiObject.TrustedSigners = expandTrustedSigners(v.([]interface{}))
+		apiObject.TrustedSigners = expandTrustedSigners(v.([]any))
 	} else {
-		apiObject.TrustedSigners = expandTrustedSigners([]interface{}{})
+		apiObject.TrustedSigners = expandTrustedSigners([]any{})
 	}
 
 	return apiObject
 }
 
-func expandCacheBehaviors(tfList []interface{}) *awstypes.CacheBehaviors {
+func expandCacheBehaviors(tfList []any) *awstypes.CacheBehaviors {
 	var items []awstypes.CacheBehavior
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1467,8 +1467,8 @@ func expandCacheBehaviors(tfList []interface{}) *awstypes.CacheBehaviors {
 	}
 }
 
-func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]interface{} {
-	tfMap := make(map[string]interface{})
+func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]any {
+	tfMap := make(map[string]any)
 
 	tfMap["cache_policy_id"] = aws.ToString(apiObject.CachePolicyId)
 	tfMap["compress"] = aws.ToBool(apiObject.Compress)
@@ -1493,7 +1493,7 @@ func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]interfac
 	}
 
 	if apiObject.ForwardedValues != nil {
-		tfMap["forwarded_values"] = []interface{}{flattenForwardedValues(apiObject.ForwardedValues)}
+		tfMap["forwarded_values"] = []any{flattenForwardedValues(apiObject.ForwardedValues)}
 	}
 
 	if len(apiObject.FunctionAssociations.Items) > 0 {
@@ -1501,7 +1501,7 @@ func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]interfac
 	}
 
 	if apiObject.GrpcConfig != nil {
-		tfMap["grpc_config"] = []interface{}{flattenGRPCConfig(apiObject.GrpcConfig)}
+		tfMap["grpc_config"] = []any{flattenGRPCConfig(apiObject.GrpcConfig)}
 	}
 
 	if len(apiObject.LambdaFunctionAssociations.Items) > 0 {
@@ -1531,12 +1531,12 @@ func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]interfac
 	return tfMap
 }
 
-func flattenCacheBehaviors(apiObject *awstypes.CacheBehaviors) []interface{} {
+func flattenCacheBehaviors(apiObject *awstypes.CacheBehaviors) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenCacheBehavior(&v))
@@ -1545,7 +1545,7 @@ func flattenCacheBehaviors(apiObject *awstypes.CacheBehaviors) []interface{} {
 	return tfList
 }
 
-func expandDefaultCacheBehavior(tfMap map[string]interface{}) *awstypes.DefaultCacheBehavior {
+func expandDefaultCacheBehavior(tfMap map[string]any) *awstypes.DefaultCacheBehavior {
 	if tfMap == nil {
 		return nil
 	}
@@ -1574,16 +1574,16 @@ func expandDefaultCacheBehavior(tfMap map[string]interface{}) *awstypes.DefaultC
 		apiObject.AllowedMethods.CachedMethods = expandCachedMethods(v.(*schema.Set).List())
 	}
 
-	if v, ok := tfMap["forwarded_values"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.ForwardedValues = expandForwardedValues(v[0].(map[string]interface{}))
+	if v, ok := tfMap["forwarded_values"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ForwardedValues = expandForwardedValues(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["function_association"]; ok {
 		apiObject.FunctionAssociations = expandFunctionAssociations(v.(*schema.Set).List())
 	}
 
-	if v, ok := tfMap["grpc_config"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.GrpcConfig = expandGRPCConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["grpc_config"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.GrpcConfig = expandGRPCConfig(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["lambda_function_association"]; ok {
@@ -1599,26 +1599,26 @@ func expandDefaultCacheBehavior(tfMap map[string]interface{}) *awstypes.DefaultC
 	}
 
 	if v, ok := tfMap["trusted_key_groups"]; ok {
-		apiObject.TrustedKeyGroups = expandTrustedKeyGroups(v.([]interface{}))
+		apiObject.TrustedKeyGroups = expandTrustedKeyGroups(v.([]any))
 	} else {
-		apiObject.TrustedKeyGroups = expandTrustedKeyGroups([]interface{}{})
+		apiObject.TrustedKeyGroups = expandTrustedKeyGroups([]any{})
 	}
 
 	if v, ok := tfMap["trusted_signers"]; ok {
-		apiObject.TrustedSigners = expandTrustedSigners(v.([]interface{}))
+		apiObject.TrustedSigners = expandTrustedSigners(v.([]any))
 	} else {
-		apiObject.TrustedSigners = expandTrustedSigners([]interface{}{})
+		apiObject.TrustedSigners = expandTrustedSigners([]any{})
 	}
 
 	return apiObject
 }
 
-func flattenDefaultCacheBehavior(apiObject *awstypes.DefaultCacheBehavior) map[string]interface{} {
+func flattenDefaultCacheBehavior(apiObject *awstypes.DefaultCacheBehavior) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"cache_policy_id":            aws.ToString(apiObject.CachePolicyId),
 		"compress":                   aws.ToBool(apiObject.Compress),
 		"field_level_encryption_id":  aws.ToString(apiObject.FieldLevelEncryptionId),
@@ -1643,7 +1643,7 @@ func flattenDefaultCacheBehavior(apiObject *awstypes.DefaultCacheBehavior) map[s
 	}
 
 	if apiObject.ForwardedValues != nil {
-		tfMap["forwarded_values"] = []interface{}{flattenForwardedValues(apiObject.ForwardedValues)}
+		tfMap["forwarded_values"] = []any{flattenForwardedValues(apiObject.ForwardedValues)}
 	}
 
 	if len(apiObject.FunctionAssociations.Items) > 0 {
@@ -1651,7 +1651,7 @@ func flattenDefaultCacheBehavior(apiObject *awstypes.DefaultCacheBehavior) map[s
 	}
 
 	if apiObject.GrpcConfig != nil {
-		tfMap["grpc_config"] = []interface{}{flattenGRPCConfig(apiObject.GrpcConfig)}
+		tfMap["grpc_config"] = []any{flattenGRPCConfig(apiObject.GrpcConfig)}
 	}
 
 	if len(apiObject.LambdaFunctionAssociations.Items) > 0 {
@@ -1677,7 +1677,7 @@ func flattenDefaultCacheBehavior(apiObject *awstypes.DefaultCacheBehavior) map[s
 	return tfMap
 }
 
-func expandTrustedKeyGroups(tfList []interface{}) *awstypes.TrustedKeyGroups {
+func expandTrustedKeyGroups(tfList []any) *awstypes.TrustedKeyGroups {
 	apiObject := &awstypes.TrustedKeyGroups{}
 
 	if len(tfList) > 0 {
@@ -1692,15 +1692,15 @@ func expandTrustedKeyGroups(tfList []interface{}) *awstypes.TrustedKeyGroups {
 	return apiObject
 }
 
-func flattenTrustedKeyGroups(apiObject *awstypes.TrustedKeyGroups) []interface{} {
+func flattenTrustedKeyGroups(apiObject *awstypes.TrustedKeyGroups) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandTrustedSigners(tfList []interface{}) *awstypes.TrustedSigners {
+func expandTrustedSigners(tfList []any) *awstypes.TrustedSigners {
 	apiObject := &awstypes.TrustedSigners{}
 
 	if len(tfList) > 0 {
@@ -1715,15 +1715,15 @@ func expandTrustedSigners(tfList []interface{}) *awstypes.TrustedSigners {
 	return apiObject
 }
 
-func flattenTrustedSigners(apiObject *awstypes.TrustedSigners) []interface{} {
+func flattenTrustedSigners(apiObject *awstypes.TrustedSigners) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandLambdaFunctionAssociation(tfMap map[string]interface{}) *awstypes.LambdaFunctionAssociation {
+func expandLambdaFunctionAssociation(tfMap map[string]any) *awstypes.LambdaFunctionAssociation {
 	if tfMap == nil {
 		return nil
 	}
@@ -1745,19 +1745,19 @@ func expandLambdaFunctionAssociation(tfMap map[string]interface{}) *awstypes.Lam
 	return apiObject
 }
 
-func expandLambdaFunctionAssociations(v interface{}) *awstypes.LambdaFunctionAssociations {
+func expandLambdaFunctionAssociations(v any) *awstypes.LambdaFunctionAssociations {
 	if v == nil {
 		return &awstypes.LambdaFunctionAssociations{
 			Quantity: aws.Int32(0),
 		}
 	}
 
-	tfList := v.([]interface{})
+	tfList := v.([]any)
 
 	var items []awstypes.LambdaFunctionAssociation
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1777,7 +1777,7 @@ func expandLambdaFunctionAssociations(v interface{}) *awstypes.LambdaFunctionAss
 	}
 }
 
-func expandFunctionAssociation(tfMap map[string]interface{}) *awstypes.FunctionAssociation {
+func expandFunctionAssociation(tfMap map[string]any) *awstypes.FunctionAssociation {
 	if tfMap == nil {
 		return nil
 	}
@@ -1795,19 +1795,19 @@ func expandFunctionAssociation(tfMap map[string]interface{}) *awstypes.FunctionA
 	return apiObject
 }
 
-func expandFunctionAssociations(v interface{}) *awstypes.FunctionAssociations {
+func expandFunctionAssociations(v any) *awstypes.FunctionAssociations {
 	if v == nil {
 		return &awstypes.FunctionAssociations{
 			Quantity: aws.Int32(0),
 		}
 	}
 
-	tfList := v.([]interface{})
+	tfList := v.([]any)
 
 	var items []awstypes.FunctionAssociation
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1827,8 +1827,8 @@ func expandFunctionAssociations(v interface{}) *awstypes.FunctionAssociations {
 	}
 }
 
-func flattenLambdaFunctionAssociation(apiObject *awstypes.LambdaFunctionAssociation) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLambdaFunctionAssociation(apiObject *awstypes.LambdaFunctionAssociation) map[string]any {
+	tfMap := map[string]any{}
 
 	if apiObject != nil {
 		tfMap["event_type"] = apiObject.EventType
@@ -1839,12 +1839,12 @@ func flattenLambdaFunctionAssociation(apiObject *awstypes.LambdaFunctionAssociat
 	return tfMap
 }
 
-func flattenLambdaFunctionAssociations(apiObject *awstypes.LambdaFunctionAssociations) []interface{} {
+func flattenLambdaFunctionAssociations(apiObject *awstypes.LambdaFunctionAssociations) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenLambdaFunctionAssociation(&v))
@@ -1853,8 +1853,8 @@ func flattenLambdaFunctionAssociations(apiObject *awstypes.LambdaFunctionAssocia
 	return tfList
 }
 
-func flattenFunctionAssociation(apiObject *awstypes.FunctionAssociation) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenFunctionAssociation(apiObject *awstypes.FunctionAssociation) map[string]any {
+	tfMap := map[string]any{}
 
 	if apiObject != nil {
 		tfMap["event_type"] = apiObject.EventType
@@ -1864,12 +1864,12 @@ func flattenFunctionAssociation(apiObject *awstypes.FunctionAssociation) map[str
 	return tfMap
 }
 
-func flattenFunctionAssociations(apiObject *awstypes.FunctionAssociations) []interface{} {
+func flattenFunctionAssociations(apiObject *awstypes.FunctionAssociations) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenFunctionAssociation(&v))
@@ -1878,7 +1878,7 @@ func flattenFunctionAssociations(apiObject *awstypes.FunctionAssociations) []int
 	return tfList
 }
 
-func expandForwardedValues(tfMap map[string]interface{}) *awstypes.ForwardedValues {
+func expandForwardedValues(tfMap map[string]any) *awstypes.ForwardedValues {
 	if len(tfMap) < 1 {
 		return nil
 	}
@@ -1887,8 +1887,8 @@ func expandForwardedValues(tfMap map[string]interface{}) *awstypes.ForwardedValu
 		QueryString: aws.Bool(tfMap["query_string"].(bool)),
 	}
 
-	if v, ok := tfMap["cookies"]; ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.Cookies = expandCookiePreference(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := tfMap["cookies"]; ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.Cookies = expandCookiePreference(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["headers"]; ok {
@@ -1896,23 +1896,23 @@ func expandForwardedValues(tfMap map[string]interface{}) *awstypes.ForwardedValu
 	}
 
 	if v, ok := tfMap["query_string_cache_keys"]; ok {
-		apiObject.QueryStringCacheKeys = expandQueryStringCacheKeys(v.([]interface{}))
+		apiObject.QueryStringCacheKeys = expandQueryStringCacheKeys(v.([]any))
 	}
 
 	return apiObject
 }
 
-func flattenForwardedValues(apiObject *awstypes.ForwardedValues) map[string]interface{} {
+func flattenForwardedValues(apiObject *awstypes.ForwardedValues) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	tfMap["query_string"] = aws.ToBool(apiObject.QueryString)
 
 	if apiObject.Cookies != nil {
-		tfMap["cookies"] = []interface{}{flattenCookiePreference(apiObject.Cookies)}
+		tfMap["cookies"] = []any{flattenCookiePreference(apiObject.Cookies)}
 	}
 
 	if apiObject.Headers != nil {
@@ -1926,37 +1926,37 @@ func flattenForwardedValues(apiObject *awstypes.ForwardedValues) map[string]inte
 	return tfMap
 }
 
-func expandForwardedValuesHeaders(tfList []interface{}) *awstypes.Headers {
+func expandForwardedValuesHeaders(tfList []any) *awstypes.Headers {
 	return &awstypes.Headers{
 		Items:    flex.ExpandStringValueList(tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenForwardedValuesHeaders(apiObject *awstypes.Headers) []interface{} {
+func flattenForwardedValuesHeaders(apiObject *awstypes.Headers) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandQueryStringCacheKeys(tfList []interface{}) *awstypes.QueryStringCacheKeys {
+func expandQueryStringCacheKeys(tfList []any) *awstypes.QueryStringCacheKeys {
 	return &awstypes.QueryStringCacheKeys{
 		Items:    flex.ExpandStringValueList(tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenQueryStringCacheKeys(apiObject *awstypes.QueryStringCacheKeys) []interface{} {
+func flattenQueryStringCacheKeys(apiObject *awstypes.QueryStringCacheKeys) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandCookiePreference(tfMap map[string]interface{}) *awstypes.CookiePreference {
+func expandCookiePreference(tfMap map[string]any) *awstypes.CookiePreference {
 	apiObject := &awstypes.CookiePreference{
 		Forward: awstypes.ItemSelection(tfMap["forward"].(string)),
 	}
@@ -1968,12 +1968,12 @@ func expandCookiePreference(tfMap map[string]interface{}) *awstypes.CookiePrefer
 	return apiObject
 }
 
-func flattenCookiePreference(apiObject *awstypes.CookiePreference) map[string]interface{} {
+func flattenCookiePreference(apiObject *awstypes.CookiePreference) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	tfMap["forward"] = apiObject.Forward
 
@@ -1984,22 +1984,22 @@ func flattenCookiePreference(apiObject *awstypes.CookiePreference) map[string]in
 	return tfMap
 }
 
-func expandCookiePreferenceCookieNames(tfList []interface{}) *awstypes.CookieNames {
+func expandCookiePreferenceCookieNames(tfList []any) *awstypes.CookieNames {
 	return &awstypes.CookieNames{
 		Items:    flex.ExpandStringValueList(tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenCookiePreferenceCookieNames(apiObject *awstypes.CookieNames) []interface{} {
+func flattenCookiePreferenceCookieNames(apiObject *awstypes.CookieNames) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandGRPCConfig(tfMap map[string]interface{}) *awstypes.GrpcConfig {
+func expandGRPCConfig(tfMap map[string]any) *awstypes.GrpcConfig {
 	if len(tfMap) < 1 {
 		return nil
 	}
@@ -2011,26 +2011,26 @@ func expandGRPCConfig(tfMap map[string]interface{}) *awstypes.GrpcConfig {
 	return apiObject
 }
 
-func flattenGRPCConfig(apiObject *awstypes.GrpcConfig) map[string]interface{} {
+func flattenGRPCConfig(apiObject *awstypes.GrpcConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrEnabled: aws.ToBool(apiObject.Enabled),
 	}
 
 	return tfMap
 }
 
-func expandAllowedMethods(tfList []interface{}) *awstypes.AllowedMethods {
+func expandAllowedMethods(tfList []any) *awstypes.AllowedMethods {
 	return &awstypes.AllowedMethods{
 		Items:    flex.ExpandStringyValueList[awstypes.Method](tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenAllowedMethods(apiObject *awstypes.AllowedMethods) []interface{} {
+func flattenAllowedMethods(apiObject *awstypes.AllowedMethods) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringyValueList(apiObject.Items)
 	}
@@ -2038,14 +2038,14 @@ func flattenAllowedMethods(apiObject *awstypes.AllowedMethods) []interface{} {
 	return nil
 }
 
-func expandCachedMethods(tfList []interface{}) *awstypes.CachedMethods {
+func expandCachedMethods(tfList []any) *awstypes.CachedMethods {
 	return &awstypes.CachedMethods{
 		Items:    flex.ExpandStringyValueList[awstypes.Method](tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenCachedMethods(apiObject *awstypes.CachedMethods) []interface{} {
+func flattenCachedMethods(apiObject *awstypes.CachedMethods) []any {
 	if apiObject.Items != nil {
 		return flex.FlattenStringyValueList(apiObject.Items)
 	}
@@ -2053,11 +2053,11 @@ func flattenCachedMethods(apiObject *awstypes.CachedMethods) []interface{} {
 	return nil
 }
 
-func expandOrigins(tfList []interface{}) *awstypes.Origins {
+func expandOrigins(tfList []any) *awstypes.Origins {
 	var items []awstypes.Origin
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2077,12 +2077,12 @@ func expandOrigins(tfList []interface{}) *awstypes.Origins {
 	}
 }
 
-func flattenOrigins(apiObject *awstypes.Origins) []interface{} {
+func flattenOrigins(apiObject *awstypes.Origins) []any {
 	if apiObject.Items == nil {
 		return nil
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenOrigin(&v))
@@ -2091,7 +2091,7 @@ func flattenOrigins(apiObject *awstypes.Origins) []interface{} {
 	return tfList
 }
 
-func expandOrigin(tfMap map[string]interface{}) *awstypes.Origin {
+func expandOrigin(tfMap map[string]any) *awstypes.Origin {
 	apiObject := &awstypes.Origin{
 		DomainName: aws.String(tfMap[names.AttrDomainName].(string)),
 		Id:         aws.String(tfMap["origin_id"].(string)),
@@ -2110,8 +2110,8 @@ func expandOrigin(tfMap map[string]interface{}) *awstypes.Origin {
 	}
 
 	if v, ok := tfMap["custom_origin_config"]; ok {
-		if v := v.([]interface{}); len(v) > 0 {
-			apiObject.CustomOriginConfig = expandCustomOriginConfig(v[0].(map[string]interface{}))
+		if v := v.([]any); len(v) > 0 {
+			apiObject.CustomOriginConfig = expandCustomOriginConfig(v[0].(map[string]any))
 		}
 	}
 
@@ -2124,20 +2124,20 @@ func expandOrigin(tfMap map[string]interface{}) *awstypes.Origin {
 	}
 
 	if v, ok := tfMap["origin_shield"]; ok {
-		if v := v.([]interface{}); len(v) > 0 {
-			apiObject.OriginShield = expandOriginShield(v[0].(map[string]interface{}))
+		if v := v.([]any); len(v) > 0 {
+			apiObject.OriginShield = expandOriginShield(v[0].(map[string]any))
 		}
 	}
 
 	if v, ok := tfMap["s3_origin_config"]; ok {
-		if v := v.([]interface{}); len(v) > 0 {
-			apiObject.S3OriginConfig = expandS3OriginConfig(v[0].(map[string]interface{}))
+		if v := v.([]any); len(v) > 0 {
+			apiObject.S3OriginConfig = expandS3OriginConfig(v[0].(map[string]any))
 		}
 	}
 
 	if v, ok := tfMap["vpc_origin_config"]; ok {
-		if v := v.([]interface{}); len(v) > 0 {
-			apiObject.VpcOriginConfig = expandVPCOriginConfig(v[0].(map[string]interface{}))
+		if v := v.([]any); len(v) > 0 {
+			apiObject.VpcOriginConfig = expandVPCOriginConfig(v[0].(map[string]any))
 		}
 	}
 
@@ -2152,12 +2152,12 @@ func expandOrigin(tfMap map[string]interface{}) *awstypes.Origin {
 	return apiObject
 }
 
-func flattenOrigin(apiObject *awstypes.Origin) map[string]interface{} {
+func flattenOrigin(apiObject *awstypes.Origin) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap[names.AttrDomainName] = aws.ToString(apiObject.DomainName)
 	tfMap["origin_id"] = aws.ToString(apiObject.Id)
 
@@ -2174,7 +2174,7 @@ func flattenOrigin(apiObject *awstypes.Origin) map[string]interface{} {
 	}
 
 	if apiObject.CustomOriginConfig != nil {
-		tfMap["custom_origin_config"] = []interface{}{flattenCustomOriginConfig(apiObject.CustomOriginConfig)}
+		tfMap["custom_origin_config"] = []any{flattenCustomOriginConfig(apiObject.CustomOriginConfig)}
 	}
 
 	if apiObject.OriginAccessControlId != nil {
@@ -2186,25 +2186,25 @@ func flattenOrigin(apiObject *awstypes.Origin) map[string]interface{} {
 	}
 
 	if apiObject.OriginShield != nil && aws.ToBool(apiObject.OriginShield.Enabled) {
-		tfMap["origin_shield"] = []interface{}{flattenOriginShield(apiObject.OriginShield)}
+		tfMap["origin_shield"] = []any{flattenOriginShield(apiObject.OriginShield)}
 	}
 
 	if apiObject.S3OriginConfig != nil && aws.ToString(apiObject.S3OriginConfig.OriginAccessIdentity) != "" {
-		tfMap["s3_origin_config"] = []interface{}{flattenS3OriginConfig(apiObject.S3OriginConfig)}
+		tfMap["s3_origin_config"] = []any{flattenS3OriginConfig(apiObject.S3OriginConfig)}
 	}
 
 	if apiObject.VpcOriginConfig != nil && aws.ToString(apiObject.VpcOriginConfig.VpcOriginId) != "" {
-		tfMap["vpc_origin_config"] = []interface{}{flattenVPCOriginConfig(apiObject.VpcOriginConfig)}
+		tfMap["vpc_origin_config"] = []any{flattenVPCOriginConfig(apiObject.VpcOriginConfig)}
 	}
 
 	return tfMap
 }
 
-func expandOriginGroups(tfList []interface{}) *awstypes.OriginGroups {
+func expandOriginGroups(tfList []any) *awstypes.OriginGroups {
 	var items []awstypes.OriginGroup
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2224,12 +2224,12 @@ func expandOriginGroups(tfList []interface{}) *awstypes.OriginGroups {
 	}
 }
 
-func flattenOriginGroups(apiObject *awstypes.OriginGroups) []interface{} {
+func flattenOriginGroups(apiObject *awstypes.OriginGroups) []any {
 	if apiObject.Items == nil {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenOriginGroup(&v))
@@ -2238,26 +2238,26 @@ func flattenOriginGroups(apiObject *awstypes.OriginGroups) []interface{} {
 	return tfList
 }
 
-func expandOriginGroup(tfMap map[string]interface{}) *awstypes.OriginGroup {
+func expandOriginGroup(tfMap map[string]any) *awstypes.OriginGroup {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.OriginGroup{
-		FailoverCriteria: expandOriginGroupFailoverCriteria(tfMap["failover_criteria"].([]interface{})[0].(map[string]interface{})),
+		FailoverCriteria: expandOriginGroupFailoverCriteria(tfMap["failover_criteria"].([]any)[0].(map[string]any)),
 		Id:               aws.String(tfMap["origin_id"].(string)),
-		Members:          expandMembers(tfMap["member"].([]interface{})),
+		Members:          expandMembers(tfMap["member"].([]any)),
 	}
 
 	return apiObject
 }
 
-func flattenOriginGroup(apiObject *awstypes.OriginGroup) map[string]interface{} {
+func flattenOriginGroup(apiObject *awstypes.OriginGroup) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap["origin_id"] = aws.ToString(apiObject.Id)
 
 	if apiObject.FailoverCriteria != nil {
@@ -2271,7 +2271,7 @@ func flattenOriginGroup(apiObject *awstypes.OriginGroup) map[string]interface{} 
 	return tfMap
 }
 
-func expandOriginGroupFailoverCriteria(tfMap map[string]interface{}) *awstypes.OriginGroupFailoverCriteria {
+func expandOriginGroupFailoverCriteria(tfMap map[string]any) *awstypes.OriginGroupFailoverCriteria {
 	apiObject := &awstypes.OriginGroupFailoverCriteria{}
 
 	if v, ok := tfMap["status_codes"]; ok {
@@ -2286,25 +2286,25 @@ func expandOriginGroupFailoverCriteria(tfMap map[string]interface{}) *awstypes.O
 	return apiObject
 }
 
-func flattenOriginGroupFailoverCriteria(apiObject *awstypes.OriginGroupFailoverCriteria) []interface{} {
+func flattenOriginGroupFailoverCriteria(apiObject *awstypes.OriginGroupFailoverCriteria) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if v := apiObject.StatusCodes.Items; v != nil {
 		tfMap["status_codes"] = flex.FlattenInt32ValueList(apiObject.StatusCodes.Items)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandMembers(tfList []interface{}) *awstypes.OriginGroupMembers {
+func expandMembers(tfList []any) *awstypes.OriginGroupMembers {
 	var items []awstypes.OriginGroupMember
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2322,15 +2322,15 @@ func expandMembers(tfList []interface{}) *awstypes.OriginGroupMembers {
 	}
 }
 
-func flattenOriginGroupMembers(apiObject *awstypes.OriginGroupMembers) []interface{} {
+func flattenOriginGroupMembers(apiObject *awstypes.OriginGroupMembers) []any {
 	if apiObject.Items == nil {
 		return nil
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, apiObject := range apiObject.Items {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"origin_id": aws.ToString(apiObject.OriginId),
 		}
 
@@ -2340,11 +2340,11 @@ func flattenOriginGroupMembers(apiObject *awstypes.OriginGroupMembers) []interfa
 	return tfList
 }
 
-func expandCustomHeaders(tfList []interface{}) *awstypes.CustomHeaders {
+func expandCustomHeaders(tfList []any) *awstypes.CustomHeaders {
 	var items []awstypes.OriginCustomHeader
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2364,12 +2364,12 @@ func expandCustomHeaders(tfList []interface{}) *awstypes.CustomHeaders {
 	}
 }
 
-func flattenCustomHeaders(apiObject *awstypes.CustomHeaders) []interface{} {
+func flattenCustomHeaders(apiObject *awstypes.CustomHeaders) []any {
 	if apiObject.Items == nil {
 		return nil
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenOriginCustomHeader(&v))
@@ -2378,7 +2378,7 @@ func flattenCustomHeaders(apiObject *awstypes.CustomHeaders) []interface{} {
 	return tfList
 }
 
-func expandOriginCustomHeader(tfMap map[string]interface{}) *awstypes.OriginCustomHeader {
+func expandOriginCustomHeader(tfMap map[string]any) *awstypes.OriginCustomHeader {
 	if tfMap == nil {
 		return nil
 	}
@@ -2389,18 +2389,18 @@ func expandOriginCustomHeader(tfMap map[string]interface{}) *awstypes.OriginCust
 	}
 }
 
-func flattenOriginCustomHeader(apiObject *awstypes.OriginCustomHeader) map[string]interface{} {
+func flattenOriginCustomHeader(apiObject *awstypes.OriginCustomHeader) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		names.AttrName:  aws.ToString(apiObject.HeaderName),
 		names.AttrValue: aws.ToString(apiObject.HeaderValue),
 	}
 }
 
-func expandCustomOriginConfig(tfMap map[string]interface{}) *awstypes.CustomOriginConfig {
+func expandCustomOriginConfig(tfMap map[string]any) *awstypes.CustomOriginConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -2417,12 +2417,12 @@ func expandCustomOriginConfig(tfMap map[string]interface{}) *awstypes.CustomOrig
 	return apiObject
 }
 
-func flattenCustomOriginConfig(apiObject *awstypes.CustomOriginConfig) map[string]interface{} {
+func flattenCustomOriginConfig(apiObject *awstypes.CustomOriginConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"http_port":                aws.ToInt32(apiObject.HTTPPort),
 		"https_port":               aws.ToInt32(apiObject.HTTPSPort),
 		"origin_keepalive_timeout": aws.ToInt32(apiObject.OriginKeepaliveTimeout),
@@ -2434,14 +2434,14 @@ func flattenCustomOriginConfig(apiObject *awstypes.CustomOriginConfig) map[strin
 	return tfMap
 }
 
-func expandCustomOriginConfigSSL(tfList []interface{}) *awstypes.OriginSslProtocols {
+func expandCustomOriginConfigSSL(tfList []any) *awstypes.OriginSslProtocols {
 	return &awstypes.OriginSslProtocols{
 		Items:    flex.ExpandStringyValueList[awstypes.SslProtocol](tfList),
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
 }
 
-func flattenCustomOriginConfigSSL(apiObject *awstypes.OriginSslProtocols) []interface{} {
+func flattenCustomOriginConfigSSL(apiObject *awstypes.OriginSslProtocols) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -2449,7 +2449,7 @@ func flattenCustomOriginConfigSSL(apiObject *awstypes.OriginSslProtocols) []inte
 	return flex.FlattenStringyValueList(apiObject.Items)
 }
 
-func expandOriginShield(tfMap map[string]interface{}) *awstypes.OriginShield {
+func expandOriginShield(tfMap map[string]any) *awstypes.OriginShield {
 	if tfMap == nil {
 		return nil
 	}
@@ -2460,7 +2460,7 @@ func expandOriginShield(tfMap map[string]interface{}) *awstypes.OriginShield {
 	}
 }
 
-func expandS3OriginConfig(tfMap map[string]interface{}) *awstypes.S3OriginConfig {
+func expandS3OriginConfig(tfMap map[string]any) *awstypes.S3OriginConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -2470,7 +2470,7 @@ func expandS3OriginConfig(tfMap map[string]interface{}) *awstypes.S3OriginConfig
 	}
 }
 
-func expandVPCOriginConfig(tfMap map[string]interface{}) *awstypes.VpcOriginConfig {
+func expandVPCOriginConfig(tfMap map[string]any) *awstypes.VpcOriginConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -2482,44 +2482,44 @@ func expandVPCOriginConfig(tfMap map[string]interface{}) *awstypes.VpcOriginConf
 	}
 }
 
-func flattenOriginShield(apiObject *awstypes.OriginShield) map[string]interface{} {
+func flattenOriginShield(apiObject *awstypes.OriginShield) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		names.AttrEnabled:      aws.ToBool(apiObject.Enabled),
 		"origin_shield_region": aws.ToString(apiObject.OriginShieldRegion),
 	}
 }
 
-func flattenS3OriginConfig(apiObject *awstypes.S3OriginConfig) map[string]interface{} {
+func flattenS3OriginConfig(apiObject *awstypes.S3OriginConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"origin_access_identity": aws.ToString(apiObject.OriginAccessIdentity),
 	}
 }
 
-func flattenVPCOriginConfig(apiObject *awstypes.VpcOriginConfig) map[string]interface{} {
+func flattenVPCOriginConfig(apiObject *awstypes.VpcOriginConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	return map[string]interface{}{
+	return map[string]any{
 		"origin_keepalive_timeout": aws.ToInt32(apiObject.OriginKeepaliveTimeout),
 		"origin_read_timeout":      aws.ToInt32(apiObject.OriginReadTimeout),
 		"vpc_origin_id":            aws.ToString(apiObject.VpcOriginId),
 	}
 }
 
-func expandCustomErrorResponses(tfList []interface{}) *awstypes.CustomErrorResponses {
+func expandCustomErrorResponses(tfList []any) *awstypes.CustomErrorResponses {
 	var items []awstypes.CustomErrorResponse
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -2539,12 +2539,12 @@ func expandCustomErrorResponses(tfList []interface{}) *awstypes.CustomErrorRespo
 	}
 }
 
-func flattenCustomErrorResponses(apiObject *awstypes.CustomErrorResponses) []interface{} {
+func flattenCustomErrorResponses(apiObject *awstypes.CustomErrorResponses) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, v := range apiObject.Items {
 		tfList = append(tfList, flattenCustomErrorResponse(&v))
@@ -2553,7 +2553,7 @@ func flattenCustomErrorResponses(apiObject *awstypes.CustomErrorResponses) []int
 	return tfList
 }
 
-func expandCustomErrorResponse(tfMap map[string]interface{}) *awstypes.CustomErrorResponse {
+func expandCustomErrorResponse(tfMap map[string]any) *awstypes.CustomErrorResponse {
 	if tfMap == nil {
 		return nil
 	}
@@ -2579,12 +2579,12 @@ func expandCustomErrorResponse(tfMap map[string]interface{}) *awstypes.CustomErr
 	return apiObject
 }
 
-func flattenCustomErrorResponse(apiObject *awstypes.CustomErrorResponse) map[string]interface{} {
+func flattenCustomErrorResponse(apiObject *awstypes.CustomErrorResponse) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap["error_code"] = aws.ToInt32(apiObject.ErrorCode)
 
 	if apiObject.ErrorCachingMinTTL != nil {
@@ -2602,7 +2602,7 @@ func flattenCustomErrorResponse(apiObject *awstypes.CustomErrorResponse) map[str
 	return tfMap
 }
 
-func expandLoggingConfig(tfMap map[string]interface{}) *awstypes.LoggingConfig {
+func expandLoggingConfig(tfMap map[string]any) *awstypes.LoggingConfig {
 	apiObject := &awstypes.LoggingConfig{}
 
 	if tfMap != nil {
@@ -2620,21 +2620,21 @@ func expandLoggingConfig(tfMap map[string]interface{}) *awstypes.LoggingConfig {
 	return apiObject
 }
 
-func flattenLoggingConfig(apiObject *awstypes.LoggingConfig) []interface{} {
+func flattenLoggingConfig(apiObject *awstypes.LoggingConfig) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrBucket:  aws.ToString(apiObject.Bucket),
 		"include_cookies": aws.ToBool(apiObject.IncludeCookies),
 		names.AttrPrefix:  aws.ToString(apiObject.Prefix),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandAliases(tfList []interface{}) *awstypes.Aliases {
+func expandAliases(tfList []any) *awstypes.Aliases {
 	apiObject := &awstypes.Aliases{
 		Quantity: aws.Int32(int32(len(tfList))),
 	}
@@ -2646,7 +2646,7 @@ func expandAliases(tfList []interface{}) *awstypes.Aliases {
 	return apiObject
 }
 
-func flattenAliases(apiObject *awstypes.Aliases) []interface{} {
+func flattenAliases(apiObject *awstypes.Aliases) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -2655,32 +2655,32 @@ func flattenAliases(apiObject *awstypes.Aliases) []interface{} {
 		return flex.FlattenStringValueList(apiObject.Items)
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandRestrictions(tfMap map[string]interface{}) *awstypes.Restrictions {
+func expandRestrictions(tfMap map[string]any) *awstypes.Restrictions {
 	if tfMap == nil {
 		return nil
 	}
 
 	return &awstypes.Restrictions{
-		GeoRestriction: expandGeoRestriction(tfMap["geo_restriction"].([]interface{})[0].(map[string]interface{})),
+		GeoRestriction: expandGeoRestriction(tfMap["geo_restriction"].([]any)[0].(map[string]any)),
 	}
 }
 
-func flattenRestrictions(apiObject *awstypes.Restrictions) []interface{} {
+func flattenRestrictions(apiObject *awstypes.Restrictions) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
-		"geo_restriction": []interface{}{flattenGeoRestriction(apiObject.GeoRestriction)},
+	tfMap := map[string]any{
+		"geo_restriction": []any{flattenGeoRestriction(apiObject.GeoRestriction)},
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandGeoRestriction(tfMap map[string]interface{}) *awstypes.GeoRestriction {
+func expandGeoRestriction(tfMap map[string]any) *awstypes.GeoRestriction {
 	if tfMap == nil {
 		return nil
 	}
@@ -2699,12 +2699,12 @@ func expandGeoRestriction(tfMap map[string]interface{}) *awstypes.GeoRestriction
 	return apiObject
 }
 
-func flattenGeoRestriction(apiObject *awstypes.GeoRestriction) map[string]interface{} {
+func flattenGeoRestriction(apiObject *awstypes.GeoRestriction) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 	tfMap["restriction_type"] = apiObject.RestrictionType
 
 	if apiObject.Items != nil {
@@ -2714,7 +2714,7 @@ func flattenGeoRestriction(apiObject *awstypes.GeoRestriction) map[string]interf
 	return tfMap
 }
 
-func expandViewerCertificate(tfMap map[string]interface{}) *awstypes.ViewerCertificate {
+func expandViewerCertificate(tfMap map[string]any) *awstypes.ViewerCertificate {
 	if tfMap == nil {
 		return nil
 	}
@@ -2738,12 +2738,12 @@ func expandViewerCertificate(tfMap map[string]interface{}) *awstypes.ViewerCerti
 	return apiObject
 }
 
-func flattenViewerCertificate(apiObject *awstypes.ViewerCertificate) []interface{} {
+func flattenViewerCertificate(apiObject *awstypes.ViewerCertificate) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.IAMCertificateId != nil {
 		tfMap["iam_certificate_id"] = aws.ToString(apiObject.IAMCertificateId)
@@ -2761,27 +2761,27 @@ func flattenViewerCertificate(apiObject *awstypes.ViewerCertificate) []interface
 
 	tfMap["minimum_protocol_version"] = apiObject.MinimumProtocolVersion
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenActiveTrustedKeyGroups(apiObject *awstypes.ActiveTrustedKeyGroups) []interface{} {
+func flattenActiveTrustedKeyGroups(apiObject *awstypes.ActiveTrustedKeyGroups) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrEnabled: aws.ToBool(apiObject.Enabled),
 		"items":           flattenKGKeyPairIDs(apiObject.Items),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenKGKeyPairIDs(apiObjects []awstypes.KGKeyPairIds) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenKGKeyPairIDs(apiObjects []awstypes.KGKeyPairIds) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"key_group_id": aws.ToString(apiObject.KeyGroupId),
 			"key_pair_ids": apiObject.KeyPairIds.Items,
 		}
@@ -2792,24 +2792,24 @@ func flattenKGKeyPairIDs(apiObjects []awstypes.KGKeyPairIds) []interface{} {
 	return tfList
 }
 
-func flattenActiveTrustedSigners(apiObject *awstypes.ActiveTrustedSigners) []interface{} {
+func flattenActiveTrustedSigners(apiObject *awstypes.ActiveTrustedSigners) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrEnabled: aws.ToBool(apiObject.Enabled),
 		"items":           flattenSigners(apiObject.Items),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSigners(apiObjects []awstypes.Signer) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenSigners(apiObjects []awstypes.Signer) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"aws_account_number": aws.ToString(apiObject.AwsAccountNumber),
 			"key_pair_ids":       apiObject.KeyPairIds.Items,
 		}

--- a/internal/service/cloudfront/distribution_data_source.go
+++ b/internal/service/cloudfront/distribution_data_source.go
@@ -72,7 +72,7 @@ func dataSourceDistribution() *schema.Resource {
 	}
 }
 
-func dataSourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/distribution_migrate.go
+++ b/internal/service/cloudfront/distribution_migrate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func resourceDistributionMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+func resourceDistributionMigrateState(v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found CloudFront Distribution state v0; migrating to v1")

--- a/internal/service/cloudfront/distribution_migrate_test.go
+++ b/internal/service/cloudfront/distribution_migrate_test.go
@@ -18,7 +18,7 @@ func TestDistributionMigrateState(t *testing.T) {
 		StateVersion int
 		Attributes   map[string]string
 		Expected     map[string]string
-		Meta         interface{}
+		Meta         any
 	}{
 		"v0_to_v1": {
 			StateVersion: 0,

--- a/internal/service/cloudfront/field_level_encryption_config.go
+++ b/internal/service/cloudfront/field_level_encryption_config.go
@@ -136,7 +136,7 @@ func resourceFieldLevelEncryptionConfig() *schema.Resource {
 	}
 }
 
-func resourceFieldLevelEncryptionConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionConfigCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -148,12 +148,12 @@ func resourceFieldLevelEncryptionConfigCreate(ctx context.Context, d *schema.Res
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("content_type_profile_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ContentTypeProfileConfig = expandContentTypeProfileConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("content_type_profile_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ContentTypeProfileConfig = expandContentTypeProfileConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("query_arg_profile_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.QueryArgProfileConfig = expandQueryArgProfileConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("query_arg_profile_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.QueryArgProfileConfig = expandQueryArgProfileConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.CreateFieldLevelEncryptionConfigInput{
@@ -171,7 +171,7 @@ func resourceFieldLevelEncryptionConfigCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceFieldLevelEncryptionConfigRead(ctx, d, meta)...)
 }
 
-func resourceFieldLevelEncryptionConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -192,7 +192,7 @@ func resourceFieldLevelEncryptionConfigRead(ctx context.Context, d *schema.Resou
 	d.Set("caller_reference", apiObject.CallerReference)
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.ContentTypeProfileConfig != nil {
-		if err := d.Set("content_type_profile_config", []interface{}{flattenContentTypeProfileConfig(apiObject.ContentTypeProfileConfig)}); err != nil {
+		if err := d.Set("content_type_profile_config", []any{flattenContentTypeProfileConfig(apiObject.ContentTypeProfileConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting content_type_profile_config: %s", err)
 		}
 	} else {
@@ -200,7 +200,7 @@ func resourceFieldLevelEncryptionConfigRead(ctx context.Context, d *schema.Resou
 	}
 	d.Set("etag", output.ETag)
 	if apiObject.QueryArgProfileConfig != nil {
-		if err := d.Set("query_arg_profile_config", []interface{}{flattenQueryArgProfileConfig(apiObject.QueryArgProfileConfig)}); err != nil {
+		if err := d.Set("query_arg_profile_config", []any{flattenQueryArgProfileConfig(apiObject.QueryArgProfileConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting query_arg_profile_config: %s", err)
 		}
 	} else {
@@ -210,7 +210,7 @@ func resourceFieldLevelEncryptionConfigRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceFieldLevelEncryptionConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -222,12 +222,12 @@ func resourceFieldLevelEncryptionConfigUpdate(ctx context.Context, d *schema.Res
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("content_type_profile_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ContentTypeProfileConfig = expandContentTypeProfileConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("content_type_profile_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ContentTypeProfileConfig = expandContentTypeProfileConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("query_arg_profile_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.QueryArgProfileConfig = expandQueryArgProfileConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("query_arg_profile_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.QueryArgProfileConfig = expandQueryArgProfileConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.UpdateFieldLevelEncryptionConfigInput{
@@ -245,7 +245,7 @@ func resourceFieldLevelEncryptionConfigUpdate(ctx context.Context, d *schema.Res
 	return append(diags, resourceFieldLevelEncryptionConfigRead(ctx, d, meta)...)
 }
 
-func resourceFieldLevelEncryptionConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -292,15 +292,15 @@ func findFieldLevelEncryptionConfigByID(ctx context.Context, conn *cloudfront.Cl
 	return output, nil
 }
 
-func expandContentTypeProfileConfig(tfMap map[string]interface{}) *awstypes.ContentTypeProfileConfig {
+func expandContentTypeProfileConfig(tfMap map[string]any) *awstypes.ContentTypeProfileConfig {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ContentTypeProfileConfig{}
 
-	if v, ok := tfMap["content_type_profiles"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.ContentTypeProfiles = expandContentTypeProfiles(v[0].(map[string]interface{}))
+	if v, ok := tfMap["content_type_profiles"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.ContentTypeProfiles = expandContentTypeProfiles(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["forward_when_content_type_is_unknown"].(bool); ok {
@@ -310,7 +310,7 @@ func expandContentTypeProfileConfig(tfMap map[string]interface{}) *awstypes.Cont
 	return apiObject
 }
 
-func expandContentTypeProfiles(tfMap map[string]interface{}) *awstypes.ContentTypeProfiles {
+func expandContentTypeProfiles(tfMap map[string]any) *awstypes.ContentTypeProfiles {
 	if tfMap == nil {
 		return nil
 	}
@@ -326,7 +326,7 @@ func expandContentTypeProfiles(tfMap map[string]interface{}) *awstypes.ContentTy
 	return apiObject
 }
 
-func expandContentTypeProfile(tfMap map[string]interface{}) *awstypes.ContentTypeProfile {
+func expandContentTypeProfile(tfMap map[string]any) *awstypes.ContentTypeProfile {
 	if tfMap == nil {
 		return nil
 	}
@@ -348,7 +348,7 @@ func expandContentTypeProfile(tfMap map[string]interface{}) *awstypes.ContentTyp
 	return apiObject
 }
 
-func expandContentTypeProfileItems(tfList []interface{}) []awstypes.ContentTypeProfile {
+func expandContentTypeProfileItems(tfList []any) []awstypes.ContentTypeProfile {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -356,7 +356,7 @@ func expandContentTypeProfileItems(tfList []interface{}) []awstypes.ContentTypeP
 	var apiObjects []awstypes.ContentTypeProfile
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -374,7 +374,7 @@ func expandContentTypeProfileItems(tfList []interface{}) []awstypes.ContentTypeP
 	return apiObjects
 }
 
-func expandQueryArgProfileConfig(tfMap map[string]interface{}) *awstypes.QueryArgProfileConfig {
+func expandQueryArgProfileConfig(tfMap map[string]any) *awstypes.QueryArgProfileConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -385,14 +385,14 @@ func expandQueryArgProfileConfig(tfMap map[string]interface{}) *awstypes.QueryAr
 		apiObject.ForwardWhenQueryArgProfileIsUnknown = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["query_arg_profiles"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.QueryArgProfiles = expandQueryArgProfiles(v[0].(map[string]interface{}))
+	if v, ok := tfMap["query_arg_profiles"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.QueryArgProfiles = expandQueryArgProfiles(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandQueryArgProfiles(tfMap map[string]interface{}) *awstypes.QueryArgProfiles {
+func expandQueryArgProfiles(tfMap map[string]any) *awstypes.QueryArgProfiles {
 	if tfMap == nil {
 		return nil
 	}
@@ -408,7 +408,7 @@ func expandQueryArgProfiles(tfMap map[string]interface{}) *awstypes.QueryArgProf
 	return apiObject
 }
 
-func expandQueryArgProfile(tfMap map[string]interface{}) *awstypes.QueryArgProfile {
+func expandQueryArgProfile(tfMap map[string]any) *awstypes.QueryArgProfile {
 	if tfMap == nil {
 		return nil
 	}
@@ -426,7 +426,7 @@ func expandQueryArgProfile(tfMap map[string]interface{}) *awstypes.QueryArgProfi
 	return apiObject
 }
 
-func expandQueryArgProfileItems(tfList []interface{}) []awstypes.QueryArgProfile {
+func expandQueryArgProfileItems(tfList []any) []awstypes.QueryArgProfile {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -434,7 +434,7 @@ func expandQueryArgProfileItems(tfList []interface{}) []awstypes.QueryArgProfile
 	var apiObjects []awstypes.QueryArgProfile
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -452,15 +452,15 @@ func expandQueryArgProfileItems(tfList []interface{}) []awstypes.QueryArgProfile
 	return apiObjects
 }
 
-func flattenContentTypeProfileConfig(apiObject *awstypes.ContentTypeProfileConfig) map[string]interface{} {
+func flattenContentTypeProfileConfig(apiObject *awstypes.ContentTypeProfileConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenContentTypeProfiles(apiObject.ContentTypeProfiles); len(v) > 0 {
-		tfMap["content_type_profiles"] = []interface{}{v}
+		tfMap["content_type_profiles"] = []any{v}
 	}
 
 	if v := apiObject.ForwardWhenContentTypeIsUnknown; v != nil {
@@ -470,12 +470,12 @@ func flattenContentTypeProfileConfig(apiObject *awstypes.ContentTypeProfileConfi
 	return tfMap
 }
 
-func flattenContentTypeProfiles(apiObject *awstypes.ContentTypeProfiles) map[string]interface{} {
+func flattenContentTypeProfiles(apiObject *awstypes.ContentTypeProfiles) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = flattenContentTypeProfileItems(v)
@@ -484,12 +484,12 @@ func flattenContentTypeProfiles(apiObject *awstypes.ContentTypeProfiles) map[str
 	return tfMap
 }
 
-func flattenContentTypeProfile(apiObject *awstypes.ContentTypeProfile) map[string]interface{} {
+func flattenContentTypeProfile(apiObject *awstypes.ContentTypeProfile) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrFormat: apiObject.Format,
 	}
 
@@ -504,12 +504,12 @@ func flattenContentTypeProfile(apiObject *awstypes.ContentTypeProfile) map[strin
 	return tfMap
 }
 
-func flattenContentTypeProfileItems(apiObjects []awstypes.ContentTypeProfile) []interface{} {
+func flattenContentTypeProfileItems(apiObjects []awstypes.ContentTypeProfile) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenContentTypeProfile(&apiObject); len(v) > 0 {
@@ -520,30 +520,30 @@ func flattenContentTypeProfileItems(apiObjects []awstypes.ContentTypeProfile) []
 	return tfList
 }
 
-func flattenQueryArgProfileConfig(apiObject *awstypes.QueryArgProfileConfig) map[string]interface{} {
+func flattenQueryArgProfileConfig(apiObject *awstypes.QueryArgProfileConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ForwardWhenQueryArgProfileIsUnknown; v != nil {
 		tfMap["forward_when_query_arg_profile_is_unknown"] = aws.ToBool(v)
 	}
 
 	if v := flattenQueryArgProfiles(apiObject.QueryArgProfiles); len(v) > 0 {
-		tfMap["query_arg_profiles"] = []interface{}{v}
+		tfMap["query_arg_profiles"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenQueryArgProfiles(apiObject *awstypes.QueryArgProfiles) map[string]interface{} {
+func flattenQueryArgProfiles(apiObject *awstypes.QueryArgProfiles) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = flattenQueryArgProfileItems(v)
@@ -552,12 +552,12 @@ func flattenQueryArgProfiles(apiObject *awstypes.QueryArgProfiles) map[string]in
 	return tfMap
 }
 
-func flattenQueryArgProfile(apiObject *awstypes.QueryArgProfile) map[string]interface{} {
+func flattenQueryArgProfile(apiObject *awstypes.QueryArgProfile) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ProfileId; v != nil {
 		tfMap["profile_id"] = aws.ToString(v)
@@ -570,12 +570,12 @@ func flattenQueryArgProfile(apiObject *awstypes.QueryArgProfile) map[string]inte
 	return tfMap
 }
 
-func flattenQueryArgProfileItems(apiObjects []awstypes.QueryArgProfile) []interface{} {
+func flattenQueryArgProfileItems(apiObjects []awstypes.QueryArgProfile) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenQueryArgProfile(&apiObject); len(v) > 0 {

--- a/internal/service/cloudfront/field_level_encryption_profile.go
+++ b/internal/service/cloudfront/field_level_encryption_profile.go
@@ -98,7 +98,7 @@ func resourceFieldLevelEncryptionProfile() *schema.Resource {
 	}
 }
 
-func resourceFieldLevelEncryptionProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionProfileCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -112,8 +112,8 @@ func resourceFieldLevelEncryptionProfileCreate(ctx context.Context, d *schema.Re
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("encryption_entities"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.EncryptionEntities = expandEncryptionEntities(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("encryption_entities"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.EncryptionEntities = expandEncryptionEntities(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.CreateFieldLevelEncryptionProfileInput{
@@ -131,7 +131,7 @@ func resourceFieldLevelEncryptionProfileCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceFieldLevelEncryptionProfileRead(ctx, d, meta)...)
 }
 
-func resourceFieldLevelEncryptionProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceFieldLevelEncryptionProfileRead(ctx context.Context, d *schema.Reso
 	d.Set("caller_reference", apiObject.CallerReference)
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.EncryptionEntities != nil {
-		if err := d.Set("encryption_entities", []interface{}{flattenEncryptionEntities(apiObject.EncryptionEntities)}); err != nil {
+		if err := d.Set("encryption_entities", []any{flattenEncryptionEntities(apiObject.EncryptionEntities)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting encryption_entities: %s", err)
 		}
 	} else {
@@ -164,7 +164,7 @@ func resourceFieldLevelEncryptionProfileRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceFieldLevelEncryptionProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -177,8 +177,8 @@ func resourceFieldLevelEncryptionProfileUpdate(ctx context.Context, d *schema.Re
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("encryption_entities"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.EncryptionEntities = expandEncryptionEntities(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("encryption_entities"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.EncryptionEntities = expandEncryptionEntities(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.UpdateFieldLevelEncryptionProfileInput{
@@ -196,7 +196,7 @@ func resourceFieldLevelEncryptionProfileUpdate(ctx context.Context, d *schema.Re
 	return append(diags, resourceFieldLevelEncryptionProfileRead(ctx, d, meta)...)
 }
 
-func resourceFieldLevelEncryptionProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFieldLevelEncryptionProfileDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -243,7 +243,7 @@ func findFieldLevelEncryptionProfileByID(ctx context.Context, conn *cloudfront.C
 	return output, nil
 }
 
-func expandEncryptionEntities(tfMap map[string]interface{}) *awstypes.EncryptionEntities {
+func expandEncryptionEntities(tfMap map[string]any) *awstypes.EncryptionEntities {
 	if tfMap == nil {
 		return nil
 	}
@@ -259,15 +259,15 @@ func expandEncryptionEntities(tfMap map[string]interface{}) *awstypes.Encryption
 	return apiObject
 }
 
-func expandEncryptionEntity(tfMap map[string]interface{}) *awstypes.EncryptionEntity {
+func expandEncryptionEntity(tfMap map[string]any) *awstypes.EncryptionEntity {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.EncryptionEntity{}
 
-	if v, ok := tfMap["field_patterns"].([]interface{}); ok && len(v) > 0 {
-		apiObject.FieldPatterns = expandFieldPatterns(v[0].(map[string]interface{}))
+	if v, ok := tfMap["field_patterns"].([]any); ok && len(v) > 0 {
+		apiObject.FieldPatterns = expandFieldPatterns(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["provider_id"].(string); ok && v != "" {
@@ -281,7 +281,7 @@ func expandEncryptionEntity(tfMap map[string]interface{}) *awstypes.EncryptionEn
 	return apiObject
 }
 
-func expandEncryptionEntityItems(tfList []interface{}) []awstypes.EncryptionEntity {
+func expandEncryptionEntityItems(tfList []any) []awstypes.EncryptionEntity {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -289,7 +289,7 @@ func expandEncryptionEntityItems(tfList []interface{}) []awstypes.EncryptionEnti
 	var apiObjects []awstypes.EncryptionEntity
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -307,7 +307,7 @@ func expandEncryptionEntityItems(tfList []interface{}) []awstypes.EncryptionEnti
 	return apiObjects
 }
 
-func expandFieldPatterns(tfMap map[string]interface{}) *awstypes.FieldPatterns {
+func expandFieldPatterns(tfMap map[string]any) *awstypes.FieldPatterns {
 	if tfMap == nil {
 		return nil
 	}
@@ -323,12 +323,12 @@ func expandFieldPatterns(tfMap map[string]interface{}) *awstypes.FieldPatterns {
 	return apiObject
 }
 
-func flattenEncryptionEntities(apiObject *awstypes.EncryptionEntities) map[string]interface{} {
+func flattenEncryptionEntities(apiObject *awstypes.EncryptionEntities) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = flattenEncryptionEntityItems(v)
@@ -337,15 +337,15 @@ func flattenEncryptionEntities(apiObject *awstypes.EncryptionEntities) map[strin
 	return tfMap
 }
 
-func flattenEncryptionEntity(apiObject *awstypes.EncryptionEntity) map[string]interface{} {
+func flattenEncryptionEntity(apiObject *awstypes.EncryptionEntity) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenFieldPatterns(apiObject.FieldPatterns); len(v) > 0 {
-		tfMap["field_patterns"] = []interface{}{v}
+		tfMap["field_patterns"] = []any{v}
 	}
 
 	if v := apiObject.ProviderId; v != nil {
@@ -359,12 +359,12 @@ func flattenEncryptionEntity(apiObject *awstypes.EncryptionEntity) map[string]in
 	return tfMap
 }
 
-func flattenEncryptionEntityItems(apiObjects []awstypes.EncryptionEntity) []interface{} {
+func flattenEncryptionEntityItems(apiObjects []awstypes.EncryptionEntity) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenEncryptionEntity(&apiObject); len(v) > 0 {
@@ -375,12 +375,12 @@ func flattenEncryptionEntityItems(apiObjects []awstypes.EncryptionEntity) []inte
 	return tfList
 }
 
-func flattenFieldPatterns(apiObject *awstypes.FieldPatterns) map[string]interface{} {
+func flattenFieldPatterns(apiObject *awstypes.FieldPatterns) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v

--- a/internal/service/cloudfront/function.go
+++ b/internal/service/cloudfront/function.go
@@ -87,7 +87,7 @@ func resourceFunction() *schema.Resource {
 	}
 }
 
-func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -129,7 +129,7 @@ func resourceFunctionCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceFunctionRead(ctx, d, meta)...)
 }
 
-func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -180,7 +180,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 	etag := d.Get("etag").(string)
@@ -225,7 +225,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceFunctionRead(ctx, d, meta)...)
 }
 
-func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFunctionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -273,12 +273,12 @@ func findFunctionByTwoPartKey(ctx context.Context, conn *cloudfront.Client, name
 	return output, nil
 }
 
-func expandKeyValueStoreAssociations(tfList []interface{}) *awstypes.KeyValueStoreAssociations {
+func expandKeyValueStoreAssociations(tfList []any) *awstypes.KeyValueStoreAssociations {
 	if len(tfList) == 0 {
 		return nil
 	}
 
-	items := tfslices.ApplyToAll(tfList, func(v interface{}) awstypes.KeyValueStoreAssociation {
+	items := tfslices.ApplyToAll(tfList, func(v any) awstypes.KeyValueStoreAssociation {
 		return awstypes.KeyValueStoreAssociation{
 			KeyValueStoreARN: aws.String(v.(string)),
 		}

--- a/internal/service/cloudfront/function_data_source.go
+++ b/internal/service/cloudfront/function_data_source.go
@@ -72,7 +72,7 @@ func dataSourceFunction() *schema.Resource {
 	}
 }
 
-func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/key_group.go
+++ b/internal/service/cloudfront/key_group.go
@@ -55,7 +55,7 @@ func resourceKeyGroup() *schema.Resource {
 	}
 }
 
-func resourceKeyGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -84,7 +84,7 @@ func resourceKeyGroupCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceKeyGroupRead(ctx, d, meta)...)
 }
 
-func resourceKeyGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -109,7 +109,7 @@ func resourceKeyGroupRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceKeyGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -137,7 +137,7 @@ func resourceKeyGroupUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceKeyGroupRead(ctx, d, meta)...)
 }
 
-func resourceKeyGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKeyGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/key_value_store.go
+++ b/internal/service/cloudfront/key_value_store.go
@@ -279,7 +279,7 @@ func findKeyValueStoreByName(ctx context.Context, conn *cloudfront.Client, name 
 }
 
 func statusKeyValueStore(ctx context.Context, conn *cloudfront.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findKeyValueStoreByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/cloudfront/log_delivery_canonical_user_id_data_source.go
+++ b/internal/service/cloudfront/log_delivery_canonical_user_id_data_source.go
@@ -35,7 +35,7 @@ func dataSourceLogDeliveryCanonicalUserID() *schema.Resource {
 	}
 }
 
-func dataSourceLogDeliveryCanonicalUserIDRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLogDeliveryCanonicalUserIDRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	canonicalUserID := defaultLogDeliveryCanonicalUserID
 

--- a/internal/service/cloudfront/monitoring_subscription.go
+++ b/internal/service/cloudfront/monitoring_subscription.go
@@ -67,7 +67,7 @@ func resourceMonitoringSubscription() *schema.Resource {
 	}
 }
 
-func resourceMonitoringSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMonitoringSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -76,8 +76,8 @@ func resourceMonitoringSubscriptionCreate(ctx context.Context, d *schema.Resourc
 		DistributionId: aws.String(id),
 	}
 
-	if v, ok := d.GetOk("monitoring_subscription"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.MonitoringSubscription = expandMonitoringSubscription(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("monitoring_subscription"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.MonitoringSubscription = expandMonitoringSubscription(v.([]any)[0].(map[string]any))
 	}
 
 	_, err := conn.CreateMonitoringSubscription(ctx, input)
@@ -93,7 +93,7 @@ func resourceMonitoringSubscriptionCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceMonitoringSubscriptionRead(ctx, d, meta)...)
 }
 
-func resourceMonitoringSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMonitoringSubscriptionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -110,7 +110,7 @@ func resourceMonitoringSubscriptionRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	if output.MonitoringSubscription != nil {
-		if err := d.Set("monitoring_subscription", []interface{}{flattenMonitoringSubscription(output.MonitoringSubscription)}); err != nil {
+		if err := d.Set("monitoring_subscription", []any{flattenMonitoringSubscription(output.MonitoringSubscription)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting monitoring_subscription: %s", err)
 		}
 	} else {
@@ -120,7 +120,7 @@ func resourceMonitoringSubscriptionRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceMonitoringSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceMonitoringSubscriptionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -141,7 +141,7 @@ func resourceMonitoringSubscriptionDelete(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceMonitoringSubscriptionImport(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+func resourceMonitoringSubscriptionImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 	d.Set("distribution_id", d.Id())
 	return []*schema.ResourceData{d}, nil
 }
@@ -171,21 +171,21 @@ func findMonitoringSubscriptionByDistributionID(ctx context.Context, conn *cloud
 	return output, nil
 }
 
-func expandMonitoringSubscription(tfMap map[string]interface{}) *awstypes.MonitoringSubscription {
+func expandMonitoringSubscription(tfMap map[string]any) *awstypes.MonitoringSubscription {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.MonitoringSubscription{}
 
-	if v, ok := tfMap["realtime_metrics_subscription_config"].([]interface{}); ok && len(v) > 0 {
-		apiObject.RealtimeMetricsSubscriptionConfig = expandRealtimeMetricsSubscriptionConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["realtime_metrics_subscription_config"].([]any); ok && len(v) > 0 {
+		apiObject.RealtimeMetricsSubscriptionConfig = expandRealtimeMetricsSubscriptionConfig(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandRealtimeMetricsSubscriptionConfig(tfMap map[string]interface{}) *awstypes.RealtimeMetricsSubscriptionConfig {
+func expandRealtimeMetricsSubscriptionConfig(tfMap map[string]any) *awstypes.RealtimeMetricsSubscriptionConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -199,26 +199,26 @@ func expandRealtimeMetricsSubscriptionConfig(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func flattenMonitoringSubscription(apiObject *awstypes.MonitoringSubscription) map[string]interface{} {
+func flattenMonitoringSubscription(apiObject *awstypes.MonitoringSubscription) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenRealtimeMetricsSubscriptionConfig(apiObject.RealtimeMetricsSubscriptionConfig); len(v) > 0 {
-		tfMap["realtime_metrics_subscription_config"] = []interface{}{v}
+		tfMap["realtime_metrics_subscription_config"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenRealtimeMetricsSubscriptionConfig(apiObject *awstypes.RealtimeMetricsSubscriptionConfig) map[string]interface{} {
+func flattenRealtimeMetricsSubscriptionConfig(apiObject *awstypes.RealtimeMetricsSubscriptionConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"realtime_metrics_subscription_status": apiObject.RealtimeMetricsSubscriptionStatus,
 	}
 

--- a/internal/service/cloudfront/origin_access_control.go
+++ b/internal/service/cloudfront/origin_access_control.go
@@ -73,7 +73,7 @@ func resourceOriginAccessControl() *schema.Resource {
 	}
 }
 
-func resourceOriginAccessControlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessControlCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -99,7 +99,7 @@ func resourceOriginAccessControlCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceOriginAccessControlRead(ctx, d, meta)...)
 }
 
-func resourceOriginAccessControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessControlRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -127,7 +127,7 @@ func resourceOriginAccessControlRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceOriginAccessControlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessControlUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceOriginAccessControlUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceOriginAccessControlRead(ctx, d, meta)...)
 }
 
-func resourceOriginAccessControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessControlDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/origin_access_identities_data_source.go
+++ b/internal/service/cloudfront/origin_access_identities_data_source.go
@@ -47,7 +47,7 @@ func dataSourceOriginAccessIdentities() *schema.Resource {
 	}
 }
 
-func dataSourceOriginAccessIdentitiesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOriginAccessIdentitiesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/origin_access_identity.go
+++ b/internal/service/cloudfront/origin_access_identity.go
@@ -67,7 +67,7 @@ func resourceOriginAccessIdentity() *schema.Resource {
 	}
 }
 
-func resourceOriginAccessIdentityCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessIdentityCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -86,7 +86,7 @@ func resourceOriginAccessIdentityCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceOriginAccessIdentityRead(ctx, d, meta)...)
 }
 
-func resourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -114,7 +114,7 @@ func resourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceOriginAccessIdentityUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessIdentityUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -133,7 +133,7 @@ func resourceOriginAccessIdentityUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceOriginAccessIdentityRead(ctx, d, meta)...)
 }
 
-func resourceOriginAccessIdentityDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginAccessIdentityDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/origin_access_identity_data_source.go
+++ b/internal/service/cloudfront/origin_access_identity_data_source.go
@@ -56,7 +56,7 @@ func dataSourceOriginAccessIdentity() *schema.Resource {
 	}
 }
 
-func dataSourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOriginAccessIdentityRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/origin_request_policy.go
+++ b/internal/service/cloudfront/origin_request_policy.go
@@ -138,7 +138,7 @@ func resourceOriginRequestPolicy() *schema.Resource {
 	}
 }
 
-func resourceOriginRequestPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginRequestPolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -151,16 +151,16 @@ func resourceOriginRequestPolicyCreate(ctx context.Context, d *schema.ResourceDa
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("cookies_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CookiesConfig = expandOriginRequestPolicyCookiesConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cookies_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CookiesConfig = expandOriginRequestPolicyCookiesConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.HeadersConfig = expandOriginRequestPolicyHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.HeadersConfig = expandOriginRequestPolicyHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("query_strings_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.QueryStringsConfig = expandOriginRequestPolicyQueryStringsConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("query_strings_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.QueryStringsConfig = expandOriginRequestPolicyQueryStringsConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.CreateOriginRequestPolicyInput{
@@ -178,7 +178,7 @@ func resourceOriginRequestPolicyCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceOriginRequestPolicyRead(ctx, d, meta)...)
 }
 
-func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -198,7 +198,7 @@ func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData
 	apiObject := output.OriginRequestPolicy.OriginRequestPolicyConfig
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.CookiesConfig != nil {
-		if err := d.Set("cookies_config", []interface{}{flattenOriginRequestPolicyCookiesConfig(apiObject.CookiesConfig)}); err != nil {
+		if err := d.Set("cookies_config", []any{flattenOriginRequestPolicyCookiesConfig(apiObject.CookiesConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cookies_config: %s", err)
 		}
 	} else {
@@ -206,7 +206,7 @@ func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set("etag", output.ETag)
 	if apiObject.HeadersConfig != nil {
-		if err := d.Set("headers_config", []interface{}{flattenOriginRequestPolicyHeadersConfig(apiObject.HeadersConfig)}); err != nil {
+		if err := d.Set("headers_config", []any{flattenOriginRequestPolicyHeadersConfig(apiObject.HeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting headers_config: %s", err)
 		}
 	} else {
@@ -214,7 +214,7 @@ func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData
 	}
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.QueryStringsConfig != nil {
-		if err := d.Set("query_strings_config", []interface{}{flattenOriginRequestPolicyQueryStringsConfig(apiObject.QueryStringsConfig)}); err != nil {
+		if err := d.Set("query_strings_config", []any{flattenOriginRequestPolicyQueryStringsConfig(apiObject.QueryStringsConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting query_strings_config: %s", err)
 		}
 	} else {
@@ -224,7 +224,7 @@ func resourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceOriginRequestPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginRequestPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -240,16 +240,16 @@ func resourceOriginRequestPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("cookies_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CookiesConfig = expandOriginRequestPolicyCookiesConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cookies_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CookiesConfig = expandOriginRequestPolicyCookiesConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.HeadersConfig = expandOriginRequestPolicyHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.HeadersConfig = expandOriginRequestPolicyHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("query_strings_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.QueryStringsConfig = expandOriginRequestPolicyQueryStringsConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("query_strings_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.QueryStringsConfig = expandOriginRequestPolicyQueryStringsConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.UpdateOriginRequestPolicyInput{
@@ -267,7 +267,7 @@ func resourceOriginRequestPolicyUpdate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceOriginRequestPolicyRead(ctx, d, meta)...)
 }
 
-func resourceOriginRequestPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOriginRequestPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -314,7 +314,7 @@ func findOriginRequestPolicyByID(ctx context.Context, conn *cloudfront.Client, i
 	return output, nil
 }
 
-func expandOriginRequestPolicyCookiesConfig(tfMap map[string]interface{}) *awstypes.OriginRequestPolicyCookiesConfig {
+func expandOriginRequestPolicyCookiesConfig(tfMap map[string]any) *awstypes.OriginRequestPolicyCookiesConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -325,14 +325,14 @@ func expandOriginRequestPolicyCookiesConfig(tfMap map[string]interface{}) *awsty
 		apiObject.CookieBehavior = awstypes.OriginRequestPolicyCookieBehavior(v)
 	}
 
-	if v, ok := tfMap["cookies"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Cookies = expandCookieNames(v[0].(map[string]interface{}))
+	if v, ok := tfMap["cookies"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Cookies = expandCookieNames(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandOriginRequestPolicyHeadersConfig(tfMap map[string]interface{}) *awstypes.OriginRequestPolicyHeadersConfig {
+func expandOriginRequestPolicyHeadersConfig(tfMap map[string]any) *awstypes.OriginRequestPolicyHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -343,14 +343,14 @@ func expandOriginRequestPolicyHeadersConfig(tfMap map[string]interface{}) *awsty
 		apiObject.HeaderBehavior = awstypes.OriginRequestPolicyHeaderBehavior(v)
 	}
 
-	if v, ok := tfMap["headers"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.Headers = expandHeaders(v[0].(map[string]interface{}))
+	if v, ok := tfMap["headers"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.Headers = expandHeaders(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandOriginRequestPolicyQueryStringsConfig(tfMap map[string]interface{}) *awstypes.OriginRequestPolicyQueryStringsConfig {
+func expandOriginRequestPolicyQueryStringsConfig(tfMap map[string]any) *awstypes.OriginRequestPolicyQueryStringsConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -361,56 +361,56 @@ func expandOriginRequestPolicyQueryStringsConfig(tfMap map[string]interface{}) *
 		apiObject.QueryStringBehavior = awstypes.OriginRequestPolicyQueryStringBehavior(v)
 	}
 
-	if v, ok := tfMap["query_strings"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.QueryStrings = expandQueryStringNames(v[0].(map[string]interface{}))
+	if v, ok := tfMap["query_strings"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.QueryStrings = expandQueryStringNames(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func flattenOriginRequestPolicyCookiesConfig(apiObject *awstypes.OriginRequestPolicyCookiesConfig) map[string]interface{} {
+func flattenOriginRequestPolicyCookiesConfig(apiObject *awstypes.OriginRequestPolicyCookiesConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"cookie_behavior": apiObject.CookieBehavior,
 	}
 
 	if v := flattenCookieNames(apiObject.Cookies); len(v) > 0 {
-		tfMap["cookies"] = []interface{}{v}
+		tfMap["cookies"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenOriginRequestPolicyHeadersConfig(apiObject *awstypes.OriginRequestPolicyHeadersConfig) map[string]interface{} {
+func flattenOriginRequestPolicyHeadersConfig(apiObject *awstypes.OriginRequestPolicyHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"header_behavior": apiObject.HeaderBehavior,
 	}
 
 	if v := flattenHeaders(apiObject.Headers); len(v) > 0 {
-		tfMap["headers"] = []interface{}{v}
+		tfMap["headers"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenOriginRequestPolicyQueryStringsConfig(apiObject *awstypes.OriginRequestPolicyQueryStringsConfig) map[string]interface{} {
+func flattenOriginRequestPolicyQueryStringsConfig(apiObject *awstypes.OriginRequestPolicyQueryStringsConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"query_string_behavior": apiObject.QueryStringBehavior,
 	}
 
 	if v := flattenQueryStringNames(apiObject.QueryStrings); len(v) > 0 {
-		tfMap["query_strings"] = []interface{}{v}
+		tfMap["query_strings"] = []any{v}
 	}
 
 	return tfMap

--- a/internal/service/cloudfront/origin_request_policy_data_source.go
+++ b/internal/service/cloudfront/origin_request_policy_data_source.go
@@ -122,7 +122,7 @@ func dataSourceOriginRequestPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -170,7 +170,7 @@ func dataSourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceDa
 	apiObject := output.OriginRequestPolicy.OriginRequestPolicyConfig
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.CookiesConfig != nil {
-		if err := d.Set("cookies_config", []interface{}{flattenOriginRequestPolicyCookiesConfig(apiObject.CookiesConfig)}); err != nil {
+		if err := d.Set("cookies_config", []any{flattenOriginRequestPolicyCookiesConfig(apiObject.CookiesConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cookies_config: %s", err)
 		}
 	} else {
@@ -178,7 +178,7 @@ func dataSourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceDa
 	}
 	d.Set("etag", output.ETag)
 	if apiObject.HeadersConfig != nil {
-		if err := d.Set("headers_config", []interface{}{flattenOriginRequestPolicyHeadersConfig(apiObject.HeadersConfig)}); err != nil {
+		if err := d.Set("headers_config", []any{flattenOriginRequestPolicyHeadersConfig(apiObject.HeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting headers_config: %s", err)
 		}
 	} else {
@@ -186,7 +186,7 @@ func dataSourceOriginRequestPolicyRead(ctx context.Context, d *schema.ResourceDa
 	}
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.QueryStringsConfig != nil {
-		if err := d.Set("query_strings_config", []interface{}{flattenOriginRequestPolicyQueryStringsConfig(apiObject.QueryStringsConfig)}); err != nil {
+		if err := d.Set("query_strings_config", []any{flattenOriginRequestPolicyQueryStringsConfig(apiObject.QueryStringsConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting query_strings_config: %s", err)
 		}
 	} else {

--- a/internal/service/cloudfront/public_key.go
+++ b/internal/service/cloudfront/public_key.go
@@ -74,7 +74,7 @@ func resourcePublicKey() *schema.Resource {
 	}
 }
 
-func resourcePublicKeyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePublicKeyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -111,7 +111,7 @@ func resourcePublicKeyCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourcePublicKeyRead(ctx, d, meta)...)
 }
 
-func resourcePublicKeyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePublicKeyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -138,7 +138,7 @@ func resourcePublicKeyRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourcePublicKeyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePublicKeyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -170,7 +170,7 @@ func resourcePublicKeyUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourcePublicKeyRead(ctx, d, meta)...)
 }
 
-func resourcePublicKeyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePublicKeyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -217,7 +217,7 @@ func findPublicKeyByID(ctx context.Context, conn *cloudfront.Client, id string) 
 	return output, nil
 }
 
-func validPublicKeyName(v interface{}, k string) (ws []string, errors []error) {
+func validPublicKeyName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z_-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -230,7 +230,7 @@ func validPublicKeyName(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func validPublicKeyNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+func validPublicKeyNamePrefix(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[0-9A-Za-z_-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(

--- a/internal/service/cloudfront/realtime_log_config.go
+++ b/internal/service/cloudfront/realtime_log_config.go
@@ -95,7 +95,7 @@ func resourceRealtimeLogConfig() *schema.Resource {
 	}
 }
 
-func resourceRealtimeLogConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRealtimeLogConfigCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -104,8 +104,8 @@ func resourceRealtimeLogConfigCreate(ctx context.Context, d *schema.ResourceData
 		Name: aws.String(name),
 	}
 
-	if v, ok := d.GetOk(names.AttrEndpoint); ok && len(v.([]interface{})) > 0 {
-		input.EndPoints = expandEndPoints(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrEndpoint); ok && len(v.([]any)) > 0 {
+		input.EndPoints = expandEndPoints(v.([]any))
 	}
 
 	if v, ok := d.GetOk("fields"); ok && v.(*schema.Set).Len() > 0 {
@@ -127,7 +127,7 @@ func resourceRealtimeLogConfigCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceRealtimeLogConfigRead(ctx, d, meta)...)
 }
 
-func resourceRealtimeLogConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRealtimeLogConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -154,7 +154,7 @@ func resourceRealtimeLogConfigRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceRealtimeLogConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRealtimeLogConfigUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -166,8 +166,8 @@ func resourceRealtimeLogConfigUpdate(ctx context.Context, d *schema.ResourceData
 		ARN: aws.String(d.Id()),
 	}
 
-	if v, ok := d.GetOk(names.AttrEndpoint); ok && len(v.([]interface{})) > 0 {
-		input.EndPoints = expandEndPoints(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrEndpoint); ok && len(v.([]any)) > 0 {
+		input.EndPoints = expandEndPoints(v.([]any))
 	}
 
 	if v, ok := d.GetOk("fields"); ok && v.(*schema.Set).Len() > 0 {
@@ -187,7 +187,7 @@ func resourceRealtimeLogConfigUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceRealtimeLogConfigRead(ctx, d, meta)...)
 }
 
-func resourceRealtimeLogConfigDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRealtimeLogConfigDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -237,15 +237,15 @@ func findRealtimeLogConfig(ctx context.Context, conn *cloudfront.Client, input *
 	return output.RealtimeLogConfig, nil
 }
 
-func expandEndPoint(tfMap map[string]interface{}) *awstypes.EndPoint {
+func expandEndPoint(tfMap map[string]any) *awstypes.EndPoint {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.EndPoint{}
 
-	if v, ok := tfMap["kinesis_stream_config"].([]interface{}); ok && len(v) > 0 {
-		apiObject.KinesisStreamConfig = expandKinesisStreamConfig(v[0].(map[string]interface{}))
+	if v, ok := tfMap["kinesis_stream_config"].([]any); ok && len(v) > 0 {
+		apiObject.KinesisStreamConfig = expandKinesisStreamConfig(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["stream_type"].(string); ok && v != "" {
@@ -255,7 +255,7 @@ func expandEndPoint(tfMap map[string]interface{}) *awstypes.EndPoint {
 	return apiObject
 }
 
-func expandEndPoints(tfList []interface{}) []awstypes.EndPoint {
+func expandEndPoints(tfList []any) []awstypes.EndPoint {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -263,7 +263,7 @@ func expandEndPoints(tfList []interface{}) []awstypes.EndPoint {
 	var apiObjects []awstypes.EndPoint
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -281,7 +281,7 @@ func expandEndPoints(tfList []interface{}) []awstypes.EndPoint {
 	return apiObjects
 }
 
-func expandKinesisStreamConfig(tfMap map[string]interface{}) *awstypes.KinesisStreamConfig {
+func expandKinesisStreamConfig(tfMap map[string]any) *awstypes.KinesisStreamConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -299,15 +299,15 @@ func expandKinesisStreamConfig(tfMap map[string]interface{}) *awstypes.KinesisSt
 	return apiObject
 }
 
-func flattenEndPoint(apiObject *awstypes.EndPoint) map[string]interface{} {
+func flattenEndPoint(apiObject *awstypes.EndPoint) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenKinesisStreamConfig(apiObject.KinesisStreamConfig); len(v) > 0 {
-		tfMap["kinesis_stream_config"] = []interface{}{v}
+		tfMap["kinesis_stream_config"] = []any{v}
 	}
 
 	if v := apiObject.StreamType; v != nil {
@@ -317,12 +317,12 @@ func flattenEndPoint(apiObject *awstypes.EndPoint) map[string]interface{} {
 	return tfMap
 }
 
-func flattenEndPoints(apiObjects []awstypes.EndPoint) []interface{} {
+func flattenEndPoints(apiObjects []awstypes.EndPoint) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenEndPoint(&apiObject); len(v) > 0 {
@@ -333,12 +333,12 @@ func flattenEndPoints(apiObjects []awstypes.EndPoint) []interface{} {
 	return tfList
 }
 
-func flattenKinesisStreamConfig(apiObject *awstypes.KinesisStreamConfig) map[string]interface{} {
+func flattenKinesisStreamConfig(apiObject *awstypes.KinesisStreamConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.RoleARN; v != nil {
 		tfMap[names.AttrRoleARN] = aws.ToString(v)

--- a/internal/service/cloudfront/realtime_log_config_data_source.go
+++ b/internal/service/cloudfront/realtime_log_config_data_source.go
@@ -71,7 +71,7 @@ func dataSourceRealtimeLogConfig() *schema.Resource {
 	}
 }
 
-func dataSourceRealtimeLogConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceRealtimeLogConfigRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 

--- a/internal/service/cloudfront/response_headers_policy.go
+++ b/internal/service/cloudfront/response_headers_policy.go
@@ -332,7 +332,7 @@ func resourceResponseHeadersPolicy() *schema.Resource {
 	}
 }
 
-func resourceResponseHeadersPolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResponseHeadersPolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -345,24 +345,24 @@ func resourceResponseHeadersPolicyCreate(ctx context.Context, d *schema.Resource
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("cors_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CorsConfig = expandResponseHeadersPolicyCorsConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cors_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CorsConfig = expandResponseHeadersPolicyCorsConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("custom_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CustomHeadersConfig = expandResponseHeadersPolicyCustomHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("custom_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CustomHeadersConfig = expandResponseHeadersPolicyCustomHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("remove_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.RemoveHeadersConfig = expandResponseHeadersPolicyRemoveHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("remove_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.RemoveHeadersConfig = expandResponseHeadersPolicyRemoveHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("security_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.SecurityHeadersConfig = expandResponseHeadersPolicySecurityHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("security_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.SecurityHeadersConfig = expandResponseHeadersPolicySecurityHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("server_timing_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ServerTimingHeadersConfig = expandResponseHeadersPolicyServerTimingHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("server_timing_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ServerTimingHeadersConfig = expandResponseHeadersPolicyServerTimingHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.CreateResponseHeadersPolicyInput{
@@ -380,7 +380,7 @@ func resourceResponseHeadersPolicyCreate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceResponseHeadersPolicyRead(ctx, d, meta)...)
 }
 
-func resourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -400,14 +400,14 @@ func resourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceDa
 	apiObject := output.ResponseHeadersPolicy.ResponseHeadersPolicyConfig
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.CorsConfig != nil {
-		if err := d.Set("cors_config", []interface{}{flattenResponseHeadersPolicyCorsConfig(apiObject.CorsConfig)}); err != nil {
+		if err := d.Set("cors_config", []any{flattenResponseHeadersPolicyCorsConfig(apiObject.CorsConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cors_config: %s", err)
 		}
 	} else {
 		d.Set("cors_config", nil)
 	}
 	if apiObject.CustomHeadersConfig != nil {
-		if err := d.Set("custom_headers_config", []interface{}{flattenResponseHeadersPolicyCustomHeadersConfig(apiObject.CustomHeadersConfig)}); err != nil {
+		if err := d.Set("custom_headers_config", []any{flattenResponseHeadersPolicyCustomHeadersConfig(apiObject.CustomHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting custom_headers_config: %s", err)
 		}
 	} else {
@@ -416,21 +416,21 @@ func resourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("etag", output.ETag)
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.RemoveHeadersConfig != nil {
-		if err := d.Set("remove_headers_config", []interface{}{flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject.RemoveHeadersConfig)}); err != nil {
+		if err := d.Set("remove_headers_config", []any{flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject.RemoveHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting remove_headers_config: %s", err)
 		}
 	} else {
 		d.Set("remove_headers_config", nil)
 	}
 	if apiObject.SecurityHeadersConfig != nil {
-		if err := d.Set("security_headers_config", []interface{}{flattenResponseHeadersPolicySecurityHeadersConfig(apiObject.SecurityHeadersConfig)}); err != nil {
+		if err := d.Set("security_headers_config", []any{flattenResponseHeadersPolicySecurityHeadersConfig(apiObject.SecurityHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting security_headers_config: %s", err)
 		}
 	} else {
 		d.Set("security_headers_config", nil)
 	}
 	if apiObject.ServerTimingHeadersConfig != nil {
-		if err := d.Set("server_timing_headers_config", []interface{}{flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject.ServerTimingHeadersConfig)}); err != nil {
+		if err := d.Set("server_timing_headers_config", []any{flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject.ServerTimingHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting server_timing_headers_config: %s", err)
 		}
 	} else {
@@ -440,7 +440,7 @@ func resourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceResponseHeadersPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResponseHeadersPolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -456,24 +456,24 @@ func resourceResponseHeadersPolicyUpdate(ctx context.Context, d *schema.Resource
 		apiObject.Comment = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("cors_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CorsConfig = expandResponseHeadersPolicyCorsConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("cors_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CorsConfig = expandResponseHeadersPolicyCorsConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("custom_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.CustomHeadersConfig = expandResponseHeadersPolicyCustomHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("custom_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.CustomHeadersConfig = expandResponseHeadersPolicyCustomHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("remove_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.RemoveHeadersConfig = expandResponseHeadersPolicyRemoveHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("remove_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.RemoveHeadersConfig = expandResponseHeadersPolicyRemoveHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("security_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.SecurityHeadersConfig = expandResponseHeadersPolicySecurityHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("security_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.SecurityHeadersConfig = expandResponseHeadersPolicySecurityHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("server_timing_headers_config"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		apiObject.ServerTimingHeadersConfig = expandResponseHeadersPolicyServerTimingHeadersConfig(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("server_timing_headers_config"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		apiObject.ServerTimingHeadersConfig = expandResponseHeadersPolicyServerTimingHeadersConfig(v.([]any)[0].(map[string]any))
 	}
 
 	input := &cloudfront.UpdateResponseHeadersPolicyInput{
@@ -491,7 +491,7 @@ func resourceResponseHeadersPolicyUpdate(ctx context.Context, d *schema.Resource
 	return append(diags, resourceResponseHeadersPolicyRead(ctx, d, meta)...)
 }
 
-func resourceResponseHeadersPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResponseHeadersPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -542,7 +542,7 @@ func findResponseHeadersPolicyByID(ctx context.Context, conn *cloudfront.Client,
 // cors_config:
 //
 
-func expandResponseHeadersPolicyCorsConfig(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyCorsConfig {
+func expandResponseHeadersPolicyCorsConfig(tfMap map[string]any) *awstypes.ResponseHeadersPolicyCorsConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -553,20 +553,20 @@ func expandResponseHeadersPolicyCorsConfig(tfMap map[string]interface{}) *awstyp
 		apiObject.AccessControlAllowCredentials = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["access_control_allow_headers"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AccessControlAllowHeaders = expandResponseHeadersPolicyAccessControlAllowHeaders(v[0].(map[string]interface{}))
+	if v, ok := tfMap["access_control_allow_headers"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AccessControlAllowHeaders = expandResponseHeadersPolicyAccessControlAllowHeaders(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["access_control_allow_methods"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AccessControlAllowMethods = expandResponseHeadersPolicyAccessControlAllowMethods(v[0].(map[string]interface{}))
+	if v, ok := tfMap["access_control_allow_methods"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AccessControlAllowMethods = expandResponseHeadersPolicyAccessControlAllowMethods(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["access_control_allow_origins"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AccessControlAllowOrigins = expandResponseHeadersPolicyAccessControlAllowOrigins(v[0].(map[string]interface{}))
+	if v, ok := tfMap["access_control_allow_origins"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AccessControlAllowOrigins = expandResponseHeadersPolicyAccessControlAllowOrigins(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["access_control_expose_headers"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AccessControlExposeHeaders = expandResponseHeadersPolicyAccessControlExposeHeaders(v[0].(map[string]interface{}))
+	if v, ok := tfMap["access_control_expose_headers"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AccessControlExposeHeaders = expandResponseHeadersPolicyAccessControlExposeHeaders(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["access_control_max_age_sec"].(int); ok && v != 0 {
@@ -580,7 +580,7 @@ func expandResponseHeadersPolicyCorsConfig(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func expandResponseHeadersPolicyAccessControlAllowHeaders(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyAccessControlAllowHeaders {
+func expandResponseHeadersPolicyAccessControlAllowHeaders(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowHeaders {
 	if tfMap == nil {
 		return nil
 	}
@@ -596,7 +596,7 @@ func expandResponseHeadersPolicyAccessControlAllowHeaders(tfMap map[string]inter
 	return apiObject
 }
 
-func expandResponseHeadersPolicyAccessControlAllowMethods(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyAccessControlAllowMethods {
+func expandResponseHeadersPolicyAccessControlAllowMethods(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowMethods {
 	if tfMap == nil {
 		return nil
 	}
@@ -612,7 +612,7 @@ func expandResponseHeadersPolicyAccessControlAllowMethods(tfMap map[string]inter
 	return apiObject
 }
 
-func expandResponseHeadersPolicyAccessControlAllowOrigins(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyAccessControlAllowOrigins {
+func expandResponseHeadersPolicyAccessControlAllowOrigins(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowOrigins {
 	if tfMap == nil {
 		return nil
 	}
@@ -628,7 +628,7 @@ func expandResponseHeadersPolicyAccessControlAllowOrigins(tfMap map[string]inter
 	return apiObject
 }
 
-func expandResponseHeadersPolicyAccessControlExposeHeaders(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyAccessControlExposeHeaders {
+func expandResponseHeadersPolicyAccessControlExposeHeaders(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlExposeHeaders {
 	if tfMap == nil {
 		return nil
 	}
@@ -644,31 +644,31 @@ func expandResponseHeadersPolicyAccessControlExposeHeaders(tfMap map[string]inte
 	return apiObject
 }
 
-func flattenResponseHeadersPolicyCorsConfig(apiObject *awstypes.ResponseHeadersPolicyCorsConfig) map[string]interface{} {
+func flattenResponseHeadersPolicyCorsConfig(apiObject *awstypes.ResponseHeadersPolicyCorsConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AccessControlAllowCredentials; v != nil {
 		tfMap["access_control_allow_credentials"] = aws.ToBool(v)
 	}
 
 	if v := flattenResponseHeadersPolicyAccessControlAllowHeaders(apiObject.AccessControlAllowHeaders); len(v) > 0 {
-		tfMap["access_control_allow_headers"] = []interface{}{v}
+		tfMap["access_control_allow_headers"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyAccessControlAllowMethods(apiObject.AccessControlAllowMethods); len(v) > 0 {
-		tfMap["access_control_allow_methods"] = []interface{}{v}
+		tfMap["access_control_allow_methods"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyAccessControlAllowOrigins(apiObject.AccessControlAllowOrigins); len(v) > 0 {
-		tfMap["access_control_allow_origins"] = []interface{}{v}
+		tfMap["access_control_allow_origins"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyAccessControlExposeHeaders(apiObject.AccessControlExposeHeaders); len(v) > 0 {
-		tfMap["access_control_expose_headers"] = []interface{}{v}
+		tfMap["access_control_expose_headers"] = []any{v}
 	}
 
 	if v := apiObject.AccessControlMaxAgeSec; v != nil {
@@ -682,12 +682,12 @@ func flattenResponseHeadersPolicyCorsConfig(apiObject *awstypes.ResponseHeadersP
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyAccessControlAllowHeaders(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowHeaders) map[string]interface{} {
+func flattenResponseHeadersPolicyAccessControlAllowHeaders(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowHeaders) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -696,12 +696,12 @@ func flattenResponseHeadersPolicyAccessControlAllowHeaders(apiObject *awstypes.R
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyAccessControlAllowMethods(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowMethods) map[string]interface{} {
+func flattenResponseHeadersPolicyAccessControlAllowMethods(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowMethods) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -710,12 +710,12 @@ func flattenResponseHeadersPolicyAccessControlAllowMethods(apiObject *awstypes.R
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyAccessControlAllowOrigins(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowOrigins) map[string]interface{} {
+func flattenResponseHeadersPolicyAccessControlAllowOrigins(apiObject *awstypes.ResponseHeadersPolicyAccessControlAllowOrigins) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -724,12 +724,12 @@ func flattenResponseHeadersPolicyAccessControlAllowOrigins(apiObject *awstypes.R
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyAccessControlExposeHeaders(apiObject *awstypes.ResponseHeadersPolicyAccessControlExposeHeaders) map[string]interface{} {
+func flattenResponseHeadersPolicyAccessControlExposeHeaders(apiObject *awstypes.ResponseHeadersPolicyAccessControlExposeHeaders) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = v
@@ -742,7 +742,7 @@ func flattenResponseHeadersPolicyAccessControlExposeHeaders(apiObject *awstypes.
 // custom_headers_config:
 //
 
-func expandResponseHeadersPolicyCustomHeadersConfig(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyCustomHeadersConfig {
+func expandResponseHeadersPolicyCustomHeadersConfig(tfMap map[string]any) *awstypes.ResponseHeadersPolicyCustomHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -758,7 +758,7 @@ func expandResponseHeadersPolicyCustomHeadersConfig(tfMap map[string]interface{}
 	return apiObject
 }
 
-func expandResponseHeadersPolicyCustomHeader(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyCustomHeader {
+func expandResponseHeadersPolicyCustomHeader(tfMap map[string]any) *awstypes.ResponseHeadersPolicyCustomHeader {
 	if tfMap == nil {
 		return nil
 	}
@@ -780,7 +780,7 @@ func expandResponseHeadersPolicyCustomHeader(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func expandResponseHeadersPolicyCustomHeaders(tfList []interface{}) []awstypes.ResponseHeadersPolicyCustomHeader {
+func expandResponseHeadersPolicyCustomHeaders(tfList []any) []awstypes.ResponseHeadersPolicyCustomHeader {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -788,7 +788,7 @@ func expandResponseHeadersPolicyCustomHeaders(tfList []interface{}) []awstypes.R
 	var apiObjects []awstypes.ResponseHeadersPolicyCustomHeader
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -806,12 +806,12 @@ func expandResponseHeadersPolicyCustomHeaders(tfList []interface{}) []awstypes.R
 	return apiObjects
 }
 
-func flattenResponseHeadersPolicyCustomHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyCustomHeadersConfig) map[string]interface{} {
+func flattenResponseHeadersPolicyCustomHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyCustomHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = flattenResponseHeadersPolicyCustomHeaders(v)
@@ -820,12 +820,12 @@ func flattenResponseHeadersPolicyCustomHeadersConfig(apiObject *awstypes.Respons
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyCustomHeader(apiObject *awstypes.ResponseHeadersPolicyCustomHeader) map[string]interface{} {
+func flattenResponseHeadersPolicyCustomHeader(apiObject *awstypes.ResponseHeadersPolicyCustomHeader) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Header; v != nil {
 		tfMap[names.AttrHeader] = aws.ToString(v)
@@ -842,12 +842,12 @@ func flattenResponseHeadersPolicyCustomHeader(apiObject *awstypes.ResponseHeader
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyCustomHeaders(apiObjects []awstypes.ResponseHeadersPolicyCustomHeader) []interface{} {
+func flattenResponseHeadersPolicyCustomHeaders(apiObjects []awstypes.ResponseHeadersPolicyCustomHeader) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenResponseHeadersPolicyCustomHeader(&apiObject); len(v) > 0 {
@@ -862,7 +862,7 @@ func flattenResponseHeadersPolicyCustomHeaders(apiObjects []awstypes.ResponseHea
 // remove_headers_config:
 //
 
-func expandResponseHeadersPolicyRemoveHeadersConfig(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyRemoveHeadersConfig {
+func expandResponseHeadersPolicyRemoveHeadersConfig(tfMap map[string]any) *awstypes.ResponseHeadersPolicyRemoveHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -878,7 +878,7 @@ func expandResponseHeadersPolicyRemoveHeadersConfig(tfMap map[string]interface{}
 	return apiObject
 }
 
-func expandResponseHeadersPolicyRemoveHeader(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyRemoveHeader {
+func expandResponseHeadersPolicyRemoveHeader(tfMap map[string]any) *awstypes.ResponseHeadersPolicyRemoveHeader {
 	if tfMap == nil {
 		return nil
 	}
@@ -892,7 +892,7 @@ func expandResponseHeadersPolicyRemoveHeader(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func expandResponseHeadersPolicyRemoveHeaders(tfList []interface{}) []awstypes.ResponseHeadersPolicyRemoveHeader {
+func expandResponseHeadersPolicyRemoveHeaders(tfList []any) []awstypes.ResponseHeadersPolicyRemoveHeader {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -900,7 +900,7 @@ func expandResponseHeadersPolicyRemoveHeaders(tfList []interface{}) []awstypes.R
 	var apiObjects []awstypes.ResponseHeadersPolicyRemoveHeader
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -918,12 +918,12 @@ func expandResponseHeadersPolicyRemoveHeaders(tfList []interface{}) []awstypes.R
 	return apiObjects
 }
 
-func flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyRemoveHeadersConfig) map[string]interface{} {
+func flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyRemoveHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Items; len(v) > 0 {
 		tfMap["items"] = flattenResponseHeadersPolicyRemoveHeaders(v)
@@ -932,12 +932,12 @@ func flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject *awstypes.Respons
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyRemoveHeader(apiObject *awstypes.ResponseHeadersPolicyRemoveHeader) map[string]interface{} {
+func flattenResponseHeadersPolicyRemoveHeader(apiObject *awstypes.ResponseHeadersPolicyRemoveHeader) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Header; v != nil {
 		tfMap[names.AttrHeader] = aws.ToString(v)
@@ -946,12 +946,12 @@ func flattenResponseHeadersPolicyRemoveHeader(apiObject *awstypes.ResponseHeader
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyRemoveHeaders(apiObjects []awstypes.ResponseHeadersPolicyRemoveHeader) []interface{} {
+func flattenResponseHeadersPolicyRemoveHeaders(apiObjects []awstypes.ResponseHeadersPolicyRemoveHeader) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		if v := flattenResponseHeadersPolicyRemoveHeader(&apiObject); len(v) > 0 {
@@ -966,41 +966,41 @@ func flattenResponseHeadersPolicyRemoveHeaders(apiObjects []awstypes.ResponseHea
 // security_headers_config:
 //
 
-func expandResponseHeadersPolicySecurityHeadersConfig(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicySecurityHeadersConfig {
+func expandResponseHeadersPolicySecurityHeadersConfig(tfMap map[string]any) *awstypes.ResponseHeadersPolicySecurityHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.ResponseHeadersPolicySecurityHeadersConfig{}
 
-	if v, ok := tfMap["content_security_policy"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ContentSecurityPolicy = expandResponseHeadersPolicyContentSecurityPolicy(v[0].(map[string]interface{}))
+	if v, ok := tfMap["content_security_policy"].([]any); ok && len(v) > 0 {
+		apiObject.ContentSecurityPolicy = expandResponseHeadersPolicyContentSecurityPolicy(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["content_type_options"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ContentTypeOptions = expandResponseHeadersPolicyContentTypeOptions(v[0].(map[string]interface{}))
+	if v, ok := tfMap["content_type_options"].([]any); ok && len(v) > 0 {
+		apiObject.ContentTypeOptions = expandResponseHeadersPolicyContentTypeOptions(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["frame_options"].([]interface{}); ok && len(v) > 0 {
-		apiObject.FrameOptions = expandResponseHeadersPolicyFrameOptions(v[0].(map[string]interface{}))
+	if v, ok := tfMap["frame_options"].([]any); ok && len(v) > 0 {
+		apiObject.FrameOptions = expandResponseHeadersPolicyFrameOptions(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["referrer_policy"].([]interface{}); ok && len(v) > 0 {
-		apiObject.ReferrerPolicy = expandResponseHeadersPolicyReferrerPolicy(v[0].(map[string]interface{}))
+	if v, ok := tfMap["referrer_policy"].([]any); ok && len(v) > 0 {
+		apiObject.ReferrerPolicy = expandResponseHeadersPolicyReferrerPolicy(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["strict_transport_security"].([]interface{}); ok && len(v) > 0 {
-		apiObject.StrictTransportSecurity = expandResponseHeadersPolicyStrictTransportSecurity(v[0].(map[string]interface{}))
+	if v, ok := tfMap["strict_transport_security"].([]any); ok && len(v) > 0 {
+		apiObject.StrictTransportSecurity = expandResponseHeadersPolicyStrictTransportSecurity(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["xss_protection"].([]interface{}); ok && len(v) > 0 {
-		apiObject.XSSProtection = expandResponseHeadersPolicyXSSProtection(v[0].(map[string]interface{}))
+	if v, ok := tfMap["xss_protection"].([]any); ok && len(v) > 0 {
+		apiObject.XSSProtection = expandResponseHeadersPolicyXSSProtection(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandResponseHeadersPolicyContentSecurityPolicy(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyContentSecurityPolicy {
+func expandResponseHeadersPolicyContentSecurityPolicy(tfMap map[string]any) *awstypes.ResponseHeadersPolicyContentSecurityPolicy {
 	if tfMap == nil {
 		return nil
 	}
@@ -1018,7 +1018,7 @@ func expandResponseHeadersPolicyContentSecurityPolicy(tfMap map[string]interface
 	return apiObject
 }
 
-func expandResponseHeadersPolicyContentTypeOptions(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyContentTypeOptions {
+func expandResponseHeadersPolicyContentTypeOptions(tfMap map[string]any) *awstypes.ResponseHeadersPolicyContentTypeOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -1032,7 +1032,7 @@ func expandResponseHeadersPolicyContentTypeOptions(tfMap map[string]interface{})
 	return apiObject
 }
 
-func expandResponseHeadersPolicyFrameOptions(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyFrameOptions {
+func expandResponseHeadersPolicyFrameOptions(tfMap map[string]any) *awstypes.ResponseHeadersPolicyFrameOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -1050,7 +1050,7 @@ func expandResponseHeadersPolicyFrameOptions(tfMap map[string]interface{}) *awst
 	return apiObject
 }
 
-func expandResponseHeadersPolicyReferrerPolicy(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyReferrerPolicy {
+func expandResponseHeadersPolicyReferrerPolicy(tfMap map[string]any) *awstypes.ResponseHeadersPolicyReferrerPolicy {
 	if tfMap == nil {
 		return nil
 	}
@@ -1068,7 +1068,7 @@ func expandResponseHeadersPolicyReferrerPolicy(tfMap map[string]interface{}) *aw
 	return apiObject
 }
 
-func expandResponseHeadersPolicyStrictTransportSecurity(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyStrictTransportSecurity {
+func expandResponseHeadersPolicyStrictTransportSecurity(tfMap map[string]any) *awstypes.ResponseHeadersPolicyStrictTransportSecurity {
 	if tfMap == nil {
 		return nil
 	}
@@ -1094,7 +1094,7 @@ func expandResponseHeadersPolicyStrictTransportSecurity(tfMap map[string]interfa
 	return apiObject
 }
 
-func expandResponseHeadersPolicyXSSProtection(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyXSSProtection {
+func expandResponseHeadersPolicyXSSProtection(tfMap map[string]any) *awstypes.ResponseHeadersPolicyXSSProtection {
 	if tfMap == nil {
 		return nil
 	}
@@ -1120,46 +1120,46 @@ func expandResponseHeadersPolicyXSSProtection(tfMap map[string]interface{}) *aws
 	return apiObject
 }
 
-func flattenResponseHeadersPolicySecurityHeadersConfig(apiObject *awstypes.ResponseHeadersPolicySecurityHeadersConfig) map[string]interface{} {
+func flattenResponseHeadersPolicySecurityHeadersConfig(apiObject *awstypes.ResponseHeadersPolicySecurityHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := flattenResponseHeadersPolicyContentSecurityPolicy(apiObject.ContentSecurityPolicy); len(v) > 0 {
-		tfMap["content_security_policy"] = []interface{}{v}
+		tfMap["content_security_policy"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyContentTypeOptions(apiObject.ContentTypeOptions); len(v) > 0 {
-		tfMap["content_type_options"] = []interface{}{v}
+		tfMap["content_type_options"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyFrameOptions(apiObject.FrameOptions); len(v) > 0 {
-		tfMap["frame_options"] = []interface{}{v}
+		tfMap["frame_options"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyReferrerPolicy(apiObject.ReferrerPolicy); len(v) > 0 {
-		tfMap["referrer_policy"] = []interface{}{v}
+		tfMap["referrer_policy"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyStrictTransportSecurity(apiObject.StrictTransportSecurity); len(v) > 0 {
-		tfMap["strict_transport_security"] = []interface{}{v}
+		tfMap["strict_transport_security"] = []any{v}
 	}
 
 	if v := flattenResponseHeadersPolicyXSSProtection(apiObject.XSSProtection); len(v) > 0 {
-		tfMap["xss_protection"] = []interface{}{v}
+		tfMap["xss_protection"] = []any{v}
 	}
 
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyContentSecurityPolicy(apiObject *awstypes.ResponseHeadersPolicyContentSecurityPolicy) map[string]interface{} {
+func flattenResponseHeadersPolicyContentSecurityPolicy(apiObject *awstypes.ResponseHeadersPolicyContentSecurityPolicy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ContentSecurityPolicy; v != nil {
 		tfMap["content_security_policy"] = aws.ToString(v)
@@ -1172,12 +1172,12 @@ func flattenResponseHeadersPolicyContentSecurityPolicy(apiObject *awstypes.Respo
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyContentTypeOptions(apiObject *awstypes.ResponseHeadersPolicyContentTypeOptions) map[string]interface{} {
+func flattenResponseHeadersPolicyContentTypeOptions(apiObject *awstypes.ResponseHeadersPolicyContentTypeOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Override; v != nil {
 		tfMap["override"] = aws.ToBool(v)
@@ -1186,12 +1186,12 @@ func flattenResponseHeadersPolicyContentTypeOptions(apiObject *awstypes.Response
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyFrameOptions(apiObject *awstypes.ResponseHeadersPolicyFrameOptions) map[string]interface{} {
+func flattenResponseHeadersPolicyFrameOptions(apiObject *awstypes.ResponseHeadersPolicyFrameOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.FrameOption; v != "" {
 		tfMap["frame_option"] = v
@@ -1204,12 +1204,12 @@ func flattenResponseHeadersPolicyFrameOptions(apiObject *awstypes.ResponseHeader
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyReferrerPolicy(apiObject *awstypes.ResponseHeadersPolicyReferrerPolicy) map[string]interface{} {
+func flattenResponseHeadersPolicyReferrerPolicy(apiObject *awstypes.ResponseHeadersPolicyReferrerPolicy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Override; v != nil {
 		tfMap["override"] = aws.ToBool(v)
@@ -1222,12 +1222,12 @@ func flattenResponseHeadersPolicyReferrerPolicy(apiObject *awstypes.ResponseHead
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyStrictTransportSecurity(apiObject *awstypes.ResponseHeadersPolicyStrictTransportSecurity) map[string]interface{} {
+func flattenResponseHeadersPolicyStrictTransportSecurity(apiObject *awstypes.ResponseHeadersPolicyStrictTransportSecurity) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AccessControlMaxAgeSec; v != nil {
 		tfMap["access_control_max_age_sec"] = aws.ToInt32(v)
@@ -1248,12 +1248,12 @@ func flattenResponseHeadersPolicyStrictTransportSecurity(apiObject *awstypes.Res
 	return tfMap
 }
 
-func flattenResponseHeadersPolicyXSSProtection(apiObject *awstypes.ResponseHeadersPolicyXSSProtection) map[string]interface{} {
+func flattenResponseHeadersPolicyXSSProtection(apiObject *awstypes.ResponseHeadersPolicyXSSProtection) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ModeBlock; v != nil {
 		tfMap["mode_block"] = aws.ToBool(v)
@@ -1278,7 +1278,7 @@ func flattenResponseHeadersPolicyXSSProtection(apiObject *awstypes.ResponseHeade
 // server_timing_headers_config:
 //
 
-func expandResponseHeadersPolicyServerTimingHeadersConfig(tfMap map[string]interface{}) *awstypes.ResponseHeadersPolicyServerTimingHeadersConfig {
+func expandResponseHeadersPolicyServerTimingHeadersConfig(tfMap map[string]any) *awstypes.ResponseHeadersPolicyServerTimingHeadersConfig {
 	if tfMap == nil {
 		return nil
 	}
@@ -1296,12 +1296,12 @@ func expandResponseHeadersPolicyServerTimingHeadersConfig(tfMap map[string]inter
 	return apiObject
 }
 
-func flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyServerTimingHeadersConfig) map[string]interface{} {
+func flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject *awstypes.ResponseHeadersPolicyServerTimingHeadersConfig) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Enabled; v != nil {
 		tfMap[names.AttrEnabled] = aws.ToBool(v)

--- a/internal/service/cloudfront/response_headers_policy_data_source.go
+++ b/internal/service/cloudfront/response_headers_policy_data_source.go
@@ -300,7 +300,7 @@ func dataSourceResponseHeadersPolicy() *schema.Resource {
 	}
 }
 
-func dataSourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceResponseHeadersPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CloudFrontClient(ctx)
 
@@ -348,14 +348,14 @@ func dataSourceResponseHeadersPolicyRead(ctx context.Context, d *schema.Resource
 	apiObject := output.ResponseHeadersPolicy.ResponseHeadersPolicyConfig
 	d.Set(names.AttrComment, apiObject.Comment)
 	if apiObject.CorsConfig != nil {
-		if err := d.Set("cors_config", []interface{}{flattenResponseHeadersPolicyCorsConfig(apiObject.CorsConfig)}); err != nil {
+		if err := d.Set("cors_config", []any{flattenResponseHeadersPolicyCorsConfig(apiObject.CorsConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting cors_config: %s", err)
 		}
 	} else {
 		d.Set("cors_config", nil)
 	}
 	if apiObject.CustomHeadersConfig != nil {
-		if err := d.Set("custom_headers_config", []interface{}{flattenResponseHeadersPolicyCustomHeadersConfig(apiObject.CustomHeadersConfig)}); err != nil {
+		if err := d.Set("custom_headers_config", []any{flattenResponseHeadersPolicyCustomHeadersConfig(apiObject.CustomHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting custom_headers_config: %s", err)
 		}
 	} else {
@@ -364,21 +364,21 @@ func dataSourceResponseHeadersPolicyRead(ctx context.Context, d *schema.Resource
 	d.Set("etag", output.ETag)
 	d.Set(names.AttrName, apiObject.Name)
 	if apiObject.RemoveHeadersConfig != nil {
-		if err := d.Set("remove_headers_config", []interface{}{flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject.RemoveHeadersConfig)}); err != nil {
+		if err := d.Set("remove_headers_config", []any{flattenResponseHeadersPolicyRemoveHeadersConfig(apiObject.RemoveHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting remove_headers_config: %s", err)
 		}
 	} else {
 		d.Set("remove_headers_config", nil)
 	}
 	if apiObject.SecurityHeadersConfig != nil {
-		if err := d.Set("security_headers_config", []interface{}{flattenResponseHeadersPolicySecurityHeadersConfig(apiObject.SecurityHeadersConfig)}); err != nil {
+		if err := d.Set("security_headers_config", []any{flattenResponseHeadersPolicySecurityHeadersConfig(apiObject.SecurityHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting security_headers_config: %s", err)
 		}
 	} else {
 		d.Set("security_headers_config", nil)
 	}
 	if apiObject.ServerTimingHeadersConfig != nil {
-		if err := d.Set("server_timing_headers_config", []interface{}{flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject.ServerTimingHeadersConfig)}); err != nil {
+		if err := d.Set("server_timing_headers_config", []any{flattenResponseHeadersPolicyServerTimingHeadersConfig(apiObject.ServerTimingHeadersConfig)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting server_timing_headers_config: %s", err)
 		}
 	} else {

--- a/internal/service/cloudfront/vpc_origin.go
+++ b/internal/service/cloudfront/vpc_origin.go
@@ -349,7 +349,7 @@ func findVPCOrigin(ctx context.Context, conn *cloudfront.Client, input *cloudfro
 }
 
 func vpcOriginStatus(ctx context.Context, conn *cloudfront.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCOriginByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
