### PR TITLE
elasticache: Modernize Go code

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -17,9 +17,9 @@ on:
 ##   - Makefile: ./GNUmakefile
 
 jobs:
-  copywrite:
-    name: Check for modern Go
-    runs-on: ubuntu-latest
+  modern-base:
+    name: Check for modern Go code base
+    runs-on: custom-linux-medium
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
@@ -42,8 +42,35 @@ jobs:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/acctest/... modern-check
-      - run: make TEST=./internal/attrmap/... modern-check
       - run: make TEST=./internal/conns/... modern-check
+      - run: make TEST=./internal/tfresource/... modern-check
+
+  non-service:
+    name: Check non-services for modern Go code
+    needs: [modern-base]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+      # See also: https://github.com/actions/setup-go/issues/54
+      - name: go env
+        run: |
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}    
+      - run: make TEST=./internal/attrmap/... modern-check
       - run: make TEST=./internal/create/... modern-check
       - run: make TEST=./internal/enum/... modern-check
       - run: make TEST=./internal/envvar/... modern-check
@@ -66,7 +93,6 @@ jobs:
       - run: make TEST=./internal/slices/... modern-check
       - run: make TEST=./internal/sweep/... modern-check
       - run: make TEST=./internal/tags/... modern-check
-      - run: make TEST=./internal/tfresource/... modern-check
       - run: make TEST=./internal/types/... modern-check
       - run: make TEST=./internal/vault/... modern-check
       - run: make TEST=./internal/verify/... modern-check
@@ -74,7 +100,31 @@ jobs:
       - run: make TEST=./names/... modern-check
       - run: make TEST=./version/... modern-check
 
-      # Services
+  services-a-i:
+    name: Check services A-I for modern Go code
+    needs: [modern-base]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+      # See also: https://github.com/actions/setup-go/issues/54
+      - name: go env
+        run: |
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }} 
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/dms modern-check
@@ -82,6 +132,32 @@ jobs:
       - run: make TEST=./internal/service/elasticache modern-check
       - run: make TEST=./internal/service/elbv2 modern-check
       - run: make TEST=./internal/service/iam modern-check
+
+  services-j-z:
+    name: Check services J-Z for modern Go code
+    needs: [modern-base]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+      # See also: https://github.com/actions/setup-go/issues/54
+      - name: go env
+        run: |
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
+      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        continue-on-error: true
+        timeout-minutes: 2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }} 
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/lambda/... modern-check
       - run: make TEST=./internal/service/mq modern-check

--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -17,7 +17,7 @@ on:
 ##   - Makefile: ./GNUmakefile
 
 jobs:
-  modern-base:
+  modern:
     name: Check for modern Go code base
     runs-on: custom-linux-medium
     steps:
@@ -41,35 +41,12 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      # long-running test
       - run: make TEST=./internal/acctest/... modern-check
       - run: make TEST=./internal/conns/... modern-check
       - run: make TEST=./internal/tfresource/... modern-check
 
-  non-service:
-    name: Check non-services for modern Go code
-    needs: [modern-base]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-      # See also: https://github.com/actions/setup-go/issues/54
-      - name: go env
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      # non-service tests
       - run: make TEST=./internal/attrmap/... modern-check
       - run: make TEST=./internal/create/... modern-check
       - run: make TEST=./internal/enum/... modern-check
@@ -100,31 +77,7 @@ jobs:
       - run: make TEST=./names/... modern-check
       - run: make TEST=./version/... modern-check
 
-  services-a-i:
-    name: Check services A-I for modern Go code
-    needs: [modern-base]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-      # See also: https://github.com/actions/setup-go/issues/54
-      - name: go env
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
+      # service tests
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/apigatewayv2 modern-check
       - run: make TEST=./internal/service/appmesh modern-check
@@ -136,32 +89,6 @@ jobs:
       - run: make TEST=./internal/service/elbv2 modern-check
       - run: make TEST=./internal/service/glue modern-check
       - run: make TEST=./internal/service/iam modern-check
-
-  services-j-z:
-    name: Check services J-Z for modern Go code
-    needs: [modern-base]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version-file: go.mod
-      # See also: https://github.com/actions/setup-go/issues/54
-      - name: go env
-        run: |
-          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-GOCACHE-${{ hashFiles('go.sum') }}-${{ hashFiles('internal/**') }}
-      - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
-        continue-on-error: true
-        timeout-minutes: 2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/lambda/... modern-check
       - run: make TEST=./internal/service/medialive modern-check

--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -79,6 +79,7 @@ jobs:
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check
+      - run: make TEST=./internal/service/elasticache modern-check
       - run: make TEST=./internal/service/elbv2 modern-check
       - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check
@@ -86,10 +87,10 @@ jobs:
       - run: make TEST=./internal/service/mq modern-check
       - run: make TEST=./internal/service/quicksight/... modern-check
       - run: make TEST=./internal/service/rds/... modern-check
