### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-03-14)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1
-	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.2
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.42.1

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/backup v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/batch v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1
-	github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.0
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.30.1

--- a/go.mod
+++ b/go.mod
@@ -127,7 +127,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.40.1
 	github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/glue v1.106.2
+	github.com/aws/aws-sdk-go-v2/service/glue v1.107.0
 	github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/greengrass v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.32.1

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3
-	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.42.1
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.52.1

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.25.1
 	github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.2

--- a/go.mod
+++ b/go.mod
@@ -154,7 +154,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.38.1
-	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.9.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1 h1:hPNjjlYHJE/oX+ok+CRudfjE
 github.com/aws/aws-sdk-go-v2/service/glacier v1.27.1/go.mod h1:iu2+iJGASnGBzM0wM1ilN42xfabxyIlcdZyctpgm//4=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1 h1:FeZccFrSQar3DzmGaygFo9sqBQtx15hkGB1n+jVXDpc=
 github.com/aws/aws-sdk-go-v2/service/globalaccelerator v1.30.1/go.mod h1:WIJ+qX03sGSWC6+BSA1LBO6Jmkewbu4TvwXspbai9N4=
-github.com/aws/aws-sdk-go-v2/service/glue v1.106.2 h1:9xUYl4v035DaMfEWHOZz5zlVfZ5L/7Urrswdg2YYweY=
-github.com/aws/aws-sdk-go-v2/service/glue v1.106.2/go.mod h1:6FqWCqW0Py6VOvY42NQyf9e7N+sNVnDEiHFklCCCoQc=
+github.com/aws/aws-sdk-go-v2/service/glue v1.107.0 h1:iO8m70j8JNSJl9aDQNTjR3BNRYbLphnrhCidSfw+4g0=
+github.com/aws/aws-sdk-go-v2/service/glue v1.107.0/go.mod h1:6FqWCqW0Py6VOvY42NQyf9e7N+sNVnDEiHFklCCCoQc=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1 h1:Pdp15V5bCybVSRGL5wm5a53KuAcAjS0h9fGeBPKe6wU=
 github.com/aws/aws-sdk-go-v2/service/grafana v1.27.1/go.mod h1:2R4VRe/oR5E3pRm9cLMCYTUNv4qLZOXwNtlTOKTFwCE=
 github.com/aws/aws-sdk-go-v2/service/greengrass v1.28.1 h1:b3Qx6kj+lYlJ6LHHHi0kaYIu7gkSlI5u1ylk17oO39U=

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.25.1 h1:hH4wylvOxgDkIL+
 github.com/aws/aws-sdk-go-v2/service/codeguruprofiler v1.25.1/go.mod h1:zYj7dX/joiDCndpJXnlEi6f8HnNWW0lwYxaA/v+k4RI=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.30.1 h1:pb8nTzdZkxYVj/jyGhKMfrh3+4pbmSJP8waDUsxGY1k=
 github.com/aws/aws-sdk-go-v2/service/codegurureviewer v1.30.1/go.mod h1:ig1WP6lzeVYg0ZP9/7V4Oc3s9FFHJ6iyFQI4JvzroEc=
