### PR TITLE
fix to allow 'aws-marketplace' as a valid arn string in the arn prefix

### DIFF
--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/types/timestamp"
 )
 
-var accountIDRegexp = regexache.MustCompile(`^(aws|aws-managed|third-party|\d{12}|cw.{10})$`)
+var accountIDRegexp = regexache.MustCompile(`^(aws|aws-managed|third-party|aws-marketplace|\d{12}|cw.{10})$`)
 var partitionRegexp = regexache.MustCompile(`^aws(-[a-z]+)*$`)
 var regionRegexp = regexache.MustCompile(`^[a-z]{2}(-[a-z]+)+-\d{1,2}$`)
 


### PR DESCRIPTION

### Description
This allows for build components to use the arn prefix including the string 'aws-marketplace'

I'm not at liberty to use testacc on company accounts so I ran the full test suite and output the relevant section below

### Relations

Closes #41818

### References



### Output from Acceptance Testing

```console
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       17.654s
...
```
