### PR TITLE
fix(aws_ecr_pull_through_cache_rule): ecr repository prefix regex

### DIFF
--- a/internal/service/ecr/pull_through_cache_rule.go
+++ b/internal/service/ecr/pull_through_cache_rule.go
@@ -47,7 +47,7 @@ func resourcePullThroughCacheRule() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
+						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*/?|ROOT`),
 						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
 				),
 			},

--- a/internal/service/ecr/pull_through_cache_rule_data_source.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source.go
@@ -32,7 +32,7 @@ func dataSourcePullThroughCacheRule() *schema.Resource {
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(2, 30),
 					validation.StringMatch(
-						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*`),
+						regexache.MustCompile(`(?:[a-z0-9]+(?:[._-][a-z0-9]+)*/)*[a-z0-9]+(?:[._-][a-z0-9]+)*/?|ROOT`),
 						"must only include alphanumeric, underscore, period, hyphen, or slash characters"),
 				),
 			},

--- a/internal/service/ecr/pull_through_cache_rule_data_source_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_data_source_test.go
@@ -35,7 +35,6 @@ func TestAccECRPullThroughCacheRuleDataSource_basic(t *testing.T) {
 
 func TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	repositoryPrefix := "ROOT"
 	dataSource := "data.aws_ecr_pull_through_cache_rule.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -45,7 +44,7 @@ func TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix(t *testing.T) {
 		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPullThroughCacheRuleDataSourceConfig_repositoryNoPrefix(repositoryPrefix),
+				Config: testAccPullThroughCacheRuleDataSourceConfig_repositoryNoPrefix(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					acctest.CheckResourceAttrAccountID(ctx, dataSource, "registry_id"),
 					resource.TestCheckResourceAttr(dataSource, "upstream_registry_url", "public.ecr.aws"),
@@ -112,17 +111,17 @@ data "aws_ecr_pull_through_cache_rule" "test" {
 `
 }
 
-func testAccPullThroughCacheRuleDataSourceConfig_repositoryNoPrefix(repositoryPrefix string) string {
-	return fmt.Sprintf(`
+func testAccPullThroughCacheRuleDataSourceConfig_repositoryNoPrefix() string {
+	return `
 resource "aws_ecr_pull_through_cache_rule" "test" {
-  ecr_repository_prefix = %[1]q
+  ecr_repository_prefix = "ROOT"
   upstream_registry_url = "public.ecr.aws"
 }
 
 data "aws_ecr_pull_through_cache_rule" "test" {
   ecr_repository_prefix = aws_ecr_pull_through_cache_rule.test.ecr_repository_prefix
 }
-`, repositoryPrefix)
+`
 }
 
 func testAccPullThroughCacheRuleDataSourceConfig_repositoryPrefixWithSlash(repositoryPrefix string) string {

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -124,30 +124,6 @@ func TestAccECRPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
 	})
 }
 
-func TestAccECRPullThroughCacheRule_repositoryNoPrefix(t *testing.T) {
-	ctx := acctest.Context(t)
-	repositoryPrefix := "ROOT"
-	resourceName := "aws_ecr_pull_through_cache_rule.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPullThroughCacheRuleConfig_basic(repositoryPrefix),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPullThroughCacheRuleExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "ecr_repository_prefix", repositoryPrefix),
-					acctest.CheckResourceAttrAccountID(ctx, resourceName, "registry_id"),
-					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)

--- a/internal/service/ecr/pull_through_cache_rule_test.go
+++ b/internal/service/ecr/pull_through_cache_rule_test.go
@@ -124,6 +124,30 @@ func TestAccECRPullThroughCacheRule_failWhenAlreadyExists(t *testing.T) {
 	})
 }
 
+func TestAccECRPullThroughCacheRule_repositoryNoPrefix(t *testing.T) {
+	ctx := acctest.Context(t)
+	repositoryPrefix := "ROOT"
+	resourceName := "aws_ecr_pull_through_cache_rule.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPullThroughCacheRuleDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPullThroughCacheRuleConfig_basic(repositoryPrefix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPullThroughCacheRuleExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "ecr_repository_prefix", repositoryPrefix),
+					acctest.CheckResourceAttrAccountID(ctx, resourceName, "registry_id"),
+					resource.TestCheckResourceAttr(resourceName, "upstream_registry_url", "public.ecr.aws"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash(t *testing.T) {
 	ctx := acctest.Context(t)
 	repositoryPrefix := "tf-test/" + sdkacctest.RandString(22)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
Fixing ECR pull through cache rule registry prefix validation by updating the regex to match with the AWS ECR API.

The [AWS UpdatePullThroughCacheRule API](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_UpdatePullThroughCacheRule.html#API_UpdatePullThroughCacheRule_RequestParameters) is using `ecrRepositoryPrefix= "ROOT"` in case of a no prefix repository.
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/19804374-0546-4f9b-9f38-10ae46314c7b" />

Also, adding a test for validation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_PROFILE=test TF_ACC_TERRAFORM_VERSION=1.10.5 make testacc TESTS=TestAccECRPullThroughCacheRule PKG=ecr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/ecr/... -v -count 1 -parallel 20 -run='TestAccECRPullThroughCacheRule'  -timeout 360m -vet=off
2025/03/17 14:24:52 Initializing Terraform AWS Provider...
=== RUN   TestAccECRPullThroughCacheRuleDataSource_basic
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_basic
=== RUN   TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix
=== RUN   TestAccECRPullThroughCacheRuleDataSource_repositoryPrefixWithSlash
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_repositoryPrefixWithSlash
=== RUN   TestAccECRPullThroughCacheRuleDataSource_credential
=== PAUSE TestAccECRPullThroughCacheRuleDataSource_credential
=== RUN   TestAccECRPullThroughCacheRule_basic
=== PAUSE TestAccECRPullThroughCacheRule_basic
=== RUN   TestAccECRPullThroughCacheRule_credentialARN
=== PAUSE TestAccECRPullThroughCacheRule_credentialARN
=== RUN   TestAccECRPullThroughCacheRule_disappears
=== PAUSE TestAccECRPullThroughCacheRule_disappears
=== RUN   TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== PAUSE TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== RUN   TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash
=== PAUSE TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash
=== CONT  TestAccECRPullThroughCacheRuleDataSource_basic
=== CONT  TestAccECRPullThroughCacheRule_failWhenAlreadyExists
=== CONT  TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash
=== CONT  TestAccECRPullThroughCacheRuleDataSource_credential
=== CONT  TestAccECRPullThroughCacheRule_basic
=== CONT  TestAccECRPullThroughCacheRule_disappears
=== CONT  TestAccECRPullThroughCacheRuleDataSource_repositoryPrefixWithSlash
=== CONT  TestAccECRPullThroughCacheRule_credentialARN
=== CONT  TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix
--- PASS: TestAccECRPullThroughCacheRule_failWhenAlreadyExists (32.43s)
--- PASS: TestAccECRPullThroughCacheRuleDataSource_basic (46.91s)
--- PASS: TestAccECRPullThroughCacheRuleDataSource_repositoryPrefixWithSlash (47.17s)
--- PASS: TestAccECRPullThroughCacheRuleDataSource_repositoryNoPrefix (50.30s)
--- PASS: TestAccECRPullThroughCacheRule_repositoryPrefixWithSlash (50.88s)
--- PASS: TestAccECRPullThroughCacheRuleDataSource_credential (50.91s)
--- PASS: TestAccECRPullThroughCacheRule_disappears (51.63s)
--- PASS: TestAccECRPullThroughCacheRule_basic (52.25s)
--- PASS: TestAccECRPullThroughCacheRule_credentialARN (55.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecr	62.161s
```