-      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/s3 modern-check
+      - run: make TEST=./internal/service/sagemaker modern-check
       - run: make TEST=./internal/service/sns modern-check
-      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/ssm modern-check
+      - run: make TEST=./internal/service/sts modern-check
       - run: make TEST=./internal/service/wafregional modern-check
       - run: make TEST=./internal/service/wafv2 modern-check

--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   modern:
-    name: Check for modern Go code base
+    name: Check for modern Go code
     runs-on: custom-linux-medium
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -69,7 +69,7 @@ jobs:
         timeout-minutes: 2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}    
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/attrmap/... modern-check
       - run: make TEST=./internal/create/... modern-check
       - run: make TEST=./internal/enum/... modern-check
@@ -124,7 +124,7 @@ jobs:
         timeout-minutes: 2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }} 
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/appmesh modern-check
       - run: make TEST=./internal/service/dms modern-check
@@ -157,7 +157,7 @@ jobs:
         timeout-minutes: 2
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }} 
+          key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
       - run: make TEST=./internal/service/kms modern-check
       - run: make TEST=./internal/service/lambda/... modern-check
       - run: make TEST=./internal/service/mq modern-check

--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -118,7 +118,7 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					// ElastiCache normalizes cluster ids to lowercase,
 					// so we have to do this too or else we can end up
 					// with non-converging diffs.
@@ -195,7 +195,7 @@ func resourceCluster() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					// ElastiCache always changes the maintenance
 					// to lowercase
 					return strings.ToLower(val.(string))
@@ -346,7 +346,7 @@ func resourceCluster() *schema.Resource {
 	}
 }
 
-func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -418,7 +418,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	if v, ok := d.GetOk("log_delivery_configuration"); ok {
 		input.LogDeliveryConfigurations = []awstypes.LogDeliveryConfigurationRequest{}
 		for _, v := range v.(*schema.Set).List() {
-			input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, expandLogDeliveryConfigurationRequests(v.(map[string]interface{})))
+			input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, expandLogDeliveryConfigurationRequests(v.(map[string]any)))
 		}
 	}
 
@@ -430,7 +430,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.NotificationTopicArn = aws.String(v.(string))
 	}
 
-	if v := d.Get("snapshot_arns").([]interface{}); len(v) > 0 {
+	if v := d.Get("snapshot_arns").([]any); len(v) > 0 {
 		input.SnapshotArns = flex.ExpandStringValueList(v)
 		log.Printf("[DEBUG] Restoring Redis cluster from S3 snapshot: %#v", v)
 	}
@@ -451,8 +451,8 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.PreferredAvailabilityZone = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]interface{})) > 0 {
-		input.PreferredAvailabilityZones = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]any)) > 0 {
+		input.PreferredAvailabilityZones = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk("ip_discovery"); ok {
@@ -483,7 +483,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 		err := createTags(ctx, conn, arn, tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceClusterRead(ctx, d, meta)...)
 		}
 
@@ -495,7 +495,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
-func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -559,7 +559,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -595,14 +595,14 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 
 			currentLogDeliveryConfig := newLogDeliveryConfig.(*schema.Set).List()
 			for _, current := range currentLogDeliveryConfig {
-				logDeliveryConfigurationRequest := expandLogDeliveryConfigurationRequests(current.(map[string]interface{}))
+				logDeliveryConfigurationRequest := expandLogDeliveryConfigurationRequests(current.(map[string]any))
 				logTypesToSubmit[string(logDeliveryConfigurationRequest.LogType)] = true
 				input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
 			}
 
 			previousLogDeliveryConfig := oldLogDeliveryConfig.(*schema.Set).List()
 			for _, previous := range previousLogDeliveryConfig {
-				logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurationRequest(previous.(map[string]interface{}))
+				logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurationRequest(previous.(map[string]any))
 				// if something was removed, send an empty request
 				if !logTypesToSubmit[string(logDeliveryConfigurationRequest.LogType)] {
 					input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
@@ -682,12 +682,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 				// than the sum of the number of active cache nodes and the number of cache
 				// nodes pending creation (which may be zero). The number of Availability Zones
 				// supplied in this list must match the cache nodes being added in this request.
-				if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]interface{})) > 0 {
+				if v, ok := d.GetOk("preferred_availability_zones"); ok && len(v.([]any)) > 0 {
 					// Here we check the list length to prevent a potential panic :)
-					if len(v.([]interface{})) != n {
-						return sdkdiag.AppendErrorf(diags, "length of preferred_availability_zones (%d) must match num_cache_nodes (%d)", len(v.([]interface{})), n)
+					if len(v.([]any)) != n {
+						return sdkdiag.AppendErrorf(diags, "length of preferred_availability_zones (%d) must match num_cache_nodes (%d)", len(v.([]any)), n)
 					}
-					input.NewAvailabilityZones = flex.ExpandStringValueList(v.([]interface{})[o:])
+					input.NewAvailabilityZones = flex.ExpandStringValueList(v.([]any)[o:])
 				}
 			}
 
@@ -714,7 +714,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceClusterRead(ctx, d, meta)...)
 }
 
