### PR TITLE
docs: add missing supported version for pre_token_configuration_type

### DIFF
--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -162,7 +162,7 @@ The following arguments are optional:
 #### pre_token_configuration_type
 
 * `lambda_arn` - (Required) The Lambda Amazon Resource Name of the Lambda function that Amazon Cognito triggers to customize access tokens. If you also set an ARN in `pre_token_generation`, its value must be identical to this one.
-* `lambda_version` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`.
+* `lambda_version` - (Required) The Lambda version represents the signature of the "version" attribute in the "event" information Amazon Cognito passes to your pre Token Generation Lambda function. The supported values are `V1_0`, `V2_0`, `V3_0`.
 
 ### password_policy
 


### PR DESCRIPTION
### Description

The attribute `lambda_config.pre_token_generation_configlambda_version` of the resource `aws_cognito_user_pool`  supports now a new value `v3_0`.

Code snippet that can be used for testing

```hcl
resource "aws_cognito_user_pool" "test" {
  name = "mypool"
 lambda_config {
  pre_token_generation_config {
    lambda_arn = "arn:aws:lambda:eu-central-1:123456789012:function:my-function"
    lambda_version = "V3_0"
  }
 }
```

### Relations

Closes #41870 

### References

- [AWS SDK Go - PreTokenGenerationLambdaVersionType](https://github.com/aws/aws-sdk-go-v2/blob/38f558d56fec53d857ae8e21b316ca0f2858fabd/service/cognitoidentityprovider/types/enums.go#L750)
- [AWS SDK Go - Cognito IDP v1.51.0 Release link](https://github.com/aws/aws-sdk-go-v2/releases/tag/service/cognitoidentityprovider/v1.51.0) (Provider version 5.90.0 uses v1.51.1 of the service)

### Output from Acceptance Testing

Not applicable, only documentation is updated.