### PR TITLE
[Enhancement] r/aws_emr_instance_fleet: support capacityreservations

### DIFF
--- a/.changelog/42082.txt
+++ b/.changelog/42082.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_emr_cluster: visible_to_all_users attribute no longer supported
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -147,9 +147,9 @@ func resourceCluster() *schema.Resource {
 									},
 									names.AttrPriority: {
 										Type:     schema.TypeFloat,
+										Computed: true,
 										Optional: true,
 										ForceNew: true,
-										Default:  -1,
 									},
 									"weighted_capacity": {
 										Type:     schema.TypeInt,
@@ -2151,7 +2151,7 @@ func flattenInstanceTypeSpecifications(apiObjects []awstypes.InstanceTypeSpecifi
 		tfMap["ebs_config"] = flattenEBSConfig(apiObject.EbsBlockDevices)
 		tfMap[names.AttrInstanceType] = aws.ToString(apiObject.InstanceType)
 		tfMap["weighted_capacity"] = int(aws.ToInt32(apiObject.WeightedCapacity))
-		tfMap[names.AttrPriority] = float64(aws.ToFloat64(apiObject.Priority))
+		tfMap[names.AttrPriority] = aws.ToFloat64(apiObject.Priority)
 
 		tfList = append(tfList, tfMap)
 	}
@@ -2273,7 +2273,7 @@ func expandInstanceTypeConfigs(tfList []any) []awstypes.InstanceTypeConfig {
 			apiObject.EbsConfiguration = expandEBSConfiguration(v.List())
 		}
 
-		if v, ok := tfMap[names.AttrPriority].(float64); ok && v != -1 {
+		if v, ok := tfMap[names.AttrPriority].(float64); ok && v != 0 {
 			apiObject.Priority = aws.Float64(v)
 		}
 
@@ -2367,7 +2367,7 @@ func resourceInstanceTypeHashConfig(v any) int {
 	if v, ok := m["weighted_capacity"]; ok && v.(int) > 0 {
 		buf.WriteString(fmt.Sprintf("%d-", v.(int)))
 	}
-	if v, ok := m[names.AttrPriority]; ok && v.(float64) > 0 {
+	if v, ok := m[names.AttrPriority]; ok {
 		buf.WriteString(fmt.Sprintf("%.6f-", v.(float64)))
 	}
 	if v, ok := m["bid_price_as_percentage_of_on_demand_price"]; ok && v.(float64) != 0 {

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -766,11 +766,6 @@ func resourceCluster() *schema.Resource {
 					Optional: true,
 					Default:  false,
 				},
-				"visible_to_all_users": {
-					Type:     schema.TypeBool,
-					Optional: true,
-					Default:  true,
-				},
 			}
 		},
 	}
@@ -922,10 +917,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		Name:         aws.String(name),
 		Applications: expandApplications(applications),
 
-		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
-		ServiceRole:       aws.String(d.Get(names.AttrServiceRole).(string)),
-		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
-		Tags:              getTagsIn(ctx),
+		ReleaseLabel: aws.String(d.Get("release_label").(string)),
+		ServiceRole:  aws.String(d.Get(names.AttrServiceRole).(string)),
+		Tags:         getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("additional_info"); ok {
@@ -1122,7 +1116,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("log_encryption_kms_key_id", cluster.LogEncryptionKmsKeyId)
 	d.Set("log_uri", cluster.LogUri)
 	d.Set("master_public_dns", cluster.MasterPublicDnsName)
-	d.Set("visible_to_all_users", cluster.VisibleToAllUsers)
 	d.Set("ebs_root_volume_size", cluster.EbsRootVolumeSize)
 	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
 	d.Set("termination_protection", cluster.TerminationProtected)
@@ -1211,19 +1204,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRClient(ctx)
-
-	if d.HasChange("visible_to_all_users") {
-		input := &emr.SetVisibleToAllUsersInput{
-			JobFlowIds:        []string{d.Id()},
-			VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
-		}
-
-		_, err := conn.SetVisibleToAllUsers(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EMR Cluster (%s): setting visibility: %s", d.Id(), err)
-		}
-	}
 
 	if d.HasChange("auto_termination_policy") {
 		_, n := d.GetChange("auto_termination_policy")

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -197,7 +197,7 @@ func resourceCluster() *schema.Resource {
 															"capacity_reservation_resource_group_arn": {
 																Type:             schema.TypeString,
 																ForceNew:         true,
-																Required:         true,
+																Optional:         true,
 																ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
 															},
 															"usage_strategy": {
@@ -2327,7 +2327,6 @@ func expandCapacityReservationOptions(tfMap map[string]any) *awstypes.OnDemandCa
 	if v, ok := tfMap["capacity_reservation_resource_group_arn"].(string); ok {
 		apiObject.CapacityReservationResourceGroupArn = aws.String(v)
 	}
-
 	if v, ok := tfMap["usage_strategy"].(string); ok {
 		apiObject.UsageStrategy = awstypes.OnDemandCapacityReservationUsageStrategy(v)
 	}

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -1799,7 +1799,7 @@ func flattenEBSConfig(apiObjects []awstypes.EbsBlockDevice) *schema.Set {
 			tfMap[names.AttrSize] = int(aws.ToInt32(apiObject.VolumeSpecification.SizeInGB))
 		}
 		if apiObject.VolumeSpecification.Throughput != nil {
-			tfMap[names.AttrThroughput] = aws.ToInt32(apiObject.VolumeSpecification.Throughput)
+			tfMap[names.AttrThroughput] = int(aws.ToInt32(apiObject.VolumeSpecification.Throughput))
 		}
 		if apiObject.VolumeSpecification.VolumeType != nil {
 			tfMap[names.AttrType] = aws.ToString(apiObject.VolumeSpecification.VolumeType)

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1496,7 +1496,9 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 				Config: testAccClusterConfig_ebs(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
+					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
 				),
 			},
@@ -3819,13 +3821,14 @@ resource "aws_emr_cluster" "test" {
     instance_count = 1
     instance_type  = "m5.xlarge"
     ebs_config {
-      size                 = 32
+      size                 = 33
       type                 = "gp2"
       volumes_per_instance = %[2]d
     }
     ebs_config {
-      size                 = 125
-      type                 = "sc1"
+      size                 = 50
+      iops                 = 3001
+      type                 = "gp3"
       volumes_per_instance = %[2]d
     }
   }

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -3943,7 +3943,6 @@ func testAccClusterConfig_instanceFleets(rName string) string {
 		testAccClusterConfig_baseVPC(rName, false),
 		testAccClusterConfig_baseIAMServiceRole(rName),
 		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseBootstrapActionBucket(rName),
 		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -4031,7 +4030,6 @@ func testAccClusterConfig_instanceFleetMultipleSubnets(rName string) string {
 		testAccClusterConfig_baseVPC(rName, false),
 		testAccClusterConfig_baseIAMServiceRole(rName),
 		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseBootstrapActionBucket(rName),
 		fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -2098,41 +2098,13 @@ resource "aws_s3_bucket" "tester" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_public_access_block" "tester" {
-  bucket = aws_s3_bucket.tester.id
-
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
-resource "aws_s3_bucket_ownership_controls" "tester" {
-  bucket = aws_s3_bucket.tester.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_acl" "tester" {
-  depends_on = [
-    aws_s3_bucket_public_access_block.tester,
-    aws_s3_bucket_ownership_controls.tester,
-  ]
-
-  bucket = aws_s3_bucket.tester.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_object" "testobject" {
-  bucket  = aws_s3_bucket_acl.tester.bucket
+  bucket  = aws_s3_bucket.tester.bucket
   key     = "testscript.sh"
   content = <<EOF
 #!/bin/bash
 echo $@
 EOF
-
-  acl = "public-read"
 }
 `, rName)
 }

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1590,7 +1590,7 @@ func TestAccEMRCluster_InstanceFleet_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "ec2_attributes.0.subnet_ids.*", subnetResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "core_instance_fleet.0.launch_specifications.0.spot_specification.0.allocation_strategy", "capacity-optimized"),
+					resource.TestCheckResourceAttr(resourceName, "core_instance_fleet.0.launch_specifications.0.spot_specification.0.allocation_strategy", "CAPACITY_OPTIMIZED"),
 				),
 			},
 			{

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1287,56 +1287,6 @@ func TestAccEMRCluster_keepJob(t *testing.T) {
 	})
 }
 
-func TestAccEMRCluster_visibleToAllUsers(t *testing.T) {
-	ctx := acctest.Context(t)
-	var cluster awstypes.Cluster
-
-	resourceName := "aws_emr_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "visible_to_all_users", acctest.CtTrue),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"cluster_state", // Ignore RUNNING versus WAITING changes
-					"configurations",
-					"keep_job_flow_alive_when_no_steps",
-				},
-			},
-			{
-				Config: testAccClusterConfig_visibleToAllUsersUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "visible_to_all_users", acctest.CtFalse),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"cluster_state", // Ignore RUNNING versus WAITING changes
-					"configurations",
-					"keep_job_flow_alive_when_no_steps",
-				},
-			},
-		},
-	})
-}
-
 func TestAccEMRCluster_s3Logging(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cluster awstypes.Cluster
@@ -3549,61 +3499,6 @@ resource "aws_emr_cluster" "test" {
   autoscaling_role = aws_iam_role.emr_autoscaling_role.arn
 }
 `, rName, keepJob))
-}
-
-func testAccClusterConfig_visibleToAllUsersUpdated(rName string) string {
-	return acctest.ConfigCompose(
-		testAccClusterConfig_baseVPC(rName, false),
-		testAccClusterConfig_baseIAMServiceRole(rName),
-		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseIAMAutoScalingRole(rName),
-		fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-resource "aws_emr_cluster" "test" {
-  name          = %[1]q
-  release_label = "emr-4.6.0"
-  applications  = ["Spark"]
-
-  ec2_attributes {
-    subnet_id                         = aws_subnet.test.id
-    emr_managed_master_security_group = aws_security_group.test.id
-    emr_managed_slave_security_group  = aws_security_group.test.id
-    instance_profile                  = aws_iam_instance_profile.emr_instance_profile.arn
-  }
-
-  master_instance_group {
-    instance_type = "c4.large"
-  }
-
-  core_instance_group {
-    instance_count = 1
-    instance_type  = "c4.large"
-  }
-
-  tags = {
-    role     = "rolename"
-    dns_zone = "env_zone"
-    env      = "env"
-    name     = "name-env"
-  }
-
-  keep_job_flow_alive_when_no_steps = true
-  visible_to_all_users              = false
-
-  configurations = "test-fixtures/emr_configurations.json"
-
-  depends_on = [
-    aws_route_table_association.test,
-    aws_iam_role_policy_attachment.emr_service,
-    aws_iam_role_policy_attachment.emr_instance_profile,
-    aws_iam_role_policy_attachment.emr_autoscaling_role,
-  ]
-
-  service_role     = aws_iam_role.emr_service.arn
-  autoscaling_role = aws_iam_role.emr_autoscaling_role.arn
-}
-`, rName))
 }
 
 func testAccClusterConfig_s3Logging(rName string) string {

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1590,7 +1590,7 @@ func TestAccEMRCluster_InstanceFleet_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "ec2_attributes.0.subnet_ids.*", subnetResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "core_instance_fleet.0.launch_specifications.0.spot_specification.0.allocation_strategy", "CAPACITY_OPTIMIZED"),
+					resource.TestCheckResourceAttr(resourceName, "core_instance_fleet.0.launch_specifications.0.spot_specification.0.allocation_strategy", "capacity-optimized"),
 				),
 			},
 			{

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1497,9 +1497,19 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
+
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "master_instance_group.0.ebs_config.*", map[string]string{
+						names.AttrSize:         "32",
+						names.AttrType:         "gp2",
+						"volumes_per_instance": "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "master_instance_group.0.ebs_config.*", map[string]string{
+						names.AttrSize:         "50",
+						names.AttrType:         "gp3",
+						names.AttrThroughput:   "500",
+						"volumes_per_instance": "2",
+					}),
 				),
 			},
 			{
@@ -1510,6 +1520,10 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 					"cluster_state", // Ignore RUNNING versus WAITING changes
 					"configurations",
 					"keep_job_flow_alive_when_no_steps",
+
+					// https://github.com/hashicorp/terraform-plugin-testing/issues/269
+					"master_instance_group.0.ebs_config",
+					"core_instance_group.0.ebs_config",
 				},
 			},
 		},

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -128,6 +128,12 @@ func resourceInstanceFleet() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						names.AttrPriority: {
+							Type:     schema.TypeFloat,
+							Optional: true,
+							ForceNew: true,
+							Default:  -1,
+						},
 						"weighted_capacity": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -157,6 +163,34 @@ func resourceInstanceFleet() *schema.Resource {
 										Required:         true,
 										ForceNew:         true,
 										ValidateDiagFunc: enum.Validate[awstypes.OnDemandProvisioningAllocationStrategy](),
+									},
+									"capacity_reservation_options": {
+										Type:     schema.TypeList,
+										Optional: true,
+										ForceNew: true,
+										MinItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"capacity_reservation_preference": {
+													Type:             schema.TypeString,
+													ForceNew:         true,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationPreference](),
+												},
+												"capacity_reservation_resource_group_arn": {
+													Type:     schema.TypeString,
+													ForceNew: true,
+													Required: true,
+													// ValidateDiagFunc: validation.IsUUID(),
+												},
+												"usage_strategy": {
+													Type:             schema.TypeString,
+													ForceNew:         true,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationUsageStrategy](),
+												},
+											},
+										},
 									},
 								},
 							},

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -16,12 +16,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -178,10 +180,10 @@ func resourceInstanceFleet() *schema.Resource {
 													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationPreference](),
 												},
 												"capacity_reservation_resource_group_arn": {
-													Type:     schema.TypeString,
-													ForceNew: true,
-													Required: true,
-													// ValidateDiagFunc: validation.IsUUID(),
+													Type:             schema.TypeString,
+													ForceNew:         true,
+													Optional:         true,
+													ValidateDiagFunc: validation.ToDiagFunc(verify.ValidARN),
 												},
 												"usage_strategy": {
 													Type:             schema.TypeString,

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -161,9 +161,11 @@ func resourceInstanceFleet() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"allocation_strategy": {
-										Type:             schema.TypeString,
-										Required:         true,
-										ForceNew:         true,
+										Type:     schema.TypeString,
+										Required: true,
+										ForceNew: true,
+										// The return value from api is wrong
+										DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 										ValidateDiagFunc: enum.Validate[awstypes.OnDemandProvisioningAllocationStrategy](),
 									},
 									"capacity_reservation_options": {
@@ -178,6 +180,8 @@ func resourceInstanceFleet() *schema.Resource {
 													ForceNew:         true,
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationPreference](),
+													// The return value from api is wrong
+													DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 												},
 												"capacity_reservation_resource_group_arn": {
 													Type:             schema.TypeString,
@@ -190,6 +194,8 @@ func resourceInstanceFleet() *schema.Resource {
 													ForceNew:         true,
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationUsageStrategy](),
+													// The return value from api is wrong
+													DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 												},
 											},
 										},
@@ -205,9 +211,11 @@ func resourceInstanceFleet() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"allocation_strategy": {
-										Type:             schema.TypeString,
-										ForceNew:         true,
-										Required:         true,
+										Type:     schema.TypeString,
+										ForceNew: true,
+										Required: true,
+										// The return value from api is wrong
+										DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 										ValidateDiagFunc: enum.Validate[awstypes.SpotProvisioningAllocationStrategy](),
 									},
 									"block_duration_minutes": {

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -161,11 +161,9 @@ func resourceInstanceFleet() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"allocation_strategy": {
-										Type:     schema.TypeString,
-										Required: true,
-										ForceNew: true,
-										// The return value from api is wrong
-										DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
+										Type:             schema.TypeString,
+										Required:         true,
+										ForceNew:         true,
 										ValidateDiagFunc: enum.Validate[awstypes.OnDemandProvisioningAllocationStrategy](),
 									},
 									"capacity_reservation_options": {
@@ -180,8 +178,6 @@ func resourceInstanceFleet() *schema.Resource {
 													ForceNew:         true,
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationPreference](),
-													// The return value from api is wrong
-													DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 												},
 												"capacity_reservation_resource_group_arn": {
 													Type:             schema.TypeString,
@@ -194,8 +190,6 @@ func resourceInstanceFleet() *schema.Resource {
 													ForceNew:         true,
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[awstypes.OnDemandCapacityReservationUsageStrategy](),
-													// The return value from api is wrong
-													DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
 												},
 											},
 										},
@@ -211,11 +205,9 @@ func resourceInstanceFleet() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"allocation_strategy": {
-										Type:     schema.TypeString,
-										ForceNew: true,
-										Required: true,
-										// The return value from api is wrong
-										DiffSuppressFunc: SuppressEquivalentStringScreamingSnakeCaseKebabCase,
+										Type:             schema.TypeString,
+										ForceNew:         true,
+										Required:         true,
 										ValidateDiagFunc: enum.Validate[awstypes.SpotProvisioningAllocationStrategy](),
 									},
 									"block_duration_minutes": {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -664,7 +664,6 @@ EOF
 * `tags` - (Optional) list of tags to apply to the EMR Cluster. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `termination_protection` - (Optional) Switch on/off termination protection (default is `false`, except when using multiple master nodes). Before attempting to destroy the resource when termination protection is enabled, this configuration must be applied with its value set to `false`.
 * `unhealthy_node_replacement` - (Optional) Whether whether Amazon EMR should gracefully replace core nodes that have degraded within the cluster. Default value is `false`.
-* `visible_to_all_users` - (Optional) Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default value is `true`.
 
 ### bootstrap_action
 
@@ -832,7 +831,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `release_label` - Release label for the Amazon EMR release.
 * `service_role` - IAM role that will be assumed by the Amazon EMR service to access AWS resources on your behalf.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `visible_to_all_users` - Indicates whether the job flow is visible to all IAM users of the AWS account associated with the job flow.
 
 ## Import
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -156,7 +156,9 @@ resource "aws_emr_cluster" "example" {
       bid_price_as_percentage_of_on_demand_price = 80
       ebs_config {
         size                 = 100
-        type                 = "gp2"
+        type                 = "gp3"
+        throughput           = 500
+        iops                 = 3000
         volumes_per_instance = 1
       }
       instance_type     = "m3.xlarge"
@@ -213,7 +215,9 @@ resource "aws_emr_instance_fleet" "task" {
     ebs_config {
       size                 = 100
       type                 = "gp2"
-      volumes_per_instance = 1
+      volumes_per_instance = 2
+      throughput           = 500
+      iops                 = 3000
     }
     instance_type     = "m4.2xlarge"
     weighted_capacity = 2

--- a/website/docs/r/emr_instance_fleet.html.markdown
+++ b/website/docs/r/emr_instance_fleet.html.markdown
@@ -88,6 +88,7 @@ Attributes for the EBS volumes attached to each EC2 instance in the `master_inst
 * `size` - (Required) The volume size, in gibibytes (GiB).
 * `type` - (Required) The volume type. Valid options are `gp2`, `io1`, `standard` and `st1`. See [EBS Volume Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html).
 * `iops` - (Optional) The number of I/O operations per second (IOPS) that the volume supports
+* `throughput` - (Optional) The throughput, in mebibyte per second (MiB/s).
 * `volumes_per_instance` - (Optional) The number of EBS volumes with this configuration to attach to each EC2 instance in the instance group (default is 1)
 
 ## launch_specifications Configuration Block


### PR DESCRIPTION
### Description

Enables the `aws_emr_cluster` and `aws_emr_instance_fleet` resources to use EC2 capacity reservations. Within EMR, only fleets support targeted reservations.

### Relations
Closes #30346. 
Relates #42082.

### Output from Acceptance Testing


> [!NOTE]  
> This branch is based on #42082, which fixes a number of unit test failures in the provider today.

```console
% make testacc PKG=emr                                                                                                                                            make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 35   -timeout 360m -vet=off
2025/04/02 21:10:02 Initializing Terraform AWS Provider...
=== RUN   TestValidCustomAMIID
=== PAUSE TestValidCustomAMIID
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial
=== PAUSE TestAccEMRBlockPublicAccessConfiguration_serial
=== RUN   TestAccEMRCluster_basic
2025/04/02 21:10:02 [WARN] Invalid log level: "JSON". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR]
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_autoTerminationPolicy
=== PAUSE TestAccEMRCluster_autoTerminationPolicy
=== RUN   TestAccEMRCluster_additionalInfo
=== PAUSE TestAccEMRCluster_additionalInfo
=== RUN   TestAccEMRCluster_disappears
=== PAUSE TestAccEMRCluster_disappears
=== RUN   TestAccEMRCluster_sJSON
=== PAUSE TestAccEMRCluster_sJSON
=== RUN   TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== RUN   TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_CoreInstanceGroup_name
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_name
=== RUN   TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== PAUSE TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== RUN   TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== PAUSE TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== RUN   TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_MasterInstanceGroup_name
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_name
=== RUN   TestAccEMRCluster_security
=== PAUSE TestAccEMRCluster_security
=== RUN   TestAccEMRCluster_Step_basic
=== PAUSE TestAccEMRCluster_Step_basic
=== RUN   TestAccEMRCluster_Step_mode
=== PAUSE TestAccEMRCluster_Step_mode
=== RUN   TestAccEMRCluster_Step_multiple
=== PAUSE TestAccEMRCluster_Step_multiple
=== RUN   TestAccEMRCluster_Step_multiple_listStates
=== PAUSE TestAccEMRCluster_Step_multiple_listStates
=== RUN   TestAccEMRCluster_Bootstrap_ordering
=== PAUSE TestAccEMRCluster_Bootstrap_ordering
=== RUN   TestAccEMRCluster_PlacementGroupConfigs
=== PAUSE TestAccEMRCluster_PlacementGroupConfigs
=== RUN   TestAccEMRCluster_terminationProtected
=== PAUSE TestAccEMRCluster_terminationProtected
=== RUN   TestAccEMRCluster_keepJob
=== PAUSE TestAccEMRCluster_keepJob
=== RUN   TestAccEMRCluster_s3Logging
=== PAUSE TestAccEMRCluster_s3Logging
=== RUN   TestAccEMRCluster_s3LogEncryption
=== PAUSE TestAccEMRCluster_s3LogEncryption
=== RUN   TestAccEMRCluster_tags
=== PAUSE TestAccEMRCluster_tags
=== RUN   TestAccEMRCluster_RootVolume_size
=== PAUSE TestAccEMRCluster_RootVolume_size
=== RUN   TestAccEMRCluster_StepConcurrency_level
=== PAUSE TestAccEMRCluster_StepConcurrency_level
=== RUN   TestAccEMRCluster_ebs
=== PAUSE TestAccEMRCluster_ebs
=== RUN   TestAccEMRCluster_CustomAMI_id
=== PAUSE TestAccEMRCluster_CustomAMI_id
=== RUN   TestAccEMRCluster_InstanceFleet_basic
=== PAUSE TestAccEMRCluster_InstanceFleet_basic
=== RUN   TestAccEMRCluster_InstanceFleetMaster_only
=== PAUSE TestAccEMRCluster_InstanceFleetMaster_only
=== RUN   TestAccEMRCluster_InstanceFleetMasterOnlyWithReservation
=== PAUSE TestAccEMRCluster_InstanceFleetMasterOnlyWithReservation
=== RUN   TestAccEMRCluster_unhealthyNodeReplacement
=== PAUSE TestAccEMRCluster_unhealthyNodeReplacement
=== RUN   TestAccEMRInstanceFleet_basic
=== PAUSE TestAccEMRInstanceFleet_basic
=== RUN   TestAccEMRInstanceFleet_Zero_count
=== PAUSE TestAccEMRInstanceFleet_Zero_count
=== RUN   TestAccEMRInstanceFleet_ebsBasic
=== PAUSE TestAccEMRInstanceFleet_ebsBasic
=== RUN   TestAccEMRInstanceFleet_full
=== PAUSE TestAccEMRInstanceFleet_full
=== RUN   TestAccEMRInstanceGroup_basic
=== PAUSE TestAccEMRInstanceGroup_basic
=== RUN   TestAccEMRInstanceGroup_disappears
=== PAUSE TestAccEMRInstanceGroup_disappears
=== RUN   TestAccEMRInstanceGroup_Disappears_emrCluster
=== PAUSE TestAccEMRInstanceGroup_Disappears_emrCluster
=== RUN   TestAccEMRInstanceGroup_bidPrice
=== PAUSE TestAccEMRInstanceGroup_bidPrice
=== RUN   TestAccEMRInstanceGroup_sJSON
=== PAUSE TestAccEMRInstanceGroup_sJSON
=== RUN   TestAccEMRInstanceGroup_autoScalingPolicy
=== PAUSE TestAccEMRInstanceGroup_autoScalingPolicy
=== RUN   TestAccEMRInstanceGroup_instanceCountDecrease
=== PAUSE TestAccEMRInstanceGroup_instanceCountDecrease
=== RUN   TestAccEMRInstanceGroup_instanceCountCreateZero
=== PAUSE TestAccEMRInstanceGroup_instanceCountCreateZero
=== RUN   TestAccEMRInstanceGroup_EBS_ebsOptimized
=== PAUSE TestAccEMRInstanceGroup_EBS_ebsOptimized
=== RUN   TestAccEMRManagedScalingPolicy_basic
=== PAUSE TestAccEMRManagedScalingPolicy_basic
=== RUN   TestAccEMRManagedScalingPolicy_disappears
=== PAUSE TestAccEMRManagedScalingPolicy_disappears
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== RUN   TestAccEMRReleaseLabels_basic
=== PAUSE TestAccEMRReleaseLabels_basic
=== RUN   TestAccEMRReleaseLabels_prefix
=== PAUSE TestAccEMRReleaseLabels_prefix
=== RUN   TestAccEMRReleaseLabels_application
=== PAUSE TestAccEMRReleaseLabels_application
=== RUN   TestAccEMRReleaseLabels_full
=== PAUSE TestAccEMRReleaseLabels_full
=== RUN   TestAccEMRReleaseLabels_empty
=== PAUSE TestAccEMRReleaseLabels_empty
=== RUN   TestAccEMRSecurityConfiguration_basic
=== PAUSE TestAccEMRSecurityConfiguration_basic
=== RUN   TestAccEMRSecurityConfiguration_disappears
=== PAUSE TestAccEMRSecurityConfiguration_disappears
=== RUN   TestAccEMRSecurityConfiguration_nameGenerated
=== PAUSE TestAccEMRSecurityConfiguration_nameGenerated
=== RUN   TestAccEMRSecurityConfiguration_namePrefix
=== PAUSE TestAccEMRSecurityConfiguration_namePrefix
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
--- PASS: TestEndpointConfiguration (0.50s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/no_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.04s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.04s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.02s)
=== RUN   TestAccEMRStudioSessionMapping_basic
=== PAUSE TestAccEMRStudioSessionMapping_basic
=== RUN   TestAccEMRStudioSessionMapping_disappears
=== PAUSE TestAccEMRStudioSessionMapping_disappears
=== RUN   TestAccEMRStudio_sso
=== PAUSE TestAccEMRStudio_sso
=== RUN   TestAccEMRStudio_iam
=== PAUSE TestAccEMRStudio_iam
=== RUN   TestAccEMRStudio_disappears
=== PAUSE TestAccEMRStudio_disappears
=== RUN   TestAccEMRStudio_workspaceStorageEncryption
=== PAUSE TestAccEMRStudio_workspaceStorageEncryption
=== RUN   TestAccEMRStudio_tags
=== PAUSE TestAccEMRStudio_tags
=== RUN   TestAccEMRSupportedInstanceTypesDataSource_basic
=== PAUSE TestAccEMRSupportedInstanceTypesDataSource_basic
=== CONT  TestValidCustomAMIID
=== CONT  TestAccEMRCluster_unhealthyNodeReplacement
=== CONT  TestAccEMRCluster_Step_basic
=== CONT  TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== CONT  TestAccEMRCluster_InstanceFleetMasterOnlyWithReservation
=== CONT  TestAccEMRStudio_workspaceStorageEncryption
=== CONT  TestAccEMRStudio_disappears
=== CONT  TestAccEMRCluster_tags
=== CONT  TestAccEMRCluster_additionalInfo
=== CONT  TestAccEMRCluster_PlacementGroupConfigs
=== CONT  TestAccEMRCluster_s3LogEncryption
=== CONT  TestAccEMRCluster_MasterInstanceGroup_name
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceType
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== CONT  TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== CONT  TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== CONT  TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== CONT  TestAccEMRCluster_CoreInstanceGroup_name
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceType
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== CONT  TestAccEMRCluster_s3Logging
=== CONT  TestAccEMRCluster_keepJob
=== CONT  TestAccEMRCluster_terminationProtected
=== CONT  TestAccEMRCluster_ebs
=== CONT  TestAccEMRCluster_InstanceFleetMaster_only
=== CONT  TestAccEMRCluster_InstanceFleet_basic
=== CONT  TestAccEMRCluster_CustomAMI_id
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== CONT  TestAccEMRSupportedInstanceTypesDataSource_basic
=== CONT  TestAccEMRStudio_tags
=== CONT  TestAccEMRCluster_StepConcurrency_level
=== CONT  TestAccEMRCluster_RootVolume_size
=== CONT  TestAccEMRStudio_iam
=== CONT  TestAccEMRStudio_sso
=== CONT  TestAccEMRStudioSessionMapping_disappears
--- PASS: TestValidCustomAMIID (0.00s)
=== CONT  TestAccEMRCluster_security
=== NAME  TestAccEMRStudioSessionMapping_disappears
    studio_session_mapping_test.go:180: AWS_IDENTITY_STORE_USER_ID env var must be set for AWS Identity Store User acceptance test. This is required until ListUsers API returns results without filtering by name.
--- SKIP: TestAccEMRStudioSessionMapping_disappears (1.12s)
=== CONT  TestAccEMRCluster_sJSON
--- PASS: TestAccEMRSupportedInstanceTypesDataSource_basic (47.30s)
=== CONT  TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
--- PASS: TestAccEMRStudio_disappears (44.93s)
=== CONT  TestAccEMRCluster_disappears
--- PASS: TestAccEMRStudio_iam (90.62s)
=== CONT  TestAccEMRCluster_Step_multiple_listStates
--- PASS: TestAccEMRStudio_workspaceStorageEncryption (108.71s)
=== CONT  TestAccEMRCluster_Bootstrap_ordering
--- PASS: TestAccEMRStudio_sso (137.96s)
=== CONT  TestAccEMRCluster_basic
--- PASS: TestAccEMRStudio_tags (150.65s)
=== CONT  TestAccEMRCluster_autoTerminationPolicy
--- PASS: TestAccEMRCluster_keepJob (363.70s)
=== CONT  TestAccEMRReleaseLabels_empty
--- PASS: TestAccEMRReleaseLabels_empty (13.32s)
=== CONT  TestAccEMRSecurityConfiguration_namePrefix
--- PASS: TestAccEMRCluster_additionalInfo (379.60s)
=== CONT  TestAccEMRSecurityConfiguration_nameGenerated
--- PASS: TestAccEMRSecurityConfiguration_namePrefix (20.62s)
=== CONT  TestAccEMRSecurityConfiguration_disappears
--- PASS: TestAccEMRCluster_terminationProtected (398.80s)
=== CONT  TestAccEMRSecurityConfiguration_basic
--- PASS: TestAccEMRSecurityConfiguration_nameGenerated (20.23s)
=== CONT  TestAccEMRCluster_Step_multiple
--- PASS: TestAccEMRCluster_security (400.32s)
=== CONT  TestAccEMRCluster_Step_mode
--- PASS: TestAccEMRCluster_Step_basic (405.02s)
=== CONT  TestAccEMRInstanceGroup_sJSON
--- PASS: TestAccEMRSecurityConfiguration_disappears (18.57s)
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
--- PASS: TestAccEMRSecurityConfiguration_basic (21.44s)
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
--- PASS: TestAccEMRCluster_sJSON (431.25s)
=== CONT  TestAccEMRManagedScalingPolicy_disappears
--- PASS: TestAccEMRCluster_ebs (449.27s)
=== CONT  TestAccEMRManagedScalingPolicy_basic
--- PASS: TestAccEMRCluster_basic (312.40s)
=== CONT  TestAccEMRInstanceGroup_EBS_ebsOptimized
--- PASS: TestAccEMRCluster_disappears (379.60s)
=== CONT  TestAccEMRInstanceGroup_instanceCountCreateZero
--- PASS: TestAccEMRCluster_Step_multiple_listStates (371.40s)
=== CONT  TestAccEMRInstanceGroup_instanceCountDecrease
--- PASS: TestAccEMRCluster_Kerberos_clusterDedicatedKdc (472.09s)
=== CONT  TestAccEMRInstanceGroup_autoScalingPolicy
--- PASS: TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy (431.52s)
=== CONT  TestAccEMRInstanceGroup_basic
--- PASS: TestAccEMRCluster_StepConcurrency_level (541.80s)
=== CONT  TestAccEMRInstanceGroup_bidPrice
--- PASS: TestAccEMRCluster_InstanceFleetMasterOnlyWithReservation (562.49s)
=== CONT  TestAccEMRInstanceGroup_Disappears_emrCluster
--- PASS: TestAccEMRCluster_s3Logging (581.11s)
=== CONT  TestAccEMRBlockPublicAccessConfiguration_serial
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/basic
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly (610.04s)
=== CONT  TestAccEMRInstanceGroup_disappears
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/disappears
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/default
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/enabledMultiRange
--- PASS: TestAccEMRCluster_unhealthyNodeReplacement (672.55s)
=== CONT  TestAccEMRInstanceFleet_ebsBasic
--- PASS: TestAccEMRCluster_CustomAMI_id (674.38s)
=== CONT  TestAccEMRInstanceFleet_full
--- PASS: TestAccEMRCluster_PlacementGroupConfigs (675.53s)
=== CONT  TestAccEMRInstanceFleet_Zero_count
--- PASS: TestAccEMRBlockPublicAccessConfiguration_serial (95.19s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/basic (38.66s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/disappears (17.72s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/default (18.72s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/enabledMultiRange (20.08s)
=== CONT  TestAccEMRInstanceFleet_basic
--- PASS: TestAccEMRCluster_RootVolume_size (695.79s)
=== CONT  TestAccEMRReleaseLabels_application
--- PASS: TestAccEMRCluster_tags (702.97s)
=== CONT  TestAccEMRReleaseLabels_prefix
--- PASS: TestAccEMRCluster_InstanceFleetMaster_only (703.63s)
=== CONT  TestAccEMRReleaseLabels_full
--- PASS: TestAccEMRReleaseLabels_application (14.41s)
=== CONT  TestAccEMRReleaseLabels_basic
--- PASS: TestAccEMRReleaseLabels_prefix (16.15s)
=== CONT  TestAccEMRStudioSessionMapping_basic
    studio_session_mapping_test.go:180: AWS_IDENTITY_STORE_USER_ID env var must be set for AWS Identity Store User acceptance test. This is required until ListUsers API returns results without filtering by name.
--- SKIP: TestAccEMRStudioSessionMapping_basic (0.00s)
--- PASS: TestAccEMRReleaseLabels_full (16.25s)
--- PASS: TestAccEMRReleaseLabels_basic (15.71s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceType (750.57s)
--- PASS: TestAccEMRCluster_Step_multiple (387.00s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_name (795.46s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_name (805.37s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_bidPrice (812.23s)
--- PASS: TestAccEMRCluster_autoTerminationPolicy (673.55s)
--- PASS: TestAccEMRCluster_s3LogEncryption (838.47s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceType (847.46s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_bidPrice (894.39s)
--- PASS: TestAccEMRInstanceGroup_instanceCountCreateZero (438.22s)
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits (538.88s)
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits (581.83s)
--- PASS: TestAccEMRManagedScalingPolicy_basic (559.47s)
--- PASS: TestAccEMRManagedScalingPolicy_disappears (597.72s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceCount (1066.58s)
--- PASS: TestAccEMRCluster_Bootstrap_ordering (975.55s)
--- PASS: TestAccEMRInstanceGroup_basic (651.00s)
--- PASS: TestAccEMRCluster_Step_mode (741.14s)
--- PASS: TestAccEMRInstanceGroup_autoScalingPolicy (720.36s)
--- PASS: TestAccEMRInstanceGroup_sJSON (859.26s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceCount (1265.08s)
--- PASS: TestAccEMRInstanceGroup_Disappears_emrCluster (703.90s)
--- PASS: TestAccEMRInstanceGroup_disappears (717.75s)
--- PASS: TestAccEMRInstanceFleet_ebsBasic (664.89s)
--- PASS: TestAccEMRInstanceFleet_full (704.73s)
--- PASS: TestAccEMRInstanceFleet_basic (722.73s)
--- PASS: TestAccEMRInstanceGroup_EBS_ebsOptimized (949.70s)
--- PASS: TestAccEMRInstanceFleet_Zero_count (820.83s)
--- PASS: TestAccEMRCluster_InstanceFleet_basic (1536.08s)
--- PASS: TestAccEMRInstanceGroup_bidPrice (1207.71s)
--- PASS: TestAccEMRInstanceGroup_instanceCountDecrease (1308.77s)
--- PASS: TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups (1905.34s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        1911.613s
```