-func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -855,7 +855,7 @@ func findCacheClusters(ctx context.Context, conn *elasticache.Client, input *ela
 }
 
 func statusCacheCluster(ctx context.Context, conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCacheClusterByID(ctx, conn, cacheClusterID)
 
 		if tfresource.NotFound(err) {
@@ -948,13 +948,13 @@ func setCacheNodeData(d *schema.ResourceData, c *awstypes.CacheCluster) error {
 		return cmp.Compare(aws.ToString(a.CacheNodeId), aws.ToString(b.CacheNodeId))
 	})
 
-	cacheNodeData := make([]map[string]interface{}, 0, len(sortedCacheNodes))
+	cacheNodeData := make([]map[string]any, 0, len(sortedCacheNodes))
 
 	for _, node := range sortedCacheNodes {
 		if node.CacheNodeId == nil || node.Endpoint == nil || node.Endpoint.Address == nil || node.Endpoint.Port == nil || node.CustomerAvailabilityZone == nil {
 			return fmt.Errorf("Unexpected nil pointer in: %+v", node)
 		}
-		cacheNodeData = append(cacheNodeData, map[string]interface{}{
+		cacheNodeData = append(cacheNodeData, map[string]any{
 			names.AttrID:               aws.ToString(node.CacheNodeId),
 			names.AttrAddress:          aws.ToString(node.Endpoint.Address),
 			names.AttrPort:             aws.ToInt32(node.Endpoint.Port),
@@ -1000,7 +1000,7 @@ func setFromCacheCluster(d *schema.ResourceData, c *awstypes.CacheCluster) error
 }
 
 // clusterValidateAZMode validates that `num_cache_nodes` is greater than 1 when `az_mode` is "cross-az"
-func clusterValidateAZMode(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func clusterValidateAZMode(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if v, ok := diff.GetOk("az_mode"); !ok || awstypes.AZMode(v.(string)) != awstypes.AZModeCrossAz {
 		return nil
 	}
@@ -1011,7 +1011,7 @@ func clusterValidateAZMode(_ context.Context, diff *schema.ResourceDiff, v inter
 }
 
 // clusterValidateNumCacheNodes validates that `num_cache_nodes` is 1 when `engine` is "redis"
-func clusterValidateNumCacheNodes(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func clusterValidateNumCacheNodes(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	engine, ok := diff.GetOk(names.AttrEngine)
 	if !ok || engine.(string) == engineMemcached {
 		return nil
@@ -1023,7 +1023,7 @@ func clusterValidateNumCacheNodes(_ context.Context, diff *schema.ResourceDiff, 
 }
 
 // clusterForceNewOnMemcachedNodeTypeChange causes re-creation when `node_type` is changed and `engine` is "memcached"
-func clusterForceNewOnMemcachedNodeTypeChange(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func clusterForceNewOnMemcachedNodeTypeChange(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	// Engine memcached does not currently support vertical scaling
 	// https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/Scaling.html#Scaling.Memcached.Vertically
 	if diff.Id() == "" || !diff.HasChange("node_type") {
@@ -1036,7 +1036,7 @@ func clusterForceNewOnMemcachedNodeTypeChange(_ context.Context, diff *schema.Re
 }
 
 // clusterValidateMemcachedSnapshotIdentifier validates that `final_snapshot_identifier` is not set when `engine` is "memcached"
-func clusterValidateMemcachedSnapshotIdentifier(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func clusterValidateMemcachedSnapshotIdentifier(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if v, ok := diff.GetOk(names.AttrEngine); !ok || v.(string) == engineRedis || v.(string) == engineValkey {
 		return nil
 	}

--- a/internal/service/elasticache/cluster_data_source.go
+++ b/internal/service/elasticache/cluster_data_source.go
@@ -69,7 +69,7 @@ func dataSourceCluster() *schema.Resource {
 			"cluster_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					value := v.(string)
 					return strings.ToLower(value)
 				},
@@ -172,7 +172,7 @@ func dataSourceCluster() *schema.Resource {
 	}
 }
 
-func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -232,7 +232,7 @@ func diffVersion(n, o *gversion.Version) (result versionDiff) {
 	segmentsNew := n.Segments64()
 	segmentsOld := o.Segments64()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		lhs := segmentsNew[i]
 		rhs := segmentsOld[i]
 		if lhs < rhs {

--- a/internal/service/elasticache/flex.go
+++ b/internal/service/elasticache/flex.go
@@ -22,15 +22,15 @@ func flattenSecurityGroupIDs(apiObjects []awstypes.SecurityGroupMembership) []st
 	})
 }
 
-func flattenLogDeliveryConfigurations(apiObjects []awstypes.LogDeliveryConfiguration) []interface{} {
+func flattenLogDeliveryConfigurations(apiObjects []awstypes.LogDeliveryConfiguration) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 
 		switch apiObject.DestinationType {
 		case awstypes.DestinationTypeKinesisFirehose:
@@ -48,7 +48,7 @@ func flattenLogDeliveryConfigurations(apiObjects []awstypes.LogDeliveryConfigura
 	return tfList
 }
 
-func expandEmptyLogDeliveryConfigurationRequest(tfMap map[string]interface{}) awstypes.LogDeliveryConfigurationRequest {
+func expandEmptyLogDeliveryConfigurationRequest(tfMap map[string]any) awstypes.LogDeliveryConfigurationRequest {
 	apiObject := awstypes.LogDeliveryConfigurationRequest{}
 
 	apiObject.Enabled = aws.Bool(false)
@@ -57,7 +57,7 @@ func expandEmptyLogDeliveryConfigurationRequest(tfMap map[string]interface{}) aw
 	return apiObject
 }
 
-func expandLogDeliveryConfigurationRequests(v map[string]interface{}) awstypes.LogDeliveryConfigurationRequest {
+func expandLogDeliveryConfigurationRequests(v map[string]any) awstypes.LogDeliveryConfigurationRequest {
 	apiObject := awstypes.LogDeliveryConfigurationRequest{}
 
 	destinationType := awstypes.DestinationType(v["destination_type"].(string))

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -475,8 +475,8 @@ func resourceGlobalReplicationGroupUpdate(ctx context.Context, d *schema.Resourc
 					return sdkdiag.AppendFromErr(diags, err)
 				}
 			} else if newNodeGroupCount < oldNodeGroupCount {
-				ids := tfslices.ApplyToAll(d.Get("global_node_groups").(*schema.Set).List(), func(tfMapRaw interface{}) string {
-					tfMap := tfMapRaw.(map[string]interface{})
+				ids := tfslices.ApplyToAll(d.Get("global_node_groups").(*schema.Set).List(), func(tfMapRaw any) string {
+					tfMap := tfMapRaw.(map[string]any)
 					return tfMap["global_node_group_id"].(string)
 				})
 				if err := decreaseGlobalReplicationGroupNodeGroupCount(ctx, conn, d.Id(), newNodeGroupCount, ids, d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -610,7 +610,7 @@ func deleteGlobalReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		RetainPrimaryReplicationGroup: aws.Bool(true),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, readyTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, readyTimeout, func() (any, error) {
 		return conn.DeleteGlobalReplicationGroup(ctx, input)
 	})
 
@@ -678,7 +678,7 @@ func findGlobalReplicationGroups(ctx context.Context, conn *elasticache.Client, 
 }
 
 func statusGlobalReplicationGroup(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGlobalReplicationGroupByID(ctx, conn, globalReplicationGroupID)
 
 		if tfresource.NotFound(err) {
@@ -774,7 +774,7 @@ func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache
 }
 
 func statusGlobalReplicationGroupMember(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGlobalReplicationGroupMemberByID(ctx, conn, globalReplicationGroupID, replicationGroupID)
 
 		if tfresource.NotFound(err) {
@@ -836,7 +836,7 @@ func flattenGlobalNodeGroups(nodeGroups []awstypes.GlobalNodeGroup) []any {
 }
 
 func flattenGlobalNodeGroup(nodeGroup awstypes.GlobalNodeGroup) map[string]any {
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if v := nodeGroup.GlobalNodeGroupId; v != nil {
 		m["global_node_group_id"] = aws.ToString(v)
@@ -870,7 +870,7 @@ func globalReplicationGroupNodeNumber(id string) int {
 }
 
 func diffHasChange(key ...string) customdiff.ResourceConditionFunc {
-	return func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+	return func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
 		return diff.HasChanges(key...)
 	}
 }

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"slices"
 	"strings"
 	"time"
 
@@ -59,7 +60,7 @@ func resourceParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					return strings.ToLower(val.(string))
 				},
 			},
@@ -86,7 +87,7 @@ func resourceParameterGroup() *schema.Resource {
 	}
 }
 
-func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -118,7 +119,7 @@ func resourceParameterGroupCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceParameterGroupUpdate(ctx, d, meta)...)
 }
 
-func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -156,7 +157,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -200,7 +201,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 
 					// Always reset the top level error and remove the reset for reserved-memory
 					err = nil
-					paramsToModify = append(paramsToModify[:i], paramsToModify[i+1:]...)
+					paramsToModify = slices.Delete(paramsToModify, i, i+1)
 
 					// If we are only trying to remove reserved-memory and not perform
 					// an update to reserved-memory or reserved-memory-percent, we
@@ -275,7 +276,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceParameterGroupRead(ctx, d, meta)...)
 }
 
-func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceParameterGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -291,7 +292,7 @@ func deleteParameterGroup(ctx context.Context, conn *elasticache.Client, name st
 	const (
 		timeout = 3 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidCacheParameterGroupStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidCacheParameterGroupStateFault](ctx, timeout, func() (any, error) {
 		return conn.DeleteCacheParameterGroup(ctx, &elasticache.DeleteCacheParameterGroupInput{
 			CacheParameterGroupName: aws.String(name),
 		})
@@ -312,7 +313,7 @@ var (
 	parameterHash = sdkv2.SimpleSchemaSetFunc(names.AttrName, names.AttrValue)
 )
 
-func parameterChanges(o, n interface{}) (remove, addOrUpdate []*awstypes.ParameterNameValue) {
+func parameterChanges(o, n any) (remove, addOrUpdate []*awstypes.ParameterNameValue) {
 	if o == nil {
 		o = new(schema.Set)
 	}
@@ -324,12 +325,12 @@ func parameterChanges(o, n interface{}) (remove, addOrUpdate []*awstypes.Paramet
 
 	om := make(map[string]*awstypes.ParameterNameValue, os.Len())
 	for _, raw := range os.List() {
-		param := raw.(map[string]interface{})
+		param := raw.(map[string]any)
 		om[param[names.AttrName].(string)] = expandParameter(param)
 	}
 	nm := make(map[string]*awstypes.ParameterNameValue, len(addOrUpdate))
 	for _, raw := range ns.List() {
-		param := raw.(map[string]interface{})
+		param := raw.(map[string]any)
 		nm[param[names.AttrName].(string)] = expandParameter(param)
 	}
 
@@ -426,19 +427,19 @@ func findCacheParameterGroups(ctx context.Context, conn *elasticache.Client, inp
 	return output, nil
 }
 
-func expandParameter(tfMap map[string]interface{}) *awstypes.ParameterNameValue {
+func expandParameter(tfMap map[string]any) *awstypes.ParameterNameValue {
 	return &awstypes.ParameterNameValue{
 		ParameterName:  aws.String(tfMap[names.AttrName].(string)),
 		ParameterValue: aws.String(tfMap[names.AttrValue].(string)),
 	}
 }
 
-func flattenParameters(apiObjects []awstypes.Parameter) []interface{} {
-	tfList := make([]interface{}, 0, len(apiObjects))
+func flattenParameters(apiObjects []awstypes.Parameter) []any {
+	tfList := make([]any, 0, len(apiObjects))
 
 	for _, apiObject := range apiObjects {
 		if apiObject.ParameterValue != nil {
-			tfList = append(tfList, map[string]interface{}{
+			tfList = append(tfList, map[string]any{
 				names.AttrName:  strings.ToLower(aws.ToString(apiObject.ParameterName)),
 				names.AttrValue: aws.ToString(apiObject.ParameterValue),
 			})

--- a/internal/service/elasticache/parameter_group_test.go
+++ b/internal/service/elasticache/parameter_group_test.go
@@ -634,8 +634,8 @@ func TestParameterChanges(t *testing.T) {
 		},
 		{
 			Name: "Remove all",
-			Old: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			Old: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "reserved-memory",
 					names.AttrValue: "0",
 				},
@@ -651,14 +651,14 @@ func TestParameterChanges(t *testing.T) {
 		},
 		{
 			Name: "No change",
-			Old: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			Old: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "reserved-memory",
 					names.AttrValue: "0",
 				},
 			}),
-			New: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			New: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "reserved-memory",
 					names.AttrValue: "0",
 				},
@@ -668,18 +668,18 @@ func TestParameterChanges(t *testing.T) {
 		},
 		{
 			Name: "Remove partial",
-			Old: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			Old: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "reserved-memory",
 					names.AttrValue: "0",
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrName:  "appendonly",
 					names.AttrValue: "yes",
 				},
 			}),
-			New: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			New: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "appendonly",
 					names.AttrValue: "yes",
 				},
@@ -694,18 +694,18 @@ func TestParameterChanges(t *testing.T) {
 		},
 		{
 			Name: "Add to existing",
-			Old: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			Old: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "appendonly",
 					names.AttrValue: "yes",
 				},
 			}),
-			New: schema.NewSet(tfelasticache.ParameterHash, []interface{}{
-				map[string]interface{}{
+			New: schema.NewSet(tfelasticache.ParameterHash, []any{
+				map[string]any{
 					names.AttrName:  "appendonly",
 					names.AttrValue: "yes",
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrName:  "appendfsync",
 					names.AttrValue: "always",
 				},

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -208,7 +208,7 @@ func resourceReplicationGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					// ElastiCache always changes the maintenance to lowercase
 					return strings.ToLower(val.(string))
 				},
@@ -298,7 +298,7 @@ func resourceReplicationGroup() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateReplicationGroupID,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					return strings.ToLower(val.(string))
 				},
 			},
@@ -375,7 +375,7 @@ func resourceReplicationGroup() *schema.Resource {
 		// SchemaVersion: 1 did not include any state changes via MigrateState.
 		// Perform a no-operation state upgrade for Terraform 0.12 compatibility.
 		// Future state migrations should be performed with StateUpgraders.
-		MigrateState: func(v int, inst *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+		MigrateState: func(v int, inst *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 			return inst, nil
 		},
 
@@ -400,7 +400,7 @@ func resourceReplicationGroup() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			replicationGroupValidateMultiAZAutomaticFailover,
 			customizeDiffEngineVersionForceNewOnDowngrade,
-			customdiff.ForceNewIf(names.AttrEngine, func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf(names.AttrEngine, func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.HasChange(names.AttrEngine) {
 					return false
 				}
@@ -409,12 +409,12 @@ func resourceReplicationGroup() *schema.Resource {
 				}
 				return true
 			}),
-			customdiff.ComputedIf("member_clusters", func(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ComputedIf("member_clusters", func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("num_cache_clusters") ||
 					diff.HasChange("num_node_groups") ||
 					diff.HasChange("replicas_per_node_group")
 			}),
-			customdiff.ForceNewIf("transit_encryption_enabled", func(_ context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+			customdiff.ForceNewIf("transit_encryption_enabled", func(_ context.Context, d *schema.ResourceDiff, meta any) bool {
 				// For Redis engine versions < 7.0.5, transit_encryption_enabled can only
 				// be configured during creation of the cluster.
 				return semver.LessThan(d.Get("engine_version_actual").(string), "7.0.5")
@@ -424,7 +424,7 @@ func resourceReplicationGroup() *schema.Resource {
 	}
 }
 
-func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -491,7 +491,7 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("log_delivery_configuration"); ok && v.(*schema.Set).Len() > 0 {
 		for _, tfMapRaw := range v.(*schema.Set).List() {
-			tfMap, ok := tfMapRaw.(map[string]interface{})
+			tfMap, ok := tfMapRaw.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -533,8 +533,8 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 		input.Port = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("preferred_cache_cluster_azs"); ok && len(v.([]interface{})) > 0 {
-		input.PreferredCacheClusterAZs = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("preferred_cache_cluster_azs"); ok && len(v.([]any)) > 0 {
+		input.PreferredCacheClusterAZs = flex.ExpandStringValueList(v.([]any))
 	}
 
 	rawConfig := d.GetRawConfig()
@@ -629,7 +629,7 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 		err := createTags(ctx, conn, aws.ToString(output.ReplicationGroup.ARN), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceReplicationGroupRead(ctx, d, meta)...)
 		}
 
@@ -641,7 +641,7 @@ func resourceReplicationGroupCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceReplicationGroupRead(ctx, d, meta)...)
 }
 
-func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -786,7 +786,7 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -862,14 +862,14 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 
 			currentLogDeliveryConfig := n.(*schema.Set).List()
 			for _, current := range currentLogDeliveryConfig {
-				logDeliveryConfigurationRequest := expandLogDeliveryConfigurationRequests(current.(map[string]interface{}))
+				logDeliveryConfigurationRequest := expandLogDeliveryConfigurationRequests(current.(map[string]any))
 				logTypesToSubmit[logDeliveryConfigurationRequest.LogType] = true
 				input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
 			}
 
 			previousLogDeliveryConfig := o.(*schema.Set).List()
 			for _, previous := range previousLogDeliveryConfig {
-				logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurationRequest(previous.(map[string]interface{}))
+				logDeliveryConfigurationRequest := expandEmptyLogDeliveryConfigurationRequest(previous.(map[string]any))
 				//if something was removed, send an empty request
 				if !logTypesToSubmit[logDeliveryConfigurationRequest.LogType] {
 					input.LogDeliveryConfigurations = append(input.LogDeliveryConfigurations, logDeliveryConfigurationRequest)
@@ -1024,7 +1024,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceReplicationGroupRead(ctx, d, meta)...)
 }
 
-func resourceReplicationGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReplicationGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -1049,7 +1049,7 @@ func resourceReplicationGroupDelete(ctx context.Context, d *schema.ResourceData,
 		timeout = 10 * time.Minute // 10 minutes should give any creating/deleting cache clusters or snapshots time to complete.
 	)
 	log.Printf("[INFO] Deleting ElastiCache Replication Group: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidReplicationGroupStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidReplicationGroupStateFault](ctx, timeout, func() (any, error) {
 		return conn.DeleteReplicationGroup(ctx, input)
 	})
 
@@ -1081,7 +1081,7 @@ func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		ReplicationGroupRegion:   aws.String(region),
 	}
 
-	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, timeout, func() (any, error) {
 		return conn.DisassociateGlobalReplicationGroup(ctx, input)
 	})
 
@@ -1292,7 +1292,7 @@ func findReplicationGroups(ctx context.Context, conn *elasticache.Client, input 
 }
 
 func statusReplicationGroup(ctx context.Context, conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findReplicationGroupByID(ctx, conn, replicationGroupID)
 
 		if tfresource.NotFound(err) {
@@ -1387,7 +1387,7 @@ func findReplicationGroupMemberClustersByID(ctx context.Context, conn *elasticac
 // statusReplicationGroupMemberClusters fetches the Replication Group's Member Clusters and either "available" or the first non-"available" status.
 // NOTE: This function assumes that the intended end-state is to have all member clusters in "available" status.
 func statusReplicationGroupMemberClusters(ctx context.Context, conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findReplicationGroupMemberClustersByID(ctx, conn, replicationGroupID)
 
 		if tfresource.NotFound(err) {
@@ -1443,7 +1443,7 @@ var validateReplicationGroupID schema.SchemaValidateFunc = validation.All(
 )
 
 // replicationGroupValidateMultiAZAutomaticFailover validates that `automatic_failover_enabled` is set when `multi_az_enabled` is true
-func replicationGroupValidateMultiAZAutomaticFailover(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func replicationGroupValidateMultiAZAutomaticFailover(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if v := diff.Get("multi_az_enabled").(bool); !v {
 		return nil
 	}
@@ -1454,7 +1454,7 @@ func replicationGroupValidateMultiAZAutomaticFailover(_ context.Context, diff *s
 }
 
 // replicationGroupValidateAutomaticFailoverNumCacheClusters validates that `automatic_failover_enabled` is set when `multi_az_enabled` is true
-func replicationGroupValidateAutomaticFailoverNumCacheClusters(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+func replicationGroupValidateAutomaticFailoverNumCacheClusters(_ context.Context, diff *schema.ResourceDiff, v any) error {
 	if v := diff.Get("automatic_failover_enabled").(bool); !v {
 		return nil
 	}

--- a/internal/service/elasticache/replication_group_data_source.go
+++ b/internal/service/elasticache/replication_group_data_source.go
@@ -125,7 +125,7 @@ func dataSourceReplicationGroup() *schema.Resource {
 	}
 }
 
-func dataSourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 

--- a/internal/service/elasticache/replication_group_migrate.go
+++ b/internal/service/elasticache/replication_group_migrate.go
@@ -16,9 +16,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func replicationGroupStateUpgradeV1(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func replicationGroupStateUpgradeV1(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
-		rawState = map[string]interface{}{}
+		rawState = map[string]any{}
 	}
 
 	// Set auth_token_update_strategy to new default value.

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -3404,7 +3404,7 @@ func testAccReplicationGroupCheckMemberClusterTags(resourceName, dataSourceNameP
 	checks := testAccCheckResourceTags(resourceName, kvs)
 	checks = append(checks, resource.TestCheckResourceAttr(resourceName, "member_clusters.#", strconv.Itoa(memberCount))) // sanity check
 
-	for i := 0; i < memberCount; i++ {
+	for i := range memberCount {
 		dataSourceName := fmt.Sprintf("%s.%d", dataSourceNamePrefix, i)
 		checks = append(checks, testAccCheckResourceTags(dataSourceName, kvs)...)
 	}

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -401,7 +401,7 @@ func (r *serverlessCacheResource) Delete(ctx context.Context, request resource.D
 
 	conn := r.Meta().ElastiCacheClient(ctx)
 
-	tflog.Debug(ctx, "deleting ElastiCache Serverless Cache", map[string]interface{}{
+	tflog.Debug(ctx, "deleting ElastiCache Serverless Cache", map[string]any{
 		names.AttrID: data.ID.ValueString(),
 	})
 
@@ -410,7 +410,7 @@ func (r *serverlessCacheResource) Delete(ctx context.Context, request resource.D
 		FinalSnapshotName:   nil,
 	}
 
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
 		return conn.DeleteServerlessCache(ctx, input)
 	}, errCodeDependencyViolation)
 
@@ -474,7 +474,7 @@ func findServerlessCacheByID(ctx context.Context, conn *elasticache.Client, id s
 }
 
 func statusServerlessCache(ctx context.Context, conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findServerlessCacheByID(ctx, conn, cacheClusterID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -52,7 +52,7 @@ func resourceSubnetGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				StateFunc: func(val interface{}) string {
+				StateFunc: func(val any) string {
 					// ElastiCache normalizes subnet names to lowercase,
 					// so we have to do this too or else we can end up
 					// with non-converging diffs.
@@ -76,7 +76,7 @@ func resourceSubnetGroup() *schema.Resource {
 	}
 }
 
-func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -113,7 +113,7 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		err := createTags(ctx, conn, aws.ToString(output.CacheSubnetGroup.ARN), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 		}
 
@@ -125,7 +125,7 @@ func resourceSubnetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
-func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -173,12 +173,12 @@ func resourceSubnetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceSubnetGroupRead(ctx, d, meta)...)
 }
 
-func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
 	log.Printf("[DEBUG] Deleting ElastiCache Subnet Group: %s", d.Id())
-	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, 5*time.Minute, func() (any, error) {
 		return conn.DeleteCacheSubnetGroup(ctx, &elasticache.DeleteCacheSubnetGroupInput{
 			CacheSubnetGroupName: aws.String(d.Id()),
 		})
@@ -195,7 +195,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceSubnetGroupCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceSubnetGroupCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
 	// Reserved ElastiCache Subnet Groups with the name "default" do not support tagging,
 	// thus we must suppress the diff originating from the provider-level default_tags configuration.
 	// Reference: https://github.com/hashicorp/terraform-provider-aws/issues/19213.

--- a/internal/service/elasticache/subnet_group_data_source.go
+++ b/internal/service/elasticache/subnet_group_data_source.go
@@ -50,7 +50,7 @@ func dataSourceSubnetGroup() *schema.Resource {
 	}
 }
 
-func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -121,7 +121,7 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -136,8 +136,8 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		UserName:           aws.String(d.Get(names.AttrUserName).(string)),
 	}
 
-	if v, ok := d.GetOk("authentication_mode"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.AuthenticationMode = expandAuthenticationMode(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("authentication_mode"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.AuthenticationMode = expandAuthenticationMode(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("passwords"); ok && v.(*schema.Set).Len() > 0 {
@@ -168,7 +168,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 		err := createTags(ctx, conn, aws.ToString(output.ARN), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceUserRead(ctx, d, meta)...)
 		}
 
@@ -180,7 +180,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -201,13 +201,13 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	d.Set("access_string", user.AccessString)
 	d.Set(names.AttrARN, user.ARN)
 	if v := user.Authentication; v != nil {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"password_count": aws.ToInt32(v.PasswordCount),
 			"passwords":      d.Get("authentication_mode.0.passwords"),
 			names.AttrType:   string(v.Type),
 		}
 
-		if err := d.Set("authentication_mode", []interface{}{tfMap}); err != nil {
+		if err := d.Set("authentication_mode", []any{tfMap}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting authentication_mode: %s", err)
 		}
 	} else {
@@ -220,7 +220,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -234,8 +234,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 		}
 
 		if d.HasChange("authentication_mode") {
-			if v, ok := d.GetOk("authentication_mode"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.AuthenticationMode = expandAuthenticationMode(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("authentication_mode"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.AuthenticationMode = expandAuthenticationMode(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -265,7 +265,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -337,7 +337,7 @@ func findUsers(ctx context.Context, conn *elasticache.Client, input *elasticache
 }
 
 func statusUser(ctx context.Context, conn *elasticache.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findUserByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -410,7 +410,7 @@ func waitUserDeleted(ctx context.Context, conn *elasticache.Client, id string, t
 	return nil, err
 }
 
-func expandAuthenticationMode(tfMap map[string]interface{}) *awstypes.AuthenticationMode {
+func expandAuthenticationMode(tfMap map[string]any) *awstypes.AuthenticationMode {
 	if tfMap == nil {
 		return nil
 	}

--- a/internal/service/elasticache/user_data_source.go
+++ b/internal/service/elasticache/user_data_source.go
@@ -68,7 +68,7 @@ func dataSourceUser() *schema.Resource {
 	}
 }
 
-func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -81,12 +81,12 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta interf
 	d.SetId(aws.ToString(user.UserId))
 	d.Set("access_string", user.AccessString)
 	if v := user.Authentication; v != nil {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"password_count": aws.ToInt32(v.PasswordCount),
 			names.AttrType:   string(v.Type),
 		}
 
-		if err := d.Set("authentication_mode", []interface{}{tfMap}); err != nil {
+		if err := d.Set("authentication_mode", []any{tfMap}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting authentication_mode: %s", err)
 		}
 	}

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -66,7 +66,7 @@ func resourceUserGroup() *schema.Resource {
 	}
 }
 
-func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 	partition := meta.(*conns.AWSClient).Partition(ctx)
@@ -106,7 +106,7 @@ func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 		err := createTags(ctx, conn, aws.ToString(output.ARN), tags)
 
 		// If default tags only, continue. Otherwise, error.
-		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]interface{})) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
+		if v, ok := d.GetOk(names.AttrTags); (!ok || len(v.(map[string]any)) == 0) && errs.IsUnsupportedOperationInPartitionError(partition, err) {
 			return append(diags, resourceUserGroupRead(ctx, d, meta)...)
 		}
 
@@ -118,7 +118,7 @@ func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceUserGroupRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -142,7 +142,7 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -181,7 +181,7 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceUserGroupRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).ElastiCacheClient(ctx)
 
@@ -253,7 +253,7 @@ func findUserGroups(ctx context.Context, conn *elasticache.Client, input *elasti
 }
 
 func statusUserGroup(ctx context.Context, conn *elasticache.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findUserGroupByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/elasticache/validate.go
+++ b/internal/service/elasticache/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validReplicationGroupAuthToken(v interface{}, k string) (ws []string, errors []error) {
+func validReplicationGroupAuthToken(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if (len(value) < 16) || (len(value) > 128) {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
