### PR TITLE
Modernize Go code: autoscaling, fsx, cognitoidp

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -81,13 +81,16 @@ jobs:
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/apigatewayv2 modern-check
       - run: make TEST=./internal/service/appmesh modern-check
+      - run: make TEST=./internal/service/autoscaling modern-check
       - run: make TEST=./internal/service/batch modern-check
       - run: make TEST=./internal/service/cloudfront modern-check
+      - run: make TEST=./internal/service/cognitoidp modern-check
       - run: make TEST=./internal/service/dms modern-check
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/ecs modern-check
       - run: make TEST=./internal/service/elasticache modern-check
       - run: make TEST=./internal/service/elbv2 modern-check
+      - run: make TEST=./internal/service/fsx modern-check
       - run: make TEST=./internal/service/glue modern-check
       - run: make TEST=./internal/service/iam modern-check
       - run: make TEST=./internal/service/kms modern-check

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -975,10 +975,10 @@ func resourceGroup() *schema.Resource {
 
 func instanceMaintenancePolicyDiffSupress(k, old, new string, d *schema.ResourceData) bool {
 	o, n := d.GetChange("instance_maintenance_policy")
-	oList, nList := o.([]interface{}), n.([]interface{})
+	oList, nList := o.([]any), n.([]any)
 
 	if len(oList) == 0 && len(nList) != 0 {
-		tfMap := nList[0].(map[string]interface{})
+		tfMap := nList[0].(map[string]any)
 		if int64(tfMap["min_healthy_percentage"].(int)) == -1 || int64(tfMap["max_healthy_percentage"].(int)) == -1 {
 			return true
 		}
@@ -988,16 +988,16 @@ func instanceMaintenancePolicyDiffSupress(k, old, new string, d *schema.Resource
 }
 
 func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.CustomizeDiffFunc {
-	return func(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+	return func(_ context.Context, diff *schema.ResourceDiff, _ any) error {
 		if diff.HasChange(subAttribute) {
 			n := diff.Get(baseAttribute)
-			ba, ok := n.([]interface{})
+			ba, ok := n.([]any)
 			if !ok {
 				return nil
 			}
 
 			if baseAttribute == names.AttrLaunchTemplate {
-				launchTemplate := ba[0].(map[string]interface{})
+				launchTemplate := ba[0].(map[string]any)
 				launchTemplate[names.AttrID] = launchTemplateIDUnknown
 
 				if err := diff.SetNew(baseAttribute, ba); err != nil {
@@ -1006,8 +1006,8 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 			}
 
 			if baseAttribute == "mixed_instances_policy" && !strings.Contains(subAttribute, "override") {
-				launchTemplate := ba[0].(map[string]interface{})[names.AttrLaunchTemplate].([]interface{})[0].(map[string]interface{})["launch_template_specification"].([]interface{})[0]
-				launchTemplateSpecification := launchTemplate.(map[string]interface{})
+				launchTemplate := ba[0].(map[string]any)[names.AttrLaunchTemplate].([]any)[0].(map[string]any)["launch_template_specification"].([]any)[0]
+				launchTemplateSpecification := launchTemplate.(map[string]any)
 				launchTemplateSpecification["launch_template_id"] = launchTemplateIDUnknown
 
 				if err := diff.SetNew(baseAttribute, ba); err != nil {
@@ -1016,13 +1016,13 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 			}
 
 			if baseAttribute == "mixed_instances_policy" && strings.Contains(subAttribute, "override") {
-				launchTemplate := ba[0].(map[string]interface{})[names.AttrLaunchTemplate].([]interface{})[0].(map[string]interface{})["override"].([]interface{})
+				launchTemplate := ba[0].(map[string]any)[names.AttrLaunchTemplate].([]any)[0].(map[string]any)["override"].([]any)
 
 				for i := range launchTemplate {
 					key := fmt.Sprintf("mixed_instances_policy.0.launch_template.0.override.%d.launch_template_specification.0.launch_template_name", i)
 
 					if diff.HasChange(key) {
-						launchTemplateSpecification := launchTemplate[i].(map[string]interface{})["launch_template_specification"].([]interface{})[0].(map[string]interface{})
+						launchTemplateSpecification := launchTemplate[i].(map[string]any)["launch_template_specification"].([]any)[0].(map[string]any)
 						launchTemplateSpecification["launch_template_id"] = launchTemplateIDUnknown
 					}
 				}
@@ -1037,7 +1037,7 @@ func launchTemplateCustomDiff(baseAttribute, subAttribute string) schema.Customi
 	}
 }
 
-func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -1090,8 +1090,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		inputCASG.AvailabilityZones = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("availability_zone_distribution"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		inputCASG.AvailabilityZoneDistribution = expandAvailabilityZoneDistribution(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("availability_zone_distribution"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		inputCASG.AvailabilityZoneDistribution = expandAvailabilityZoneDistribution(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("capacity_rebalance"); ok {
@@ -1119,15 +1119,15 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if v, ok := d.GetOk("instance_maintenance_policy"); ok {
-		inputCASG.InstanceMaintenancePolicy = expandInstanceMaintenancePolicy(v.([]interface{}))
+		inputCASG.InstanceMaintenancePolicy = expandInstanceMaintenancePolicy(v.([]any))
 	}
 
 	if v, ok := d.GetOk("launch_configuration"); ok {
 		inputCASG.LaunchConfigurationName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		inputCASG.LaunchTemplate = expandLaunchTemplateSpecification(v.([]interface{})[0].(map[string]interface{}), false)
+	if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		inputCASG.LaunchTemplate = expandLaunchTemplateSpecification(v.([]any)[0].(map[string]any), false)
 	}
 
 	if v, ok := d.GetOk("load_balancers"); ok && v.(*schema.Set).Len() > 0 {
@@ -1138,8 +1138,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		inputCASG.MaxInstanceLifetime = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		inputCASG.MixedInstancesPolicy = expandMixedInstancesPolicy(v.([]interface{})[0].(map[string]interface{}), true)
+	if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		inputCASG.MixedInstancesPolicy = expandMixedInstancesPolicy(v.([]any)[0].(map[string]any), true)
 	}
 
 	if v, ok := d.GetOk("placement_group"); ok {
@@ -1158,8 +1158,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		inputCASG.TargetGroupARNs = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("termination_policies"); ok && len(v.([]interface{})) > 0 {
-		inputCASG.TerminationPolicies = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("termination_policies"); ok && len(v.([]any)) > 0 {
+		inputCASG.TerminationPolicies = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk("traffic_source"); ok && v.(*schema.Set).Len() > 0 {
@@ -1171,7 +1171,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateAutoScalingGroup(ctx, inputCASG)
 		},
 		// ValidationError: You must use a valid fully-formed launch template. Value (tf-acc-test-6643732652421074386) for parameter iamInstanceProfile.name is invalid. Invalid IAM Instance Profile name
@@ -1189,7 +1189,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 				timeout = 5 * time.Minute
 			)
 			_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, timeout,
-				func() (interface{}, error) {
+				func() (any, error) {
 					return conn.PutLifecycleHook(ctx, input)
 				},
 				errCodeValidationError, "Unable to publish test message to notification target")
@@ -1264,8 +1264,8 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	if v, ok := d.GetOk("warm_pool"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		_, err := conn.PutWarmPool(ctx, expandPutWarmPoolInput(d.Id(), v.([]interface{})[0].(map[string]interface{})))
+	if v, ok := d.GetOk("warm_pool"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		_, err := conn.PutWarmPool(ctx, expandPutWarmPoolInput(d.Id(), v.([]any)[0].(map[string]any)))
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating Auto Scaling Warm Pool (%s): %s", d.Id(), err)
@@ -1275,7 +1275,7 @@ func resourceGroupCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -1294,7 +1294,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 
 	d.Set(names.AttrARN, g.AutoScalingGroupARN)
 	d.Set(names.AttrAvailabilityZones, g.AvailabilityZones)
-	d.Set("availability_zone_distribution", []interface{}{flattenAvailabilityZoneDistribution(g.AvailabilityZoneDistribution)})
+	d.Set("availability_zone_distribution", []any{flattenAvailabilityZoneDistribution(g.AvailabilityZoneDistribution)})
 	d.Set("capacity_rebalance", g.CapacityRebalance)
 	d.Set("context", g.Context)
 	d.Set("default_cooldown", g.DefaultCooldown)
@@ -1315,7 +1315,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 	d.Set("launch_configuration", g.LaunchConfigurationName)
 	if g.LaunchTemplate != nil {
-		if err := d.Set(names.AttrLaunchTemplate, []interface{}{flattenLaunchTemplateSpecification(g.LaunchTemplate)}); err != nil {
+		if err := d.Set(names.AttrLaunchTemplate, []any{flattenLaunchTemplateSpecification(g.LaunchTemplate)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting launch_template: %s", err)
 		}
 	} else {
@@ -1326,7 +1326,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	d.Set("max_size", g.MaxSize)
 	d.Set("min_size", g.MinSize)
 	if g.MixedInstancesPolicy != nil {
-		if err := d.Set("mixed_instances_policy", []interface{}{flattenMixedInstancesPolicy(g.MixedInstancesPolicy)}); err != nil {
+		if err := d.Set("mixed_instances_policy", []any{flattenMixedInstancesPolicy(g.MixedInstancesPolicy)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting mixed_instances_policy: %s", err)
 		}
 	} else {
@@ -1357,7 +1357,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 		d.Set("vpc_zone_identifier", nil)
 	}
 	if g.WarmPoolConfiguration != nil {
-		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(g.WarmPoolConfiguration)}); err != nil {
+		if err := d.Set("warm_pool", []any{flattenWarmPoolConfiguration(g.WarmPoolConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
 		}
 	} else {
@@ -1372,7 +1372,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -1402,8 +1402,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("availability_zone_distribution") {
-			if v, ok := d.GetOk("availability_zone_distribution"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.AvailabilityZoneDistribution = expandAvailabilityZoneDistribution(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("availability_zone_distribution"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.AvailabilityZoneDistribution = expandAvailabilityZoneDistribution(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -1449,7 +1449,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("instance_maintenance_policy") {
-			input.InstanceMaintenancePolicy = expandInstanceMaintenancePolicy(d.Get("instance_maintenance_policy").([]interface{}))
+			input.InstanceMaintenancePolicy = expandInstanceMaintenancePolicy(d.Get("instance_maintenance_policy").([]any))
 		}
 
 		if d.HasChange("launch_configuration") {
@@ -1460,8 +1460,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange(names.AttrLaunchTemplate) {
-			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.LaunchTemplate = expandLaunchTemplateSpecification(v.([]interface{})[0].(map[string]interface{}), false)
+			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.LaunchTemplate = expandLaunchTemplateSpecification(v.([]any)[0].(map[string]any), false)
 			}
 			shouldRefreshInstances = true
 		}
@@ -1480,8 +1480,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if d.HasChange("mixed_instances_policy") {
-			if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				input.MixedInstancesPolicy = expandMixedInstancesPolicy(v.([]interface{})[0].(map[string]interface{}), true)
+			if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.MixedInstancesPolicy = expandMixedInstancesPolicy(v.([]any)[0].(map[string]any), true)
 			}
 			shouldRefreshInstances = true
 		}
@@ -1497,8 +1497,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if d.HasChange("termination_policies") {
 			// If the termination policy is set to null, we need to explicitly set
 			// it back to "Default", or the API won't reset it for us.
-			if v, ok := d.GetOk("termination_policies"); ok && len(v.([]interface{})) > 0 {
-				input.TerminationPolicies = flex.ExpandStringValueList(v.([]interface{}))
+			if v, ok := d.GetOk("termination_policies"); ok && len(v.([]any)) > 0 {
+				input.TerminationPolicies = flex.ExpandStringValueList(v.([]any))
 			} else {
 				input.TerminationPolicies = []string{defaultTerminationPolicy}
 			}
@@ -1509,7 +1509,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutUpdate),
-			func() (interface{}, error) {
+			func() (any, error) {
 				return conn.UpdateAutoScalingGroup(ctx, input)
 			},
 			errCodeOperationError, errCodeUpdateASG, errCodeValidationError)
@@ -1652,8 +1652,8 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 	}
 
-	if v, ok := d.GetOk("instance_refresh"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := d.GetOk("instance_refresh"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		tfMap := v.([]any)[0].(map[string]any)
 
 		if !shouldRefreshInstances {
 			if v, ok := tfMap[names.AttrTriggers].(*schema.Set); ok && v.Len() > 0 {
@@ -1672,14 +1672,14 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if shouldRefreshInstances {
 			var launchTemplate *awstypes.LaunchTemplateSpecification
 
-			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				launchTemplate = expandLaunchTemplateSpecification(v.([]interface{})[0].(map[string]interface{}), false)
+			if v, ok := d.GetOk(names.AttrLaunchTemplate); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				launchTemplate = expandLaunchTemplateSpecification(v.([]any)[0].(map[string]any), false)
 			}
 
 			var mixedInstancesPolicy *awstypes.MixedInstancesPolicy
 
-			if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				mixedInstancesPolicy = expandMixedInstancesPolicy(v.([]interface{})[0].(map[string]interface{}), true)
+			if v, ok := d.GetOk("mixed_instances_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				mixedInstancesPolicy = expandMixedInstancesPolicy(v.([]any)[0].(map[string]any), true)
 			}
 
 			if err := startInstanceRefresh(ctx, conn, expandStartInstanceRefreshInput(d.Id(), tfMap, launchTemplate, mixedInstancesPolicy)); err != nil {
@@ -1689,7 +1689,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("warm_pool") {
-		w := d.Get("warm_pool").([]interface{})
+		w := d.Get("warm_pool").([]any)
 
 		// No warm pool exists in new config. Delete it.
 		if len(w) == 0 || w[0] == nil {
@@ -1699,7 +1699,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 				return sdkdiag.AppendFromErr(diags, err)
 			}
 		} else {
-			_, err := conn.PutWarmPool(ctx, expandPutWarmPoolInput(d.Id(), w[0].(map[string]interface{})))
+			_, err := conn.PutWarmPool(ctx, expandPutWarmPoolInput(d.Id(), w[0].(map[string]any)))
 
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "updating Auto Scaling Warm Pool (%s): %s", d.Id(), err)
@@ -1803,7 +1803,7 @@ func resourceGroupUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceGroupRead(ctx, d, meta)...)
 }
 
-func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -1838,7 +1838,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Group: %s", d.Id())
 	_, err = tfresource.RetryWhenAWSErrCodeEquals(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteAutoScalingGroup(ctx, &autoscaling.DeleteAutoScalingGroupInput{
 				AutoScalingGroupName: aws.String(d.Id()),
 				ForceDelete:          aws.Bool(forceDeleteGroup),
@@ -1855,7 +1855,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (interface{}, error) {
+		func() (any, error) {
 			return findGroupByName(ctx, conn, d.Id())
 		})
 
@@ -1931,7 +1931,7 @@ func deleteWarmPool(ctx context.Context, conn *autoscaling.Client, name string, 
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Warm Pool: %s", name)
 	_, err := tfresource.RetryWhenAWSErrCodeEquals(ctx, timeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteWarmPool(ctx, &autoscaling.DeleteWarmPoolInput{
 				AutoScalingGroupName: aws.String(name),
 				ForceDelete:          aws.Bool(force),
@@ -2291,7 +2291,7 @@ func findWarmPoolByName(ctx context.Context, conn *autoscaling.Client, name stri
 }
 
 func statusGroupCapacity(ctx context.Context, conn *autoscaling.Client, elbconn *elasticloadbalancing.Client, elbv2conn *elasticloadbalancingv2.Client, name string, cb func(int, int) error, startTime time.Time, ignoreFailedScalingActivities bool) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		if !ignoreFailedScalingActivities {
 			// Check for fatal error in activity logs.
 			scalingActivities, err := findScalingActivitiesByName(ctx, conn, name, startTime)
@@ -2396,7 +2396,7 @@ func statusGroupCapacity(ctx context.Context, conn *autoscaling.Client, elbconn 
 }
 
 func statusGroupInstanceCount(ctx context.Context, conn *autoscaling.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGroupByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -2412,7 +2412,7 @@ func statusGroupInstanceCount(ctx context.Context, conn *autoscaling.Client, nam
 }
 
 func statusInstanceRefresh(ctx context.Context, conn *autoscaling.Client, name, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		input := &autoscaling.DescribeInstanceRefreshesInput{
 			AutoScalingGroupName: aws.String(name),
 			InstanceRefreshIds:   []string{id},
@@ -2433,7 +2433,7 @@ func statusInstanceRefresh(ctx context.Context, conn *autoscaling.Client, name, 
 }
 
 func statusLoadBalancerInStateCount(ctx context.Context, conn *autoscaling.Client, name string, states ...string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findLoadBalancerStates(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -2447,11 +2447,8 @@ func statusLoadBalancerInStateCount(ctx context.Context, conn *autoscaling.Clien
 		var count int
 
 		for _, v := range output {
-			for _, state := range states {
-				if aws.ToString(v.State) == state {
-					count++
-					break
-				}
+			if slices.Contains(states, aws.ToString(v.State)) {
+				count++
 			}
 		}
 
@@ -2460,7 +2457,7 @@ func statusLoadBalancerInStateCount(ctx context.Context, conn *autoscaling.Clien
 }
 
 func statusLoadBalancerTargetGroupInStateCount(ctx context.Context, conn *autoscaling.Client, name string, states ...string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findLoadBalancerTargetGroupStates(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -2474,11 +2471,8 @@ func statusLoadBalancerTargetGroupInStateCount(ctx context.Context, conn *autosc
 		var count int
 
 		for _, v := range output {
-			for _, state := range states {
-				if aws.ToString(v.State) == state {
-					count++
-					break
-				}
+			if slices.Contains(states, aws.ToString(v.State)) {
+				count++
 			}
 		}
 
@@ -2487,7 +2481,7 @@ func statusLoadBalancerTargetGroupInStateCount(ctx context.Context, conn *autosc
 }
 
 func statusTrafficSourcesInStateCount(ctx context.Context, conn *autoscaling.Client, asgName, trafficSourceType string, states ...string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTrafficSourceStatesByTwoPartKey(ctx, conn, asgName, trafficSourceType)
 
 		if tfresource.NotFound(err) {
@@ -2501,11 +2495,8 @@ func statusTrafficSourcesInStateCount(ctx context.Context, conn *autoscaling.Cli
 		var count int
 
 		for _, v := range output {
-			for _, state := range states {
-				if aws.ToString(v.State) == state {
-					count++
-					break
-				}
+			if slices.Contains(states, aws.ToString(v.State)) {
+				count++
 			}
 		}
 
@@ -2514,7 +2505,7 @@ func statusTrafficSourcesInStateCount(ctx context.Context, conn *autoscaling.Cli
 }
 
 func statusWarmPool(ctx context.Context, conn *autoscaling.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findWarmPoolByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -2530,7 +2521,7 @@ func statusWarmPool(ctx context.Context, conn *autoscaling.Client, name string) 
 }
 
 func statusWarmPoolInstanceCount(ctx context.Context, conn *autoscaling.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findWarmPoolByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -2741,7 +2732,7 @@ func waitWarmPoolDrained(ctx context.Context, conn *autoscaling.Client, name str
 	return nil, err
 }
 
-func expandInstancesDistribution(tfMap map[string]interface{}) *awstypes.InstancesDistribution {
+func expandInstancesDistribution(tfMap map[string]any) *awstypes.InstancesDistribution {
 	if tfMap == nil {
 		return nil
 	}
@@ -2775,33 +2766,33 @@ func expandInstancesDistribution(tfMap map[string]interface{}) *awstypes.Instanc
 	return apiObject
 }
 
-func expandLaunchTemplate(tfMap map[string]interface{}, hasDefaultVersion bool) *awstypes.LaunchTemplate {
+func expandLaunchTemplate(tfMap map[string]any, hasDefaultVersion bool) *awstypes.LaunchTemplate {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.LaunchTemplate{}
 
-	if v, ok := tfMap["launch_template_specification"].([]interface{}); ok && len(v) > 0 {
-		apiObject.LaunchTemplateSpecification = expandLaunchTemplateSpecificationForMixedInstancesPolicy(v[0].(map[string]interface{}), hasDefaultVersion)
+	if v, ok := tfMap["launch_template_specification"].([]any); ok && len(v) > 0 {
+		apiObject.LaunchTemplateSpecification = expandLaunchTemplateSpecificationForMixedInstancesPolicy(v[0].(map[string]any), hasDefaultVersion)
 	}
 
-	if v, ok := tfMap["override"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["override"].([]any); ok && len(v) > 0 {
 		apiObject.Overrides = expandLaunchTemplateOverrideses(v, hasDefaultVersion)
 	}
 
 	return apiObject
 }
 
-func expandLaunchTemplateOverrides(tfMap map[string]interface{}, hasDefaultVersion bool) awstypes.LaunchTemplateOverrides {
+func expandLaunchTemplateOverrides(tfMap map[string]any, hasDefaultVersion bool) awstypes.LaunchTemplateOverrides {
 	apiObject := awstypes.LaunchTemplateOverrides{}
 
-	if v, ok := tfMap["instance_requirements"].([]interface{}); ok && len(v) > 0 {
-		apiObject.InstanceRequirements = expandInstanceRequirements(v[0].(map[string]interface{}))
+	if v, ok := tfMap["instance_requirements"].([]any); ok && len(v) > 0 {
+		apiObject.InstanceRequirements = expandInstanceRequirements(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["launch_template_specification"].([]interface{}); ok && len(v) > 0 {
-		apiObject.LaunchTemplateSpecification = expandLaunchTemplateSpecificationForMixedInstancesPolicy(v[0].(map[string]interface{}), hasDefaultVersion)
+	if v, ok := tfMap["launch_template_specification"].([]any); ok && len(v) > 0 {
+		apiObject.LaunchTemplateSpecification = expandLaunchTemplateSpecificationForMixedInstancesPolicy(v[0].(map[string]any), hasDefaultVersion)
 	}
 
 	if v, ok := tfMap[names.AttrInstanceType].(string); ok && v != "" {
@@ -2815,7 +2806,7 @@ func expandLaunchTemplateOverrides(tfMap map[string]interface{}, hasDefaultVersi
 	return apiObject
 }
 
-func expandLaunchTemplateOverrideses(tfList []interface{}, hasDefaultVersion bool) []awstypes.LaunchTemplateOverrides {
+func expandLaunchTemplateOverrideses(tfList []any, hasDefaultVersion bool) []awstypes.LaunchTemplateOverrides {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -2823,7 +2814,7 @@ func expandLaunchTemplateOverrideses(tfList []interface{}, hasDefaultVersion boo
 	var apiObjects []awstypes.LaunchTemplateOverrides
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -2836,15 +2827,15 @@ func expandLaunchTemplateOverrideses(tfList []interface{}, hasDefaultVersion boo
 	return apiObjects
 }
 
-func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.InstanceRequirements {
+func expandInstanceRequirements(tfMap map[string]any) *awstypes.InstanceRequirements {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.InstanceRequirements{}
 
-	if v, ok := tfMap["accelerator_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AcceleratorCount = expandAcceleratorCountRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_count"].([]any); ok && len(v) > 0 {
+		apiObject.AcceleratorCount = expandAcceleratorCountRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_manufacturers"].(*schema.Set); ok && v.Len() > 0 {
@@ -2855,8 +2846,8 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.AcceleratorNames = flex.ExpandStringyValueSet[awstypes.AcceleratorName](v)
 	}
 
-	if v, ok := tfMap["accelerator_total_memory_mib"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["accelerator_total_memory_mib"].([]any); ok && len(v) > 0 {
+		apiObject.AcceleratorTotalMemoryMiB = expandAcceleratorTotalMemoryMiBRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["accelerator_types"].(*schema.Set); ok && v.Len() > 0 {
@@ -2871,8 +2862,8 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.BareMetal = awstypes.BareMetal(v)
 	}
 
-	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]interface{}); ok && len(v) > 0 {
-		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["baseline_ebs_bandwidth_mbps"].([]any); ok && len(v) > 0 {
+		apiObject.BaselineEbsBandwidthMbps = expandBaselineEBSBandwidthMbpsRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["burstable_performance"].(string); ok && v != "" {
@@ -2903,20 +2894,20 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.MaxSpotPriceAsPercentageOfOptimalOnDemandPrice = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["memory_gib_per_vcpu"].([]interface{}); ok && len(v) > 0 {
-		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPURequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_gib_per_vcpu"].([]any); ok && len(v) > 0 {
+		apiObject.MemoryGiBPerVCpu = expandMemoryGiBPerVCPURequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["memory_mib"].([]interface{}); ok && len(v) > 0 {
-		apiObject.MemoryMiB = expandMemoryMiBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["memory_mib"].([]any); ok && len(v) > 0 {
+		apiObject.MemoryMiB = expandMemoryMiBRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["network_bandwidth_gbps"].([]interface{}); ok && len(v) > 0 {
-		apiObject.NetworkBandwidthGbps = expandNetworkBandwidthGbpsRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["network_bandwidth_gbps"].([]any); ok && len(v) > 0 {
+		apiObject.NetworkBandwidthGbps = expandNetworkBandwidthGbpsRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["network_interface_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCountRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["network_interface_count"].([]any); ok && len(v) > 0 {
+		apiObject.NetworkInterfaceCount = expandNetworkInterfaceCountRequest(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["on_demand_max_price_percentage_over_lowest_price"].(int); ok && v != 0 {
@@ -2931,18 +2922,18 @@ func expandInstanceRequirements(tfMap map[string]interface{}) *awstypes.Instance
 		apiObject.SpotMaxPricePercentageOverLowestPrice = aws.Int32(int32(v))
 	}
 
-	if v, ok := tfMap["total_local_storage_gb"].([]interface{}); ok && len(v) > 0 {
-		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGBRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["total_local_storage_gb"].([]any); ok && len(v) > 0 {
+		apiObject.TotalLocalStorageGB = expandTotalLocalStorageGBRequest(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["vcpu_count"].([]interface{}); ok && len(v) > 0 {
-		apiObject.VCpuCount = expandVCPUCountRequest(v[0].(map[string]interface{}))
+	if v, ok := tfMap["vcpu_count"].([]any); ok && len(v) > 0 {
+		apiObject.VCpuCount = expandVCPUCountRequest(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandAcceleratorCountRequest(tfMap map[string]interface{}) *awstypes.AcceleratorCountRequest {
+func expandAcceleratorCountRequest(tfMap map[string]any) *awstypes.AcceleratorCountRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2962,7 +2953,7 @@ func expandAcceleratorCountRequest(tfMap map[string]interface{}) *awstypes.Accel
 	return apiObject
 }
 
-func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.AcceleratorTotalMemoryMiBRequest {
+func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]any) *awstypes.AcceleratorTotalMemoryMiBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -2982,7 +2973,7 @@ func expandAcceleratorTotalMemoryMiBRequest(tfMap map[string]interface{}) *awsty
 	return apiObject
 }
 
-func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]interface{}) *awstypes.BaselineEbsBandwidthMbpsRequest {
+func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]any) *awstypes.BaselineEbsBandwidthMbpsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3002,7 +2993,7 @@ func expandBaselineEBSBandwidthMbpsRequest(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func expandMemoryGiBPerVCPURequest(tfMap map[string]interface{}) *awstypes.MemoryGiBPerVCpuRequest {
+func expandMemoryGiBPerVCPURequest(tfMap map[string]any) *awstypes.MemoryGiBPerVCpuRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3022,7 +3013,7 @@ func expandMemoryGiBPerVCPURequest(tfMap map[string]interface{}) *awstypes.Memor
 	return apiObject
 }
 
-func expandMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.MemoryMiBRequest {
+func expandMemoryMiBRequest(tfMap map[string]any) *awstypes.MemoryMiBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3042,7 +3033,7 @@ func expandMemoryMiBRequest(tfMap map[string]interface{}) *awstypes.MemoryMiBReq
 	return apiObject
 }
 
-func expandNetworkBandwidthGbpsRequest(tfMap map[string]interface{}) *awstypes.NetworkBandwidthGbpsRequest {
+func expandNetworkBandwidthGbpsRequest(tfMap map[string]any) *awstypes.NetworkBandwidthGbpsRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3062,7 +3053,7 @@ func expandNetworkBandwidthGbpsRequest(tfMap map[string]interface{}) *awstypes.N
 	return apiObject
 }
 
-func expandNetworkInterfaceCountRequest(tfMap map[string]interface{}) *awstypes.NetworkInterfaceCountRequest {
+func expandNetworkInterfaceCountRequest(tfMap map[string]any) *awstypes.NetworkInterfaceCountRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3082,7 +3073,7 @@ func expandNetworkInterfaceCountRequest(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func expandTotalLocalStorageGBRequest(tfMap map[string]interface{}) *awstypes.TotalLocalStorageGBRequest {
+func expandTotalLocalStorageGBRequest(tfMap map[string]any) *awstypes.TotalLocalStorageGBRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3102,7 +3093,7 @@ func expandTotalLocalStorageGBRequest(tfMap map[string]interface{}) *awstypes.To
 	return apiObject
 }
 
-func expandVCPUCountRequest(tfMap map[string]interface{}) *awstypes.VCpuCountRequest {
+func expandVCPUCountRequest(tfMap map[string]any) *awstypes.VCpuCountRequest {
 	if tfMap == nil {
 		return nil
 	}
@@ -3122,7 +3113,7 @@ func expandVCPUCountRequest(tfMap map[string]interface{}) *awstypes.VCpuCountReq
 	return apiObject
 }
 
-func expandLaunchTemplateSpecificationForMixedInstancesPolicy(tfMap map[string]interface{}, hasDefaultVersion bool) *awstypes.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecificationForMixedInstancesPolicy(tfMap map[string]any, hasDefaultVersion bool) *awstypes.LaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -3149,7 +3140,7 @@ func expandLaunchTemplateSpecificationForMixedInstancesPolicy(tfMap map[string]i
 	return apiObject
 }
 
-func expandLaunchTemplateSpecification(tfMap map[string]interface{}, hasDefaultVersion bool) *awstypes.LaunchTemplateSpecification {
+func expandLaunchTemplateSpecification(tfMap map[string]any, hasDefaultVersion bool) *awstypes.LaunchTemplateSpecification {
 	if tfMap == nil {
 		return nil
 	}
@@ -3175,25 +3166,25 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}, hasDefaultV
 	return apiObject
 }
 
-func expandMixedInstancesPolicy(tfMap map[string]interface{}, hasDefaultVersion bool) *awstypes.MixedInstancesPolicy {
+func expandMixedInstancesPolicy(tfMap map[string]any, hasDefaultVersion bool) *awstypes.MixedInstancesPolicy {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.MixedInstancesPolicy{}
 
-	if v, ok := tfMap["instances_distribution"].([]interface{}); ok && len(v) > 0 {
-		apiObject.InstancesDistribution = expandInstancesDistribution(v[0].(map[string]interface{}))
+	if v, ok := tfMap["instances_distribution"].([]any); ok && len(v) > 0 {
+		apiObject.InstancesDistribution = expandInstancesDistribution(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap[names.AttrLaunchTemplate].([]interface{}); ok && len(v) > 0 {
-		apiObject.LaunchTemplate = expandLaunchTemplate(v[0].(map[string]interface{}), hasDefaultVersion)
+	if v, ok := tfMap[names.AttrLaunchTemplate].([]any); ok && len(v) > 0 {
+		apiObject.LaunchTemplate = expandLaunchTemplate(v[0].(map[string]any), hasDefaultVersion)
 	}
 
 	return apiObject
 }
 
-func expandPutLifecycleHookInput(name string, tfMap map[string]interface{}) *autoscaling.PutLifecycleHookInput {
+func expandPutLifecycleHookInput(name string, tfMap map[string]any) *autoscaling.PutLifecycleHookInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -3233,7 +3224,7 @@ func expandPutLifecycleHookInput(name string, tfMap map[string]interface{}) *aut
 	return apiObject
 }
 
-func expandPutLifecycleHookInputs(name string, tfList []interface{}) []*autoscaling.PutLifecycleHookInput {
+func expandPutLifecycleHookInputs(name string, tfList []any) []*autoscaling.PutLifecycleHookInput {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -3241,7 +3232,7 @@ func expandPutLifecycleHookInputs(name string, tfList []interface{}) []*autoscal
 	var apiObjects []*autoscaling.PutLifecycleHookInput
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -3259,7 +3250,7 @@ func expandPutLifecycleHookInputs(name string, tfList []interface{}) []*autoscal
 	return apiObjects
 }
 
-func expandPutWarmPoolInput(name string, tfMap map[string]interface{}) *autoscaling.PutWarmPoolInput {
+func expandPutWarmPoolInput(name string, tfMap map[string]any) *autoscaling.PutWarmPoolInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -3268,8 +3259,8 @@ func expandPutWarmPoolInput(name string, tfMap map[string]interface{}) *autoscal
 		AutoScalingGroupName: aws.String(name),
 	}
 
-	if v, ok := tfMap["instance_reuse_policy"].([]interface{}); ok && len(v) > 0 {
-		apiObject.InstanceReusePolicy = expandInstanceReusePolicy(v[0].(map[string]interface{}))
+	if v, ok := tfMap["instance_reuse_policy"].([]any); ok && len(v) > 0 {
+		apiObject.InstanceReusePolicy = expandInstanceReusePolicy(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["max_group_prepared_capacity"].(int); ok {
@@ -3287,7 +3278,7 @@ func expandPutWarmPoolInput(name string, tfMap map[string]interface{}) *autoscal
 	return apiObject
 }
 
-func expandInstanceReusePolicy(tfMap map[string]interface{}) *awstypes.InstanceReusePolicy {
+func expandInstanceReusePolicy(tfMap map[string]any) *awstypes.InstanceReusePolicy {
 	if tfMap == nil {
 		return nil
 	}
@@ -3301,7 +3292,7 @@ func expandInstanceReusePolicy(tfMap map[string]interface{}) *awstypes.InstanceR
 	return apiObject
 }
 
-func expandStartInstanceRefreshInput(name string, tfMap map[string]interface{}, launchTemplate *awstypes.LaunchTemplateSpecification, mixedInstancesPolicy *awstypes.MixedInstancesPolicy) *autoscaling.StartInstanceRefreshInput {
+func expandStartInstanceRefreshInput(name string, tfMap map[string]any, launchTemplate *awstypes.LaunchTemplateSpecification, mixedInstancesPolicy *awstypes.MixedInstancesPolicy) *autoscaling.StartInstanceRefreshInput {
 	if tfMap == nil {
 		return nil
 	}
@@ -3310,8 +3301,8 @@ func expandStartInstanceRefreshInput(name string, tfMap map[string]interface{}, 
 		AutoScalingGroupName: aws.String(name),
 	}
 
-	if v, ok := tfMap["preferences"].([]interface{}); ok && len(v) > 0 {
-		apiObject.Preferences = expandRefreshPreferences(v[0].(map[string]interface{}))
+	if v, ok := tfMap["preferences"].([]any); ok && len(v) > 0 {
+		apiObject.Preferences = expandRefreshPreferences(v[0].(map[string]any))
 
 		// "The AutoRollback parameter cannot be set to true when the DesiredConfiguration parameter is empty".
 		if aws.ToBool(apiObject.Preferences.AutoRollback) {
@@ -3329,15 +3320,15 @@ func expandStartInstanceRefreshInput(name string, tfMap map[string]interface{}, 
 	return apiObject
 }
 
-func expandRefreshPreferences(tfMap map[string]interface{}) *awstypes.RefreshPreferences {
+func expandRefreshPreferences(tfMap map[string]any) *awstypes.RefreshPreferences {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.RefreshPreferences{}
 
-	if v, ok := tfMap["alarm_specification"].([]interface{}); ok && len(v) > 0 {
-		apiObject.AlarmSpecification = expandAlarmSpecification(v[0].(map[string]interface{}))
+	if v, ok := tfMap["alarm_specification"].([]any); ok && len(v) > 0 {
+		apiObject.AlarmSpecification = expandAlarmSpecification(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["auto_rollback"].(bool); ok {
@@ -3350,7 +3341,7 @@ func expandRefreshPreferences(tfMap map[string]interface{}) *awstypes.RefreshPre
 		}
 	}
 
-	if v, ok := tfMap["checkpoint_percentages"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["checkpoint_percentages"].([]any); ok && len(v) > 0 {
 		apiObject.CheckpointPercentages = flex.ExpandInt32ValueList(v)
 	}
 
@@ -3383,21 +3374,21 @@ func expandRefreshPreferences(tfMap map[string]interface{}) *awstypes.RefreshPre
 	return apiObject
 }
 
-func expandAlarmSpecification(tfMap map[string]interface{}) *awstypes.AlarmSpecification {
+func expandAlarmSpecification(tfMap map[string]any) *awstypes.AlarmSpecification {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.AlarmSpecification{}
 
-	if v, ok := tfMap["alarms"].([]interface{}); ok {
+	if v, ok := tfMap["alarms"].([]any); ok {
 		apiObject.Alarms = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandVPCZoneIdentifiers(tfList []interface{}) *string {
+func expandVPCZoneIdentifiers(tfList []any) *string {
 	vpcZoneIDs := make([]string, len(tfList))
 
 	for i, v := range tfList {
@@ -3407,7 +3398,7 @@ func expandVPCZoneIdentifiers(tfList []interface{}) *string {
 	return aws.String(strings.Join(vpcZoneIDs, ","))
 }
 
-func expandAvailabilityZoneDistribution(tfMap map[string]interface{}) *awstypes.AvailabilityZoneDistribution {
+func expandAvailabilityZoneDistribution(tfMap map[string]any) *awstypes.AvailabilityZoneDistribution {
 	if tfMap == nil {
 		return nil
 	}
@@ -3421,7 +3412,7 @@ func expandAvailabilityZoneDistribution(tfMap map[string]interface{}) *awstypes.
 	return apiObject
 }
 
-func expandTrafficSourceIdentifier(tfMap map[string]interface{}) awstypes.TrafficSourceIdentifier {
+func expandTrafficSourceIdentifier(tfMap map[string]any) awstypes.TrafficSourceIdentifier {
 	apiObject := awstypes.TrafficSourceIdentifier{}
 
 	if v, ok := tfMap[names.AttrIdentifier].(string); ok && v != "" {
@@ -3435,7 +3426,7 @@ func expandTrafficSourceIdentifier(tfMap map[string]interface{}) awstypes.Traffi
 	return apiObject
 }
 
-func expandTrafficSourceIdentifiers(tfList []interface{}) []awstypes.TrafficSourceIdentifier {
+func expandTrafficSourceIdentifiers(tfList []any) []awstypes.TrafficSourceIdentifier {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -3443,7 +3434,7 @@ func expandTrafficSourceIdentifiers(tfList []interface{}) []awstypes.TrafficSour
 	var apiObjects []awstypes.TrafficSourceIdentifier
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -3456,12 +3447,12 @@ func expandTrafficSourceIdentifiers(tfList []interface{}) []awstypes.TrafficSour
 	return apiObjects
 }
 
-func flattenAvailabilityZoneDistribution(apiObject *awstypes.AvailabilityZoneDistribution) map[string]interface{} {
+func flattenAvailabilityZoneDistribution(apiObject *awstypes.AvailabilityZoneDistribution) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if v := apiObject.CapacityDistributionStrategy; v != "" {
 		tfMap["capacity_distribution_strategy"] = string(v)
 	}
@@ -3481,12 +3472,12 @@ func flattenEnabledMetrics(apiObjects []awstypes.EnabledMetric) []string {
 	return tfList
 }
 
-func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecification) map[string]interface{} {
+func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateId; v != nil {
 		tfMap[names.AttrID] = aws.ToString(v)
@@ -3503,30 +3494,30 @@ func flattenLaunchTemplateSpecification(apiObject *awstypes.LaunchTemplateSpecif
 	return tfMap
 }
 
-func flattenMixedInstancesPolicy(apiObject *awstypes.MixedInstancesPolicy) map[string]interface{} {
+func flattenMixedInstancesPolicy(apiObject *awstypes.MixedInstancesPolicy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.InstancesDistribution; v != nil {
-		tfMap["instances_distribution"] = []interface{}{flattenInstancesDistribution(v)}
+		tfMap["instances_distribution"] = []any{flattenInstancesDistribution(v)}
 	}
 
 	if v := apiObject.LaunchTemplate; v != nil {
-		tfMap[names.AttrLaunchTemplate] = []interface{}{flattenLaunchTemplate(v)}
+		tfMap[names.AttrLaunchTemplate] = []any{flattenLaunchTemplate(v)}
 	}
 
 	return tfMap
 }
 
-func flattenInstancesDistribution(apiObject *awstypes.InstancesDistribution) map[string]interface{} {
+func flattenInstancesDistribution(apiObject *awstypes.InstancesDistribution) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.OnDemandAllocationStrategy; v != nil {
 		tfMap["on_demand_allocation_strategy"] = aws.ToString(v)
@@ -3555,7 +3546,7 @@ func flattenInstancesDistribution(apiObject *awstypes.InstancesDistribution) map
 	return tfMap
 }
 
-func expandInstanceMaintenancePolicy(l []interface{}) *awstypes.InstanceMaintenancePolicy {
+func expandInstanceMaintenancePolicy(l []any) *awstypes.InstanceMaintenancePolicy {
 	if len(l) == 0 {
 		//Empty InstanceMaintenancePolicy block will reset already assigned values
 		return &awstypes.InstanceMaintenancePolicy{
@@ -3564,7 +3555,7 @@ func expandInstanceMaintenancePolicy(l []interface{}) *awstypes.InstanceMaintena
 		}
 	}
 
-	tfMap := l[0].(map[string]interface{})
+	tfMap := l[0].(map[string]any)
 
 	return &awstypes.InstanceMaintenancePolicy{
 		MinHealthyPercentage: aws.Int32(int32(tfMap["min_healthy_percentage"].(int))),
@@ -3572,28 +3563,28 @@ func expandInstanceMaintenancePolicy(l []interface{}) *awstypes.InstanceMaintena
 	}
 }
 
-func flattenInstanceMaintenancePolicy(instanceMaintenancePolicy *awstypes.InstanceMaintenancePolicy) []interface{} {
+func flattenInstanceMaintenancePolicy(instanceMaintenancePolicy *awstypes.InstanceMaintenancePolicy) []any {
 	if instanceMaintenancePolicy == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"min_healthy_percentage": instanceMaintenancePolicy.MinHealthyPercentage,
 		"max_healthy_percentage": instanceMaintenancePolicy.MaxHealthyPercentage,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenLaunchTemplate(apiObject *awstypes.LaunchTemplate) map[string]interface{} {
+func flattenLaunchTemplate(apiObject *awstypes.LaunchTemplate) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateSpecification; v != nil {
-		tfMap["launch_template_specification"] = []interface{}{flattenLaunchTemplateSpecificationForMixedInstancesPolicy(v)}
+		tfMap["launch_template_specification"] = []any{flattenLaunchTemplateSpecificationForMixedInstancesPolicy(v)}
 	}
 
 	if v := apiObject.Overrides; v != nil {
@@ -3603,12 +3594,12 @@ func flattenLaunchTemplate(apiObject *awstypes.LaunchTemplate) map[string]interf
 	return tfMap
 }
 
-func flattenLaunchTemplateSpecificationForMixedInstancesPolicy(apiObject *awstypes.LaunchTemplateSpecification) map[string]interface{} {
+func flattenLaunchTemplateSpecificationForMixedInstancesPolicy(apiObject *awstypes.LaunchTemplateSpecification) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.LaunchTemplateId; v != nil {
 		tfMap["launch_template_id"] = aws.ToString(v)
@@ -3625,11 +3616,11 @@ func flattenLaunchTemplateSpecificationForMixedInstancesPolicy(apiObject *awstyp
 	return tfMap
 }
 
-func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.InstanceRequirements; v != nil {
-		tfMap["instance_requirements"] = []interface{}{flattenInstanceRequirements(v)}
+		tfMap["instance_requirements"] = []any{flattenInstanceRequirements(v)}
 	}
 
 	if v := apiObject.InstanceType; v != nil {
@@ -3637,7 +3628,7 @@ func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) 
 	}
 
 	if v := apiObject.LaunchTemplateSpecification; v != nil {
-		tfMap["launch_template_specification"] = []interface{}{flattenLaunchTemplateSpecificationForMixedInstancesPolicy(v)}
+		tfMap["launch_template_specification"] = []any{flattenLaunchTemplateSpecificationForMixedInstancesPolicy(v)}
 	}
 
 	if v := apiObject.WeightedCapacity; v != nil {
@@ -3647,12 +3638,12 @@ func flattenLaunchTemplateOverrides(apiObject awstypes.LaunchTemplateOverrides) 
 	return tfMap
 }
 
-func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverrides) []interface{} {
+func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverrides) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenLaunchTemplateOverrides(apiObject))
@@ -3661,15 +3652,15 @@ func flattenLaunchTemplateOverrideses(apiObjects []awstypes.LaunchTemplateOverri
 	return tfList
 }
 
-func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[string]interface{} {
+func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AcceleratorCount; v != nil {
-		tfMap["accelerator_count"] = []interface{}{flattenAcceleratorCount(v)}
+		tfMap["accelerator_count"] = []any{flattenAcceleratorCount(v)}
 	}
 
 	if apiObject.AcceleratorManufacturers != nil {
@@ -3681,7 +3672,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.AcceleratorTotalMemoryMiB; v != nil {
-		tfMap["accelerator_total_memory_mib"] = []interface{}{flattenAcceleratorTotalMemoryMiB(v)}
+		tfMap["accelerator_total_memory_mib"] = []any{flattenAcceleratorTotalMemoryMiB(v)}
 	}
 
 	if apiObject.AcceleratorTypes != nil {
@@ -3695,7 +3686,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	tfMap["bare_metal"] = apiObject.BareMetal
 
 	if v := apiObject.BaselineEbsBandwidthMbps; v != nil {
-		tfMap["baseline_ebs_bandwidth_mbps"] = []interface{}{flattenBaselineEBSBandwidthMbps(v)}
+		tfMap["baseline_ebs_bandwidth_mbps"] = []any{flattenBaselineEBSBandwidthMbps(v)}
 	}
 
 	tfMap["burstable_performance"] = apiObject.BurstablePerformance
@@ -3723,19 +3714,19 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.MemoryGiBPerVCpu; v != nil {
-		tfMap["memory_gib_per_vcpu"] = []interface{}{flattenMemoryGiBPerVCPU(v)}
+		tfMap["memory_gib_per_vcpu"] = []any{flattenMemoryGiBPerVCPU(v)}
 	}
 
 	if v := apiObject.MemoryMiB; v != nil {
-		tfMap["memory_mib"] = []interface{}{flattenMemoryMiB(v)}
+		tfMap["memory_mib"] = []any{flattenMemoryMiB(v)}
 	}
 
 	if v := apiObject.NetworkBandwidthGbps; v != nil {
-		tfMap["network_bandwidth_gbps"] = []interface{}{flattenNetworkBandwidthGbps(v)}
+		tfMap["network_bandwidth_gbps"] = []any{flattenNetworkBandwidthGbps(v)}
 	}
 
 	if v := apiObject.NetworkInterfaceCount; v != nil {
-		tfMap["network_interface_count"] = []interface{}{flattenNetworkInterfaceCount(v)}
+		tfMap["network_interface_count"] = []any{flattenNetworkInterfaceCount(v)}
 	}
 
 	if v := apiObject.OnDemandMaxPricePercentageOverLowestPrice; v != nil {
@@ -3751,22 +3742,22 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.TotalLocalStorageGB; v != nil {
-		tfMap["total_local_storage_gb"] = []interface{}{flattentTotalLocalStorageGB(v)}
+		tfMap["total_local_storage_gb"] = []any{flattentTotalLocalStorageGB(v)}
 	}
 
 	if v := apiObject.VCpuCount; v != nil {
-		tfMap["vcpu_count"] = []interface{}{flattenVCPUCount(v)}
+		tfMap["vcpu_count"] = []any{flattenVCPUCount(v)}
 	}
 
 	return tfMap
 }
 
-func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCountRequest) map[string]interface{} {
+func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCountRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3779,12 +3770,12 @@ func flattenAcceleratorCount(apiObject *awstypes.AcceleratorCountRequest) map[st
 	return tfMap
 }
 
-func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemoryMiBRequest) map[string]interface{} {
+func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemoryMiBRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3797,12 +3788,12 @@ func flattenAcceleratorTotalMemoryMiB(apiObject *awstypes.AcceleratorTotalMemory
 	return tfMap
 }
 
-func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbpsRequest) map[string]interface{} {
+func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbpsRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3815,12 +3806,12 @@ func flattenBaselineEBSBandwidthMbps(apiObject *awstypes.BaselineEbsBandwidthMbp
 	return tfMap
 }
 
-func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpuRequest) map[string]interface{} {
+func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpuRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -3833,12 +3824,12 @@ func flattenMemoryGiBPerVCPU(apiObject *awstypes.MemoryGiBPerVCpuRequest) map[st
 	return tfMap
 }
 
-func flattenMemoryMiB(apiObject *awstypes.MemoryMiBRequest) map[string]interface{} {
+func flattenMemoryMiB(apiObject *awstypes.MemoryMiBRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3851,12 +3842,12 @@ func flattenMemoryMiB(apiObject *awstypes.MemoryMiBRequest) map[string]interface
 	return tfMap
 }
 
-func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbpsRequest) map[string]interface{} {
+func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbpsRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -3869,12 +3860,12 @@ func flattenNetworkBandwidthGbps(apiObject *awstypes.NetworkBandwidthGbpsRequest
 	return tfMap
 }
 
-func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCountRequest) map[string]interface{} {
+func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCountRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3887,12 +3878,12 @@ func flattenNetworkInterfaceCount(apiObject *awstypes.NetworkInterfaceCountReque
 	return tfMap
 }
 
-func flattentTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGBRequest) map[string]interface{} {
+func flattentTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGBRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToFloat64(v)
@@ -3905,8 +3896,8 @@ func flattentTotalLocalStorageGB(apiObject *awstypes.TotalLocalStorageGBRequest)
 	return tfMap
 }
 
-func flattenTrafficSourceIdentifier(apiObject awstypes.TrafficSourceIdentifier) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenTrafficSourceIdentifier(apiObject awstypes.TrafficSourceIdentifier) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := apiObject.Identifier; v != nil {
 		tfMap[names.AttrIdentifier] = aws.ToString(v)
@@ -3919,12 +3910,12 @@ func flattenTrafficSourceIdentifier(apiObject awstypes.TrafficSourceIdentifier) 
 	return tfMap
 }
 
-func flattenTrafficSourceIdentifiers(apiObjects []awstypes.TrafficSourceIdentifier) []interface{} {
+func flattenTrafficSourceIdentifiers(apiObjects []awstypes.TrafficSourceIdentifier) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenTrafficSourceIdentifier(apiObject))
@@ -3933,12 +3924,12 @@ func flattenTrafficSourceIdentifiers(apiObjects []awstypes.TrafficSourceIdentifi
 	return tfList
 }
 
-func flattenVCPUCount(apiObject *awstypes.VCpuCountRequest) map[string]interface{} {
+func flattenVCPUCount(apiObject *awstypes.VCpuCountRequest) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Max; v != nil {
 		tfMap[names.AttrMax] = aws.ToInt32(v)
@@ -3967,15 +3958,15 @@ func flattenSuspendedProcesses(apiObjects []awstypes.SuspendedProcess) []string 
 	return tfList
 }
 
-func flattenWarmPoolConfiguration(apiObject *awstypes.WarmPoolConfiguration) map[string]interface{} {
+func flattenWarmPoolConfiguration(apiObject *awstypes.WarmPoolConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.InstanceReusePolicy; v != nil {
-		tfMap["instance_reuse_policy"] = []interface{}{flattenWarmPoolInstanceReusePolicy(v)}
+		tfMap["instance_reuse_policy"] = []any{flattenWarmPoolInstanceReusePolicy(v)}
 	}
 
 	if v := apiObject.MaxGroupPreparedCapacity; v != nil {
@@ -3993,12 +3984,12 @@ func flattenWarmPoolConfiguration(apiObject *awstypes.WarmPoolConfiguration) map
 	return tfMap
 }
 
-func flattenWarmPoolInstanceReusePolicy(apiObject *awstypes.InstanceReusePolicy) map[string]interface{} {
+func flattenWarmPoolInstanceReusePolicy(apiObject *awstypes.InstanceReusePolicy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ReuseOnScaleIn; v != nil {
 		tfMap["reuse_on_scale_in"] = aws.ToBool(v)
@@ -4035,7 +4026,7 @@ func startInstanceRefresh(ctx context.Context, conn *autoscaling.Client, input *
 	name := aws.ToString(input.AutoScalingGroupName)
 
 	_, err := tfresource.RetryWhen(ctx, instanceRefreshStartedTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.StartInstanceRefresh(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -4057,7 +4048,7 @@ func startInstanceRefresh(ctx context.Context, conn *autoscaling.Client, input *
 	return nil
 }
 
-func validateGroupInstanceRefreshTriggerFields(i interface{}, path cty.Path) diag.Diagnostics {
+func validateGroupInstanceRefreshTriggerFields(i any, path cty.Path) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	v, ok := i.(string)

--- a/internal/service/autoscaling/group_data_source.go
+++ b/internal/service/autoscaling/group_data_source.go
@@ -564,7 +564,7 @@ func dataSourceGroup() *schema.Resource {
 	}
 }
 
-func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -590,7 +590,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("launch_configuration", group.LaunchConfigurationName)
 	if group.LaunchTemplate != nil {
-		if err := d.Set(names.AttrLaunchTemplate, []interface{}{flattenLaunchTemplateSpecification(group.LaunchTemplate)}); err != nil {
+		if err := d.Set(names.AttrLaunchTemplate, []any{flattenLaunchTemplateSpecification(group.LaunchTemplate)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting launch_template: %s", err)
 		}
 	} else {
@@ -601,7 +601,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	d.Set("max_size", group.MaxSize)
 	d.Set("min_size", group.MinSize)
 	if group.MixedInstancesPolicy != nil {
-		if err := d.Set("mixed_instances_policy", []interface{}{flattenMixedInstancesPolicy(group.MixedInstancesPolicy)}); err != nil {
+		if err := d.Set("mixed_instances_policy", []any{flattenMixedInstancesPolicy(group.MixedInstancesPolicy)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting mixed_instances_policy: %s", err)
 		}
 	} else {
@@ -624,7 +624,7 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 	d.Set("vpc_zone_identifier", group.VPCZoneIdentifier)
 	if group.WarmPoolConfiguration != nil {
-		if err := d.Set("warm_pool", []interface{}{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {
+		if err := d.Set("warm_pool", []any{flattenWarmPoolConfiguration(group.WarmPoolConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting warm_pool: %s", err)
 		}
 	} else {

--- a/internal/service/autoscaling/group_migrate.go
+++ b/internal/service/autoscaling/group_migrate.go
@@ -742,9 +742,9 @@ func resourceGroupV0() *schema.Resource {
 	}
 }
 
-func GroupStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func GroupStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
-		rawState = map[string]interface{}{}
+		rawState = map[string]any{}
 	}
 
 	if _, ok := rawState["ignore_failed_scaling_activities"]; !ok {

--- a/internal/service/autoscaling/group_migrate_test.go
+++ b/internal/service/autoscaling/group_migrate_test.go
@@ -17,24 +17,24 @@ func TestGroupStateUpgradeV0(t *testing.T) {
 
 	testCases := []struct {
 		testName string
-		rawState map[string]interface{}
-		want     map[string]interface{}
+		rawState map[string]any
+		want     map[string]any
 	}{
 		{
 			testName: "empty state",
-			rawState: map[string]interface{}{},
-			want: map[string]interface{}{
+			rawState: map[string]any{},
+			want: map[string]any{
 				"ignore_failed_scaling_activities": acctest.CtFalse,
 			},
 		},
 		{
 			testName: "non-empty state",
-			rawState: map[string]interface{}{
+			rawState: map[string]any{
 				"capacity_rebalance":        acctest.CtTrue,
 				"health_check_grace_period": "600",
 				"max_instance_lifetime":     "3600",
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"capacity_rebalance":               acctest.CtTrue,
 				"health_check_grace_period":        "600",
 				"ignore_failed_scaling_activities": acctest.CtFalse,
@@ -43,13 +43,13 @@ func TestGroupStateUpgradeV0(t *testing.T) {
 		},
 		{
 			testName: "ignore_failed_scaling_activities set",
-			rawState: map[string]interface{}{
+			rawState: map[string]any{
 				"capacity_rebalance":               acctest.CtFalse,
 				"health_check_grace_period":        "400",
 				"ignore_failed_scaling_activities": acctest.CtTrue,
 				"max_instance_lifetime":            "36000",
 			},
-			want: map[string]interface{}{
+			want: map[string]any{
 				"capacity_rebalance":               acctest.CtFalse,
 				"health_check_grace_period":        "400",
 				"ignore_failed_scaling_activities": acctest.CtTrue,

--- a/internal/service/autoscaling/group_tag.go
+++ b/internal/service/autoscaling/group_tag.go
@@ -60,13 +60,13 @@ func resourceGroupTag() *schema.Resource {
 	}
 }
 
-func resourceGroupTagCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
+func resourceGroupTagCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics { // nosemgrep:ci.semgrep.tags.calling-UpdateTags-in-resource-create
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	identifier := d.Get("autoscaling_group_name").(string)
-	tags := d.Get("tag").([]interface{})
-	key := tags[0].(map[string]interface{})[names.AttrKey].(string)
+	tags := d.Get("tag").([]any)
+	key := tags[0].(map[string]any)[names.AttrKey].(string)
 
 	if err := updateTags(ctx, conn, identifier, TagResourceTypeGroup, nil, tags); err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating AutoScaling Group (%s) tag (%s): %s", identifier, key, err)
@@ -77,7 +77,7 @@ func resourceGroupTagCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceGroupTagRead(ctx, d, meta)...)
 }
 
-func resourceGroupTagRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupTagRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	identifier, key, err := tftags.GetResourceID(d.Id())
@@ -100,7 +100,7 @@ func resourceGroupTagRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	d.Set("autoscaling_group_name", identifier)
 
-	if err := d.Set("tag", []map[string]interface{}{{
+	if err := d.Set("tag", []map[string]any{{
 		names.AttrKey:         key,
 		names.AttrValue:       value.Value,
 		"propagate_at_launch": value.AdditionalBoolFields["PropagateAtLaunch"],
@@ -111,7 +111,7 @@ func resourceGroupTagRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceGroupTagUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupTagUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	identifier, key, err := tftags.GetResourceID(d.Id())
@@ -127,7 +127,7 @@ func resourceGroupTagUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceGroupTagRead(ctx, d, meta)...)
 }
 
-func resourceGroupTagDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGroupTagDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	identifier, key, err := tftags.GetResourceID(d.Id())

--- a/internal/service/autoscaling/group_test.go
+++ b/internal/service/autoscaling/group_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -4243,10 +4244,8 @@ func testAccCheckInstanceRefreshStatus(ctx context.Context, v *awstypes.AutoScal
 
 		status := output[index].Status
 
-		for _, v := range expected {
-			if status == v {
-				return nil
-			}
+		if slices.Contains(expected, status) {
+			return nil
 		}
 
 		return fmt.Errorf("Expected Instance Refresh at index %d to be in %q, got %q", index, expected, status)

--- a/internal/service/autoscaling/groups_data_source.go
+++ b/internal/service/autoscaling/groups_data_source.go
@@ -59,9 +59,9 @@ func dataSourceGroups() *schema.Resource {
 func buildFiltersDataSource(set *schema.Set) []awstypes.Filter {
 	var filters []awstypes.Filter
 	for _, v := range set.List() {
-		m := v.(map[string]interface{})
+		m := v.(map[string]any)
 		var filterValues []string
-		for _, e := range m[names.AttrValues].([]interface{}) {
+		for _, e := range m[names.AttrValues].([]any) {
 			filterValues = append(filterValues, e.(string))
 		}
 
@@ -83,14 +83,14 @@ func buildFiltersDataSource(set *schema.Set) []awstypes.Filter {
 	return filters
 }
 
-func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceGroupsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	input := &autoscaling.DescribeAutoScalingGroupsInput{}
 
-	if v, ok := d.GetOk(names.AttrNames); ok && len(v.([]interface{})) > 0 {
-		input.AutoScalingGroupNames = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrNames); ok && len(v.([]any)) > 0 {
+		input.AutoScalingGroupNames = flex.ExpandStringValueList(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrFilter); ok {

--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -291,7 +291,7 @@ func resourceLaunchConfiguration() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"user_data_base64"},
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					switch v := v.(type) {
 					case string:
 						return userDataHashSum(v)
@@ -312,7 +312,7 @@ func resourceLaunchConfiguration() *schema.Resource {
 	}
 }
 
-func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	autoscalingconn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	ec2conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -342,8 +342,8 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 		input.KeyName = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("metadata_options"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.MetadataOptions = expandInstanceMetadataOptions(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("metadata_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.MetadataOptions = expandInstanceMetadataOptions(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("placement_tenancy"); ok {
@@ -391,8 +391,8 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 		blockDeviceMappings = append(blockDeviceMappings, v...)
 	}
 
-	if v, ok := d.GetOk("root_block_device"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		v := expandBlockDeviceMappingForRootBlockDevice(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("root_block_device"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		v := expandBlockDeviceMappingForRootBlockDevice(v.([]any)[0].(map[string]any))
 		v.DeviceName = aws.String(rootDeviceName)
 
 		blockDeviceMappings = append(blockDeviceMappings, v)
@@ -405,7 +405,7 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
 	_, err = tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return autoscalingconn.CreateLaunchConfiguration(ctx, &input)
 		},
 		func(err error) (bool, error) {
@@ -426,7 +426,7 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceLaunchConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	autoscalingconn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	ec2conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -456,7 +456,7 @@ func resourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData
 	d.Set(names.AttrInstanceType, lc.InstanceType)
 	d.Set("key_name", lc.KeyName)
 	if lc.MetadataOptions != nil {
-		if err := d.Set("metadata_options", []interface{}{flattenInstanceMetadataOptions(lc.MetadataOptions)}); err != nil {
+		if err := d.Set("metadata_options", []any{flattenInstanceMetadataOptions(lc.MetadataOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting metadata_options: %s", err)
 		}
 	} else {
@@ -484,11 +484,11 @@ func resourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading Auto Scaling Launch Configuration (%s): %s", d.Id(), err)
 	}
 
-	configuredEBSBlockDevices := make(map[string]map[string]interface{})
+	configuredEBSBlockDevices := make(map[string]map[string]any)
 
 	if v, ok := d.GetOk("ebs_block_device"); ok && v.(*schema.Set).Len() > 0 {
 		for _, v := range v.(*schema.Set).List() {
-			tfMap, ok := v.(map[string]interface{})
+			tfMap, ok := v.(map[string]any)
 
 			if !ok {
 				continue
@@ -513,13 +513,13 @@ func resourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceLaunchConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLaunchConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Auto Scaling Launch Configuration: %s", d.Id())
 	_, err := tfresource.RetryWhenIsA[*awstypes.ResourceInUseFault](ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.DeleteLaunchConfiguration(ctx, &autoscaling.DeleteLaunchConfigurationInput{
 				LaunchConfigurationName: aws.String(d.Id()),
 			})
@@ -536,7 +536,7 @@ func resourceLaunchConfigurationDelete(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func expandBlockDeviceMappingForEBSBlockDevice(tfMap map[string]interface{}) awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingForEBSBlockDevice(tfMap map[string]any) awstypes.BlockDeviceMapping {
 	apiObject := awstypes.BlockDeviceMapping{
 		Ebs: &awstypes.Ebs{},
 	}
@@ -578,7 +578,7 @@ func expandBlockDeviceMappingForEBSBlockDevice(tfMap map[string]interface{}) aws
 	return apiObject
 }
 
-func expandBlockDeviceMappingForEphemeralBlockDevice(tfMap map[string]interface{}) awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingForEphemeralBlockDevice(tfMap map[string]any) awstypes.BlockDeviceMapping {
 	apiObject := awstypes.BlockDeviceMapping{}
 
 	if v, ok := tfMap[names.AttrDeviceName].(string); ok && v != "" {
@@ -596,7 +596,7 @@ func expandBlockDeviceMappingForEphemeralBlockDevice(tfMap map[string]interface{
 	return apiObject
 }
 
-func expandBlockDeviceMappingForRootBlockDevice(tfMap map[string]interface{}) awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappingForRootBlockDevice(tfMap map[string]any) awstypes.BlockDeviceMapping {
 	apiObject := awstypes.BlockDeviceMapping{
 		Ebs: &awstypes.Ebs{},
 	}
@@ -628,7 +628,7 @@ func expandBlockDeviceMappingForRootBlockDevice(tfMap map[string]interface{}) aw
 	return apiObject
 }
 
-func expandBlockDeviceMappings(tfList []interface{}, fn func(map[string]interface{}) awstypes.BlockDeviceMapping) []awstypes.BlockDeviceMapping {
+func expandBlockDeviceMappings(tfList []any, fn func(map[string]any) awstypes.BlockDeviceMapping) []awstypes.BlockDeviceMapping {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -636,7 +636,7 @@ func expandBlockDeviceMappings(tfList []interface{}, fn func(map[string]interfac
 	var apiObjects []awstypes.BlockDeviceMapping
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -649,15 +649,15 @@ func expandBlockDeviceMappings(tfList []interface{}, fn func(map[string]interfac
 	return apiObjects
 }
 
-func flattenBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping, rootDeviceName string, configuredEBSBlockDevices map[string]map[string]interface{}) ([]interface{}, []interface{}, []interface{}) {
+func flattenBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping, rootDeviceName string, configuredEBSBlockDevices map[string]map[string]any) ([]any, []any, []any) {
 	if len(apiObjects) == 0 {
 		return nil, nil, nil
 	}
 
-	var tfListEBSBlockDevice, tfListEphemeralBlockDevice, tfListRootBlockDevice []interface{}
+	var tfListEBSBlockDevice, tfListEphemeralBlockDevice, tfListRootBlockDevice []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 
 		if v := apiObject.NoDevice; v != nil {
 			if v, ok := configuredEBSBlockDevices[aws.ToString(apiObject.DeviceName)]; ok {
@@ -728,7 +728,7 @@ func flattenBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping, rootDe
 	return tfListEBSBlockDevice, tfListEphemeralBlockDevice, tfListRootBlockDevice
 }
 
-func expandInstanceMetadataOptions(tfMap map[string]interface{}) *awstypes.InstanceMetadataOptions {
+func expandInstanceMetadataOptions(tfMap map[string]any) *awstypes.InstanceMetadataOptions {
 	if tfMap == nil {
 		return nil
 	}
@@ -752,12 +752,12 @@ func expandInstanceMetadataOptions(tfMap map[string]interface{}) *awstypes.Insta
 	return apiObject
 }
 
-func flattenInstanceMetadataOptions(apiObject *awstypes.InstanceMetadataOptions) map[string]interface{} {
+func flattenInstanceMetadataOptions(apiObject *awstypes.InstanceMetadataOptions) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["http_endpoint"] = string(apiObject.HttpEndpoint)
 

--- a/internal/service/autoscaling/launch_configuration_data_source.go
+++ b/internal/service/autoscaling/launch_configuration_data_source.go
@@ -188,7 +188,7 @@ func dataSourceLaunchConfiguration() *schema.Resource {
 	}
 }
 
-func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	autoscalingconn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 	ec2conn := meta.(*conns.AWSClient).EC2Client(ctx)
@@ -215,7 +215,7 @@ func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	d.Set(names.AttrInstanceType, lc.InstanceType)
 	d.Set("key_name", lc.KeyName)
 	if lc.MetadataOptions != nil {
-		if err := d.Set("metadata_options", []interface{}{flattenInstanceMetadataOptions(lc.MetadataOptions)}); err != nil {
+		if err := d.Set("metadata_options", []any{flattenInstanceMetadataOptions(lc.MetadataOptions)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting metadata_options: %s", err)
 		}
 	} else {
@@ -233,7 +233,7 @@ func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceDa
 		return sdkdiag.AppendErrorf(diags, "reading Auto Scaling Launch Configuration (%s): %s", name, err)
 	}
 
-	tfListEBSBlockDevice, tfListEphemeralBlockDevice, tfListRootBlockDevice := flattenBlockDeviceMappings(lc.BlockDeviceMappings, rootDeviceName, map[string]map[string]interface{}{})
+	tfListEBSBlockDevice, tfListEphemeralBlockDevice, tfListRootBlockDevice := flattenBlockDeviceMappings(lc.BlockDeviceMappings, rootDeviceName, map[string]map[string]any{})
 
 	if err := d.Set("ebs_block_device", tfListEBSBlockDevice); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting ebs_block_device: %s", err)

--- a/internal/service/autoscaling/lifecycle_hook.go
+++ b/internal/service/autoscaling/lifecycle_hook.go
@@ -88,7 +88,7 @@ func resourceLifecycleHook() *schema.Resource {
 	}
 }
 
-func resourceLifecycleHookPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLifecycleHookPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -123,7 +123,7 @@ func resourceLifecycleHookPut(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, 5*time.Minute,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.PutLifecycleHook(ctx, input)
 		},
 		errCodeValidationError, "Unable to publish test message to notification target")
@@ -137,7 +137,7 @@ func resourceLifecycleHookPut(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceLifecycleHookRead(ctx, d, meta)...)
 }
 
-func resourceLifecycleHookRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLifecycleHookRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -164,7 +164,7 @@ func resourceLifecycleHookRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceLifecycleHookDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLifecycleHookDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -186,7 +186,7 @@ func resourceLifecycleHookDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceLifecycleHookImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceLifecycleHookImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), "/", 2)
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format (%q), expected <asg-name>/<lifecycle-hook-name>", d.Id())

--- a/internal/service/autoscaling/notification.go
+++ b/internal/service/autoscaling/notification.go
@@ -50,7 +50,7 @@ func resourceNotification() *schema.Resource {
 	}
 }
 
-func resourceNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNotificationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -66,7 +66,7 @@ func resourceNotificationCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceNotificationRead(ctx, d, meta)...)
 }
 
-func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -102,7 +102,7 @@ func resourceNotificationRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -141,7 +141,7 @@ func resourceNotificationUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceNotificationRead(ctx, d, meta)...)
 }
 
-func resourceNotificationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceNotificationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 

--- a/internal/service/autoscaling/notification_test.go
+++ b/internal/service/autoscaling/notification_test.go
@@ -117,7 +117,7 @@ func TestAccAutoScalingNotification_paginated(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_autoscaling_notification.test"
 	var groups []string
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		groups = append(groups, fmt.Sprintf("%s-%d", rName, i))
 	}
 

--- a/internal/service/autoscaling/policy.go
+++ b/internal/service/autoscaling/policy.go
@@ -510,7 +510,7 @@ func resourcePolicy() *schema.Resource {
 	}
 }
 
-func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -531,7 +531,7 @@ func resourcePolicyCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourcePolicyRead(ctx, d, meta)...)
 }
 
-func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -571,7 +571,7 @@ func resourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -589,7 +589,7 @@ func resourcePolicyUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourcePolicyRead(ctx, d, meta)...)
 }
 
-func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -611,7 +611,7 @@ func resourcePolicyDelete(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourcePolicyImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourcePolicyImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.SplitN(d.Id(), "/", 2)
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format (%q), expected <asg-name>/<policy-name>", d.Id())
@@ -719,7 +719,7 @@ func expandPutScalingPolicyInput(d *schema.ResourceData) (*autoscaling.PutScalin
 		input.MinAdjustmentMagnitude = aws.Int32(int32(v.(int)))
 	}
 
-	if v := d.Get("predictive_scaling_configuration").([]interface{}); len(v) > 0 {
+	if v := d.Get("predictive_scaling_configuration").([]any); len(v) > 0 {
 		input.PredictiveScalingConfiguration = expandPredictiveScalingConfiguration(v)
 	}
 
@@ -751,7 +751,7 @@ func expandPutScalingPolicyInput(d *schema.ResourceData) (*autoscaling.PutScalin
 
 	// This parameter is required if the policy type is TargetTrackingScaling and not supported otherwise.
 	if v, ok := d.GetOk("target_tracking_configuration"); ok {
-		input.TargetTrackingConfiguration = expandTargetTrackingConfiguration(v.([]interface{}))
+		input.TargetTrackingConfiguration = expandTargetTrackingConfiguration(v.([]any))
 		if policyType != policyTypeTargetTrackingScaling {
 			return input, fmt.Errorf("target_tracking_configuration is only supported for policy type TargetTrackingScaling")
 		}
@@ -762,20 +762,20 @@ func expandPutScalingPolicyInput(d *schema.ResourceData) (*autoscaling.PutScalin
 	return input, nil
 }
 
-func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTrackingConfiguration {
+func expandTargetTrackingConfiguration(tfList []any) *awstypes.TargetTrackingConfiguration {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.TargetTrackingConfiguration{}
 
 	apiObject.TargetValue = aws.Float64(tfMap["target_value"].(float64))
 	if v, ok := tfMap["disable_scale_in"]; ok {
 		apiObject.DisableScaleIn = aws.Bool(v.(bool))
 	}
-	if v, ok := tfMap["predefined_metric_specification"]; ok && len(v.([]interface{})) > 0 {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := tfMap["predefined_metric_specification"]; ok && len(v.([]any)) > 0 {
+		tfMap := v.([]any)[0].(map[string]any)
 		predefinedMetricSpecification := &awstypes.PredefinedMetricSpecification{
 			PredefinedMetricType: awstypes.MetricType(tfMap["predefined_metric_type"].(string)),
 		}
@@ -784,17 +784,17 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 		}
 		apiObject.PredefinedMetricSpecification = predefinedMetricSpecification
 	}
-	if v, ok := tfMap["customized_metric_specification"]; ok && len(v.([]interface{})) > 0 {
-		tfMap := v.([]interface{})[0].(map[string]interface{})
+	if v, ok := tfMap["customized_metric_specification"]; ok && len(v.([]any)) > 0 {
+		tfMap := v.([]any)[0].(map[string]any)
 		customizedMetricSpecification := &awstypes.CustomizedMetricSpecification{}
 		if v, ok := tfMap["metrics"].(*schema.Set); ok && v.Len() > 0 {
 			customizedMetricSpecification.Metrics = expandTargetTrackingMetricDataQueries(v.List())
 		} else {
 			if v, ok := tfMap["metric_dimension"]; ok {
-				tfList := v.([]interface{})
+				tfList := v.([]any)
 				metricDimensions := make([]awstypes.MetricDimension, len(tfList))
 				for i := range metricDimensions {
-					tfMap := tfList[i].(map[string]interface{})
+					tfMap := tfList[i].(map[string]any)
 					metricDimensions[i] = awstypes.MetricDimension{
 						Name:  aws.String(tfMap[names.AttrName].(string)),
 						Value: aws.String(tfMap[names.AttrValue].(string)),
@@ -818,7 +818,7 @@ func expandTargetTrackingConfiguration(tfList []interface{}) *awstypes.TargetTra
 	return apiObject
 }
 
-func expandTargetTrackingMetricDataQueries(tfList []interface{}) []awstypes.TargetTrackingMetricDataQuery {
+func expandTargetTrackingMetricDataQueries(tfList []any) []awstypes.TargetTrackingMetricDataQuery {
 	if len(tfList) < 1 {
 		return nil
 	}
@@ -826,7 +826,7 @@ func expandTargetTrackingMetricDataQueries(tfList []interface{}) []awstypes.Targ
 	apiObjects := make([]awstypes.TargetTrackingMetricDataQuery, len(tfList))
 
 	for i := range apiObjects {
-		tfMap := tfList[i].(map[string]interface{})
+		tfMap := tfList[i].(map[string]any)
 		apiObject := awstypes.TargetTrackingMetricDataQuery{
 			Id: aws.String(tfMap[names.AttrID].(string)),
 		}
@@ -836,9 +836,9 @@ func expandTargetTrackingMetricDataQueries(tfList []interface{}) []awstypes.Targ
 		if v, ok := tfMap["label"]; ok && v.(string) != "" {
 			apiObject.Label = aws.String(v.(string))
 		}
-		if v, ok := tfMap["metric_stat"]; ok && len(v.([]interface{})) > 0 {
-			tfMapMetricStat := v.([]interface{})[0].(map[string]interface{})
-			tfMapMetric := tfMapMetricStat["metric"].([]interface{})[0].(map[string]interface{})
+		if v, ok := tfMap["metric_stat"]; ok && len(v.([]any)) > 0 {
+			tfMapMetricStat := v.([]any)[0].(map[string]any)
+			tfMapMetric := tfMapMetricStat["metric"].([]any)[0].(map[string]any)
 			metric := &awstypes.Metric{
 				MetricName: aws.String(tfMapMetric[names.AttrMetricName].(string)),
 				Namespace:  aws.String(tfMapMetric[names.AttrNamespace].(string)),
@@ -847,7 +847,7 @@ func expandTargetTrackingMetricDataQueries(tfList []interface{}) []awstypes.Targ
 				tfList := v.(*schema.Set).List()
 				metricDimensions := make([]awstypes.MetricDimension, len(tfList))
 				for i := range metricDimensions {
-					tfMap := tfList[i].(map[string]interface{})
+					tfMap := tfList[i].(map[string]any)
 					metricDimensions[i] = awstypes.MetricDimension{
 						Name:  aws.String(tfMap[names.AttrName].(string)),
 						Value: aws.String(tfMap[names.AttrValue].(string)),
@@ -876,15 +876,15 @@ func expandTargetTrackingMetricDataQueries(tfList []interface{}) []awstypes.Targ
 	return apiObjects
 }
 
-func expandPredictiveScalingConfiguration(tfList []interface{}) *awstypes.PredictiveScalingConfiguration {
+func expandPredictiveScalingConfiguration(tfList []any) *awstypes.PredictiveScalingConfiguration {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingConfiguration{
 		MaxCapacityBreachBehavior: awstypes.PredictiveScalingMaxCapacityBreachBehavior(tfMap["max_capacity_breach_behavior"].(string)),
-		MetricSpecifications:      expandPredictiveScalingMetricSpecifications(tfMap["metric_specification"].([]interface{})),
+		MetricSpecifications:      expandPredictiveScalingMetricSpecifications(tfMap["metric_specification"].([]any)),
 		Mode:                      awstypes.PredictiveScalingMode(tfMap[names.AttrMode].(string)),
 	}
 	if v, null, _ := nullable.Int(tfMap["max_capacity_buffer"].(string)).ValueInt32(); !null {
@@ -897,31 +897,31 @@ func expandPredictiveScalingConfiguration(tfList []interface{}) *awstypes.Predic
 	return apiObject
 }
 
-func expandPredictiveScalingMetricSpecifications(tfList []interface{}) []awstypes.PredictiveScalingMetricSpecification {
+func expandPredictiveScalingMetricSpecifications(tfList []any) []awstypes.PredictiveScalingMetricSpecification {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := awstypes.PredictiveScalingMetricSpecification{
-		CustomizedCapacityMetricSpecification: expandPredictiveScalingCustomizedCapacityMetric(tfMap["customized_capacity_metric_specification"].([]interface{})),
-		CustomizedLoadMetricSpecification:     expandPredictiveScalingCustomizedLoadMetric(tfMap["customized_load_metric_specification"].([]interface{})),
-		CustomizedScalingMetricSpecification:  expandPredictiveScalingCustomizedScalingMetric(tfMap["customized_scaling_metric_specification"].([]interface{})),
-		PredefinedLoadMetricSpecification:     expandPredictiveScalingPredefinedLoadMetric(tfMap["predefined_load_metric_specification"].([]interface{})),
-		PredefinedMetricPairSpecification:     expandPredictiveScalingPredefinedMetricPair(tfMap["predefined_metric_pair_specification"].([]interface{})),
-		PredefinedScalingMetricSpecification:  expandPredictiveScalingPredefinedScalingMetric(tfMap["predefined_scaling_metric_specification"].([]interface{})),
+		CustomizedCapacityMetricSpecification: expandPredictiveScalingCustomizedCapacityMetric(tfMap["customized_capacity_metric_specification"].([]any)),
+		CustomizedLoadMetricSpecification:     expandPredictiveScalingCustomizedLoadMetric(tfMap["customized_load_metric_specification"].([]any)),
+		CustomizedScalingMetricSpecification:  expandPredictiveScalingCustomizedScalingMetric(tfMap["customized_scaling_metric_specification"].([]any)),
+		PredefinedLoadMetricSpecification:     expandPredictiveScalingPredefinedLoadMetric(tfMap["predefined_load_metric_specification"].([]any)),
+		PredefinedMetricPairSpecification:     expandPredictiveScalingPredefinedMetricPair(tfMap["predefined_metric_pair_specification"].([]any)),
+		PredefinedScalingMetricSpecification:  expandPredictiveScalingPredefinedScalingMetric(tfMap["predefined_scaling_metric_specification"].([]any)),
 		TargetValue:                           aws.Float64(tfMap["target_value"].(float64)),
 	}
 
 	return []awstypes.PredictiveScalingMetricSpecification{apiObject}
 }
 
-func expandPredictiveScalingPredefinedLoadMetric(tfList []interface{}) *awstypes.PredictiveScalingPredefinedLoadMetric {
+func expandPredictiveScalingPredefinedLoadMetric(tfList []any) *awstypes.PredictiveScalingPredefinedLoadMetric {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingPredefinedLoadMetric{
 		PredefinedMetricType: awstypes.PredefinedLoadMetricType(tfMap["predefined_metric_type"].(string)),
 	}
@@ -932,12 +932,12 @@ func expandPredictiveScalingPredefinedLoadMetric(tfList []interface{}) *awstypes
 	return apiObject
 }
 
-func expandPredictiveScalingPredefinedMetricPair(tfList []interface{}) *awstypes.PredictiveScalingPredefinedMetricPair {
+func expandPredictiveScalingPredefinedMetricPair(tfList []any) *awstypes.PredictiveScalingPredefinedMetricPair {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingPredefinedMetricPair{
 		PredefinedMetricType: awstypes.PredefinedMetricPairType(tfMap["predefined_metric_type"].(string)),
 	}
@@ -948,12 +948,12 @@ func expandPredictiveScalingPredefinedMetricPair(tfList []interface{}) *awstypes
 	return apiObject
 }
 
-func expandPredictiveScalingPredefinedScalingMetric(tfList []interface{}) *awstypes.PredictiveScalingPredefinedScalingMetric {
+func expandPredictiveScalingPredefinedScalingMetric(tfList []any) *awstypes.PredictiveScalingPredefinedScalingMetric {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingPredefinedScalingMetric{
 		PredefinedMetricType: awstypes.PredefinedScalingMetricType(tfMap["predefined_metric_type"].(string)),
 	}
@@ -964,46 +964,46 @@ func expandPredictiveScalingPredefinedScalingMetric(tfList []interface{}) *awsty
 	return apiObject
 }
 
-func expandPredictiveScalingCustomizedScalingMetric(tfList []interface{}) *awstypes.PredictiveScalingCustomizedScalingMetric {
+func expandPredictiveScalingCustomizedScalingMetric(tfList []any) *awstypes.PredictiveScalingCustomizedScalingMetric {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingCustomizedScalingMetric{
-		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]interface{})),
+		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]any)),
 	}
 
 	return apiObject
 }
 
-func expandPredictiveScalingCustomizedLoadMetric(tfList []interface{}) *awstypes.PredictiveScalingCustomizedLoadMetric {
+func expandPredictiveScalingCustomizedLoadMetric(tfList []any) *awstypes.PredictiveScalingCustomizedLoadMetric {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingCustomizedLoadMetric{
-		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]interface{})),
+		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]any)),
 	}
 
 	return apiObject
 }
 
-func expandPredictiveScalingCustomizedCapacityMetric(tfList []interface{}) *awstypes.PredictiveScalingCustomizedCapacityMetric {
+func expandPredictiveScalingCustomizedCapacityMetric(tfList []any) *awstypes.PredictiveScalingCustomizedCapacityMetric {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.PredictiveScalingCustomizedCapacityMetric{
-		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]interface{})),
+		MetricDataQueries: expandMetricDataQueries(tfMap["metric_data_queries"].([]any)),
 	}
 
 	return apiObject
 }
 
-func expandMetricDataQueries(tfList []interface{}) []awstypes.MetricDataQuery {
+func expandMetricDataQueries(tfList []any) []awstypes.MetricDataQuery {
 	if len(tfList) < 1 {
 		return nil
 	}
@@ -1011,7 +1011,7 @@ func expandMetricDataQueries(tfList []interface{}) []awstypes.MetricDataQuery {
 	apiObjects := make([]awstypes.MetricDataQuery, len(tfList))
 
 	for i := range apiObjects {
-		tfMap := tfList[i].(map[string]interface{})
+		tfMap := tfList[i].(map[string]any)
 		apiObject := awstypes.MetricDataQuery{
 			Id: aws.String(tfMap[names.AttrID].(string)),
 		}
@@ -1021,9 +1021,9 @@ func expandMetricDataQueries(tfList []interface{}) []awstypes.MetricDataQuery {
 		if v, ok := tfMap["label"]; ok && v.(string) != "" {
 			apiObject.Label = aws.String(v.(string))
 		}
-		if v, ok := tfMap["metric_stat"]; ok && len(v.([]interface{})) > 0 {
-			tfMapMetricStat := v.([]interface{})[0].(map[string]interface{})
-			tfMapMetric := tfMapMetricStat["metric"].([]interface{})[0].(map[string]interface{})
+		if v, ok := tfMap["metric_stat"]; ok && len(v.([]any)) > 0 {
+			tfMapMetricStat := v.([]any)[0].(map[string]any)
+			tfMapMetric := tfMapMetricStat["metric"].([]any)[0].(map[string]any)
 			metric := &awstypes.Metric{
 				MetricName: aws.String(tfMapMetric[names.AttrMetricName].(string)),
 				Namespace:  aws.String(tfMapMetric[names.AttrNamespace].(string)),
@@ -1032,7 +1032,7 @@ func expandMetricDataQueries(tfList []interface{}) []awstypes.MetricDataQuery {
 				tfList := v.(*schema.Set).List()
 				metricDimensions := make([]awstypes.MetricDimension, len(tfList))
 				for i := range metricDimensions {
-					tfMap := tfList[i].(map[string]interface{})
+					tfMap := tfList[i].(map[string]any)
 					metricDimensions[i] = awstypes.MetricDimension{
 						Name:  aws.String(tfMap[names.AttrName].(string)),
 						Value: aws.String(tfMap[names.AttrValue].(string)),
@@ -1058,7 +1058,7 @@ func expandMetricDataQueries(tfList []interface{}) []awstypes.MetricDataQuery {
 	return apiObjects
 }
 
-func expandStepAdjustments(tfList []interface{}) []awstypes.StepAdjustment {
+func expandStepAdjustments(tfList []any) []awstypes.StepAdjustment {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -1066,7 +1066,7 @@ func expandStepAdjustments(tfList []interface{}) []awstypes.StepAdjustment {
 	var apiObjects []awstypes.StepAdjustment
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1093,21 +1093,21 @@ func expandStepAdjustments(tfList []interface{}) []awstypes.StepAdjustment {
 	return apiObjects
 }
 
-func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfiguration) []interface{} {
+func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfiguration) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	if apiObject := apiObject.CustomizedMetricSpecification; apiObject != nil {
-		tfMapCustomizedMetricSpecification := map[string]interface{}{}
+		tfMapCustomizedMetricSpecification := map[string]any{}
 		if v := apiObject.Metrics; v != nil {
 			tfMapCustomizedMetricSpecification["metrics"] = flattenTargetTrackingMetricDataQueries(v)
 		} else {
 			if apiObjects := apiObject.Dimensions; apiObjects != nil {
-				tfList := make([]interface{}, len(apiObjects))
+				tfList := make([]any, len(apiObjects))
 				for i := range tfList {
-					tfMap := map[string]interface{}{}
+					tfMap := map[string]any{}
 					apiObject := apiObjects[i]
 					tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 					tfMap[names.AttrValue] = aws.ToString(apiObject.Value)
@@ -1125,27 +1125,27 @@ func flattenTargetTrackingConfiguration(apiObject *awstypes.TargetTrackingConfig
 				tfMapCustomizedMetricSpecification[names.AttrUnit] = aws.ToString(v)
 			}
 		}
-		tfMap["customized_metric_specification"] = []map[string]interface{}{tfMapCustomizedMetricSpecification}
+		tfMap["customized_metric_specification"] = []map[string]any{tfMapCustomizedMetricSpecification}
 	}
 	tfMap["disable_scale_in"] = aws.ToBool(apiObject.DisableScaleIn)
 	if apiObject := apiObject.PredefinedMetricSpecification; apiObject != nil {
-		tfMapPredefinedMetricSpecification := map[string]interface{}{}
+		tfMapPredefinedMetricSpecification := map[string]any{}
 		tfMapPredefinedMetricSpecification["predefined_metric_type"] = apiObject.PredefinedMetricType
 		if v := apiObject.ResourceLabel; v != nil {
 			tfMapPredefinedMetricSpecification["resource_label"] = aws.ToString(v)
 		}
-		tfMap["predefined_metric_specification"] = []map[string]interface{}{tfMapPredefinedMetricSpecification}
+		tfMap["predefined_metric_specification"] = []map[string]any{tfMapPredefinedMetricSpecification}
 	}
 	tfMap["target_value"] = aws.ToFloat64(apiObject.TargetValue)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTrackingMetricDataQuery) []interface{} {
-	tfList := make([]interface{}, len(apiObjects))
+func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTrackingMetricDataQuery) []any {
+	tfList := make([]any, len(apiObjects))
 
 	for i := range tfList {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		apiObject := apiObjects[i]
 		if v := apiObject.Expression; v != nil {
 			tfMap[names.AttrExpression] = aws.ToString(v)
@@ -1155,13 +1155,13 @@ func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTracking
 			tfMap["label"] = aws.ToString(v)
 		}
 		if apiObject := apiObject.MetricStat; apiObject != nil {
-			tfMapMetricStat := map[string]interface{}{}
+			tfMapMetricStat := map[string]any{}
 			if apiObject := apiObject.Metric; apiObject != nil {
-				tfMapMetric := map[string]interface{}{}
+				tfMapMetric := map[string]any{}
 				if apiObjects := apiObject.Dimensions; apiObjects != nil {
-					tfList := make([]interface{}, len(apiObjects))
+					tfList := make([]any, len(apiObjects))
 					for i := range tfList {
-						tfMap := map[string]interface{}{}
+						tfMap := map[string]any{}
 						apiObject := apiObject.Dimensions[i]
 						tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 						tfMap[names.AttrValue] = aws.ToString(apiObject.Value)
@@ -1171,7 +1171,7 @@ func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTracking
 				}
 				tfMapMetric[names.AttrMetricName] = aws.ToString(apiObject.MetricName)
 				tfMapMetric[names.AttrNamespace] = aws.ToString(apiObject.Namespace)
-				tfMapMetricStat["metric"] = []map[string]interface{}{tfMapMetric}
+				tfMapMetricStat["metric"] = []map[string]any{tfMapMetric}
 			}
 			if v := apiObject.Period; v != nil {
 				tfMapMetricStat["period"] = aws.ToInt32(v)
@@ -1180,7 +1180,7 @@ func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTracking
 			if v := apiObject.Unit; v != nil {
 				tfMapMetricStat[names.AttrUnit] = aws.ToString(v)
 			}
-			tfMap["metric_stat"] = []map[string]interface{}{tfMapMetricStat}
+			tfMap["metric_stat"] = []map[string]any{tfMapMetricStat}
 		}
 		if v := apiObject.ReturnData; v != nil {
 			tfMap["return_data"] = aws.ToBool(v)
@@ -1191,12 +1191,12 @@ func flattenTargetTrackingMetricDataQueries(apiObjects []awstypes.TargetTracking
 	return tfList
 }
 
-func flattenPredictiveScalingConfiguration(apiObject *awstypes.PredictiveScalingConfiguration) []interface{} {
+func flattenPredictiveScalingConfiguration(apiObject *awstypes.PredictiveScalingConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	tfMap["max_capacity_breach_behavior"] = string(apiObject.MaxCapacityBreachBehavior)
 	if v := apiObject.MaxCapacityBuffer; v != nil {
 		tfMap["max_capacity_buffer"] = flex.Int32ToStringValue(v)
@@ -1209,13 +1209,13 @@ func flattenPredictiveScalingConfiguration(apiObject *awstypes.PredictiveScaling
 		tfMap["scheduling_buffer_time"] = flex.Int32ToStringValue(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingMetricSpecifications(apiObjects []awstypes.PredictiveScalingMetricSpecification) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingMetricSpecifications(apiObjects []awstypes.PredictiveScalingMetricSpecification) []any {
+	tfMap := map[string]any{}
 	if len(apiObjects) < 1 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	apiObject := apiObjects[0]
@@ -1241,83 +1241,83 @@ func flattenPredictiveScalingMetricSpecifications(apiObjects []awstypes.Predicti
 		tfMap["target_value"] = aws.ToFloat64(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingPredefinedScalingMetric(apiObject *awstypes.PredictiveScalingPredefinedScalingMetric) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingPredefinedScalingMetric(apiObject *awstypes.PredictiveScalingPredefinedScalingMetric) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["predefined_metric_type"] = apiObject.PredefinedMetricType
 	tfMap["resource_label"] = aws.ToString(apiObject.ResourceLabel)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingPredefinedLoadMetric(apiObject *awstypes.PredictiveScalingPredefinedLoadMetric) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingPredefinedLoadMetric(apiObject *awstypes.PredictiveScalingPredefinedLoadMetric) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["predefined_metric_type"] = apiObject.PredefinedMetricType
 	tfMap["resource_label"] = aws.ToString(apiObject.ResourceLabel)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingPredefinedMetricPair(apiObject *awstypes.PredictiveScalingPredefinedMetricPair) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingPredefinedMetricPair(apiObject *awstypes.PredictiveScalingPredefinedMetricPair) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["predefined_metric_type"] = apiObject.PredefinedMetricType
 	tfMap["resource_label"] = aws.ToString(apiObject.ResourceLabel)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingCustomizedScalingMetric(apiObject *awstypes.PredictiveScalingCustomizedScalingMetric) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingCustomizedScalingMetric(apiObject *awstypes.PredictiveScalingCustomizedScalingMetric) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["metric_data_queries"] = flattenMetricDataQueries(apiObject.MetricDataQueries)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingCustomizedLoadMetric(apiObject *awstypes.PredictiveScalingCustomizedLoadMetric) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingCustomizedLoadMetric(apiObject *awstypes.PredictiveScalingCustomizedLoadMetric) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["metric_data_queries"] = flattenMetricDataQueries(apiObject.MetricDataQueries)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPredictiveScalingCustomizedCapacityMetric(apiObject *awstypes.PredictiveScalingCustomizedCapacityMetric) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenPredictiveScalingCustomizedCapacityMetric(apiObject *awstypes.PredictiveScalingCustomizedCapacityMetric) []any {
+	tfMap := map[string]any{}
 	if apiObject == nil {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
 	tfMap["metric_data_queries"] = flattenMetricDataQueries(apiObject.MetricDataQueries)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenMetricDataQueries(apiObjects []awstypes.MetricDataQuery) []interface{} {
-	tfList := make([]interface{}, len(apiObjects))
+func flattenMetricDataQueries(apiObjects []awstypes.MetricDataQuery) []any {
+	tfList := make([]any, len(apiObjects))
 
 	for i := range tfList {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		apiObject := apiObjects[i]
 
 		if v := apiObject.Expression; v != nil {
@@ -1328,13 +1328,13 @@ func flattenMetricDataQueries(apiObjects []awstypes.MetricDataQuery) []interface
 			tfMap["label"] = aws.ToString(v)
 		}
 		if apiObject := apiObject.MetricStat; apiObject != nil {
-			tfMapMetricStat := map[string]interface{}{}
+			tfMapMetricStat := map[string]any{}
 			if apiObject := apiObject.Metric; apiObject != nil {
-				tfMapMetric := map[string]interface{}{}
+				tfMapMetric := map[string]any{}
 				if apiObjects := apiObject.Dimensions; apiObjects != nil {
-					tfList := make([]interface{}, len(apiObjects))
+					tfList := make([]any, len(apiObjects))
 					for i := range tfList {
-						tfMap := map[string]interface{}{}
+						tfMap := map[string]any{}
 						apiObject := apiObject.Dimensions[i]
 						tfMap[names.AttrName] = aws.ToString(apiObject.Name)
 						tfMap[names.AttrValue] = aws.ToString(apiObject.Value)
@@ -1344,13 +1344,13 @@ func flattenMetricDataQueries(apiObjects []awstypes.MetricDataQuery) []interface
 				}
 				tfMapMetric[names.AttrMetricName] = aws.ToString(apiObject.MetricName)
 				tfMapMetric[names.AttrNamespace] = aws.ToString(apiObject.Namespace)
-				tfMapMetricStat["metric"] = []map[string]interface{}{tfMapMetric}
+				tfMapMetricStat["metric"] = []map[string]any{tfMapMetric}
 			}
 			tfMapMetricStat["stat"] = aws.ToString(apiObject.Stat)
 			if v := apiObject.Unit; v != nil {
 				tfMapMetricStat[names.AttrUnit] = aws.ToString(v)
 			}
-			tfMap["metric_stat"] = []map[string]interface{}{tfMapMetricStat}
+			tfMap["metric_stat"] = []map[string]any{tfMapMetricStat}
 		}
 		if v := apiObject.ReturnData; v != nil {
 			tfMap["return_data"] = aws.ToBool(v)
@@ -1361,15 +1361,15 @@ func flattenMetricDataQueries(apiObjects []awstypes.MetricDataQuery) []interface
 	return tfList
 }
 
-func flattenStepAdjustments(apiObjects []awstypes.StepAdjustment) []interface{} {
+func flattenStepAdjustments(apiObjects []awstypes.StepAdjustment) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"scaling_adjustment": aws.ToInt32(apiObject.ScalingAdjustment),
 		}
 

--- a/internal/service/autoscaling/schedule.go
+++ b/internal/service/autoscaling/schedule.go
@@ -93,7 +93,7 @@ func resourceSchedule() *schema.Resource {
 	}
 }
 
-func resourceSchedulePut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSchedulePut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -155,7 +155,7 @@ func resourceSchedulePut(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceScheduleRead(ctx, d, meta)...)
 }
 
-func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -200,7 +200,7 @@ func resourceScheduleRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -222,7 +222,7 @@ func resourceScheduleDelete(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceScheduleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceScheduleImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	splitId := strings.Split(d.Id(), "/")
 	if len(splitId) != 2 {
 		return []*schema.ResourceData{}, fmt.Errorf("wrong format of import ID (%s), use: 'asg-name/action-name'", d.Id())
@@ -286,7 +286,7 @@ func findScheduleByTwoPartKey(ctx context.Context, conn *autoscaling.Client, asg
 	return findSchedule(ctx, conn, input)
 }
 
-func validScheduleTimestamp(v interface{}, k string) (ws []string, errors []error) {
+func validScheduleTimestamp(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	_, err := time.Parse(ScheduleTimeLayout, value)
 	if err != nil {

--- a/internal/service/autoscaling/traffic_source_attachment.go
+++ b/internal/service/autoscaling/traffic_source_attachment.go
@@ -69,12 +69,12 @@ func resourceTrafficSourceAttachment() *schema.Resource {
 	}
 }
 
-func resourceTrafficSourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficSourceAttachmentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
 	asgName := d.Get("autoscaling_group_name").(string)
-	trafficSource := expandTrafficSourceIdentifier(d.Get("traffic_source").([]interface{})[0].(map[string]interface{}))
+	trafficSource := expandTrafficSourceIdentifier(d.Get("traffic_source").([]any)[0].(map[string]any))
 	trafficSourceID := aws.ToString(trafficSource.Identifier)
 	trafficSourceType := aws.ToString(trafficSource.Type)
 	id := trafficSourceAttachmentCreateResourceID(asgName, trafficSourceType, trafficSourceID)
@@ -98,7 +98,7 @@ func resourceTrafficSourceAttachmentCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceTrafficSourceAttachmentRead(ctx, d, meta)...)
 }
 
-func resourceTrafficSourceAttachmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficSourceAttachmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -122,7 +122,7 @@ func resourceTrafficSourceAttachmentRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceTrafficSourceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTrafficSourceAttachmentDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AutoScalingClient(ctx)
 
@@ -131,7 +131,7 @@ func resourceTrafficSourceAttachmentDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	trafficSource := expandTrafficSourceIdentifier(d.Get("traffic_source").([]interface{})[0].(map[string]interface{}))
+	trafficSource := expandTrafficSourceIdentifier(d.Get("traffic_source").([]any)[0].(map[string]any))
 
 	log.Printf("[INFO] Deleting Auto Scaling Traffic Source Attachment: %s", d.Id())
 	input := autoscaling.DetachTrafficSourcesInput{
@@ -194,7 +194,7 @@ func findTrafficSourceAttachmentByThreePartKey(ctx context.Context, conn *autosc
 }
 
 func statusTrafficSourceAttachment(ctx context.Context, conn *autoscaling.Client, asgName, trafficSourceType, trafficSourceID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTrafficSourceAttachmentByThreePartKey(ctx, conn, asgName, trafficSourceType, trafficSourceID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/cognitoidp/identity_provider.go
+++ b/internal/service/cognitoidp/identity_provider.go
@@ -85,7 +85,7 @@ func resourceIdentityProvider() *schema.Resource {
 	}
 }
 
-func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -98,16 +98,16 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 		UserPoolId:   aws.String(userPoolID),
 	}
 
-	if v, ok := d.GetOk("attribute_mapping"); ok && len(v.(map[string]interface{})) > 0 {
-		input.AttributeMapping = flex.ExpandStringValueMap(v.(map[string]interface{}))
+	if v, ok := d.GetOk("attribute_mapping"); ok && len(v.(map[string]any)) > 0 {
+		input.AttributeMapping = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("idp_identifiers"); ok && len(v.([]interface{})) > 0 {
-		input.IdpIdentifiers = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("idp_identifiers"); ok && len(v.([]any)) > 0 {
+		input.IdpIdentifiers = flex.ExpandStringValueList(v.([]any))
 	}
 
-	if v, ok := d.GetOk("provider_details"); ok && len(v.(map[string]interface{})) > 0 {
-		input.ProviderDetails = flex.ExpandStringValueMap(v.(map[string]interface{}))
+	if v, ok := d.GetOk("provider_details"); ok && len(v.(map[string]any)) > 0 {
+		input.ProviderDetails = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	_, err := conn.CreateIdentityProvider(ctx, input)
@@ -121,7 +121,7 @@ func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceIdentityProviderRead(ctx, d, meta)...)
 }
 
-func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceIdentityProviderRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -167,15 +167,15 @@ func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	}
 
 	if d.HasChange("attribute_mapping") {
-		input.AttributeMapping = flex.ExpandStringValueMap(d.Get("attribute_mapping").(map[string]interface{}))
+		input.AttributeMapping = flex.ExpandStringValueMap(d.Get("attribute_mapping").(map[string]any))
 	}
 
 	if d.HasChange("idp_identifiers") {
-		input.IdpIdentifiers = flex.ExpandStringValueList(d.Get("idp_identifiers").([]interface{}))
+		input.IdpIdentifiers = flex.ExpandStringValueList(d.Get("idp_identifiers").([]any))
 	}
 
 	if d.HasChange("provider_details") {
-		v := flex.ExpandStringValueMap(d.Get("provider_details").(map[string]interface{}))
+		v := flex.ExpandStringValueMap(d.Get("provider_details").(map[string]any))
 		delete(v, "ActiveEncryptionCertificate")
 		input.ProviderDetails = v
 	}
@@ -189,7 +189,7 @@ func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceIdentityProviderRead(ctx, d, meta)...)
 }
 
-func resourceIdentityProviderDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceIdentityProviderDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/managed_user_pool_client.go
+++ b/internal/service/cognitoidp/managed_user_pool_client.go
@@ -463,7 +463,7 @@ func (r *managedUserPoolClientResource) Create(ctx context.Context, request reso
 		const (
 			timeout = 2 * time.Minute
 		)
-		output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (interface{}, error) {
+		output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
 			return conn.UpdateUserPoolClient(ctx, &input)
 		})
 		if err != nil {
@@ -565,7 +565,7 @@ func (r *managedUserPoolClientResource) Update(ctx context.Context, request reso
 	const (
 		timeout = 2 * time.Minute
 	)
-	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (interface{}, error) {
+	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
 		return conn.UpdateUserPoolClient(ctx, &input)
 	})
 	if err != nil {

--- a/internal/service/cognitoidp/resource_server.go
+++ b/internal/service/cognitoidp/resource_server.go
@@ -82,7 +82,7 @@ func resourceResourceServer() *schema.Resource {
 	}
 }
 
-func resourceResourceServerCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourceServerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -110,7 +110,7 @@ func resourceResourceServerCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceResourceServerRead(ctx, d, meta)...)
 }
 
-func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -138,7 +138,7 @@ func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, met
 	if err := d.Set(names.AttrScope, scopes); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting scope: %s", err)
 	}
-	d.Set("scope_identifiers", tfslices.ApplyToAll(scopes, func(tfMap map[string]interface{}) string {
+	d.Set("scope_identifiers", tfslices.ApplyToAll(scopes, func(tfMap map[string]any) string {
 		return identifier + "/" + tfMap["scope_name"].(string)
 	}))
 	d.Set(names.AttrUserPoolID, resourceServer.UserPoolId)
@@ -146,7 +146,7 @@ func resourceResourceServerRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceResourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourceServerUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -171,7 +171,7 @@ func resourceResourceServerUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceResourceServerRead(ctx, d, meta)...)
 }
 
-func resourceResourceServerDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceResourceServerDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -243,11 +243,11 @@ func findResourceServerByTwoPartKey(ctx context.Context, conn *cognitoidentitypr
 	return output.ResourceServer, nil
 }
 
-func expandResourceServerScopeTypes(tfList []interface{}) []awstypes.ResourceServerScopeType {
+func expandResourceServerScopeTypes(tfList []any) []awstypes.ResourceServerScopeType {
 	apiObjects := make([]awstypes.ResourceServerScopeType, len(tfList))
 
 	for i, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.ResourceServerScopeType{}
 
 		if v, ok := tfMap["scope_description"]; ok {
@@ -264,11 +264,11 @@ func expandResourceServerScopeTypes(tfList []interface{}) []awstypes.ResourceSer
 	return apiObjects
 }
 
-func flattenResourceServerScopeTypes(apiObjects []awstypes.ResourceServerScopeType) []map[string]interface{} {
-	tfList := make([]map[string]interface{}, 0)
+func flattenResourceServerScopeTypes(apiObjects []awstypes.ResourceServerScopeType) []map[string]any {
+	tfList := make([]map[string]any, 0)
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"scope_description": aws.ToString(apiObject.ScopeDescription),
 			"scope_name":        aws.ToString(apiObject.ScopeName),
 		}

--- a/internal/service/cognitoidp/risk_configuration.go
+++ b/internal/service/cognitoidp/risk_configuration.go
@@ -293,7 +293,7 @@ func resourceRiskConfiguration() *schema.Resource {
 	}
 }
 
-func resourceRiskConfigurationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRiskConfigurationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -309,16 +309,16 @@ func resourceRiskConfigurationPut(ctx context.Context, d *schema.ResourceData, m
 		id = userPoolID + riskConfigurationResourceIDSeparator + v
 	}
 
-	if v, ok := d.GetOk("account_takeover_risk_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.AccountTakeoverRiskConfiguration = expandAccountTakeoverRiskConfigurationType(v.([]interface{}))
+	if v, ok := d.GetOk("account_takeover_risk_configuration"); ok && len(v.([]any)) > 0 {
+		input.AccountTakeoverRiskConfiguration = expandAccountTakeoverRiskConfigurationType(v.([]any))
 	}
 
-	if v, ok := d.GetOk("compromised_credentials_risk_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.CompromisedCredentialsRiskConfiguration = expandCompromisedCredentialsRiskConfigurationType(v.([]interface{}))
+	if v, ok := d.GetOk("compromised_credentials_risk_configuration"); ok && len(v.([]any)) > 0 {
+		input.CompromisedCredentialsRiskConfiguration = expandCompromisedCredentialsRiskConfigurationType(v.([]any))
 	}
 
-	if v, ok := d.GetOk("risk_exception_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.RiskExceptionConfiguration = expandRiskExceptionConfigurationType(v.([]interface{}))
+	if v, ok := d.GetOk("risk_exception_configuration"); ok && len(v.([]any)) > 0 {
+		input.RiskExceptionConfiguration = expandRiskExceptionConfigurationType(v.([]any))
 	}
 
 	_, err := conn.SetRiskConfiguration(ctx, input)
@@ -334,7 +334,7 @@ func resourceRiskConfigurationPut(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceRiskConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceRiskConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRiskConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -374,7 +374,7 @@ func resourceRiskConfigurationRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceRiskConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRiskConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -448,12 +448,12 @@ func findRiskConfigurationByTwoPartKey(ctx context.Context, conn *cognitoidentit
 	return output.RiskConfiguration, nil
 }
 
-func expandRiskExceptionConfigurationType(tfList []interface{}) *awstypes.RiskExceptionConfigurationType {
+func expandRiskExceptionConfigurationType(tfList []any) *awstypes.RiskExceptionConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.RiskExceptionConfigurationType{}
 
 	if v, ok := tfMap["blocked_ip_range_list"].(*schema.Set); ok && v.Len() > 0 {
@@ -467,12 +467,12 @@ func expandRiskExceptionConfigurationType(tfList []interface{}) *awstypes.RiskEx
 	return apiObject
 }
 
-func flattenRiskExceptionConfiguration(apiObject *awstypes.RiskExceptionConfigurationType) []interface{} {
+func flattenRiskExceptionConfiguration(apiObject *awstypes.RiskExceptionConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.BlockedIPRangeList; v != nil {
 		tfMap["blocked_ip_range_list"] = v
@@ -482,34 +482,34 @@ func flattenRiskExceptionConfiguration(apiObject *awstypes.RiskExceptionConfigur
 		tfMap["skipped_ip_range_list"] = v
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandCompromisedCredentialsRiskConfigurationType(tfList []interface{}) *awstypes.CompromisedCredentialsRiskConfigurationType {
+func expandCompromisedCredentialsRiskConfigurationType(tfList []any) *awstypes.CompromisedCredentialsRiskConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.CompromisedCredentialsRiskConfigurationType{}
 
 	if v, ok := tfMap["event_filter"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.EventFilter = flex.ExpandStringyValueSet[awstypes.EventFilterType](v)
 	}
 
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandCompromisedCredentialsActionsType(v)
 	}
 
 	return apiObject
 }
 
-func flattenCompromisedCredentialsRiskConfiguration(apiObject *awstypes.CompromisedCredentialsRiskConfigurationType) []interface{} {
+func flattenCompromisedCredentialsRiskConfiguration(apiObject *awstypes.CompromisedCredentialsRiskConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.EventFilter; v != nil {
 		tfMap["event_filter"] = v
@@ -519,15 +519,15 @@ func flattenCompromisedCredentialsRiskConfiguration(apiObject *awstypes.Compromi
 		tfMap[names.AttrActions] = flattenCompromisedCredentialsActions(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandCompromisedCredentialsActionsType(tfList []interface{}) *awstypes.CompromisedCredentialsActionsType {
+func expandCompromisedCredentialsActionsType(tfList []any) *awstypes.CompromisedCredentialsActionsType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.CompromisedCredentialsActionsType{}
 
 	if v, ok := tfMap["event_action"].(string); ok && v != "" {
@@ -537,43 +537,43 @@ func expandCompromisedCredentialsActionsType(tfList []interface{}) *awstypes.Com
 	return apiObject
 }
 
-func flattenCompromisedCredentialsActions(apiObject *awstypes.CompromisedCredentialsActionsType) []interface{} {
+func flattenCompromisedCredentialsActions(apiObject *awstypes.CompromisedCredentialsActionsType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"event_action": apiObject.EventAction,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandAccountTakeoverRiskConfigurationType(tfList []interface{}) *awstypes.AccountTakeoverRiskConfigurationType {
+func expandAccountTakeoverRiskConfigurationType(tfList []any) *awstypes.AccountTakeoverRiskConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.AccountTakeoverRiskConfigurationType{}
 
-	if v, ok := tfMap[names.AttrActions].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrActions].([]any); ok && len(v) > 0 {
 		apiObject.Actions = expandAccountTakeoverActionsType(v)
 	}
 
-	if v, ok := tfMap["notify_configuration"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["notify_configuration"].([]any); ok && len(v) > 0 {
 		apiObject.NotifyConfiguration = expandNotifyConfigurationType(v)
 	}
 
 	return apiObject
 }
 
-func flattenAccountTakeoverRiskConfigurationType(apiObject *awstypes.AccountTakeoverRiskConfigurationType) []interface{} {
+func flattenAccountTakeoverRiskConfigurationType(apiObject *awstypes.AccountTakeoverRiskConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Actions; v != nil {
 		tfMap[names.AttrActions] = flattenAccountTakeoverActionsType(v)
@@ -583,38 +583,38 @@ func flattenAccountTakeoverRiskConfigurationType(apiObject *awstypes.AccountTake
 		tfMap["notify_configuration"] = flattemNotifyConfigurationType(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandAccountTakeoverActionsType(tfList []interface{}) *awstypes.AccountTakeoverActionsType {
+func expandAccountTakeoverActionsType(tfList []any) *awstypes.AccountTakeoverActionsType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.AccountTakeoverActionsType{}
 
-	if v, ok := tfMap["high_action"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["high_action"].([]any); ok && len(v) > 0 {
 		apiObject.HighAction = expandAccountTakeoverActionType(v)
 	}
 
-	if v, ok := tfMap["low_action"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["low_action"].([]any); ok && len(v) > 0 {
 		apiObject.LowAction = expandAccountTakeoverActionType(v)
 	}
 
-	if v, ok := tfMap["medium_action"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["medium_action"].([]any); ok && len(v) > 0 {
 		apiObject.MediumAction = expandAccountTakeoverActionType(v)
 	}
 
 	return apiObject
 }
 
-func flattenAccountTakeoverActionsType(apiObject *awstypes.AccountTakeoverActionsType) []interface{} {
+func flattenAccountTakeoverActionsType(apiObject *awstypes.AccountTakeoverActionsType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.HighAction; v != nil {
 		tfMap["high_action"] = flattenAccountTakeoverActionType(v)
@@ -628,15 +628,15 @@ func flattenAccountTakeoverActionsType(apiObject *awstypes.AccountTakeoverAction
 		tfMap["medium_action"] = flattenAccountTakeoverActionType(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandAccountTakeoverActionType(tfList []interface{}) *awstypes.AccountTakeoverActionType {
+func expandAccountTakeoverActionType(tfList []any) *awstypes.AccountTakeoverActionType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.AccountTakeoverActionType{}
 
 	if v, ok := tfMap["event_action"].(string); ok && v != "" {
@@ -650,28 +650,28 @@ func expandAccountTakeoverActionType(tfList []interface{}) *awstypes.AccountTake
 	return apiObject
 }
 
-func flattenAccountTakeoverActionType(apiObject *awstypes.AccountTakeoverActionType) []interface{} {
+func flattenAccountTakeoverActionType(apiObject *awstypes.AccountTakeoverActionType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"event_action": apiObject.EventAction,
 		"notify":       apiObject.Notify,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandNotifyConfigurationType(tfList []interface{}) *awstypes.NotifyConfigurationType {
+func expandNotifyConfigurationType(tfList []any) *awstypes.NotifyConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.NotifyConfigurationType{}
 
-	if v, ok := tfMap["block_email"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["block_email"].([]any); ok && len(v) > 0 {
 		apiObject.BlockEmail = expandNotifyEmailType(v)
 	}
 
@@ -679,11 +679,11 @@ func expandNotifyConfigurationType(tfList []interface{}) *awstypes.NotifyConfigu
 		apiObject.From = aws.String(v)
 	}
 
-	if v, ok := tfMap["mfa_email"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["mfa_email"].([]any); ok && len(v) > 0 {
 		apiObject.MfaEmail = expandNotifyEmailType(v)
 	}
 
-	if v, ok := tfMap["no_action_email"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["no_action_email"].([]any); ok && len(v) > 0 {
 		apiObject.NoActionEmail = expandNotifyEmailType(v)
 	}
 
@@ -698,12 +698,12 @@ func expandNotifyConfigurationType(tfList []interface{}) *awstypes.NotifyConfigu
 	return apiObject
 }
 
-func flattemNotifyConfigurationType(apiObject *awstypes.NotifyConfigurationType) []interface{} {
+func flattemNotifyConfigurationType(apiObject *awstypes.NotifyConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.BlockEmail; v != nil {
 		tfMap["block_email"] = flattenNotifyEmailType(v)
@@ -729,15 +729,15 @@ func flattemNotifyConfigurationType(apiObject *awstypes.NotifyConfigurationType)
 		tfMap["source_arn"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandNotifyEmailType(tfList []interface{}) *awstypes.NotifyEmailType {
+func expandNotifyEmailType(tfList []any) *awstypes.NotifyEmailType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.NotifyEmailType{}
 
 	if v, ok := tfMap["html_body"].(string); ok && v != "" {
@@ -755,12 +755,12 @@ func expandNotifyEmailType(tfList []interface{}) *awstypes.NotifyEmailType {
 	return apiObject
 }
 
-func flattenNotifyEmailType(apiObject *awstypes.NotifyEmailType) []interface{} {
+func flattenNotifyEmailType(apiObject *awstypes.NotifyEmailType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.HtmlBody; v != nil {
 		tfMap["html_body"] = aws.ToString(v)
@@ -774,5 +774,5 @@ func flattenNotifyEmailType(apiObject *awstypes.NotifyEmailType) []interface{} {
 		tfMap["text_body"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/cognitoidp/user.go
+++ b/internal/service/cognitoidp/user.go
@@ -38,7 +38,7 @@ func resourceUser() *schema.Resource {
 		DeleteWithoutTimeout: resourceUserDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				parts := strings.Split(d.Id(), userResourceIDSeparator)
 
 				if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
@@ -157,7 +157,7 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -170,7 +170,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if v, ok := d.GetOk("client_metadata"); ok {
-		input.ClientMetadata = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		input.ClientMetadata = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("desired_delivery_mediums"); ok {
@@ -190,11 +190,11 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	if v, ok := d.GetOk(names.AttrAttributes); ok {
-		input.UserAttributes = expandAttributeTypes(v.(map[string]interface{}))
+		input.UserAttributes = expandAttributeTypes(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("validation_data"); ok {
-		input.ValidationData = expandAttributeTypes(v.(map[string]interface{}))
+		input.ValidationData = expandAttributeTypes(v.(map[string]any))
 	}
 
 	_, err := conn.AdminCreateUser(ctx, input)
@@ -236,7 +236,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -271,7 +271,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -279,7 +279,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 
 	if d.HasChange(names.AttrAttributes) {
 		o, n := d.GetChange(names.AttrAttributes)
-		upd, del := expandUpdateUserAttributes(o.(map[string]interface{}), n.(map[string]interface{}))
+		upd, del := expandUpdateUserAttributes(o.(map[string]any), n.(map[string]any))
 
 		if len(upd) > 0 {
 			input := &cognitoidentityprovider.AdminUpdateUserAttributesInput{
@@ -289,7 +289,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 			}
 
 			if v, ok := d.GetOk("client_metadata"); ok {
-				input.ClientMetadata = flex.ExpandStringValueMap(v.(map[string]interface{}))
+				input.ClientMetadata = flex.ExpandStringValueMap(v.(map[string]any))
 			}
 
 			_, err := conn.AdminUpdateUserAttributes(ctx, input)
@@ -381,7 +381,7 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourceUserRead(ctx, d, meta)...)
 }
 
-func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -442,7 +442,7 @@ func findUserByTwoPartKey(ctx context.Context, conn *cognitoidentityprovider.Cli
 	return output, nil
 }
 
-func expandAttributeTypes(tfMap map[string]interface{}) []awstypes.AttributeType {
+func expandAttributeTypes(tfMap map[string]any) []awstypes.AttributeType {
 	if len(tfMap) == 0 {
 		return nil
 	}
@@ -459,8 +459,8 @@ func expandAttributeTypes(tfMap map[string]interface{}) []awstypes.AttributeType
 	return apiObjects
 }
 
-func flattenAttributeTypes(apiObjects []awstypes.AttributeType) map[string]interface{} {
-	tfMap := make(map[string]interface{})
+func flattenAttributeTypes(apiObjects []awstypes.AttributeType) map[string]any {
+	tfMap := make(map[string]any)
 
 	for _, apiObject := range apiObjects {
 		if apiObject.Name != nil {
@@ -486,8 +486,8 @@ func flattenUserSub(apiObjects []awstypes.AttributeType) *string {
 	return nil
 }
 
-func expandUpdateUserAttributes(oldMap, newMap map[string]interface{}) (map[string]interface{}, []string) {
-	upd := make(map[string]interface{})
+func expandUpdateUserAttributes(oldMap, newMap map[string]any) (map[string]any, []string) {
+	upd := make(map[string]any)
 
 	for k, v := range newMap {
 		if old, ok := oldMap[k]; ok {

--- a/internal/service/cognitoidp/user_group.go
+++ b/internal/service/cognitoidp/user_group.go
@@ -68,7 +68,7 @@ func resourceUserGroup() *schema.Resource {
 	}
 }
 
-func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -101,7 +101,7 @@ func resourceUserGroupCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceUserGroupRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -131,7 +131,7 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -166,7 +166,7 @@ func resourceUserGroupUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceUserGroupRead(ctx, d, meta)...)
 }
 
-func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/user_in_group.go
+++ b/internal/service/cognitoidp/user_in_group.go
@@ -51,7 +51,7 @@ func resourceUserInGroup() *schema.Resource {
 	}
 }
 
-func resourceUserInGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserInGroupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -81,7 +81,7 @@ func resourceUserInGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceUserInGroupRead(ctx, d, meta)...)
 }
 
-func resourceUserInGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserInGroupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -100,7 +100,7 @@ func resourceUserInGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceUserInGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserInGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -714,7 +714,7 @@ func resourceUserPool() *schema.Resource {
 	}
 }
 
-func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -725,13 +725,13 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("account_recovery_setting"); ok {
-		if config, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+		if config, ok := v.([]any)[0].(map[string]any); ok {
 			input.AccountRecoverySetting = expandAccountRecoverySettingType(config)
 		}
 	}
 
 	if v, ok := d.GetOk("admin_create_user_config"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.AdminCreateUserConfig = expandAdminCreateUserConfigType(v)
 		}
 	}
@@ -749,13 +749,13 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("device_configuration"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.DeviceConfiguration = expandDeviceConfigurationType(v)
 		}
 	}
 
-	if v, ok := d.GetOk("email_configuration"); ok && len(v.([]interface{})) > 0 {
-		input.EmailConfiguration = expandEmailConfigurationType(v.([]interface{}))
+	if v, ok := d.GetOk("email_configuration"); ok && len(v.([]any)) > 0 {
+		input.EmailConfiguration = expandEmailConfigurationType(v.([]any))
 	}
 
 	if v, ok := d.GetOk("email_verification_subject"); ok {
@@ -767,13 +767,13 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("lambda_config"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.LambdaConfig = expandLambdaConfigType(v)
 		}
 	}
 
 	if v, ok := d.GetOk("password_policy"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			passwordPolicy := expandPasswordPolicyType(v)
 			if input.Policies == nil {
 				input.Policies = &awstypes.UserPoolPolicyType{}
@@ -787,7 +787,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("sign_in_policy"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			signInPolicy := expandSignInPolicyType(v)
 			if input.Policies == nil {
 				input.Policies = &awstypes.UserPoolPolicyType{}
@@ -805,7 +805,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	// Include the SMS configuration outside of MFA configuration since it
 	// can be used for user verification.
 	if v, ok := d.GetOk("sms_configuration"); ok {
-		input.SmsConfiguration = expandSMSConfigurationType(v.([]interface{}))
+		input.SmsConfiguration = expandSMSConfigurationType(v.([]any))
 	}
 
 	if v, ok := d.GetOk("sms_verification_message"); ok {
@@ -817,19 +817,19 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("username_configuration"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.UsernameConfiguration = expandUsernameConfigurationType(v)
 		}
 	}
 
 	if v, ok := d.GetOk("user_attribute_update_settings"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.UserAttributeUpdateSettings = expandUserAttributeUpdateSettingsType(v)
 		}
 	}
 
 	if v, ok := d.GetOk("user_pool_add_ons"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.UserPoolAddOns = &awstypes.UserPoolAddOnsType{}
 
 			if v, ok := v["advanced_security_mode"]; ok && v.(string) != "" {
@@ -839,7 +839,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	if v, ok := d.GetOk("verification_message_template"); ok {
-		if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+		if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 			input.VerificationMessageTemplate = expandVerificationMessageTemplateType(v)
 		}
 	}
@@ -858,21 +858,21 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 
 	d.SetId(aws.ToString(outputRaw.(*cognitoidentityprovider.CreateUserPoolOutput).UserPool.Id))
 
-	if mfaConfig := awstypes.UserPoolMfaType(d.Get("mfa_configuration").(string)); mfaConfig != awstypes.UserPoolMfaTypeOff || len(d.Get("web_authn_configuration").([]interface{})) > 0 {
+	if mfaConfig := awstypes.UserPoolMfaType(d.Get("mfa_configuration").(string)); mfaConfig != awstypes.UserPoolMfaTypeOff || len(d.Get("web_authn_configuration").([]any)) > 0 {
 		input := &cognitoidentityprovider.SetUserPoolMfaConfigInput{
 			UserPoolId: aws.String(d.Id()),
 		}
 
 		if mfaConfig != awstypes.UserPoolMfaTypeOff {
 			input.MfaConfiguration = mfaConfig
-			input.SoftwareTokenMfaConfiguration = expandSoftwareTokenMFAConfigType(d.Get("software_token_mfa_configuration").([]interface{}))
+			input.SoftwareTokenMfaConfiguration = expandSoftwareTokenMFAConfigType(d.Get("software_token_mfa_configuration").([]any))
 		}
 
-		if v := d.Get("email_mfa_configuration").([]interface{}); len(v) > 0 && v[0] != nil {
+		if v := d.Get("email_mfa_configuration").([]any); len(v) > 0 && v[0] != nil {
 			input.EmailMfaConfiguration = expandEmailMFAConfigType(v)
 		}
 
-		if v := d.Get("sms_configuration").([]interface{}); len(v) > 0 && v[0] != nil {
+		if v := d.Get("sms_configuration").([]any); len(v) > 0 && v[0] != nil {
 			input.SmsMfaConfiguration = &awstypes.SmsMfaConfigType{
 				SmsConfiguration: expandSMSConfigurationType(v),
 			}
@@ -882,7 +882,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
-		if webAuthnConfig := d.Get("web_authn_configuration").([]interface{}); len(webAuthnConfig) > 0 {
+		if webAuthnConfig := d.Get("web_authn_configuration").([]any); len(webAuthnConfig) > 0 {
 			input.WebAuthnConfiguration = expandWebAuthnConfigurationConfigType(webAuthnConfig)
 		}
 
@@ -898,7 +898,7 @@ func resourceUserPoolCreate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceUserPoolRead(ctx, d, meta)...)
 }
 
-func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -947,7 +947,7 @@ func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("password_policy", flattenPasswordPolicyType(userPool.Policies.PasswordPolicy)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting password_policy: %s", err)
 	}
-	var configuredSchema []interface{}
+	var configuredSchema []any
 	if v, ok := d.GetOk(names.AttrSchema); ok {
 		configuredSchema = v.(*schema.Set).List()
 	}
@@ -999,7 +999,7 @@ func resourceUserPoolRead(ctx context.Context, d *schema.ResourceData, meta inte
 	return diags
 }
 
-func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -1015,16 +1015,16 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		mfaConfiguration := awstypes.UserPoolMfaType(d.Get("mfa_configuration").(string))
 		input := &cognitoidentityprovider.SetUserPoolMfaConfigInput{
 			MfaConfiguration:              mfaConfiguration,
-			EmailMfaConfiguration:         expandEmailMFAConfigType(d.Get("email_mfa_configuration").([]interface{})),
-			SoftwareTokenMfaConfiguration: expandSoftwareTokenMFAConfigType(d.Get("software_token_mfa_configuration").([]interface{})),
+			EmailMfaConfiguration:         expandEmailMFAConfigType(d.Get("email_mfa_configuration").([]any)),
+			SoftwareTokenMfaConfiguration: expandSoftwareTokenMFAConfigType(d.Get("software_token_mfa_configuration").([]any)),
 			UserPoolId:                    aws.String(d.Id()),
-			WebAuthnConfiguration:         expandWebAuthnConfigurationConfigType(d.Get("web_authn_configuration").([]interface{})),
+			WebAuthnConfiguration:         expandWebAuthnConfigurationConfigType(d.Get("web_authn_configuration").([]any)),
 		}
 
 		// Since SMS configuration applies to both verification and MFA, only include if MFA is enabled.
 		// Otherwise, the API will return the following error:
 		// InvalidParameterException: Invalid MFA configuration given, can't turn off MFA and configure an MFA together.
-		if v := d.Get("sms_configuration").([]interface{}); len(v) > 0 && v[0] != nil && mfaConfiguration != awstypes.UserPoolMfaTypeOff {
+		if v := d.Get("sms_configuration").([]any); len(v) > 0 && v[0] != nil && mfaConfiguration != awstypes.UserPoolMfaTypeOff {
 			input.SmsMfaConfiguration = &awstypes.SmsMfaConfigType{
 				SmsConfiguration: expandSMSConfigurationType(v),
 			}
@@ -1077,13 +1077,13 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("account_recovery_setting"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok {
+			if v, ok := v.([]any)[0].(map[string]any); ok {
 				input.AccountRecoverySetting = expandAccountRecoverySettingType(v)
 			}
 		}
 
 		if v, ok := d.GetOk("admin_create_user_config"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				input.AdminCreateUserConfig = expandAdminCreateUserConfigType(v)
 			}
 		}
@@ -1097,13 +1097,13 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("device_configuration"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				input.DeviceConfiguration = expandDeviceConfigurationType(v)
 			}
 		}
 
-		if v, ok := d.GetOk("email_configuration"); ok && len(v.([]interface{})) > 0 {
-			input.EmailConfiguration = expandEmailConfigurationType(v.([]interface{}))
+		if v, ok := d.GetOk("email_configuration"); ok && len(v.([]any)) > 0 {
+			input.EmailConfiguration = expandEmailConfigurationType(v.([]any))
 		}
 
 		if v, ok := d.GetOk("email_verification_subject"); ok {
@@ -1115,13 +1115,13 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("lambda_config"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				if d.HasChange("lambda_config.0.pre_token_generation") {
 					preTokenGeneration := d.Get("lambda_config.0.pre_token_generation")
-					if tfList, ok := v["pre_token_generation_config"].([]interface{}); ok && len(tfList) > 0 && tfList[0] != nil {
-						v["pre_token_generation_config"].([]interface{})[0].(map[string]interface{})["lambda_arn"] = preTokenGeneration
+					if tfList, ok := v["pre_token_generation_config"].([]any); ok && len(tfList) > 0 && tfList[0] != nil {
+						v["pre_token_generation_config"].([]any)[0].(map[string]any)["lambda_arn"] = preTokenGeneration
 					} else {
-						v["pre_token_generation_config"] = []interface{}{map[string]interface{}{
+						v["pre_token_generation_config"] = []any{map[string]any{
 							"lambda_arn":     preTokenGeneration,
 							"lambda_version": string(awstypes.PreTokenGenerationLambdaVersionTypeV10), // A guess...
 						}}
@@ -1141,7 +1141,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("password_policy"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				passwordPolicy := expandPasswordPolicyType(v)
 				if input.Policies == nil {
 					input.Policies = &awstypes.UserPoolPolicyType{}
@@ -1151,7 +1151,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("sign_in_policy"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				signInPolicy := expandSignInPolicyType(v)
 				if input.Policies == nil {
 					input.Policies = &awstypes.UserPoolPolicyType{}
@@ -1165,7 +1165,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("sms_configuration"); ok {
-			input.SmsConfiguration = expandSMSConfigurationType(v.([]interface{}))
+			input.SmsConfiguration = expandSMSConfigurationType(v.([]any))
 		}
 
 		if v, ok := d.GetOk("sms_verification_message"); ok {
@@ -1173,7 +1173,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("user_attribute_update_settings"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				input.UserAttributeUpdateSettings = expandUserAttributeUpdateSettingsType(v)
 			}
 		}
@@ -1186,7 +1186,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("user_pool_add_ons"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				input.UserPoolAddOns = &awstypes.UserPoolAddOnsType{}
 
 				if v, ok := v["advanced_security_mode"]; ok && v.(string) != "" {
@@ -1196,7 +1196,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if v, ok := d.GetOk("verification_message_template"); ok {
-			if v, ok := v.([]interface{})[0].(map[string]interface{}); ok && v != nil {
+			if v, ok := v.([]any)[0].(map[string]any); ok && v != nil {
 				if d.HasChange("email_verification_message") {
 					v["email_message"] = d.Get("email_verification_message")
 				}
@@ -1262,7 +1262,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceUserPoolRead(ctx, d, meta)...)
 }
 
-func resourceUserPoolDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -1345,12 +1345,12 @@ func findUserPoolMFAConfigByID(ctx context.Context, conn *cognitoidentityprovide
 	return output, nil
 }
 
-func expandEmailMFAConfigType(tfList []interface{}) *awstypes.EmailMfaConfigType {
+func expandEmailMFAConfigType(tfList []any) *awstypes.EmailMfaConfigType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.EmailMfaConfigType{}
 
 	if v, ok := tfMap[names.AttrMessage].(string); ok && v != "" {
@@ -1364,12 +1364,12 @@ func expandEmailMFAConfigType(tfList []interface{}) *awstypes.EmailMfaConfigType
 	return apiObject
 }
 
-func expandSMSConfigurationType(tfList []interface{}) *awstypes.SmsConfigurationType {
+func expandSMSConfigurationType(tfList []any) *awstypes.SmsConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.SmsConfigurationType{}
 
 	if v, ok := tfMap[names.AttrExternalID].(string); ok && v != "" {
@@ -1387,12 +1387,12 @@ func expandSMSConfigurationType(tfList []interface{}) *awstypes.SmsConfiguration
 	return apiObject
 }
 
-func expandSoftwareTokenMFAConfigType(tfList []interface{}) *awstypes.SoftwareTokenMfaConfigType {
+func expandSoftwareTokenMFAConfigType(tfList []any) *awstypes.SoftwareTokenMfaConfigType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.SoftwareTokenMfaConfigType{}
 
 	if v, ok := tfMap[names.AttrEnabled].(bool); ok {
@@ -1402,12 +1402,12 @@ func expandSoftwareTokenMFAConfigType(tfList []interface{}) *awstypes.SoftwareTo
 	return apiObject
 }
 
-func expandWebAuthnConfigurationConfigType(tfList []interface{}) *awstypes.WebAuthnConfigurationType {
+func expandWebAuthnConfigurationConfigType(tfList []any) *awstypes.WebAuthnConfigurationType {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 
 	apiObject := &awstypes.WebAuthnConfigurationType{}
 
@@ -1422,12 +1422,12 @@ func expandWebAuthnConfigurationConfigType(tfList []interface{}) *awstypes.WebAu
 	return apiObject
 }
 
-func flattenSMSConfigurationType(apiObject *awstypes.SmsConfigurationType) []interface{} {
+func flattenSMSConfigurationType(apiObject *awstypes.SmsConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.ExternalId; v != nil {
 		tfMap[names.AttrExternalID] = aws.ToString(v)
@@ -1441,15 +1441,15 @@ func flattenSMSConfigurationType(apiObject *awstypes.SmsConfigurationType) []int
 		tfMap["sns_region"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenEmailMFAConfigType(apiObject *awstypes.EmailMfaConfigType) []interface{} {
+func flattenEmailMFAConfigType(apiObject *awstypes.EmailMfaConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.Message; v != nil {
 		tfMap[names.AttrMessage] = aws.ToString(v)
@@ -1459,27 +1459,27 @@ func flattenEmailMFAConfigType(apiObject *awstypes.EmailMfaConfigType) []interfa
 		tfMap["subject"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenSoftwareTokenMFAConfigType(apiObject *awstypes.SoftwareTokenMfaConfigType) []interface{} {
+func flattenSoftwareTokenMFAConfigType(apiObject *awstypes.SoftwareTokenMfaConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrEnabled: apiObject.Enabled,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenWebAuthnConfigType(apiObject *awstypes.WebAuthnConfigurationType) []interface{} {
+func flattenWebAuthnConfigType(apiObject *awstypes.WebAuthnConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"user_verification": apiObject.UserVerification,
 	}
 
@@ -1487,10 +1487,10 @@ func flattenWebAuthnConfigType(apiObject *awstypes.WebAuthnConfigurationType) []
 		tfMap["relying_party_id"] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandAccountRecoverySettingType(tfMap map[string]interface{}) *awstypes.AccountRecoverySettingType {
+func expandAccountRecoverySettingType(tfMap map[string]any) *awstypes.AccountRecoverySettingType {
 	if len(tfMap) == 0 {
 		return nil
 	}
@@ -1499,7 +1499,7 @@ func expandAccountRecoverySettingType(tfMap map[string]interface{}) *awstypes.Ac
 
 	if v, ok := tfMap["recovery_mechanism"]; ok {
 		for _, tfMapRaw := range v.(*schema.Set).List() {
-			tfMap := tfMapRaw.(map[string]interface{})
+			tfMap := tfMapRaw.(map[string]any)
 			apiObject := awstypes.RecoveryOptionType{}
 
 			if v, ok := tfMap[names.AttrName]; ok {
@@ -1521,15 +1521,15 @@ func expandAccountRecoverySettingType(tfMap map[string]interface{}) *awstypes.Ac
 	return apiObject
 }
 
-func flattenAccountRecoverySettingType(apiObject *awstypes.AccountRecoverySettingType) []interface{} {
+func flattenAccountRecoverySettingType(apiObject *awstypes.AccountRecoverySettingType) []any {
 	if apiObject == nil || len(apiObject.RecoveryMechanisms) == 0 {
 		return nil
 	}
 
-	tfList := make([]map[string]interface{}, 0)
+	tfList := make([]map[string]any, 0)
 
 	for _, apiObject := range apiObject.RecoveryMechanisms {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrName:     apiObject.Name,
 			names.AttrPriority: aws.ToInt32(apiObject.Priority),
 		}
@@ -1537,19 +1537,19 @@ func flattenAccountRecoverySettingType(apiObject *awstypes.AccountRecoverySettin
 		tfList = append(tfList, tfMap)
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"recovery_mechanism": tfList,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenEmailConfigurationType(apiObject *awstypes.EmailConfigurationType) []interface{} {
+func flattenEmailConfigurationType(apiObject *awstypes.EmailConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.ConfigurationSet != nil {
 		tfMap["configuration_set"] = aws.ToString(apiObject.ConfigurationSet)
@@ -1570,13 +1570,13 @@ func flattenEmailConfigurationType(apiObject *awstypes.EmailConfigurationType) [
 	}
 
 	if len(tfMap) > 0 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandAdminCreateUserConfigType(tfMap map[string]interface{}) *awstypes.AdminCreateUserConfigType {
+func expandAdminCreateUserConfigType(tfMap map[string]any) *awstypes.AdminCreateUserConfigType {
 	apiObject := &awstypes.AdminCreateUserConfigType{}
 
 	if v, ok := tfMap["allow_admin_create_user_only"]; ok {
@@ -1584,8 +1584,8 @@ func expandAdminCreateUserConfigType(tfMap map[string]interface{}) *awstypes.Adm
 	}
 
 	if v, ok := tfMap["invite_message_template"]; ok {
-		if tfList := v.([]interface{}); len(tfList) > 0 {
-			if tfMap, ok := tfList[0].(map[string]interface{}); ok {
+		if tfList := v.([]any); len(tfList) > 0 {
+			if tfMap, ok := tfList[0].(map[string]any); ok {
 				imt := &awstypes.MessageTemplateType{}
 
 				if v, ok := tfMap["email_message"]; ok {
@@ -1608,17 +1608,17 @@ func expandAdminCreateUserConfigType(tfMap map[string]interface{}) *awstypes.Adm
 	return apiObject
 }
 
-func flattenAdminCreateUserConfigType(apiObject *awstypes.AdminCreateUserConfigType) []interface{} {
+func flattenAdminCreateUserConfigType(apiObject *awstypes.AdminCreateUserConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"allow_admin_create_user_only": apiObject.AllowAdminCreateUserOnly,
 	}
 
 	if apiObject := apiObject.InviteMessageTemplate; apiObject != nil {
-		imt := map[string]interface{}{}
+		imt := map[string]any{}
 
 		if apiObject.EmailMessage != nil {
 			imt["email_message"] = aws.ToString(apiObject.EmailMessage)
@@ -1633,14 +1633,14 @@ func flattenAdminCreateUserConfigType(apiObject *awstypes.AdminCreateUserConfigT
 		}
 
 		if len(imt) > 0 {
-			tfMap["invite_message_template"] = []map[string]interface{}{imt}
+			tfMap["invite_message_template"] = []map[string]any{imt}
 		}
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandDeviceConfigurationType(tfMap map[string]interface{}) *awstypes.DeviceConfigurationType {
+func expandDeviceConfigurationType(tfMap map[string]any) *awstypes.DeviceConfigurationType {
 	apiObject := &awstypes.DeviceConfigurationType{}
 
 	if v, ok := tfMap["challenge_required_on_new_device"]; ok {
@@ -1654,15 +1654,15 @@ func expandDeviceConfigurationType(tfMap map[string]interface{}) *awstypes.Devic
 	return apiObject
 }
 
-func expandLambdaConfigType(tfMap map[string]interface{}) *awstypes.LambdaConfigType {
+func expandLambdaConfigType(tfMap map[string]any) *awstypes.LambdaConfigType {
 	apiObject := &awstypes.LambdaConfigType{}
 
 	if v, ok := tfMap["create_auth_challenge"]; ok && v.(string) != "" {
 		apiObject.CreateAuthChallenge = aws.String(v.(string))
 	}
 
-	if v, ok := tfMap["custom_email_sender"].([]interface{}); ok && len(v) > 0 {
-		if v, ok := v[0].(map[string]interface{}); ok && v != nil {
+	if v, ok := tfMap["custom_email_sender"].([]any); ok && len(v) > 0 {
+		if v, ok := v[0].(map[string]any); ok && v != nil {
 			apiObject.CustomEmailSender = expandCustomEmailLambdaVersionConfigType(v)
 		}
 	}
@@ -1671,8 +1671,8 @@ func expandLambdaConfigType(tfMap map[string]interface{}) *awstypes.LambdaConfig
 		apiObject.CustomMessage = aws.String(v.(string))
 	}
 
-	if v, ok := tfMap["custom_sms_sender"].([]interface{}); ok && len(v) > 0 {
-		if v, ok := v[0].(map[string]interface{}); ok && v != nil {
+	if v, ok := tfMap["custom_sms_sender"].([]any); ok && len(v) > 0 {
+		if v, ok := v[0].(map[string]any); ok && v != nil {
 			apiObject.CustomSMSSender = expandCustomSMSLambdaVersionConfigType(v)
 		}
 	}
@@ -1705,8 +1705,8 @@ func expandLambdaConfigType(tfMap map[string]interface{}) *awstypes.LambdaConfig
 		apiObject.PreTokenGeneration = aws.String(v.(string))
 	}
 
-	if v, ok := tfMap["pre_token_generation_config"].([]interface{}); ok && len(v) > 0 {
-		if v, ok := v[0].(map[string]interface{}); ok && v != nil {
+	if v, ok := tfMap["pre_token_generation_config"].([]any); ok && len(v) > 0 {
+		if v, ok := v[0].(map[string]any); ok && v != nil {
 			apiObject.PreTokenGenerationConfig = expandPreTokenGenerationVersionConfigType(v)
 		}
 	}
@@ -1722,12 +1722,12 @@ func expandLambdaConfigType(tfMap map[string]interface{}) *awstypes.LambdaConfig
 	return apiObject
 }
 
-func flattenLambdaConfigType(apiObject *awstypes.LambdaConfigType) []interface{} {
+func flattenLambdaConfigType(apiObject *awstypes.LambdaConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.CreateAuthChallenge != nil {
 		tfMap["create_auth_challenge"] = aws.ToString(apiObject.CreateAuthChallenge)
@@ -1786,13 +1786,13 @@ func flattenLambdaConfigType(apiObject *awstypes.LambdaConfigType) []interface{}
 	}
 
 	if len(tfMap) > 0 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandPasswordPolicyType(tfMap map[string]interface{}) *awstypes.PasswordPolicyType {
+func expandPasswordPolicyType(tfMap map[string]any) *awstypes.PasswordPolicyType {
 	apiObject := &awstypes.PasswordPolicyType{}
 
 	if v, ok := tfMap["minimum_length"]; ok {
@@ -1826,7 +1826,7 @@ func expandPasswordPolicyType(tfMap map[string]interface{}) *awstypes.PasswordPo
 	return apiObject
 }
 
-func expandSignInPolicyType(tfMap map[string]interface{}) *awstypes.SignInPolicyType {
+func expandSignInPolicyType(tfMap map[string]any) *awstypes.SignInPolicyType {
 	apiObject := &awstypes.SignInPolicyType{}
 
 	if v, ok := tfMap["allowed_first_auth_factors"]; ok {
@@ -1836,23 +1836,23 @@ func expandSignInPolicyType(tfMap map[string]interface{}) *awstypes.SignInPolicy
 	return apiObject
 }
 
-func flattenUserPoolAddOnsType(apiObject *awstypes.UserPoolAddOnsType) []interface{} {
+func flattenUserPoolAddOnsType(apiObject *awstypes.UserPoolAddOnsType) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	tfMap["advanced_security_mode"] = apiObject.AdvancedSecurityMode
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandSchemaAttributeTypes(tfList []interface{}) []awstypes.SchemaAttributeType {
+func expandSchemaAttributeTypes(tfList []any) []awstypes.SchemaAttributeType {
 	apiObjects := make([]awstypes.SchemaAttributeType, len(tfList))
 
 	for i, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.SchemaAttributeType{}
 
 		if v, ok := tfMap["attribute_data_type"]; ok {
@@ -1872,8 +1872,8 @@ func expandSchemaAttributeTypes(tfList []interface{}) []awstypes.SchemaAttribute
 		}
 
 		if v, ok := tfMap["number_attribute_constraints"]; ok {
-			if tfList := v.([]interface{}); len(tfList) > 0 {
-				if tfMap, ok := tfList[0].(map[string]interface{}); ok {
+			if tfList := v.([]any); len(tfList) > 0 {
+				if tfMap, ok := tfList[0].(map[string]any); ok {
 					nact := &awstypes.NumberAttributeConstraintsType{}
 
 					if v, ok := tfMap["max_value"]; ok && v.(string) != "" {
@@ -1894,8 +1894,8 @@ func expandSchemaAttributeTypes(tfList []interface{}) []awstypes.SchemaAttribute
 		}
 
 		if v, ok := tfMap["string_attribute_constraints"]; ok {
-			if tfList := v.([]interface{}); len(tfList) > 0 {
-				if tfMap, ok := tfList[0].(map[string]interface{}); ok {
+			if tfList := v.([]any); len(tfList) > 0 {
+				if tfMap, ok := tfList[0].(map[string]any); ok {
 					sact := &awstypes.StringAttributeConstraintsType{}
 
 					if v, ok := tfMap["max_length"]; ok && v.(string) != "" {
@@ -1921,8 +1921,8 @@ func expandSchemaAttributeTypes(tfList []interface{}) []awstypes.SchemaAttribute
 	return apiObjects
 }
 
-func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.SchemaAttributeType) []interface{} {
-	tfList := make([]interface{}, 0)
+func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.SchemaAttributeType) []any {
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
 		// The API returns all standard attributes
@@ -1956,7 +1956,7 @@ func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.Sch
 			}
 		}
 
-		var tfMap = map[string]interface{}{
+		var tfMap = map[string]any{
 			"attribute_data_type":      apiObject.AttributeDataType,
 			"developer_only_attribute": aws.ToBool(apiObject.DeveloperOnlyAttribute),
 			"mutable":                  aws.ToBool(apiObject.Mutable),
@@ -1965,7 +1965,7 @@ func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.Sch
 		}
 
 		if apiObject.NumberAttributeConstraints != nil {
-			nact := make(map[string]interface{})
+			nact := make(map[string]any)
 
 			if apiObject.NumberAttributeConstraints.MaxValue != nil {
 				nact["max_value"] = aws.ToString(apiObject.NumberAttributeConstraints.MaxValue)
@@ -1975,11 +1975,11 @@ func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.Sch
 				nact["min_value"] = aws.ToString(apiObject.NumberAttributeConstraints.MinValue)
 			}
 
-			tfMap["number_attribute_constraints"] = []interface{}{nact}
+			tfMap["number_attribute_constraints"] = []any{nact}
 		}
 
 		if apiObject.StringAttributeConstraints != nil && !skipFlatteningStringAttributeContraints(configuredAttributes, &apiObject) {
-			sact := make(map[string]interface{})
+			sact := make(map[string]any)
 
 			if apiObject.StringAttributeConstraints.MaxLength != nil {
 				sact["max_length"] = aws.ToString(apiObject.StringAttributeConstraints.MaxLength)
@@ -1989,7 +1989,7 @@ func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.Sch
 				sact["min_length"] = aws.ToString(apiObject.StringAttributeConstraints.MinLength)
 			}
 
-			tfMap["string_attribute_constraints"] = []interface{}{sact}
+			tfMap["string_attribute_constraints"] = []any{sact}
 		}
 
 		tfList = append(tfList, tfMap)
@@ -1998,7 +1998,7 @@ func flattenSchemaAttributeTypes(configuredAttributes, apiObjects []awstypes.Sch
 	return tfList
 }
 
-func expandUsernameConfigurationType(tfMap map[string]interface{}) *awstypes.UsernameConfigurationType {
+func expandUsernameConfigurationType(tfMap map[string]any) *awstypes.UsernameConfigurationType {
 	apiObject := &awstypes.UsernameConfigurationType{
 		CaseSensitive: aws.Bool(tfMap["case_sensitive"].(bool)),
 	}
@@ -2006,19 +2006,19 @@ func expandUsernameConfigurationType(tfMap map[string]interface{}) *awstypes.Use
 	return apiObject
 }
 
-func flattenUsernameConfigurationType(apiObject *awstypes.UsernameConfigurationType) []interface{} {
+func flattenUsernameConfigurationType(apiObject *awstypes.UsernameConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["case_sensitive"] = aws.ToBool(apiObject.CaseSensitive)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandVerificationMessageTemplateType(tfMap map[string]interface{}) *awstypes.VerificationMessageTemplateType {
+func expandVerificationMessageTemplateType(tfMap map[string]any) *awstypes.VerificationMessageTemplateType {
 	apiObject := &awstypes.VerificationMessageTemplateType{}
 
 	if v, ok := tfMap["default_email_option"]; ok && v.(string) != "" {
@@ -2048,12 +2048,12 @@ func expandVerificationMessageTemplateType(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func flattenVerificationMessageTemplateType(apiObject *awstypes.VerificationMessageTemplateType) []interface{} {
+func flattenVerificationMessageTemplateType(apiObject *awstypes.VerificationMessageTemplateType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"default_email_option": apiObject.DefaultEmailOption,
 	}
 
@@ -2078,31 +2078,31 @@ func flattenVerificationMessageTemplateType(apiObject *awstypes.VerificationMess
 	}
 
 	if len(tfMap) > 0 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func flattenDeviceConfigurationType(apiObject *awstypes.DeviceConfigurationType) []interface{} {
+func flattenDeviceConfigurationType(apiObject *awstypes.DeviceConfigurationType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"challenge_required_on_new_device":      apiObject.ChallengeRequiredOnNewDevice,
 		"device_only_remembered_on_user_prompt": apiObject.DeviceOnlyRememberedOnUserPrompt,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenPasswordPolicyType(apiObject *awstypes.PasswordPolicyType) []interface{} {
+func flattenPasswordPolicyType(apiObject *awstypes.PasswordPolicyType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"require_lowercase":                apiObject.RequireLowercase,
 		"require_numbers":                  apiObject.RequireNumbers,
 		"require_symbols":                  apiObject.RequireSymbols,
@@ -2119,29 +2119,29 @@ func flattenPasswordPolicyType(apiObject *awstypes.PasswordPolicyType) []interfa
 	}
 
 	if len(tfMap) > 0 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func flattenSignInPolicyType(apiObject *awstypes.SignInPolicyType) []interface{} {
+func flattenSignInPolicyType(apiObject *awstypes.SignInPolicyType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"allowed_first_auth_factors": apiObject.AllowedFirstAuthFactors,
 	}
 
 	if len(tfMap) > 0 {
-		return []interface{}{tfMap}
+		return []any{tfMap}
 	}
 
-	return []interface{}{}
+	return []any{}
 }
 
-func expandPreTokenGenerationVersionConfigType(tfMap map[string]interface{}) *awstypes.PreTokenGenerationVersionConfigType {
+func expandPreTokenGenerationVersionConfigType(tfMap map[string]any) *awstypes.PreTokenGenerationVersionConfigType {
 	apiObject := &awstypes.PreTokenGenerationVersionConfigType{
 		LambdaArn:     aws.String(tfMap["lambda_arn"].(string)),
 		LambdaVersion: awstypes.PreTokenGenerationLambdaVersionType(tfMap["lambda_version"].(string)),
@@ -2150,20 +2150,20 @@ func expandPreTokenGenerationVersionConfigType(tfMap map[string]interface{}) *aw
 	return apiObject
 }
 
-func flattenPreTokenGenerationVersionConfigType(apiObject *awstypes.PreTokenGenerationVersionConfigType) []interface{} {
+func flattenPreTokenGenerationVersionConfigType(apiObject *awstypes.PreTokenGenerationVersionConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["lambda_arn"] = aws.ToString(apiObject.LambdaArn)
 	tfMap["lambda_version"] = apiObject.LambdaVersion
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandCustomSMSLambdaVersionConfigType(tfMap map[string]interface{}) *awstypes.CustomSMSLambdaVersionConfigType {
+func expandCustomSMSLambdaVersionConfigType(tfMap map[string]any) *awstypes.CustomSMSLambdaVersionConfigType {
 	apiObject := &awstypes.CustomSMSLambdaVersionConfigType{
 		LambdaArn:     aws.String(tfMap["lambda_arn"].(string)),
 		LambdaVersion: awstypes.CustomSMSSenderLambdaVersionType(tfMap["lambda_version"].(string)),
@@ -2172,20 +2172,20 @@ func expandCustomSMSLambdaVersionConfigType(tfMap map[string]interface{}) *awsty
 	return apiObject
 }
 
-func flattenCustomSMSLambdaVersionConfigType(apiObject *awstypes.CustomSMSLambdaVersionConfigType) []interface{} {
+func flattenCustomSMSLambdaVersionConfigType(apiObject *awstypes.CustomSMSLambdaVersionConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["lambda_arn"] = aws.ToString(apiObject.LambdaArn)
 	tfMap["lambda_version"] = apiObject.LambdaVersion
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandCustomEmailLambdaVersionConfigType(tfMap map[string]interface{}) *awstypes.CustomEmailLambdaVersionConfigType {
+func expandCustomEmailLambdaVersionConfigType(tfMap map[string]any) *awstypes.CustomEmailLambdaVersionConfigType {
 	apiObject := &awstypes.CustomEmailLambdaVersionConfigType{
 		LambdaArn:     aws.String(tfMap["lambda_arn"].(string)),
 		LambdaVersion: awstypes.CustomEmailSenderLambdaVersionType(tfMap["lambda_version"].(string)),
@@ -2194,21 +2194,21 @@ func expandCustomEmailLambdaVersionConfigType(tfMap map[string]interface{}) *aws
 	return apiObject
 }
 
-func flattenCustomEmailLambdaVersionConfigType(apiObject *awstypes.CustomEmailLambdaVersionConfigType) []interface{} {
+func flattenCustomEmailLambdaVersionConfigType(apiObject *awstypes.CustomEmailLambdaVersionConfigType) []any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap["lambda_arn"] = aws.ToString(apiObject.LambdaArn)
 	tfMap["lambda_version"] = apiObject.LambdaVersion
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func expandEmailConfigurationType(tfList []interface{}) *awstypes.EmailConfigurationType {
-	tfMap := tfList[0].(map[string]interface{})
+func expandEmailConfigurationType(tfList []any) *awstypes.EmailConfigurationType {
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.EmailConfigurationType{}
 
 	if v, ok := tfMap["configuration_set"]; ok && v.(string) != "" {
@@ -2234,7 +2234,7 @@ func expandEmailConfigurationType(tfList []interface{}) *awstypes.EmailConfigura
 	return apiObject
 }
 
-func expandUserAttributeUpdateSettingsType(tfMap map[string]interface{}) *awstypes.UserAttributeUpdateSettingsType {
+func expandUserAttributeUpdateSettingsType(tfMap map[string]any) *awstypes.UserAttributeUpdateSettingsType {
 	apiObject := &awstypes.UserAttributeUpdateSettingsType{}
 
 	if v, ok := tfMap["attributes_require_verification_before_update"]; ok {
@@ -2244,7 +2244,7 @@ func expandUserAttributeUpdateSettingsType(tfMap map[string]interface{}) *awstyp
 	return apiObject
 }
 
-func flattenUserAttributeUpdateSettingsType(apiObject *awstypes.UserAttributeUpdateSettingsType) []interface{} {
+func flattenUserAttributeUpdateSettingsType(apiObject *awstypes.UserAttributeUpdateSettingsType) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -2254,10 +2254,10 @@ func flattenUserAttributeUpdateSettingsType(apiObject *awstypes.UserAttributeUpd
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 	tfMap["attributes_require_verification_before_update"] = apiObject.AttributesRequireVerificationBeforeUpdate
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 // skipFlatteningStringAttributeContraints returns true when all of the schema arguments

--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -444,7 +444,7 @@ func (r *userPoolClientResource) Update(ctx context.Context, request resource.Up
 	const (
 		timeout = 2 * time.Minute
 	)
-	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (interface{}, error) {
+	output, err := tfresource.RetryWhenIsA[*awstypes.ConcurrentModificationException](ctx, timeout, func() (any, error) {
 		return conn.UpdateUserPoolClient(ctx, &input)
 	})
 	if err != nil {
@@ -479,7 +479,7 @@ func (r *userPoolClientResource) Delete(ctx context.Context, request resource.De
 
 	params := state.deleteInput(ctx)
 
-	tflog.Debug(ctx, "deleting Cognito User Pool Client", map[string]interface{}{
+	tflog.Debug(ctx, "deleting Cognito User Pool Client", map[string]any{
 		names.AttrID:         state.ID.ValueString(),
 		names.AttrUserPoolID: state.UserPoolID.ValueString(),
 	})

--- a/internal/service/cognitoidp/user_pool_client_data_source.go
+++ b/internal/service/cognitoidp/user_pool_client_data_source.go
@@ -182,7 +182,7 @@ func dataSourceUserPoolClient() *schema.Resource {
 	}
 }
 
-func dataSourceUserPoolClientRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserPoolClientRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -224,12 +224,12 @@ func dataSourceUserPoolClientRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func flattenUserPoolClientAnalyticsConfig(apiObject *awstypes.AnalyticsConfigurationType) []interface{} {
+func flattenUserPoolClientAnalyticsConfig(apiObject *awstypes.AnalyticsConfigurationType) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"user_data_shared": apiObject.UserDataShared,
 	}
 
@@ -249,10 +249,10 @@ func flattenUserPoolClientAnalyticsConfig(apiObject *awstypes.AnalyticsConfigura
 		tfMap[names.AttrRoleARN] = aws.ToString(apiObject.RoleArn)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenUserPoolClientTokenValidityUnitsType(apiObject *awstypes.TokenValidityUnitsType) []interface{} {
+func flattenUserPoolClientTokenValidityUnitsType(apiObject *awstypes.TokenValidityUnitsType) []any {
 	if apiObject == nil {
 		return nil
 	}
@@ -262,11 +262,11 @@ func flattenUserPoolClientTokenValidityUnitsType(apiObject *awstypes.TokenValidi
 		return nil
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"access_token":  apiObject.AccessToken,
 		"id_token":      apiObject.IdToken,
 		"refresh_token": apiObject.RefreshToken,
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/cognitoidp/user_pool_clients_data_source.go
+++ b/internal/service/cognitoidp/user_pool_clients_data_source.go
@@ -42,7 +42,7 @@ func dataSourceUserPoolClients() *schema.Resource {
 	}
 }
 
-func dataSourceuserPoolClientsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceuserPoolClientsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/user_pool_data_source_test.go
+++ b/internal/service/cognitoidp/user_pool_data_source_test.go
@@ -131,7 +131,7 @@ func testSchemaAttributes(n string) resource.TestCheckFunc {
 		checksCompleted := map[string]bool{
 			names.AttrEmail: false,
 		}
-		for i := 0; i < numAttributes; i++ {
+		for i := range numAttributes {
 			// Get the attribute
 			attribute := fmt.Sprintf("schema_attributes.%d.name", i)
 			name, ok := rs.Primary.Attributes[attribute]

--- a/internal/service/cognitoidp/user_pool_domain.go
+++ b/internal/service/cognitoidp/user_pool_domain.go
@@ -80,14 +80,14 @@ func resourceUserPoolDomain() *schema.Resource {
 			},
 		},
 
-		CustomizeDiff: customdiff.ForceNewIfChange(names.AttrCertificateARN, func(_ context.Context, old, new, meta interface{}) bool {
+		CustomizeDiff: customdiff.ForceNewIfChange(names.AttrCertificateARN, func(_ context.Context, old, new, meta any) bool {
 			// If the cert arn is being changed to a new arn, don't force new.
 			return !(old.(string) != "" && new.(string) != "")
 		}),
 	}
 }
 
-func resourceUserPoolDomainCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolDomainCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -120,7 +120,7 @@ func resourceUserPoolDomainCreate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceUserPoolDomainRead(ctx, d, meta)...)
 }
 
-func resourceUserPoolDomainRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolDomainRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -152,7 +152,7 @@ func resourceUserPoolDomainRead(ctx context.Context, d *schema.ResourceData, met
 	return diags
 }
 
-func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -180,7 +180,7 @@ func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceUserPoolDomainRead(ctx, d, meta)...)
 }
 
-func resourceUserPoolDomainDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolDomainDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -239,7 +239,7 @@ func findUserPoolDomain(ctx context.Context, conn *cognitoidentityprovider.Clien
 }
 
 func statusUserPoolDomain(ctx context.Context, conn *cognitoidentityprovider.Client, domain string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findUserPoolDomain(ctx, conn, domain)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/cognitoidp/user_pool_signing_certificate_data_source.go
+++ b/internal/service/cognitoidp/user_pool_signing_certificate_data_source.go
@@ -37,7 +37,7 @@ func dataSourceUserPoolSigningCertificate() *schema.Resource {
 	}
 }
 
-func dataSourceUserPoolSigningCertificateRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserPoolSigningCertificateRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/user_pool_ui_customization.go
+++ b/internal/service/cognitoidp/user_pool_ui_customization.go
@@ -79,7 +79,7 @@ const (
 	userPoolUICustomizationResourceIDPartCount = 2
 )
 
-func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -115,7 +115,7 @@ func resourceUserPoolUICustomizationPut(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceUserPoolUICustomizationRead(ctx, d, meta)...)
 }
 
-func resourceUserPoolUICustomizationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolUICustomizationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 
@@ -148,7 +148,7 @@ func resourceUserPoolUICustomizationRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceUserPoolUICustomizationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceUserPoolUICustomizationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/user_pools_data_source.go
+++ b/internal/service/cognitoidp/user_pools_data_source.go
@@ -41,7 +41,7 @@ func dataSourceUserPools() *schema.Resource {
 	}
 }
 
-func dataSourceUserPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceUserPoolsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).CognitoIDPClient(ctx)
 

--- a/internal/service/cognitoidp/validate.go
+++ b/internal/service/cognitoidp/validate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
-func validIdentityProviderName(v interface{}, k string) (ws []string, es []error) {
+func validIdentityProviderName(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 1 {
@@ -28,7 +28,7 @@ func validIdentityProviderName(v interface{}, k string) (ws []string, es []error
 	return
 }
 
-func validResourceServerScopeName(v interface{}, k string) (ws []string, errors []error) {
+func validResourceServerScopeName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 
 	if len(value) < 1 {
@@ -43,7 +43,7 @@ func validResourceServerScopeName(v interface{}, k string) (ws []string, errors 
 	return
 }
 
-func validUserGroupName(v interface{}, k string) (ws []string, es []error) {
+func validUserGroupName(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 1 {
@@ -60,7 +60,7 @@ func validUserGroupName(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func validUserPoolEmailVerificationMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolEmailVerificationMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -77,7 +77,7 @@ func validUserPoolEmailVerificationMessage(v interface{}, k string) (ws []string
 	return
 }
 
-func validUserPoolEmailVerificationSubject(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolEmailVerificationSubject(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 1 {
@@ -94,7 +94,7 @@ func validUserPoolEmailVerificationSubject(v interface{}, k string) (ws []string
 	return
 }
 
-func validUserPoolID(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolID(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[\w-]+_[0-9A-Za-z]+$`).MatchString(value) {
 		es = append(es, fmt.Errorf("%q must be the region name followed by an underscore and then alphanumeric pattern", k))
@@ -102,7 +102,7 @@ func validUserPoolID(v interface{}, k string) (ws []string, es []error) {
 	return
 }
 
-func validUserPoolInviteTemplateEmailMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolInviteTemplateEmailMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -123,7 +123,7 @@ func validUserPoolInviteTemplateEmailMessage(v interface{}, k string) (ws []stri
 	return
 }
 
-func validUserPoolInviteTemplateSMSMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolInviteTemplateSMSMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -144,7 +144,7 @@ func validUserPoolInviteTemplateSMSMessage(v interface{}, k string) (ws []string
 	return
 }
 
-func validUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolSchemaName(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	if len(value) < 1 {
 		es = append(es, fmt.Errorf("%q cannot be less than 1 character", k))
@@ -160,7 +160,7 @@ func validUserPoolSchemaName(v interface{}, k string) (ws []string, es []error) 
 	return
 }
 
-func validUserPoolSMSAuthenticationMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolSMSAuthenticationMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -177,7 +177,7 @@ func validUserPoolSMSAuthenticationMessage(v interface{}, k string) (ws []string
 	return
 }
 
-func validUserPoolSMSVerificationMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolSMSVerificationMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -194,7 +194,7 @@ func validUserPoolSMSVerificationMessage(v interface{}, k string) (ws []string, 
 	return
 }
 
-func validUserPoolTemplateEmailMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolTemplateEmailMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -211,7 +211,7 @@ func validUserPoolTemplateEmailMessage(v interface{}, k string) (ws []string, es
 	return
 }
 
-func validUserPoolTemplateEmailMessageByLink(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolTemplateEmailMessageByLink(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {
@@ -228,7 +228,7 @@ func validUserPoolTemplateEmailMessageByLink(v interface{}, k string) (ws []stri
 	return
 }
 
-func validUserPoolTemplateEmailSubject(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolTemplateEmailSubject(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 1 {
@@ -245,7 +245,7 @@ func validUserPoolTemplateEmailSubject(v interface{}, k string) (ws []string, es
 	return
 }
 
-func validUserPoolTemplateEmailSubjectByLink(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolTemplateEmailSubjectByLink(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 1 {
@@ -262,7 +262,7 @@ func validUserPoolTemplateEmailSubjectByLink(v interface{}, k string) (ws []stri
 	return
 }
 
-func validUserPoolTemplateSMSMessage(v interface{}, k string) (ws []string, es []error) {
+func validUserPoolTemplateSMSMessage(v any, k string) (ws []string, es []error) {
 	value := v.(string)
 	count := utf8.RuneCountInString(value)
 	if count < 6 {

--- a/internal/service/fsx/backup.go
+++ b/internal/service/fsx/backup.go
@@ -76,7 +76,7 @@ func resourceBackup() *schema.Resource {
 	}
 }
 
-func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -116,7 +116,7 @@ func resourceBackupCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceBackupRead(ctx, d, meta)...)
 }
 
-func resourceBackupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBackupRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -148,7 +148,7 @@ func resourceBackupRead(ctx context.Context, d *schema.ResourceData, meta interf
 	return diags
 }
 
-func resourceBackupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBackupUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -156,7 +156,7 @@ func resourceBackupUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	return append(diags, resourceBackupRead(ctx, d, meta)...)
 }
 
-func resourceBackupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceBackupDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -227,7 +227,7 @@ func findBackups(ctx context.Context, conn *fsx.Client, input *fsx.DescribeBacku
 }
 
 func statusBackup(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findBackupByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/fsx/common_schema_data_source.go
+++ b/internal/service/fsx/common_schema_data_source.go
@@ -16,11 +16,11 @@ func newSnapshotFilterList(s *schema.Set) []awstypes.SnapshotFilter {
 		return []awstypes.SnapshotFilter{}
 	}
 
-	return tfslices.ApplyToAll(s.List(), func(tfList interface{}) awstypes.SnapshotFilter {
-		tfMap := tfList.(map[string]interface{})
+	return tfslices.ApplyToAll(s.List(), func(tfList any) awstypes.SnapshotFilter {
+		tfMap := tfList.(map[string]any)
 		return awstypes.SnapshotFilter{
 			Name:   awstypes.SnapshotFilterName(tfMap[names.AttrName].(string)),
-			Values: flex.ExpandStringValueList(tfMap[names.AttrValues].([]interface{})),
+			Values: flex.ExpandStringValueList(tfMap[names.AttrValues].([]any)),
 		}
 	})
 }
@@ -52,11 +52,11 @@ func newStorageVirtualMachineFilterList(s *schema.Set) []awstypes.StorageVirtual
 		return []awstypes.StorageVirtualMachineFilter{}
 	}
 
-	return tfslices.ApplyToAll(s.List(), func(tfList interface{}) awstypes.StorageVirtualMachineFilter {
-		tfMap := tfList.(map[string]interface{})
+	return tfslices.ApplyToAll(s.List(), func(tfList any) awstypes.StorageVirtualMachineFilter {
+		tfMap := tfList.(map[string]any)
 		return awstypes.StorageVirtualMachineFilter{
 			Name:   awstypes.StorageVirtualMachineFilterName(tfMap[names.AttrName].(string)),
-			Values: flex.ExpandStringValueList(tfMap[names.AttrValues].([]interface{})),
+			Values: flex.ExpandStringValueList(tfMap[names.AttrValues].([]any)),
 		}
 	})
 }

--- a/internal/service/fsx/data_repository_association.go
+++ b/internal/service/fsx/data_repository_association.go
@@ -158,7 +158,7 @@ func resourceDataRepositoryAssociation() *schema.Resource {
 	}
 }
 
-func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -179,7 +179,7 @@ func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.Reso
 	}
 
 	if v, ok := d.GetOk("s3"); ok {
-		input.S3 = expandDataRepositoryAssociationS3(v.([]interface{}))
+		input.S3 = expandDataRepositoryAssociationS3(v.([]any))
 	}
 
 	output, err := conn.CreateDataRepositoryAssociation(ctx, input)
@@ -197,7 +197,7 @@ func resourceDataRepositoryAssociationCreate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceDataRepositoryAssociationRead(ctx, d, meta)...)
 }
 
-func resourceDataRepositoryAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataRepositoryAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -228,7 +228,7 @@ func resourceDataRepositoryAssociationRead(ctx context.Context, d *schema.Resour
 	return diags
 }
 
-func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -243,7 +243,7 @@ func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.Reso
 		}
 
 		if d.HasChange("s3") {
-			input.S3 = expandDataRepositoryAssociationS3(d.Get("s3").([]interface{}))
+			input.S3 = expandDataRepositoryAssociationS3(d.Get("s3").([]any))
 		}
 
 		_, err := conn.UpdateDataRepositoryAssociation(ctx, input)
@@ -260,7 +260,7 @@ func resourceDataRepositoryAssociationUpdate(ctx context.Context, d *schema.Reso
 	return append(diags, resourceDataRepositoryAssociationRead(ctx, d, meta)...)
 }
 
-func resourceDataRepositoryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDataRepositoryAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -335,7 +335,7 @@ func findDataRepositoryAssociations(ctx context.Context, conn *fsx.Client, input
 }
 
 func statusDataRepositoryAssociation(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findDataRepositoryAssociationByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -416,61 +416,61 @@ func waitDataRepositoryAssociationDeleted(ctx context.Context, conn *fsx.Client,
 	return nil, err
 }
 
-func expandDataRepositoryAssociationS3(cfg []interface{}) *awstypes.S3DataRepositoryConfiguration {
+func expandDataRepositoryAssociationS3(cfg []any) *awstypes.S3DataRepositoryConfiguration {
 	if len(cfg) == 0 || cfg[0] == nil {
 		return nil
 	}
 
-	m := cfg[0].(map[string]interface{})
+	m := cfg[0].(map[string]any)
 
 	s3Config := &awstypes.S3DataRepositoryConfiguration{}
 
 	if v, ok := m["auto_export_policy"]; ok {
-		policy := v.([]interface{})
+		policy := v.([]any)
 		s3Config.AutoExportPolicy = expandDataRepositoryAssociationS3AutoExportPolicy(policy)
 	}
 	if v, ok := m["auto_import_policy"]; ok {
-		policy := v.([]interface{})
+		policy := v.([]any)
 		s3Config.AutoImportPolicy = expandDataRepositoryAssociationS3AutoImportPolicy(policy)
 	}
 
 	return s3Config
 }
 
-func expandDataRepositoryAssociationS3AutoExportPolicy(policy []interface{}) *awstypes.AutoExportPolicy {
+func expandDataRepositoryAssociationS3AutoExportPolicy(policy []any) *awstypes.AutoExportPolicy {
 	if len(policy) == 0 || policy[0] == nil {
 		return nil
 	}
 
-	m := policy[0].(map[string]interface{})
+	m := policy[0].(map[string]any)
 	autoExportPolicy := &awstypes.AutoExportPolicy{}
 
 	if v, ok := m["events"]; ok {
-		autoExportPolicy.Events = flex.ExpandStringyValueList[awstypes.EventType](v.([]interface{}))
+		autoExportPolicy.Events = flex.ExpandStringyValueList[awstypes.EventType](v.([]any))
 	}
 
 	return autoExportPolicy
 }
 
-func expandDataRepositoryAssociationS3AutoImportPolicy(policy []interface{}) *awstypes.AutoImportPolicy {
+func expandDataRepositoryAssociationS3AutoImportPolicy(policy []any) *awstypes.AutoImportPolicy {
 	if len(policy) == 0 || policy[0] == nil {
 		return nil
 	}
 
-	m := policy[0].(map[string]interface{})
+	m := policy[0].(map[string]any)
 	autoImportPolicy := &awstypes.AutoImportPolicy{}
 
 	if v, ok := m["events"]; ok {
-		autoImportPolicy.Events = flex.ExpandStringyValueList[awstypes.EventType](v.([]interface{}))
+		autoImportPolicy.Events = flex.ExpandStringyValueList[awstypes.EventType](v.([]any))
 	}
 
 	return autoImportPolicy
 }
 
-func flattenDataRepositoryAssociationS3(s3Config *awstypes.S3DataRepositoryConfiguration) []map[string]interface{} {
-	result := make(map[string]interface{})
+func flattenDataRepositoryAssociationS3(s3Config *awstypes.S3DataRepositoryConfiguration) []map[string]any {
+	result := make(map[string]any)
 	if s3Config == nil {
-		return []map[string]interface{}{result}
+		return []map[string]any{result}
 	}
 
 	if s3Config.AutoExportPolicy != nil {
@@ -480,29 +480,29 @@ func flattenDataRepositoryAssociationS3(s3Config *awstypes.S3DataRepositoryConfi
 		result["auto_import_policy"] = flattenS3AutoImportPolicy(s3Config.AutoImportPolicy)
 	}
 
-	return []map[string]interface{}{result}
+	return []map[string]any{result}
 }
 
-func flattenS3AutoExportPolicy(policy *awstypes.AutoExportPolicy) []map[string][]interface{} {
-	result := make(map[string][]interface{})
+func flattenS3AutoExportPolicy(policy *awstypes.AutoExportPolicy) []map[string][]any {
+	result := make(map[string][]any)
 	if policy == nil {
-		return []map[string][]interface{}{result}
+		return []map[string][]any{result}
 	}
 	if policy.Events != nil {
 		result["events"] = flex.FlattenStringyValueList(policy.Events)
 	}
 
-	return []map[string][]interface{}{result}
+	return []map[string][]any{result}
 }
 
-func flattenS3AutoImportPolicy(policy *awstypes.AutoImportPolicy) []map[string][]interface{} {
-	result := make(map[string][]interface{})
+func flattenS3AutoImportPolicy(policy *awstypes.AutoImportPolicy) []map[string][]any {
+	result := make(map[string][]any)
 	if policy == nil {
-		return []map[string][]interface{}{result}
+		return []map[string][]any{result}
 	}
 	if policy.Events != nil {
 		result["events"] = flex.FlattenStringyValueList(policy.Events)
 	}
 
-	return []map[string][]interface{}{result}
+	return []map[string][]any{result}
 }

--- a/internal/service/fsx/file_cache.go
+++ b/internal/service/fsx/file_cache.go
@@ -292,7 +292,7 @@ func resourceFileCache() *schema.Resource {
 	}
 }
 
-func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -301,7 +301,7 @@ func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta i
 		FileCacheType:        awstypes.FileCacheType(d.Get("file_cache_type").(string)),
 		FileCacheTypeVersion: aws.String(d.Get("file_cache_type_version").(string)),
 		StorageCapacity:      aws.Int32(int32(d.Get("storage_capacity").(int))),
-		SubnetIds:            flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:            flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:                 getTagsIn(ctx),
 	}
 
@@ -340,7 +340,7 @@ func resourceFileCacheCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceFileCacheRead(ctx, d, meta)...)
 }
 
-func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -388,7 +388,7 @@ func resourceFileCacheRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceFileCacheUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFileCacheUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -400,7 +400,7 @@ func resourceFileCacheUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		}
 
 		if d.HasChanges("lustre_configuration") {
-			input.LustreConfiguration = expandUpdateFileCacheLustreConfiguration(d.Get("lustre_configuration").([]interface{}))
+			input.LustreConfiguration = expandUpdateFileCacheLustreConfiguration(d.Get("lustre_configuration").([]any))
 		}
 
 		_, err := conn.UpdateFileCache(ctx, input)
@@ -417,7 +417,7 @@ func resourceFileCacheUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceFileCacheRead(ctx, d, meta)...)
 }
 
-func resourceFileCacheDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFileCacheDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -489,7 +489,7 @@ func findFileCaches(ctx context.Context, conn *fsx.Client, input *fsx.DescribeFi
 }
 
 func statusFileCache(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFileCacheByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -577,17 +577,17 @@ func findDataRepositoryAssociationsByIDs(ctx context.Context, conn *fsx.Client, 
 	return findDataRepositoryAssociations(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DataRepositoryAssociation]())
 }
 
-func flattenDataRepositoryAssociations(ctx context.Context, dataRepositoryAssociations []awstypes.DataRepositoryAssociation, defaultTagsConfig *tftags.DefaultConfig, ignoreTagsConfig *tftags.IgnoreConfig) []interface{} {
+func flattenDataRepositoryAssociations(ctx context.Context, dataRepositoryAssociations []awstypes.DataRepositoryAssociation, defaultTagsConfig *tftags.DefaultConfig, ignoreTagsConfig *tftags.IgnoreConfig) []any {
 	if len(dataRepositoryAssociations) == 0 {
 		return nil
 	}
 
-	var flattenedDataRepositoryAssociations []interface{}
+	var flattenedDataRepositoryAssociations []any
 
 	for _, dataRepositoryAssociation := range dataRepositoryAssociations {
 		tags := KeyValueTags(ctx, dataRepositoryAssociation.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
 
-		values := map[string]interface{}{
+		values := map[string]any{
 			names.AttrAssociationID:          dataRepositoryAssociation.AssociationId,
 			"data_repository_path":           dataRepositoryAssociation.DataRepositoryPath,
 			"data_repository_subdirectories": dataRepositoryAssociation.DataRepositorySubdirectories,
@@ -603,23 +603,23 @@ func flattenDataRepositoryAssociations(ctx context.Context, dataRepositoryAssoci
 	return flattenedDataRepositoryAssociations
 }
 
-func flattenNFSDataRepositoryConfiguration(nfsDataRepositoryConfiguration *awstypes.NFSDataRepositoryConfiguration) []map[string]interface{} {
+func flattenNFSDataRepositoryConfiguration(nfsDataRepositoryConfiguration *awstypes.NFSDataRepositoryConfiguration) []map[string]any {
 	if nfsDataRepositoryConfiguration == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	values := map[string]interface{}{
+	values := map[string]any{
 		"dns_ips":         nfsDataRepositoryConfiguration.DnsIps,
 		names.AttrVersion: string(nfsDataRepositoryConfiguration.Version),
 	}
-	return []map[string]interface{}{values}
+	return []map[string]any{values}
 }
 
-func flattenFileCacheLustreConfiguration(fileCacheLustreConfiguration *awstypes.FileCacheLustreConfiguration) []interface{} {
+func flattenFileCacheLustreConfiguration(fileCacheLustreConfiguration *awstypes.FileCacheLustreConfiguration) []any {
 	if fileCacheLustreConfiguration == nil {
-		return []interface{}{}
+		return []any{}
 	}
-	values := make(map[string]interface{})
+	values := make(map[string]any)
 
 	values["deployment_type"] = string(fileCacheLustreConfiguration.DeploymentType)
 
@@ -639,19 +639,19 @@ func flattenFileCacheLustreConfiguration(fileCacheLustreConfiguration *awstypes.
 		values["weekly_maintenance_start_time"] = aws.ToString(fileCacheLustreConfiguration.WeeklyMaintenanceStartTime)
 	}
 
-	return []interface{}{values}
+	return []any{values}
 }
 
-func flattenFileCacheLustreMetadataConfiguration(fileCacheLustreMetadataConfiguration *awstypes.FileCacheLustreMetadataConfiguration) []interface{} {
-	values := make(map[string]interface{})
+func flattenFileCacheLustreMetadataConfiguration(fileCacheLustreMetadataConfiguration *awstypes.FileCacheLustreMetadataConfiguration) []any {
+	values := make(map[string]any)
 	if fileCacheLustreMetadataConfiguration.StorageCapacity != nil {
 		values["storage_capacity"] = aws.ToInt32(fileCacheLustreMetadataConfiguration.StorageCapacity)
 	}
 
-	return []interface{}{values}
+	return []any{values}
 }
 
-func expandDataRepositoryAssociations(l []interface{}) []awstypes.FileCacheDataRepositoryAssociation {
+func expandDataRepositoryAssociations(l []any) []awstypes.FileCacheDataRepositoryAssociation {
 	if len(l) == 0 {
 		return nil
 	}
@@ -659,7 +659,7 @@ func expandDataRepositoryAssociations(l []interface{}) []awstypes.FileCacheDataR
 	var dataRepositoryAssociations []awstypes.FileCacheDataRepositoryAssociation
 
 	for _, tfMapRaw := range l {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -684,11 +684,11 @@ func expandDataRepositoryAssociations(l []interface{}) []awstypes.FileCacheDataR
 	return dataRepositoryAssociations
 }
 
-func expandFileCacheNFSConfiguration(l []interface{}) *awstypes.FileCacheNFSConfiguration {
+func expandFileCacheNFSConfiguration(l []any) *awstypes.FileCacheNFSConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 
 	req := &awstypes.FileCacheNFSConfiguration{}
 	if v, ok := data["dns_ips"]; ok {
@@ -701,12 +701,12 @@ func expandFileCacheNFSConfiguration(l []interface{}) *awstypes.FileCacheNFSConf
 	return req
 }
 
-func expandUpdateFileCacheLustreConfiguration(l []interface{}) *awstypes.UpdateFileCacheLustreConfiguration {
+func expandUpdateFileCacheLustreConfiguration(l []any) *awstypes.UpdateFileCacheLustreConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.UpdateFileCacheLustreConfiguration{}
 
 	if v, ok := data["weekly_maintenance_start_time"].(string); ok {
@@ -716,11 +716,11 @@ func expandUpdateFileCacheLustreConfiguration(l []interface{}) *awstypes.UpdateF
 	return req
 }
 
-func expandCreateFileCacheLustreConfiguration(l []interface{}) *awstypes.CreateFileCacheLustreConfiguration {
+func expandCreateFileCacheLustreConfiguration(l []any) *awstypes.CreateFileCacheLustreConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.CreateFileCacheLustreConfiguration{}
 
 	if v, ok := data["deployment_type"].(string); ok {
@@ -739,11 +739,11 @@ func expandCreateFileCacheLustreConfiguration(l []interface{}) *awstypes.CreateF
 	return req
 }
 
-func expandFileCacheLustreMetadataConfiguration(l []interface{}) *awstypes.FileCacheLustreMetadataConfiguration {
+func expandFileCacheLustreMetadataConfiguration(l []any) *awstypes.FileCacheLustreMetadataConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.FileCacheLustreMetadataConfiguration{}
 
 	if v, ok := data["storage_capacity"].(int); ok {

--- a/internal/service/fsx/lustre_file_system.go
+++ b/internal/service/fsx/lustre_file_system.go
@@ -44,7 +44,7 @@ func resourceLustreFileSystem() *schema.Resource {
 		DeleteWithoutTimeout: resourceLustreFileSystemDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("skip_final_backup", true)
 
 				return []*schema.ResourceData{d}, nil
@@ -339,7 +339,7 @@ func resourceLustreFileSystemStorageCapacityCustomizeDiff(_ context.Context, d *
 func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	//metadata_configuration is only supported when deployment_type is persistent2
 	if v, ok := d.GetOk("metadata_configuration"); ok {
-		if len(v.([]interface{})) > 0 {
+		if len(v.([]any)) > 0 {
 			if deploymentType := awstypes.LustreDeploymentType(d.Get("deployment_type").(string)); deploymentType != awstypes.LustreDeploymentTypePersistent2 {
 				return fmt.Errorf("metadata_configuration can only be set when deployment type is %s", awstypes.LustreDeploymentTypePersistent2)
 			}
@@ -348,21 +348,21 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 
 	// we want to force a new resource if the new Iops is less than the old one
 	if d.HasChange("metadata_configuration") {
-		if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
+		if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			if mode := awstypes.MetadataConfigurationMode(d.Get("metadata_configuration.0.mode").(string)); mode == awstypes.MetadataConfigurationModeUserProvisioned {
 				o, n := d.GetChange("metadata_configuration")
 
-				oldV := o.([]interface{})
-				newV := n.([]interface{})
-				var metaOld map[string]interface{}
-				var metaNew map[string]interface{}
+				oldV := o.([]any)
+				newV := n.([]any)
+				var metaOld map[string]any
+				var metaNew map[string]any
 
 				for _, v := range oldV {
-					metaOld = v.(map[string]interface{})
+					metaOld = v.(map[string]any)
 				}
 
 				for _, v := range newV {
-					metaNew = v.(map[string]interface{})
+					metaNew = v.(map[string]any)
 				}
 
 				if len(metaNew) > 0 && len(metaOld) > 0 {
@@ -380,7 +380,7 @@ func resourceLustreFileSystemMetadataConfigCustomizeDiff(_ context.Context, d *s
 	return nil
 }
 
-func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -392,7 +392,7 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		},
 		StorageCapacity: aws.Int32(int32(d.Get("storage_capacity").(int))),
 		StorageType:     awstypes.StorageType(d.Get(names.AttrStorageType).(string)),
-		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:            getTagsIn(ctx),
 	}
 	inputB := &fsx.CreateFileSystemFromBackupInput{
@@ -401,7 +401,7 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 			DeploymentType: awstypes.LustreDeploymentType(d.Get("deployment_type").(string)),
 		},
 		StorageType: awstypes.StorageType(d.Get(names.AttrStorageType).(string)),
-		SubnetIds:   flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:   flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:        getTagsIn(ctx),
 	}
 
@@ -466,14 +466,14 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		inputB.KmsKeyId = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("log_configuration"); ok && len(v.([]interface{})) > 0 {
-		inputC.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(v.([]interface{}))
-		inputB.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("log_configuration"); ok && len(v.([]any)) > 0 {
+		inputC.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(v.([]any))
+		inputB.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]interface{})) > 0 {
-		inputC.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]interface{}))
-		inputB.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("metadata_configuration"); ok && len(v.([]any)) > 0 {
+		inputC.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]any))
+		inputB.LustreConfiguration.MetadataConfiguration = expandLustreMetadataCreateConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("per_unit_storage_throughput"); ok {
@@ -481,9 +481,9 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 		inputB.LustreConfiguration.PerUnitStorageThroughput = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("root_squash_configuration"); ok && len(v.([]interface{})) > 0 {
-		inputC.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(v.([]interface{}))
-		inputB.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("root_squash_configuration"); ok && len(v.([]any)) > 0 {
+		inputC.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(v.([]any))
+		inputB.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrSecurityGroupIDs); ok {
@@ -524,7 +524,7 @@ func resourceLustreFileSystemCreate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceLustreFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -585,7 +585,7 @@ func resourceLustreFileSystemRead(ctx context.Context, d *schema.ResourceData, m
 	return diags
 }
 
-func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -618,11 +618,11 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if d.HasChange("log_configuration") {
-			input.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(d.Get("log_configuration").([]interface{}))
+			input.LustreConfiguration.LogConfiguration = expandLustreLogCreateConfiguration(d.Get("log_configuration").([]any))
 		}
 
 		if d.HasChange("metadata_configuration") {
-			input.LustreConfiguration.MetadataConfiguration = expandLustreMetadataUpdateConfiguration(d.Get("metadata_configuration").([]interface{}))
+			input.LustreConfiguration.MetadataConfiguration = expandLustreMetadataUpdateConfiguration(d.Get("metadata_configuration").([]any))
 		}
 
 		if d.HasChange("per_unit_storage_throughput") {
@@ -630,7 +630,7 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 
 		if d.HasChange("root_squash_configuration") {
-			input.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(d.Get("root_squash_configuration").([]interface{}))
+			input.LustreConfiguration.RootSquashConfiguration = expandLustreRootSquashConfiguration(d.Get("root_squash_configuration").([]any))
 		}
 
 		if d.HasChange("storage_capacity") {
@@ -660,7 +660,7 @@ func resourceLustreFileSystemUpdate(ctx context.Context, d *schema.ResourceData,
 	return append(diags, resourceLustreFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceLustreFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceLustreFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -676,7 +676,7 @@ func resourceLustreFileSystemDelete(ctx context.Context, d *schema.ResourceData,
 			SkipFinalBackup: aws.Bool(d.Get("skip_final_backup").(bool)),
 		}
 
-		if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]interface{})) > 0 {
+		if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]any)) > 0 {
 			lustreConfig.FinalBackupTags = Tags(tftags.New(ctx, v))
 		}
 
@@ -773,7 +773,7 @@ func findFileSystems(ctx context.Context, conn *fsx.Client, input *fsx.DescribeF
 }
 
 func statusFileSystem(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFileSystemByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -894,7 +894,7 @@ func findFileSystemAdministrativeAction(ctx context.Context, conn *fsx.Client, f
 }
 
 func statusFileSystemAdministrativeAction(ctx context.Context, conn *fsx.Client, fsID string, actionType awstypes.AdministrativeActionType) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFileSystemAdministrativeAction(ctx, conn, fsID, actionType)
 
 		if tfresource.NotFound(err) {
@@ -931,12 +931,12 @@ func waitFileSystemAdministrativeActionCompleted(ctx context.Context, conn *fsx.
 	return nil, err
 }
 
-func expandLustreRootSquashConfiguration(l []interface{}) *awstypes.LustreRootSquashConfiguration {
+func expandLustreRootSquashConfiguration(l []any) *awstypes.LustreRootSquashConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.LustreRootSquashConfiguration{}
 
 	if v, ok := data["root_squash"].(string); ok && v != "" {
@@ -950,12 +950,12 @@ func expandLustreRootSquashConfiguration(l []interface{}) *awstypes.LustreRootSq
 	return req
 }
 
-func flattenLustreRootSquashConfiguration(adopts *awstypes.LustreRootSquashConfiguration) []map[string]interface{} {
+func flattenLustreRootSquashConfiguration(adopts *awstypes.LustreRootSquashConfiguration) []map[string]any {
 	if adopts == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if adopts.RootSquash != nil {
 		m["root_squash"] = aws.ToString(adopts.RootSquash)
@@ -965,15 +965,15 @@ func flattenLustreRootSquashConfiguration(adopts *awstypes.LustreRootSquashConfi
 		m["no_squash_nids"] = flex.FlattenStringValueSet(adopts.NoSquashNids)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandLustreLogCreateConfiguration(l []interface{}) *awstypes.LustreLogCreateConfiguration {
+func expandLustreLogCreateConfiguration(l []any) *awstypes.LustreLogCreateConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.LustreLogCreateConfiguration{
 		Level: awstypes.LustreAccessAuditLogLevel(data["level"].(string)),
 	}
@@ -985,12 +985,12 @@ func expandLustreLogCreateConfiguration(l []interface{}) *awstypes.LustreLogCrea
 	return req
 }
 
-func flattenLustreLogConfiguration(adopts *awstypes.LustreLogConfiguration) []map[string]interface{} {
+func flattenLustreLogConfiguration(adopts *awstypes.LustreLogConfiguration) []map[string]any {
 	if adopts == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"level": string(adopts.Level),
 	}
 
@@ -998,15 +998,15 @@ func flattenLustreLogConfiguration(adopts *awstypes.LustreLogConfiguration) []ma
 		m[names.AttrDestination] = aws.ToString(adopts.Destination)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandLustreMetadataCreateConfiguration(l []interface{}) *awstypes.CreateFileSystemLustreMetadataConfiguration {
+func expandLustreMetadataCreateConfiguration(l []any) *awstypes.CreateFileSystemLustreMetadataConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.CreateFileSystemLustreMetadataConfiguration{
 		Mode: awstypes.MetadataConfigurationMode(data[names.AttrMode].(string)),
 	}
@@ -1018,12 +1018,12 @@ func expandLustreMetadataCreateConfiguration(l []interface{}) *awstypes.CreateFi
 	return req
 }
 
-func expandLustreMetadataUpdateConfiguration(l []interface{}) *awstypes.UpdateFileSystemLustreMetadataConfiguration {
+func expandLustreMetadataUpdateConfiguration(l []any) *awstypes.UpdateFileSystemLustreMetadataConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.UpdateFileSystemLustreMetadataConfiguration{
 		Mode: awstypes.MetadataConfigurationMode(data[names.AttrMode].(string)),
 	}
@@ -1035,12 +1035,12 @@ func expandLustreMetadataUpdateConfiguration(l []interface{}) *awstypes.UpdateFi
 	return req
 }
 
-func flattenLustreMetadataConfiguration(adopts *awstypes.FileSystemLustreMetadataConfiguration) []map[string]interface{} {
+func flattenLustreMetadataConfiguration(adopts *awstypes.FileSystemLustreMetadataConfiguration) []map[string]any {
 	if adopts == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrMode: string(adopts.Mode),
 	}
 
@@ -1048,10 +1048,10 @@ func flattenLustreMetadataConfiguration(adopts *awstypes.FileSystemLustreMetadat
 		m[names.AttrIOPS] = aws.ToInt32(adopts.Iops)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func logStateFunc(v interface{}) string {
+func logStateFunc(v any) string {
 	value := v.(string)
 	// API returns the specific log stream arn instead of provided log group
 	logArn, _ := arn.Parse(value)

--- a/internal/service/fsx/ontap_file_system.go
+++ b/internal/service/fsx/ontap_file_system.go
@@ -283,7 +283,7 @@ func resourceONTAPFileSystemHAPairsCustomizeDiff(_ context.Context, d *schema.Re
 	return nil
 }
 
-func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -297,7 +297,7 @@ func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 		},
 		StorageCapacity: aws.Int32(int32(d.Get("storage_capacity").(int))),
 		StorageType:     awstypes.StorageType(d.Get(names.AttrStorageType).(string)),
-		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:            getTagsIn(ctx),
 	}
 
@@ -306,7 +306,7 @@ func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 
 	if v, ok := d.GetOk("disk_iops_configuration"); ok {
-		input.OntapConfiguration.DiskIopsConfiguration = expandOntapFileDiskIopsConfiguration(v.([]interface{}))
+		input.OntapConfiguration.DiskIopsConfiguration = expandOntapFileDiskIopsConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("endpoint_ip_address_range"); ok {
@@ -363,7 +363,7 @@ func resourceONTAPFileSystemCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceONTAPFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -419,7 +419,7 @@ func resourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceONTAPFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -439,7 +439,7 @@ func resourceONTAPFileSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 		}
 
 		if d.HasChange("disk_iops_configuration") {
-			input.OntapConfiguration.DiskIopsConfiguration = expandOntapFileDiskIopsConfiguration(d.Get("disk_iops_configuration").([]interface{}))
+			input.OntapConfiguration.DiskIopsConfiguration = expandOntapFileDiskIopsConfiguration(d.Get("disk_iops_configuration").([]any))
 		}
 
 		if d.HasChange("fsx_admin_password") {
@@ -501,7 +501,7 @@ func resourceONTAPFileSystemUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceONTAPFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceONTAPFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -525,12 +525,12 @@ func resourceONTAPFileSystemDelete(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func expandOntapFileDiskIopsConfiguration(cfg []interface{}) *awstypes.DiskIopsConfiguration {
+func expandOntapFileDiskIopsConfiguration(cfg []any) *awstypes.DiskIopsConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.DiskIopsConfiguration{}
 
@@ -544,27 +544,27 @@ func expandOntapFileDiskIopsConfiguration(cfg []interface{}) *awstypes.DiskIopsC
 	return &out
 }
 
-func flattenOntapFileDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []interface{} {
+func flattenOntapFileDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m[names.AttrMode] = string(rs.Mode)
 
 	if rs.Iops != nil {
 		m[names.AttrIOPS] = aws.ToInt64(rs.Iops)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenOntapFileSystemEndpoints(rs *awstypes.FileSystemEndpoints) []interface{} {
+func flattenOntapFileSystemEndpoints(rs *awstypes.FileSystemEndpoints) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.Intercluster != nil {
 		m["intercluster"] = flattenOntapFileSystemEndpoint(rs.Intercluster)
 	}
@@ -572,15 +572,15 @@ func flattenOntapFileSystemEndpoints(rs *awstypes.FileSystemEndpoints) []interfa
 		m["management"] = flattenOntapFileSystemEndpoint(rs.Management)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenOntapFileSystemEndpoint(rs *awstypes.FileSystemEndpoint) []interface{} {
+func flattenOntapFileSystemEndpoint(rs *awstypes.FileSystemEndpoint) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.DNSName != nil {
 		m[names.AttrDNSName] = aws.ToString(rs.DNSName)
 	}
@@ -588,7 +588,7 @@ func flattenOntapFileSystemEndpoint(rs *awstypes.FileSystemEndpoint) []interface
 		m[names.AttrIPAddresses] = flex.FlattenStringValueSet(rs.IpAddresses)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 func findONTAPFileSystemByID(ctx context.Context, conn *fsx.Client, id string) (*awstypes.FileSystem, error) {

--- a/internal/service/fsx/ontap_file_system_data_source.go
+++ b/internal/service/fsx/ontap_file_system_data_source.go
@@ -171,7 +171,7 @@ func dataSourceONTAPFileSystem() *schema.Resource {
 	}
 }
 
-func dataSourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceONTAPFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 

--- a/internal/service/fsx/ontap_storage_virtual_machine.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine.go
@@ -236,7 +236,7 @@ func resourceONTAPStorageVirtualMachine() *schema.Resource {
 	}
 }
 
-func resourceONTAPStorageVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPStorageVirtualMachineCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -248,7 +248,7 @@ func resourceONTAPStorageVirtualMachineCreate(ctx context.Context, d *schema.Res
 	}
 
 	if v, ok := d.GetOk("active_directory_configuration"); ok {
-		input.ActiveDirectoryConfiguration = expandCreateSvmActiveDirectoryConfiguration(v.([]interface{}))
+		input.ActiveDirectoryConfiguration = expandCreateSvmActiveDirectoryConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("root_volume_security_style"); ok {
@@ -274,7 +274,7 @@ func resourceONTAPStorageVirtualMachineCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceONTAPStorageVirtualMachineRead(ctx, d, meta)...)
 }
 
-func resourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -311,7 +311,7 @@ func resourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceONTAPStorageVirtualMachineUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPStorageVirtualMachineUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -322,7 +322,7 @@ func resourceONTAPStorageVirtualMachineUpdate(ctx context.Context, d *schema.Res
 		}
 
 		if d.HasChange("active_directory_configuration") {
-			input.ActiveDirectoryConfiguration = expandUpdateSvmActiveDirectoryConfiguration(d.Get("active_directory_configuration").([]interface{}))
+			input.ActiveDirectoryConfiguration = expandUpdateSvmActiveDirectoryConfiguration(d.Get("active_directory_configuration").([]any))
 		}
 
 		if d.HasChange("svm_admin_password") {
@@ -343,7 +343,7 @@ func resourceONTAPStorageVirtualMachineUpdate(ctx context.Context, d *schema.Res
 	return append(diags, resourceONTAPStorageVirtualMachineRead(ctx, d, meta)...)
 }
 
-func resourceONTAPStorageVirtualMachineDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPStorageVirtualMachineDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -414,7 +414,7 @@ func findStorageVirtualMachines(ctx context.Context, conn *fsx.Client, input *fs
 }
 
 func statusStorageVirtualMachine(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findStorageVirtualMachineByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -496,12 +496,12 @@ func waitStorageVirtualMachineDeleted(ctx context.Context, conn *fsx.Client, id 
 	return nil, err
 }
 
-func expandCreateSvmActiveDirectoryConfiguration(cfg []interface{}) *awstypes.CreateSvmActiveDirectoryConfiguration {
+func expandCreateSvmActiveDirectoryConfiguration(cfg []any) *awstypes.CreateSvmActiveDirectoryConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.CreateSvmActiveDirectoryConfiguration{}
 
@@ -509,19 +509,19 @@ func expandCreateSvmActiveDirectoryConfiguration(cfg []interface{}) *awstypes.Cr
 		out.NetBiosName = aws.String(v)
 	}
 
-	if v, ok := conf["self_managed_active_directory_configuration"].([]interface{}); ok {
+	if v, ok := conf["self_managed_active_directory_configuration"].([]any); ok {
 		out.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfiguration(v)
 	}
 
 	return &out
 }
 
-func expandSelfManagedActiveDirectoryConfiguration(cfg []interface{}) *awstypes.SelfManagedActiveDirectoryConfiguration {
+func expandSelfManagedActiveDirectoryConfiguration(cfg []any) *awstypes.SelfManagedActiveDirectoryConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.SelfManagedActiveDirectoryConfiguration{}
 
@@ -552,12 +552,12 @@ func expandSelfManagedActiveDirectoryConfiguration(cfg []interface{}) *awstypes.
 	return &out
 }
 
-func expandUpdateSvmActiveDirectoryConfiguration(cfg []interface{}) *awstypes.UpdateSvmActiveDirectoryConfiguration {
+func expandUpdateSvmActiveDirectoryConfiguration(cfg []any) *awstypes.UpdateSvmActiveDirectoryConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.UpdateSvmActiveDirectoryConfiguration{}
 
@@ -565,19 +565,19 @@ func expandUpdateSvmActiveDirectoryConfiguration(cfg []interface{}) *awstypes.Up
 		out.NetBiosName = aws.String(v)
 	}
 
-	if v, ok := conf["self_managed_active_directory_configuration"].([]interface{}); ok {
+	if v, ok := conf["self_managed_active_directory_configuration"].([]any); ok {
 		out.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationUpdates(v)
 	}
 
 	return &out
 }
 
-func expandSelfManagedActiveDirectoryConfigurationUpdates(cfg []interface{}) *awstypes.SelfManagedActiveDirectoryConfigurationUpdates {
+func expandSelfManagedActiveDirectoryConfigurationUpdates(cfg []any) *awstypes.SelfManagedActiveDirectoryConfigurationUpdates {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.SelfManagedActiveDirectoryConfigurationUpdates{}
 
@@ -608,12 +608,12 @@ func expandSelfManagedActiveDirectoryConfigurationUpdates(cfg []interface{}) *aw
 	return &out
 }
 
-func flattenSvmActiveDirectoryConfiguration(d *schema.ResourceData, rs *awstypes.SvmActiveDirectoryConfiguration) []interface{} {
+func flattenSvmActiveDirectoryConfiguration(d *schema.ResourceData, rs *awstypes.SvmActiveDirectoryConfiguration) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.NetBiosName != nil {
 		m["netbios_name"] = rs.NetBiosName
 	}
@@ -622,15 +622,15 @@ func flattenSvmActiveDirectoryConfiguration(d *schema.ResourceData, rs *awstypes
 		m["self_managed_active_directory_configuration"] = flattenSelfManagedActiveDirectoryAttributes(d, rs.SelfManagedActiveDirectoryConfiguration)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenSelfManagedActiveDirectoryAttributes(d *schema.ResourceData, rs *awstypes.SelfManagedActiveDirectoryAttributes) []interface{} {
+func flattenSelfManagedActiveDirectoryAttributes(d *schema.ResourceData, rs *awstypes.SelfManagedActiveDirectoryAttributes) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.DnsIps != nil {
 		m["dns_ips"] = rs.DnsIps
 	}
@@ -661,15 +661,15 @@ func flattenSelfManagedActiveDirectoryAttributes(d *schema.ResourceData, rs *aws
 		m[names.AttrPassword] = v.(string)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenSvmEndpoints(rs *awstypes.SvmEndpoints) []interface{} {
+func flattenSvmEndpoints(rs *awstypes.SvmEndpoints) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.Iscsi != nil {
 		m["iscsi"] = flattenSvmEndpoint(rs.Iscsi)
 	}
@@ -682,15 +682,15 @@ func flattenSvmEndpoints(rs *awstypes.SvmEndpoints) []interface{} {
 	if rs.Smb != nil {
 		m["smb"] = flattenSvmEndpoint(rs.Smb)
 	}
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenSvmEndpoint(rs *awstypes.SvmEndpoint) []interface{} {
+func flattenSvmEndpoint(rs *awstypes.SvmEndpoint) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	if rs.DNSName != nil {
 		m[names.AttrDNSName] = aws.ToString(rs.DNSName)
 	}
@@ -698,5 +698,5 @@ func flattenSvmEndpoint(rs *awstypes.SvmEndpoint) []interface{} {
 		m[names.AttrIPAddresses] = flex.FlattenStringValueSet(rs.IpAddresses)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_data_source.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_data_source.go
@@ -193,7 +193,7 @@ func dataSourceONTAPStorageVirtualMachine() *schema.Resource {
 	}
 }
 
-func dataSourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
@@ -253,16 +253,16 @@ func dataSourceONTAPStorageVirtualMachineRead(ctx context.Context, d *schema.Res
 	return diags
 }
 
-func flattenLifecycleTransitionReason(rs *awstypes.LifecycleTransitionReason) []interface{} {
+func flattenLifecycleTransitionReason(rs *awstypes.LifecycleTransitionReason) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	if rs.Message != nil {
 		m[names.AttrMessage] = aws.ToString(rs.Message)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate.go
@@ -211,7 +211,7 @@ func resourceONTAPStorageVirtualMachineV0() *schema.Resource {
 	}
 }
 
-func resourceONTAPStorageVirtualMachineStateUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceONTAPStorageVirtualMachineStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
 
 	rawState["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name"] = rawState["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"]

--- a/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
+++ b/internal/service/fsx/ontap_storage_virtual_machine_migrate_test.go
@@ -10,15 +10,15 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func testOntapStorageVirtualMachineStateDataV0() map[string]interface{} {
-	return map[string]interface{}{
+func testOntapStorageVirtualMachineStateDataV0() map[string]any {
+	return map[string]any{
 		"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name": "MeArrugoDerrito",
 	}
 }
 
-func testOntapStorageVirtualMachineStateDataV1() map[string]interface{} {
+func testOntapStorageVirtualMachineStateDataV1() map[string]any {
 	v0 := testOntapStorageVirtualMachineStateDataV0()
-	return map[string]interface{}{
+	return map[string]any{
 		"active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguished_name": v0["active_directory_configuration.0.self_managed_active_directory_configuration.0.organizational_unit_distinguidshed_name"],
 	}
 }

--- a/internal/service/fsx/ontap_storage_virtual_machines_data_source.go
+++ b/internal/service/fsx/ontap_storage_virtual_machines_data_source.go
@@ -33,7 +33,7 @@ func dataSourceONTAPStorageVirtualMachines() *schema.Resource {
 	}
 }
 
-func dataSourceONTAPStorageVirtualMachinesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceONTAPStorageVirtualMachinesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 

--- a/internal/service/fsx/ontap_volume.go
+++ b/internal/service/fsx/ontap_volume.go
@@ -42,7 +42,7 @@ func resourceONTAPVolume() *schema.Resource {
 		DeleteWithoutTimeout: resourceONTAPVolumeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("bypass_snaplock_enterprise_retention", false)
 				d.Set("skip_final_backup", false)
 
@@ -344,7 +344,7 @@ func resourceONTAPVolume() *schema.Resource {
 	}
 }
 
-func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -352,8 +352,8 @@ func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta
 		StorageVirtualMachineId: aws.String(d.Get("storage_virtual_machine_id").(string)),
 	}
 
-	if v, ok := d.GetOk("aggregate_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		ontapConfig.AggregateConfiguration = expandAggregateConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("aggregate_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		ontapConfig.AggregateConfiguration = expandAggregateConfiguration(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("copy_tags_to_backups"); ok {
@@ -380,8 +380,8 @@ func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta
 		ontapConfig.SizeInMegabytes = aws.Int32(int32(v.(int)))
 	}
 
-	if v, ok := d.GetOk("snaplock_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		ontapConfig.SnaplockConfiguration = expandCreateSnaplockConfiguration(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("snaplock_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		ontapConfig.SnaplockConfiguration = expandCreateSnaplockConfiguration(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("snapshot_policy"); ok {
@@ -392,8 +392,8 @@ func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta
 		ontapConfig.StorageEfficiencyEnabled = aws.Bool(v.(bool))
 	}
 
-	if v, ok := d.GetOk("tiering_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		ontapConfig.TieringPolicy = expandTieringPolicy(v.([]interface{})[0].(map[string]interface{}))
+	if v, ok := d.GetOk("tiering_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		ontapConfig.TieringPolicy = expandTieringPolicy(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk("volume_style"); ok {
@@ -423,7 +423,7 @@ func resourceONTAPVolumeCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceONTAPVolumeRead(ctx, d, meta)...)
 }
 
-func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -442,7 +442,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	ontapConfig := volume.OntapConfiguration
 
 	if ontapConfig.AggregateConfiguration != nil {
-		if err := d.Set("aggregate_configuration", []interface{}{flattenAggregateConfiguration(ontapConfig.AggregateConfiguration)}); err != nil {
+		if err := d.Set("aggregate_configuration", []any{flattenAggregateConfiguration(ontapConfig.AggregateConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting aggregate_configuration: %s", err)
 		}
 	} else {
@@ -458,7 +458,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("size_in_bytes", flex.Int64ToStringValue(ontapConfig.SizeInBytes))
 	d.Set("size_in_megabytes", ontapConfig.SizeInMegabytes)
 	if ontapConfig.SnaplockConfiguration != nil {
-		if err := d.Set("snaplock_configuration", []interface{}{flattenSnaplockConfiguration(ontapConfig.SnaplockConfiguration)}); err != nil {
+		if err := d.Set("snaplock_configuration", []any{flattenSnaplockConfiguration(ontapConfig.SnaplockConfiguration)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting snaplock_configuration: %s", err)
 		}
 	} else {
@@ -468,7 +468,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	d.Set("storage_efficiency_enabled", ontapConfig.StorageEfficiencyEnabled)
 	d.Set("storage_virtual_machine_id", ontapConfig.StorageVirtualMachineId)
 	if ontapConfig.TieringPolicy != nil {
-		if err := d.Set("tiering_policy", []interface{}{flattenTieringPolicy(ontapConfig.TieringPolicy)}); err != nil {
+		if err := d.Set("tiering_policy", []any{flattenTieringPolicy(ontapConfig.TieringPolicy)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting tiering_policy: %s", err)
 		}
 	} else {
@@ -484,7 +484,7 @@ func resourceONTAPVolumeRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceONTAPVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -519,8 +519,8 @@ func resourceONTAPVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if d.HasChange("snaplock_configuration") {
-			if v, ok := d.GetOk("snaplock_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				ontapConfig.SnaplockConfiguration = expandUpdateSnaplockConfiguration(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("snaplock_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				ontapConfig.SnaplockConfiguration = expandUpdateSnaplockConfiguration(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -533,8 +533,8 @@ func resourceONTAPVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		if d.HasChange("tiering_policy") {
-			if v, ok := d.GetOk("tiering_policy"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-				ontapConfig.TieringPolicy = expandTieringPolicy(v.([]interface{})[0].(map[string]interface{}))
+			if v, ok := d.GetOk("tiering_policy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				ontapConfig.TieringPolicy = expandTieringPolicy(v.([]any)[0].(map[string]any))
 			}
 		}
 
@@ -563,7 +563,7 @@ func resourceONTAPVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceONTAPVolumeRead(ctx, d, meta)...)
 }
 
-func resourceONTAPVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceONTAPVolumeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -575,7 +575,7 @@ func resourceONTAPVolumeDelete(ctx context.Context, d *schema.ResourceData, meta
 		VolumeId: aws.String(d.Id()),
 	}
 
-	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]interface{})) > 0 {
+	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]any)) > 0 {
 		input.OntapConfiguration.FinalBackupTags = Tags(tftags.New(ctx, v))
 	}
 
@@ -669,7 +669,7 @@ func findVolumes(ctx context.Context, conn *fsx.Client, input *fsx.DescribeVolum
 }
 
 func statusVolume(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVolumeByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {
@@ -787,7 +787,7 @@ func findVolumeAdministrativeAction(ctx context.Context, conn *fsx.Client, volID
 }
 
 func statusVolumeAdministrativeAction(ctx context.Context, conn *fsx.Client, volID string, actionType awstypes.AdministrativeActionType) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVolumeAdministrativeAction(ctx, conn, volID, actionType)
 
 		if tfresource.NotFound(err) {
@@ -824,14 +824,14 @@ func waitVolumeAdministrativeActionCompleted(ctx context.Context, conn *fsx.Clie
 	return nil, err
 }
 
-func expandAggregateConfiguration(tfMap map[string]interface{}) *awstypes.CreateAggregateConfiguration {
+func expandAggregateConfiguration(tfMap map[string]any) *awstypes.CreateAggregateConfiguration {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.CreateAggregateConfiguration{}
 
-	if v, ok := tfMap["aggregates"].([]interface{}); ok && v != nil {
+	if v, ok := tfMap["aggregates"].([]any); ok && v != nil {
 		apiObject.Aggregates = flex.ExpandStringValueList(v)
 	}
 
@@ -842,12 +842,12 @@ func expandAggregateConfiguration(tfMap map[string]interface{}) *awstypes.Create
 	return apiObject
 }
 
-func flattenAggregateConfiguration(apiObject *awstypes.AggregateConfiguration) map[string]interface{} {
+func flattenAggregateConfiguration(apiObject *awstypes.AggregateConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	var aggregates int32
 
@@ -872,7 +872,7 @@ func flattenAggregateConfiguration(apiObject *awstypes.AggregateConfiguration) m
 
 const minTieringPolicyCoolingPeriod = 2
 
-func expandTieringPolicy(tfMap map[string]interface{}) *awstypes.TieringPolicy {
+func expandTieringPolicy(tfMap map[string]any) *awstypes.TieringPolicy {
 	if tfMap == nil {
 		return nil
 	}
@@ -894,12 +894,12 @@ func expandTieringPolicy(tfMap map[string]interface{}) *awstypes.TieringPolicy {
 	return apiObject
 }
 
-func flattenTieringPolicy(apiObject *awstypes.TieringPolicy) map[string]interface{} {
+func flattenTieringPolicy(apiObject *awstypes.TieringPolicy) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.CoolingPeriod; v != nil {
 		if v := aws.ToInt32(v); v >= minTieringPolicyCoolingPeriod {
@@ -912,7 +912,7 @@ func flattenTieringPolicy(apiObject *awstypes.TieringPolicy) map[string]interfac
 	return tfMap
 }
 
-func expandCreateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.CreateSnaplockConfiguration {
+func expandCreateSnaplockConfiguration(tfMap map[string]any) *awstypes.CreateSnaplockConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -923,16 +923,16 @@ func expandCreateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.C
 		apiObject.AuditLogVolume = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["autocommit_period"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AutocommitPeriod = expandAutocommitPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap["autocommit_period"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AutocommitPeriod = expandAutocommitPeriod(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["privileged_delete"].(string); ok && v != "" {
 		apiObject.PrivilegedDelete = awstypes.PrivilegedDelete(v)
 	}
 
-	if v, ok := tfMap[names.AttrRetentionPeriod].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.RetentionPeriod = expandSnaplockRetentionPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap[names.AttrRetentionPeriod].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.RetentionPeriod = expandSnaplockRetentionPeriod(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["snaplock_type"].(string); ok && v != "" {
@@ -946,7 +946,7 @@ func expandCreateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.C
 	return apiObject
 }
 
-func expandUpdateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.UpdateSnaplockConfiguration {
+func expandUpdateSnaplockConfiguration(tfMap map[string]any) *awstypes.UpdateSnaplockConfiguration {
 	if tfMap == nil {
 		return nil
 	}
@@ -957,16 +957,16 @@ func expandUpdateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.U
 		apiObject.AuditLogVolume = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["autocommit_period"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.AutocommitPeriod = expandAutocommitPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap["autocommit_period"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.AutocommitPeriod = expandAutocommitPeriod(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["privileged_delete"].(string); ok && v != "" {
 		apiObject.PrivilegedDelete = awstypes.PrivilegedDelete(v)
 	}
 
-	if v, ok := tfMap[names.AttrRetentionPeriod].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.RetentionPeriod = expandSnaplockRetentionPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap[names.AttrRetentionPeriod].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.RetentionPeriod = expandSnaplockRetentionPeriod(v[0].(map[string]any))
 	}
 
 	if v, ok := tfMap["volume_append_mode_enabled"].(bool); ok && v {
@@ -976,7 +976,7 @@ func expandUpdateSnaplockConfiguration(tfMap map[string]interface{}) *awstypes.U
 	return apiObject
 }
 
-func expandAutocommitPeriod(tfMap map[string]interface{}) *awstypes.AutocommitPeriod {
+func expandAutocommitPeriod(tfMap map[string]any) *awstypes.AutocommitPeriod {
 	if tfMap == nil {
 		return nil
 	}
@@ -994,29 +994,29 @@ func expandAutocommitPeriod(tfMap map[string]interface{}) *awstypes.AutocommitPe
 	return apiObject
 }
 
-func expandSnaplockRetentionPeriod(tfMap map[string]interface{}) *awstypes.SnaplockRetentionPeriod {
+func expandSnaplockRetentionPeriod(tfMap map[string]any) *awstypes.SnaplockRetentionPeriod {
 	if tfMap == nil {
 		return nil
 	}
 
 	apiObject := &awstypes.SnaplockRetentionPeriod{}
 
-	if v, ok := tfMap["default_retention"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.DefaultRetention = expandRetentionPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap["default_retention"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.DefaultRetention = expandRetentionPeriod(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["maximum_retention"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.MaximumRetention = expandRetentionPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap["maximum_retention"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.MaximumRetention = expandRetentionPeriod(v[0].(map[string]any))
 	}
 
-	if v, ok := tfMap["minimum_retention"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-		apiObject.MinimumRetention = expandRetentionPeriod(v[0].(map[string]interface{}))
+	if v, ok := tfMap["minimum_retention"].([]any); ok && len(v) > 0 && v[0] != nil {
+		apiObject.MinimumRetention = expandRetentionPeriod(v[0].(map[string]any))
 	}
 
 	return apiObject
 }
 
-func expandRetentionPeriod(tfMap map[string]interface{}) *awstypes.RetentionPeriod {
+func expandRetentionPeriod(tfMap map[string]any) *awstypes.RetentionPeriod {
 	if tfMap == nil {
 		return nil
 	}
@@ -1034,25 +1034,25 @@ func expandRetentionPeriod(tfMap map[string]interface{}) *awstypes.RetentionPeri
 	return apiObject
 }
 
-func flattenSnaplockConfiguration(apiObject *awstypes.SnaplockConfiguration) map[string]interface{} {
+func flattenSnaplockConfiguration(apiObject *awstypes.SnaplockConfiguration) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.AuditLogVolume; v != nil {
 		tfMap["audit_log_volume"] = aws.ToBool(v)
 	}
 
 	if v := apiObject.AutocommitPeriod; v != nil {
-		tfMap["autocommit_period"] = []interface{}{flattenAutocommitPeriod(v)}
+		tfMap["autocommit_period"] = []any{flattenAutocommitPeriod(v)}
 	}
 
 	tfMap["privileged_delete"] = string(apiObject.PrivilegedDelete)
 
 	if v := apiObject.RetentionPeriod; v != nil {
-		tfMap[names.AttrRetentionPeriod] = []interface{}{flattenSnaplockRetentionPeriod(v)}
+		tfMap[names.AttrRetentionPeriod] = []any{flattenSnaplockRetentionPeriod(v)}
 	}
 
 	tfMap["snaplock_type"] = string(apiObject.SnaplockType)
@@ -1064,12 +1064,12 @@ func flattenSnaplockConfiguration(apiObject *awstypes.SnaplockConfiguration) map
 	return tfMap
 }
 
-func flattenAutocommitPeriod(apiObject *awstypes.AutocommitPeriod) map[string]interface{} {
+func flattenAutocommitPeriod(apiObject *awstypes.AutocommitPeriod) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrType] = string(apiObject.Type)
 
@@ -1080,34 +1080,34 @@ func flattenAutocommitPeriod(apiObject *awstypes.AutocommitPeriod) map[string]in
 	return tfMap
 }
 
-func flattenSnaplockRetentionPeriod(apiObject *awstypes.SnaplockRetentionPeriod) map[string]interface{} {
+func flattenSnaplockRetentionPeriod(apiObject *awstypes.SnaplockRetentionPeriod) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if v := apiObject.DefaultRetention; v != nil {
-		tfMap["default_retention"] = []interface{}{flattenRetentionPeriod(v)}
+		tfMap["default_retention"] = []any{flattenRetentionPeriod(v)}
 	}
 
 	if v := apiObject.MaximumRetention; v != nil {
-		tfMap["maximum_retention"] = []interface{}{flattenRetentionPeriod(v)}
+		tfMap["maximum_retention"] = []any{flattenRetentionPeriod(v)}
 	}
 
 	if v := apiObject.MinimumRetention; v != nil {
-		tfMap["minimum_retention"] = []interface{}{flattenRetentionPeriod(v)}
+		tfMap["minimum_retention"] = []any{flattenRetentionPeriod(v)}
 	}
 
 	return tfMap
 }
 
-func flattenRetentionPeriod(apiObject *awstypes.RetentionPeriod) map[string]interface{} {
+func flattenRetentionPeriod(apiObject *awstypes.RetentionPeriod) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	tfMap[names.AttrType] = string(apiObject.Type)
 

--- a/internal/service/fsx/openzfs_file_system.go
+++ b/internal/service/fsx/openzfs_file_system.go
@@ -40,7 +40,7 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 		DeleteWithoutTimeout: resourceOpenZFSFileSystemDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("skip_final_backup", false)
 
 				return []*schema.ResourceData{d}, nil
@@ -316,7 +316,7 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			validateDiskConfigurationIOPS,
-			func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, d *schema.ResourceDiff, meta any) error {
 				var (
 					singleAZ1ThroughputCapacityValues            = []int{64, 128, 256, 512, 1024, 2048, 3072, 4096}
 					singleAZ2AndMultiAZ1ThroughputCapacityValues = []int{160, 320, 640, 1280, 2560, 3840, 5120, 7680, 10240}
@@ -341,12 +341,12 @@ func resourceOpenZFSFileSystem() *schema.Resource {
 	}
 }
 
-func validateDiskConfigurationIOPS(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+func validateDiskConfigurationIOPS(_ context.Context, d *schema.ResourceDiff, meta any) error {
 	deploymentType := d.Get("deployment_type").(string)
 
 	if diskConfiguration, ok := d.GetOk("disk_iops_configuration"); ok {
-		if len(diskConfiguration.([]interface{})) > 0 {
-			m := diskConfiguration.([]interface{})[0].(map[string]interface{})
+		if len(diskConfiguration.([]any)) > 0 {
+			m := diskConfiguration.([]any)[0].(map[string]any)
 
 			if v, ok := m[names.AttrIOPS].(int); ok {
 				if deploymentType == string(awstypes.OpenZFSDeploymentTypeSingleAz1) {
@@ -365,7 +365,7 @@ func validateDiskConfigurationIOPS(_ context.Context, d *schema.ResourceDiff, me
 	return nil
 }
 
-func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -378,7 +378,7 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		},
 		StorageCapacity: aws.Int32(int32(d.Get("storage_capacity").(int))),
 		StorageType:     awstypes.StorageType(d.Get(names.AttrStorageType).(string)),
-		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:       flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:            getTagsIn(ctx),
 	}
 	inputB := &fsx.CreateFileSystemFromBackupInput{
@@ -388,7 +388,7 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 			AutomaticBackupRetentionDays: aws.Int32(int32(d.Get("automatic_backup_retention_days").(int))),
 		},
 		StorageType: awstypes.StorageType(d.Get(names.AttrStorageType).(string)),
-		SubnetIds:   flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:   flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:        getTagsIn(ctx),
 	}
 
@@ -408,8 +408,8 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if v, ok := d.GetOk("disk_iops_configuration"); ok {
-		inputC.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(v.([]interface{}))
-		inputB.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(v.([]interface{}))
+		inputC.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(v.([]any))
+		inputB.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("endpoint_ip_address_range"); ok {
@@ -428,8 +428,8 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if v, ok := d.GetOk("root_volume_configuration"); ok {
-		inputC.OpenZFSConfiguration.RootVolumeConfiguration = expandOpenZFSCreateRootVolumeConfiguration(v.([]interface{}))
-		inputB.OpenZFSConfiguration.RootVolumeConfiguration = expandOpenZFSCreateRootVolumeConfiguration(v.([]interface{}))
+		inputC.OpenZFSConfiguration.RootVolumeConfiguration = expandOpenZFSCreateRootVolumeConfiguration(v.([]any))
+		inputB.OpenZFSConfiguration.RootVolumeConfiguration = expandOpenZFSCreateRootVolumeConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("route_table_ids"); ok {
@@ -480,7 +480,7 @@ func resourceOpenZFSFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceOpenZFSFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -540,7 +540,7 @@ func resourceOpenZFSFileSystemRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -574,7 +574,7 @@ func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("disk_iops_configuration") {
-			input.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(d.Get("disk_iops_configuration").([]interface{}))
+			input.OpenZFSConfiguration.DiskIopsConfiguration = expandDiskIopsConfiguration(d.Get("disk_iops_configuration").([]any))
 		}
 
 		if d.HasChange("route_table_ids") {
@@ -621,7 +621,7 @@ func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 			rootVolumeID := d.Get("root_volume_id").(string)
 			input := &fsx.UpdateVolumeInput{
 				ClientRequestToken:   aws.String(id.UniqueId()),
-				OpenZFSConfiguration: expandUpdateOpenZFSVolumeConfiguration(d.Get("root_volume_configuration").([]interface{})),
+				OpenZFSConfiguration: expandUpdateOpenZFSVolumeConfiguration(d.Get("root_volume_configuration").([]any)),
 				VolumeId:             aws.String(rootVolumeID),
 			}
 
@@ -645,7 +645,7 @@ func resourceOpenZFSFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceOpenZFSFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -660,7 +660,7 @@ func resourceOpenZFSFileSystemDelete(ctx context.Context, d *schema.ResourceData
 		input.OpenZFSConfiguration.Options = flex.ExpandStringyValueSet[awstypes.DeleteFileSystemOpenZFSOption](v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]interface{})) > 0 {
+	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]any)) > 0 {
 		input.OpenZFSConfiguration.FinalBackupTags = Tags(tftags.New(ctx, v))
 	}
 
@@ -682,12 +682,12 @@ func resourceOpenZFSFileSystemDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func expandDiskIopsConfiguration(cfg []interface{}) *awstypes.DiskIopsConfiguration {
+func expandDiskIopsConfiguration(cfg []any) *awstypes.DiskIopsConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.DiskIopsConfiguration{}
 
@@ -702,12 +702,12 @@ func expandDiskIopsConfiguration(cfg []interface{}) *awstypes.DiskIopsConfigurat
 	return &out
 }
 
-func expandOpenZFSCreateRootVolumeConfiguration(tfList []interface{}) *awstypes.OpenZFSCreateRootVolumeConfiguration {
+func expandOpenZFSCreateRootVolumeConfiguration(tfList []any) *awstypes.OpenZFSCreateRootVolumeConfiguration {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.OpenZFSCreateRootVolumeConfiguration{}
 
 	if v, ok := tfMap["copy_tags_to_snapshots"].(bool); ok {
@@ -718,7 +718,7 @@ func expandOpenZFSCreateRootVolumeConfiguration(tfList []interface{}) *awstypes.
 		apiObject.DataCompressionType = awstypes.OpenZFSDataCompressionType(v)
 	}
 
-	if v, ok := tfMap["nfs_exports"].([]interface{}); ok {
+	if v, ok := tfMap["nfs_exports"].([]any); ok {
 		apiObject.NfsExports = expandOpenZFSNfsExports(v)
 	}
 
@@ -737,19 +737,19 @@ func expandOpenZFSCreateRootVolumeConfiguration(tfList []interface{}) *awstypes.
 	return apiObject
 }
 
-func expandUpdateOpenZFSVolumeConfiguration(tfList []interface{}) *awstypes.UpdateOpenZFSVolumeConfiguration {
+func expandUpdateOpenZFSVolumeConfiguration(tfList []any) *awstypes.UpdateOpenZFSVolumeConfiguration {
 	if len(tfList) < 1 {
 		return nil
 	}
 
-	tfMap := tfList[0].(map[string]interface{})
+	tfMap := tfList[0].(map[string]any)
 	apiObject := &awstypes.UpdateOpenZFSVolumeConfiguration{}
 
 	if v, ok := tfMap["data_compression_type"].(string); ok {
 		apiObject.DataCompressionType = awstypes.OpenZFSDataCompressionType(v)
 	}
 
-	if v, ok := tfMap["nfs_exports"].([]interface{}); ok {
+	if v, ok := tfMap["nfs_exports"].([]any); ok {
 		apiObject.NfsExports = expandOpenZFSNfsExports(v)
 	}
 
@@ -768,26 +768,26 @@ func expandUpdateOpenZFSVolumeConfiguration(tfList []interface{}) *awstypes.Upda
 	return apiObject
 }
 
-func flattenDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []interface{} {
+func flattenDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m[names.AttrMode] = string(rs.Mode)
 	if rs.Iops != nil {
 		m[names.AttrIOPS] = aws.ToInt64(rs.Iops)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenOpenZFSFileSystemRootVolume(apiObject *awstypes.Volume) []interface{} {
+func flattenOpenZFSFileSystemRootVolume(apiObject *awstypes.Volume) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := make(map[string]interface{})
+	tfMap := make(map[string]any)
 
 	if apiObject.OpenZFSConfiguration.CopyTagsToSnapshots != nil {
 		tfMap["copy_tags_to_snapshots"] = aws.ToBool(apiObject.OpenZFSConfiguration.CopyTagsToSnapshots)
@@ -806,7 +806,7 @@ func flattenOpenZFSFileSystemRootVolume(apiObject *awstypes.Volume) []interface{
 		tfMap["user_and_group_quotas"] = flattenOpenZFSUserOrGroupQuotas(apiObject.OpenZFSConfiguration.UserAndGroupQuotas)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 func findOpenZFSFileSystemByID(ctx context.Context, conn *fsx.Client, id string) (*awstypes.FileSystem, error) {

--- a/internal/service/fsx/openzfs_snapshot.go
+++ b/internal/service/fsx/openzfs_snapshot.go
@@ -73,7 +73,7 @@ func resourceOpenZFSSnapshot() *schema.Resource {
 	}
 }
 
-func resourceOpenZFSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSSnapshotCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -99,7 +99,7 @@ func resourceOpenZFSSnapshotCreate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceOpenZFSSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -126,7 +126,7 @@ func resourceOpenZFSSnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func resourceOpenZFSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -154,7 +154,7 @@ func resourceOpenZFSSnapshotUpdate(ctx context.Context, d *schema.ResourceData, 
 	return append(diags, resourceOpenZFSSnapshotRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSSnapshotDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -225,7 +225,7 @@ func findSnapshots(ctx context.Context, conn *fsx.Client, input *fsx.DescribeSna
 }
 
 func statusSnapshot(ctx context.Context, conn *fsx.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findSnapshotByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/fsx/openzfs_snapshot_data_source.go
+++ b/internal/service/fsx/openzfs_snapshot_data_source.go
@@ -63,15 +63,15 @@ func dataSourceOpenzfsSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceOpenZFSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceOpenZFSSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
 
 	input := &fsx.DescribeSnapshotsInput{}
 
-	if v, ok := d.GetOk("snapshot_ids"); ok && len(v.([]interface{})) > 0 {
-		input.SnapshotIds = flex.ExpandStringValueList(v.([]interface{}))
+	if v, ok := d.GetOk("snapshot_ids"); ok && len(v.([]any)) > 0 {
+		input.SnapshotIds = flex.ExpandStringValueList(v.([]any))
 	}
 
 	input.Filters = append(input.Filters, newSnapshotFilterList(

--- a/internal/service/fsx/openzfs_volume.go
+++ b/internal/service/fsx/openzfs_volume.go
@@ -37,7 +37,7 @@ func resourceOpenZFSVolume() *schema.Resource {
 		DeleteWithoutTimeout: resourceOpenZFSVolumeDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("delete_volume_options", nil)
 
 				return []*schema.ResourceData{d}, nil
@@ -208,7 +208,7 @@ func resourceOpenZFSVolume() *schema.Resource {
 	}
 }
 
-func resourceOpenZFSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSVolumeCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -225,11 +225,11 @@ func resourceOpenZFSVolumeCreate(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if v, ok := d.GetOk("nfs_exports"); ok {
-		openzfsConfig.NfsExports = expandOpenZFSNfsExports(v.([]interface{}))
+		openzfsConfig.NfsExports = expandOpenZFSNfsExports(v.([]any))
 	}
 
 	if v, ok := d.GetOk("origin_snapshot"); ok {
-		openzfsConfig.OriginSnapshot = expandCreateOpenZFSOriginSnapshotConfiguration(v.([]interface{}))
+		openzfsConfig.OriginSnapshot = expandCreateOpenZFSOriginSnapshotConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("read_only"); ok {
@@ -276,7 +276,7 @@ func resourceOpenZFSVolumeCreate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceOpenZFSVolumeRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSVolumeRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSVolumeRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -320,7 +320,7 @@ func resourceOpenZFSVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	return diags
 }
 
-func resourceOpenZFSVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSVolumeUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -332,7 +332,7 @@ func resourceOpenZFSVolumeUpdate(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		if d.HasChange("nfs_exports") {
-			openzfsConfig.NfsExports = expandOpenZFSNfsExports(d.Get("nfs_exports").([]interface{}))
+			openzfsConfig.NfsExports = expandOpenZFSNfsExports(d.Get("nfs_exports").([]any))
 		}
 
 		if d.HasChange("read_only") {
@@ -384,7 +384,7 @@ func resourceOpenZFSVolumeUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceOpenZFSVolumeRead(ctx, d, meta)...)
 }
 
-func resourceOpenZFSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceOpenZFSVolumeDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -392,9 +392,9 @@ func resourceOpenZFSVolumeDelete(ctx context.Context, d *schema.ResourceData, me
 		VolumeId: aws.String(d.Id()),
 	}
 
-	if v, ok := d.GetOk("delete_volume_options"); ok && len(v.([]interface{})) > 0 {
+	if v, ok := d.GetOk("delete_volume_options"); ok && len(v.([]any)) > 0 {
 		input.OpenZFSConfiguration = &awstypes.DeleteVolumeOpenZFSConfiguration{
-			Options: flex.ExpandStringyValueList[awstypes.DeleteOpenZFSVolumeOption](v.([]interface{})),
+			Options: flex.ExpandStringyValueList[awstypes.DeleteOpenZFSVolumeOption](v.([]any)),
 		}
 	}
 
@@ -416,11 +416,11 @@ func resourceOpenZFSVolumeDelete(ctx context.Context, d *schema.ResourceData, me
 	return diags
 }
 
-func expandOpenZFSUserOrGroupQuotas(cfg []interface{}) []awstypes.OpenZFSUserOrGroupQuota {
+func expandOpenZFSUserOrGroupQuotas(cfg []any) []awstypes.OpenZFSUserOrGroupQuota {
 	quotas := []awstypes.OpenZFSUserOrGroupQuota{}
 
 	for _, quota := range cfg {
-		expandedQuota := expandOpenZFSUserOrGroupQuota(quota.(map[string]interface{}))
+		expandedQuota := expandOpenZFSUserOrGroupQuota(quota.(map[string]any))
 		if expandedQuota != nil {
 			quotas = append(quotas, *expandedQuota)
 		}
@@ -429,7 +429,7 @@ func expandOpenZFSUserOrGroupQuotas(cfg []interface{}) []awstypes.OpenZFSUserOrG
 	return quotas
 }
 
-func expandOpenZFSUserOrGroupQuota(conf map[string]interface{}) *awstypes.OpenZFSUserOrGroupQuota {
+func expandOpenZFSUserOrGroupQuota(conf map[string]any) *awstypes.OpenZFSUserOrGroupQuota {
 	if len(conf) < 1 {
 		return nil
 	}
@@ -451,11 +451,11 @@ func expandOpenZFSUserOrGroupQuota(conf map[string]interface{}) *awstypes.OpenZF
 	return &out
 }
 
-func expandOpenZFSNfsExports(tfList []interface{}) []awstypes.OpenZFSNfsExport { // nosemgrep:ci.caps4-in-func-name
+func expandOpenZFSNfsExports(tfList []any) []awstypes.OpenZFSNfsExport { // nosemgrep:ci.caps4-in-func-name
 	apiObjects := []awstypes.OpenZFSNfsExport{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -466,7 +466,7 @@ func expandOpenZFSNfsExports(tfList []interface{}) []awstypes.OpenZFSNfsExport {
 	return apiObjects
 }
 
-func expandOpenZFSNfsExport(tfMap map[string]interface{}) awstypes.OpenZFSNfsExport { // nosemgrep:ci.caps4-in-func-name
+func expandOpenZFSNfsExport(tfMap map[string]any) awstypes.OpenZFSNfsExport { // nosemgrep:ci.caps4-in-func-name
 	apiObject := awstypes.OpenZFSNfsExport{}
 
 	if v, ok := tfMap["client_configurations"]; ok {
@@ -476,11 +476,11 @@ func expandOpenZFSNfsExport(tfMap map[string]interface{}) awstypes.OpenZFSNfsExp
 	return apiObject
 }
 
-func expandOpenZFSClientConfigurations(tfList []interface{}) []awstypes.OpenZFSClientConfiguration {
+func expandOpenZFSClientConfigurations(tfList []any) []awstypes.OpenZFSClientConfiguration {
 	apiObjects := []awstypes.OpenZFSClientConfiguration{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -491,26 +491,26 @@ func expandOpenZFSClientConfigurations(tfList []interface{}) []awstypes.OpenZFSC
 	return apiObjects
 }
 
-func expandOpenZFSClientConfiguration(tfMap map[string]interface{}) awstypes.OpenZFSClientConfiguration {
+func expandOpenZFSClientConfiguration(tfMap map[string]any) awstypes.OpenZFSClientConfiguration {
 	apiObject := awstypes.OpenZFSClientConfiguration{}
 
 	if v, ok := tfMap["clients"].(string); ok && len(v) > 0 {
 		apiObject.Clients = aws.String(v)
 	}
 
-	if v, ok := tfMap["options"].([]interface{}); ok {
+	if v, ok := tfMap["options"].([]any); ok {
 		apiObject.Options = flex.ExpandStringValueList(v)
 	}
 
 	return apiObject
 }
 
-func expandCreateOpenZFSOriginSnapshotConfiguration(cfg []interface{}) *awstypes.CreateOpenZFSOriginSnapshotConfiguration {
+func expandCreateOpenZFSOriginSnapshotConfiguration(cfg []any) *awstypes.CreateOpenZFSOriginSnapshotConfiguration {
 	if len(cfg) < 1 {
 		return nil
 	}
 
-	conf := cfg[0].(map[string]interface{})
+	conf := cfg[0].(map[string]any)
 
 	out := awstypes.CreateOpenZFSOriginSnapshotConfiguration{}
 
@@ -525,8 +525,8 @@ func expandCreateOpenZFSOriginSnapshotConfiguration(cfg []interface{}) *awstypes
 	return &out
 }
 
-func flattenOpenZFSNfsExports(apiObjects []awstypes.OpenZFSNfsExport) []interface{} { // nosemgrep:ci.caps4-in-func-name
-	tfList := make([]interface{}, 0)
+func flattenOpenZFSNfsExports(apiObjects []awstypes.OpenZFSNfsExport) []any { // nosemgrep:ci.caps4-in-func-name
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
 		// The API may return '"NfsExports":[null]'.
@@ -534,7 +534,7 @@ func flattenOpenZFSNfsExports(apiObjects []awstypes.OpenZFSNfsExport) []interfac
 			continue
 		}
 
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 		tfMap["client_configurations"] = flattenOpenZFSClientConfigurations(apiObject.ClientConfigurations)
 		tfList = append(tfList, tfMap)
 	}
@@ -546,11 +546,11 @@ func flattenOpenZFSNfsExports(apiObjects []awstypes.OpenZFSNfsExport) []interfac
 	return nil
 }
 
-func flattenOpenZFSClientConfigurations(apiObjects []awstypes.OpenZFSClientConfiguration) []interface{} {
-	tfList := make([]interface{}, 0)
+func flattenOpenZFSClientConfigurations(apiObjects []awstypes.OpenZFSClientConfiguration) []any {
+	tfList := make([]any, 0)
 
 	for _, apiObject := range apiObjects {
-		tfMap := make(map[string]interface{})
+		tfMap := make(map[string]any)
 		tfMap["clients"] = aws.ToString(apiObject.Clients)
 		tfMap["options"] = apiObject.Options
 		tfList = append(tfList, tfMap)
@@ -563,11 +563,11 @@ func flattenOpenZFSClientConfigurations(apiObjects []awstypes.OpenZFSClientConfi
 	return nil
 }
 
-func flattenOpenZFSUserOrGroupQuotas(rs []awstypes.OpenZFSUserOrGroupQuota) []map[string]interface{} {
-	quotas := make([]map[string]interface{}, 0)
+func flattenOpenZFSUserOrGroupQuotas(rs []awstypes.OpenZFSUserOrGroupQuota) []map[string]any {
+	quotas := make([]map[string]any, 0)
 
 	for _, quota := range rs {
-		cfg := make(map[string]interface{})
+		cfg := make(map[string]any)
 		cfg[names.AttrID] = aws.ToInt32(quota.Id)
 		cfg["storage_capacity_quota_gib"] = aws.ToInt32(quota.StorageCapacityQuotaGiB)
 		cfg[names.AttrType] = string(quota.Type)
@@ -581,18 +581,18 @@ func flattenOpenZFSUserOrGroupQuotas(rs []awstypes.OpenZFSUserOrGroupQuota) []ma
 	return nil
 }
 
-func flattenOpenZFSOriginSnapshotConfiguration(rs *awstypes.OpenZFSOriginSnapshotConfiguration) []interface{} {
+func flattenOpenZFSOriginSnapshotConfiguration(rs *awstypes.OpenZFSOriginSnapshotConfiguration) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["copy_strategy"] = string(rs.CopyStrategy)
 	if rs.SnapshotARN != nil {
 		m["snapshot_arn"] = aws.ToString(rs.SnapshotARN)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 func findOpenZFSVolumeByID(ctx context.Context, conn *fsx.Client, id string) (*awstypes.Volume, error) {

--- a/internal/service/fsx/windows_file_system.go
+++ b/internal/service/fsx/windows_file_system.go
@@ -40,7 +40,7 @@ func resourceWindowsFileSystem() *schema.Resource {
 		DeleteWithoutTimeout: resourceWindowsFileSystemDelete,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				d.Set("skip_final_backup", false)
 
 				return []*schema.ResourceData{d}, nil
@@ -300,7 +300,7 @@ func resourceWindowsFileSystem() *schema.Resource {
 	}
 }
 
-func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -308,7 +308,7 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		ClientRequestToken: aws.String(id.UniqueId()),
 		FileSystemType:     awstypes.FileSystemTypeWindows,
 		StorageCapacity:    aws.Int32(int32(d.Get("storage_capacity").(int))),
-		SubnetIds:          flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:          flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:               getTagsIn(ctx),
 		WindowsConfiguration: &awstypes.CreateFileSystemWindowsConfiguration{
 			AutomaticBackupRetentionDays: aws.Int32(int32(d.Get("automatic_backup_retention_days").(int))),
@@ -318,7 +318,7 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	}
 	inputB := &fsx.CreateFileSystemFromBackupInput{
 		ClientRequestToken: aws.String(id.UniqueId()),
-		SubnetIds:          flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]interface{})),
+		SubnetIds:          flex.ExpandStringValueList(d.Get(names.AttrSubnetIDs).([]any)),
 		Tags:               getTagsIn(ctx),
 		WindowsConfiguration: &awstypes.CreateFileSystemWindowsConfiguration{
 			AutomaticBackupRetentionDays: aws.Int32(int32(d.Get("automatic_backup_retention_days").(int))),
@@ -337,9 +337,9 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		inputB.WindowsConfiguration.Aliases = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
-	if v, ok := d.GetOk("audit_log_configuration"); ok && len(v.([]interface{})) > 0 {
-		inputC.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(v.([]interface{}))
-		inputB.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("audit_log_configuration"); ok && len(v.([]any)) > 0 {
+		inputC.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(v.([]any))
+		inputB.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("daily_automatic_backup_start_time"); ok {
@@ -347,9 +347,9 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 		inputB.WindowsConfiguration.DailyAutomaticBackupStartTime = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("disk_iops_configuration"); ok && len(v.([]interface{})) > 0 {
-		inputC.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(v.([]interface{}))
-		inputB.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("disk_iops_configuration"); ok && len(v.([]any)) > 0 {
+		inputC.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(v.([]any))
+		inputB.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(v.([]any))
 	}
 
 	if v, ok := d.GetOk("deployment_type"); ok {
@@ -373,8 +373,8 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	}
 
 	if v, ok := d.GetOk("self_managed_active_directory"); ok {
-		inputC.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationCreate(v.([]interface{}))
-		inputB.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationCreate(v.([]interface{}))
+		inputC.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationCreate(v.([]any))
+		inputB.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationCreate(v.([]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrStorageType); ok {
@@ -415,7 +415,7 @@ func resourceWindowsFileSystemCreate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceWindowsFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -468,7 +468,7 @@ func resourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, 
 	return diags
 }
 
-func resourceWindowsFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWindowsFileSystemUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -556,7 +556,7 @@ func resourceWindowsFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("audit_log_configuration") {
-			input.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(d.Get("audit_log_configuration").([]interface{}))
+			input.WindowsConfiguration.AuditLogConfiguration = expandWindowsAuditLogCreateConfiguration(d.Get("audit_log_configuration").([]any))
 		}
 
 		if d.HasChange("automatic_backup_retention_days") {
@@ -568,11 +568,11 @@ func resourceWindowsFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 		}
 
 		if d.HasChange("disk_iops_configuration") {
-			input.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(d.Get("disk_iops_configuration").([]interface{}))
+			input.WindowsConfiguration.DiskIopsConfiguration = expandWindowsDiskIopsConfiguration(d.Get("disk_iops_configuration").([]any))
 		}
 
 		if d.HasChange("self_managed_active_directory") {
-			input.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationUpdate(d.Get("self_managed_active_directory").([]interface{}))
+			input.WindowsConfiguration.SelfManagedActiveDirectoryConfiguration = expandSelfManagedActiveDirectoryConfigurationUpdate(d.Get("self_managed_active_directory").([]any))
 		}
 
 		if d.HasChange("storage_capacity") {
@@ -606,7 +606,7 @@ func resourceWindowsFileSystemUpdate(ctx context.Context, d *schema.ResourceData
 	return append(diags, resourceWindowsFileSystemRead(ctx, d, meta)...)
 }
 
-func resourceWindowsFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceWindowsFileSystemDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 
@@ -618,7 +618,7 @@ func resourceWindowsFileSystemDelete(ctx context.Context, d *schema.ResourceData
 		},
 	}
 
-	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]interface{})) > 0 {
+	if v, ok := d.GetOk("final_backup_tags"); ok && len(v.(map[string]any)) > 0 {
 		input.WindowsConfiguration.FinalBackupTags = Tags(tftags.New(ctx, v))
 	}
 
@@ -651,12 +651,12 @@ func expandAliasValues(aliases []awstypes.Alias) []*string {
 	return alternateDNSNames
 }
 
-func expandSelfManagedActiveDirectoryConfigurationCreate(l []interface{}) *awstypes.SelfManagedActiveDirectoryConfiguration {
+func expandSelfManagedActiveDirectoryConfigurationCreate(l []any) *awstypes.SelfManagedActiveDirectoryConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.SelfManagedActiveDirectoryConfiguration{
 		DomainName: aws.String(data[names.AttrDomainName].(string)),
 		DnsIps:     flex.ExpandStringValueSet(data["dns_ips"].(*schema.Set)),
@@ -675,12 +675,12 @@ func expandSelfManagedActiveDirectoryConfigurationCreate(l []interface{}) *awsty
 	return req
 }
 
-func expandSelfManagedActiveDirectoryConfigurationUpdate(l []interface{}) *awstypes.SelfManagedActiveDirectoryConfigurationUpdates {
+func expandSelfManagedActiveDirectoryConfigurationUpdate(l []any) *awstypes.SelfManagedActiveDirectoryConfigurationUpdates {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.SelfManagedActiveDirectoryConfigurationUpdates{}
 
 	if v, ok := data["dns_ips"].(*schema.Set); ok && v.Len() > 0 {
@@ -698,9 +698,9 @@ func expandSelfManagedActiveDirectoryConfigurationUpdate(l []interface{}) *awsty
 	return req
 }
 
-func flattenSelfManagedActiveDirectoryConfiguration(d *schema.ResourceData, adopts *awstypes.SelfManagedActiveDirectoryAttributes) []map[string]interface{} {
+func flattenSelfManagedActiveDirectoryConfiguration(d *schema.ResourceData, adopts *awstypes.SelfManagedActiveDirectoryAttributes) []map[string]any {
 	if adopts == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
 	// Since we are in a configuration block and the FSx API does not return
@@ -709,7 +709,7 @@ func flattenSelfManagedActiveDirectoryConfiguration(d *schema.ResourceData, adop
 	// This is not a pattern that should be used normally.
 	// See also: flattenEmrKerberosAttributes
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"dns_ips":                                adopts.DnsIps,
 		names.AttrDomainName:                     aws.ToString(adopts.DomainName),
 		"file_system_administrators_group":       aws.ToString(adopts.FileSystemAdministratorsGroup),
@@ -718,15 +718,15 @@ func flattenSelfManagedActiveDirectoryConfiguration(d *schema.ResourceData, adop
 		names.AttrUsername:                       aws.ToString(adopts.UserName),
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandWindowsAuditLogCreateConfiguration(l []interface{}) *awstypes.WindowsAuditLogCreateConfiguration {
+func expandWindowsAuditLogCreateConfiguration(l []any) *awstypes.WindowsAuditLogCreateConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	fileAccessAuditLogLevel, ok1 := data["file_access_audit_log_level"].(string)
 	fileShareAccessAuditLogLevel, ok2 := data["file_share_access_audit_log_level"].(string)
 
@@ -751,12 +751,12 @@ func expandWindowsAuditLogCreateConfiguration(l []interface{}) *awstypes.Windows
 	return req
 }
 
-func flattenWindowsAuditLogConfiguration(adopts *awstypes.WindowsAuditLogConfiguration) []map[string]interface{} {
+func flattenWindowsAuditLogConfiguration(adopts *awstypes.WindowsAuditLogConfiguration) []map[string]any {
 	if adopts == nil {
-		return []map[string]interface{}{}
+		return []map[string]any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"file_access_audit_log_level":       string(adopts.FileAccessAuditLogLevel),
 		"file_share_access_audit_log_level": string(adopts.FileShareAccessAuditLogLevel),
 	}
@@ -765,15 +765,15 @@ func flattenWindowsAuditLogConfiguration(adopts *awstypes.WindowsAuditLogConfigu
 		m["audit_log_destination"] = aws.ToString(adopts.AuditLogDestination)
 	}
 
-	return []map[string]interface{}{m}
+	return []map[string]any{m}
 }
 
-func expandWindowsDiskIopsConfiguration(l []interface{}) *awstypes.DiskIopsConfiguration {
+func expandWindowsDiskIopsConfiguration(l []any) *awstypes.DiskIopsConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	data := l[0].(map[string]interface{})
+	data := l[0].(map[string]any)
 	req := &awstypes.DiskIopsConfiguration{}
 
 	if v, ok := data[names.AttrIOPS].(int); ok {
@@ -787,22 +787,22 @@ func expandWindowsDiskIopsConfiguration(l []interface{}) *awstypes.DiskIopsConfi
 	return req
 }
 
-func flattenWindowsDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []interface{} {
+func flattenWindowsDiskIopsConfiguration(rs *awstypes.DiskIopsConfiguration) []any {
 	if rs == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if rs.Iops != nil {
 		m[names.AttrIOPS] = aws.ToInt64(rs.Iops)
 	}
 	m[names.AttrMode] = string(rs.Mode)
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func windowsAuditLogStateFunc(v interface{}) string {
+func windowsAuditLogStateFunc(v any) string {
 	value := v.(string)
 	// API returns the specific log stream arn instead of provided log group
 	logArn, _ := arn.Parse(value)

--- a/internal/service/fsx/windows_file_system_data_source.go
+++ b/internal/service/fsx/windows_file_system_data_source.go
@@ -166,7 +166,7 @@ func dataSourceWindowsFileSystem() *schema.Resource {
 	}
 }
 
-func dataSourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceWindowsFileSystemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).FSxClient(ctx)
 


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