-github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.1 h1:gUKS/hsRPGMPLJHapanzWILEnqQ6XlO4D7pZ6+eBSHc=
-github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.1/go.mod h1:DbwgOhGcyAQbyKZDXbErngumtUExzwvd1uyMbKQcXto=
+github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.2 h1:GgKnIVh0S1bhiTZTvPikWI80yj1g7Yq+bjpSith0bTI=
+github.com/aws/aws-sdk-go-v2/service/codepipeline v1.40.2/go.mod h1:DbwgOhGcyAQbyKZDXbErngumtUExzwvd1uyMbKQcXto=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1 h1:AMRtxvWtFD9xtltd9OJIVKnngMPDpiWA4iBR2LLo90I=
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1/go.mod h1:+18+c7rxDXs/LEAJgndyQfrdxK89kNDuIguXWOG1PqY=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1 h1:l1v0149pvLMFLqaw2Oay8TmKRX+Qeq87kEKlF/0jSSY=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/aws/aws-sdk-go-v2/service/batch v1.51.1 h1:vP+Mma3uVDnydU3yjVI5rjU6Qe
 github.com/aws/aws-sdk-go-v2/service/batch v1.51.1/go.mod h1:F8tHrowT/XPtWMERTbDvJDUILrZgUV8W2lg4MmiuMtc=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1 h1:ll+yMQBP4zDYVR5g7OYI92OotFZx3runteOtwRvVs5Q=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1/go.mod h1:py9ul1V8YOAOcDtYs9mXfyhWr/tYaJm8kZ5ycgR0SR4=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.0 h1:pqrqfWc8Tr6teqN4LWkwK5y8C/zJzIy2ghR+yBl+puw=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.0/go.mod h1:rZOgAxQVRg9v5ZEQHrrKw0Gkb9DBAASeeRiwUmmXcG0=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1 h1:TajmkfP6PeFhZbyg+LRS+F2fAbrQ4FYa40Yn8jDrKOo=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1/go.mod h1:rZOgAxQVRg9v5ZEQHrrKw0Gkb9DBAASeeRiwUmmXcG0=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0 h1:f2ydyCtj8E5e1eaQXBBhaaWpeDUfl5bcNS3VrjIezko=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0/go.mod h1:WlMBqEPeaBywfaXoMAfpitHvwezq555o8waYL3cCPqo=
 github.com/aws/aws-sdk-go-v2/service/billing v1.2.1 h1:T7zx2zhdm5ZFRhv2QlJC9PtnFGO8E34bRwyLz9ARzsA=

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1 h1:l1v0149pvL
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1/go.mod h1:TM3YCc7lwvzfgSbdSHL0pHxxwCx3TJfzoU4WbWWkR3k=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3 h1:d/lwsyP303VtAS/3DQiM+2X1/h8sK48VQ/HXIZm6sEk=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3/go.mod h1:0Ib8jnQoQsXzyVskVOZpG4Ur0K0/wmge2gAtD3GJjpY=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2 h1:TQ7HdTPNhFVXmZ4TKmP1mdVQiJvwMYP+xjKli1LC/fk=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2/go.mod h1:ygltZT++6Wn2uG4+tqE0NW1MkdEtb5W2O/CFc0xJX/g=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.3 h1:4U9dpQZTvJ0Mi1qn8L1hRJ4igFCQYEjwUuOmYkWM5tE=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.3/go.mod h1:ygltZT++6Wn2uG4+tqE0NW1MkdEtb5W2O/CFc0xJX/g=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.36.1 h1:10pnjANvaKA72oPG/z14brot7/NFlikFtH17mUNr1MQ=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.36.1/go.mod h1:Wztvp5ZZlbSeiRDcH/JII+W6yAHLXGSHt262NYcIy80=
 github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.42.1 h1:133FTf4YexUuKYXMgjPXVgSyDSbooIk+rrqifyxCA8w=

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.28.1 h1:rXHQDCTQahF0x9v3uJv
 github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.28.1/go.mod h1:2dyA630lVgg1/13E2yAbhl7dtw8VXqlb711cte35YnA=
 github.com/aws/aws-sdk-go-v2/service/kms v1.38.1 h1:tecq7+mAav5byF+Mr+iONJnCBf4B4gon8RSp4BrweSc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.38.1/go.mod h1:cQn6tAF77Di6m4huxovNM7NVAozWTZLsDRp9t8Z/WYk=
-github.com/aws/aws-sdk-go-v2/service/lakeformation v1.40.1 h1:MNlWR7bWp605CcoHBPUyX+SAKYUck/bcYRcQRZCdpYw=
-github.com/aws/aws-sdk-go-v2/service/lakeformation v1.40.1/go.mod h1:GicrlTk25ZC3c5WVMuffJLoFEJosQUmagR/WRuhFebM=
+github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0 h1:hTw4cXL81wZQ/jrUw8GBxqxmq2ry3SjlSXEryola0lI=
+github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0/go.mod h1:GicrlTk25ZC3c5WVMuffJLoFEJosQUmagR/WRuhFebM=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1 h1:EabaKQAptxXAeSL0sXKqfupPe/CpH965wqoloUK0aMM=
 github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1/go.mod h1:c27kk10S36lBYgbG1jR3opn4OAS5Y/4wjJa1GiHK/X4=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.9.1 h1:k9tiuuhl/W6WKdmfy3QGpb8XqbPjwE6sYKZQOADFgZ4=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1 h1:AMRtxvWtFD9x
 github.com/aws/aws-sdk-go-v2/service/codestarconnections v1.30.1/go.mod h1:+18+c7rxDXs/LEAJgndyQfrdxK89kNDuIguXWOG1PqY=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1 h1:l1v0149pvLMFLqaw2Oay8TmKRX+Qeq87kEKlF/0jSSY=
 github.com/aws/aws-sdk-go-v2/service/codestarnotifications v1.27.1/go.mod h1:TM3YCc7lwvzfgSbdSHL0pHxxwCx3TJfzoU4WbWWkR3k=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.2 h1:CG3RlDClJIBf4nvs4+94l+LKFAOOa7NEHalKjYIiiHc=
-github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.2/go.mod h1:0Ib8jnQoQsXzyVskVOZpG4Ur0K0/wmge2gAtD3GJjpY=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3 h1:d/lwsyP303VtAS/3DQiM+2X1/h8sK48VQ/HXIZm6sEk=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.29.3/go.mod h1:0Ib8jnQoQsXzyVskVOZpG4Ur0K0/wmge2gAtD3GJjpY=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2 h1:TQ7HdTPNhFVXmZ4TKmP1mdVQiJvwMYP+xjKli1LC/fk=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.51.2/go.mod h1:ygltZT++6Wn2uG4+tqE0NW1MkdEtb5W2O/CFc0xJX/g=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.36.1 h1:10pnjANvaKA72oPG/z14brot7/NFlikFtH17mUNr1MQ=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [`Release 2024-03-14`](https://github.com/aws/aws-sdk-go-v2/commit/70ffc994fe02e9d9b8e0222bdad91c33a99becb3) as [`dependabot` failed](https://github.com/hashicorp/terraform-provider-aws/network/updates/981395841).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: https://github.com/hashicorp/terraform-provider-aws/issues/39287.