### PR TITLE
Modernize Go code: dynamodb, backup, appconfig, apprunner

### DIFF
--- a/.github/workflows/modern_go.yml
+++ b/.github/workflows/modern_go.yml
@@ -80,12 +80,16 @@ jobs:
       # service tests
       - run: make TEST=./internal/service/apigateway modern-check
       - run: make TEST=./internal/service/apigatewayv2 modern-check
+      - run: make TEST=./internal/service/appconfig modern-check
       - run: make TEST=./internal/service/appmesh modern-check
+      - run: make TEST=./internal/service/apprunner modern-check
       - run: make TEST=./internal/service/autoscaling modern-check
+      - run: make TEST=./internal/service/backup modern-check
       - run: make TEST=./internal/service/batch modern-check
       - run: make TEST=./internal/service/cloudfront modern-check
       - run: make TEST=./internal/service/cognitoidp modern-check
       - run: make TEST=./internal/service/dms modern-check
+      - run: make TEST=./internal/service/dynamodb modern-check
       - run: make TEST=./internal/service/ec2 modern-check
       - run: make TEST=./internal/service/ecs modern-check
       - run: make TEST=./internal/service/elasticache modern-check

--- a/internal/service/appconfig/application.go
+++ b/internal/service/appconfig/application.go
@@ -55,7 +55,7 @@ func ResourceApplication() *schema.Resource {
 	}
 }
 
-func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -84,7 +84,7 @@ func resourceApplicationCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceApplicationRead(ctx, d, meta)...)
 }
 
-func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -123,7 +123,7 @@ func resourceApplicationRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -150,7 +150,7 @@ func resourceApplicationUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceApplicationRead(ctx, d, meta)...)
 }
 
-func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 

--- a/internal/service/appconfig/configuration_profile.go
+++ b/internal/service/appconfig/configuration_profile.go
@@ -118,7 +118,7 @@ func ResourceConfigurationProfile() *schema.Resource {
 	}
 }
 
-func resourceConfigurationProfileCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConfigurationProfileCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -166,7 +166,7 @@ func resourceConfigurationProfileCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceConfigurationProfileRead(ctx, d, meta)...)
 }
 
-func resourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -222,7 +222,7 @@ func resourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceConfigurationProfileUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConfigurationProfileUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -268,7 +268,7 @@ func resourceConfigurationProfileUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceConfigurationProfileRead(ctx, d, meta)...)
 }
 
-func resourceConfigurationProfileDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConfigurationProfileDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -305,7 +305,7 @@ func ConfigurationProfileParseID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func expandValidator(tfMap map[string]interface{}) awstypes.Validator {
+func expandValidator(tfMap map[string]any) awstypes.Validator {
 	validator := awstypes.Validator{}
 
 	// AppConfig API supports empty content
@@ -320,13 +320,13 @@ func expandValidator(tfMap map[string]interface{}) awstypes.Validator {
 	return validator
 }
 
-func expandValidators(tfList []interface{}) []awstypes.Validator {
+func expandValidators(tfList []any) []awstypes.Validator {
 	// AppConfig API requires a 0 length slice instead of a nil value
 	// when updating from N validators to 0/nil validators
 	validators := make([]awstypes.Validator, 0)
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -339,8 +339,8 @@ func expandValidators(tfList []interface{}) []awstypes.Validator {
 	return validators
 }
 
-func flattenValidator(validator awstypes.Validator) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenValidator(validator awstypes.Validator) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := validator.Content; v != nil {
 		tfMap[names.AttrContent] = aws.ToString(v)
@@ -351,12 +351,12 @@ func flattenValidator(validator awstypes.Validator) map[string]interface{} {
 	return tfMap
 }
 
-func flattenValidators(validators []awstypes.Validator) []interface{} {
+func flattenValidators(validators []awstypes.Validator) []any {
 	if len(validators) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, validator := range validators {
 		tfList = append(tfList, flattenValidator(validator))

--- a/internal/service/appconfig/configuration_profile_data_source.go
+++ b/internal/service/appconfig/configuration_profile_data_source.go
@@ -89,7 +89,7 @@ const (
 	DSNameConfigurationProfile = "Configuration Profile Data Source"
 )
 
-func dataSourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceConfigurationProfileRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)

--- a/internal/service/appconfig/configuration_profiles_data_source.go
+++ b/internal/service/appconfig/configuration_profiles_data_source.go
@@ -38,7 +38,7 @@ const (
 	DSNameConfigurationProfiles = "Configuration Profiles Data Source"
 )
 
-func dataSourceConfigurationProfilesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceConfigurationProfilesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)

--- a/internal/service/appconfig/deployment.go
+++ b/internal/service/appconfig/deployment.go
@@ -109,7 +109,7 @@ func ResourceDeployment() *schema.Resource {
 	}
 }
 
-func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -130,7 +130,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	const (
 		timeout = 30 * time.Minute // AWS SDK for Go v1 compatibility.
 	)
-	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, timeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, timeout, func() (any, error) {
 		return conn.StartDeployment(ctx, input)
 	})
 
@@ -147,7 +147,7 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDeploymentRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -202,7 +202,7 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -210,7 +210,7 @@ func resourceDeploymentUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceDeploymentRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentDelete(ctx context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+func resourceDeploymentDelete(ctx context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	log.Printf("[WARN] Cannot destroy AppConfig Deployment. Terraform will remove this resource from the state file, however this resource remains.")
 	return diags

--- a/internal/service/appconfig/deployment_strategy.go
+++ b/internal/service/appconfig/deployment_strategy.go
@@ -84,7 +84,7 @@ func ResourceDeploymentStrategy() *schema.Resource {
 	}
 }
 
-func resourceDeploymentStrategyCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentStrategyCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -117,7 +117,7 @@ func resourceDeploymentStrategyCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceDeploymentStrategyRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentStrategyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentStrategyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -161,7 +161,7 @@ func resourceDeploymentStrategyRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceDeploymentStrategyUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentStrategyUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -200,7 +200,7 @@ func resourceDeploymentStrategyUpdate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceDeploymentStrategyRead(ctx, d, meta)...)
 }
 
-func resourceDeploymentStrategyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceDeploymentStrategyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 

--- a/internal/service/appconfig/environment_data_source.go
+++ b/internal/service/appconfig/environment_data_source.go
@@ -77,7 +77,7 @@ const (
 	DSNameEnvironment = "Environment Data Source"
 )
 
-func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -120,12 +120,12 @@ func findEnvironmentByApplicationAndEnvironment(ctx context.Context, conn *appco
 	return res, nil
 }
 
-func flattenEnvironmentMonitors(monitors []awstypes.Monitor) []interface{} {
+func flattenEnvironmentMonitors(monitors []awstypes.Monitor) []any {
 	if len(monitors) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, monitor := range monitors {
 		tfList = append(tfList, flattenEnvironmentMonitor(monitor))
@@ -134,8 +134,8 @@ func flattenEnvironmentMonitors(monitors []awstypes.Monitor) []interface{} {
 	return tfList
 }
 
-func flattenEnvironmentMonitor(monitor awstypes.Monitor) map[string]interface{} {
-	tfMap := map[string]interface{}{}
+func flattenEnvironmentMonitor(monitor awstypes.Monitor) map[string]any {
+	tfMap := map[string]any{}
 
 	if v := monitor.AlarmArn; v != nil {
 		tfMap["alarm_arn"] = aws.ToString(v)

--- a/internal/service/appconfig/environments_data_source.go
+++ b/internal/service/appconfig/environments_data_source.go
@@ -41,7 +41,7 @@ const (
 	DSNameEnvironments = "Environments Data Source"
 )
 
-func dataSourceEnvironmentsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceEnvironmentsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)

--- a/internal/service/appconfig/extension.go
+++ b/internal/service/appconfig/extension.go
@@ -123,7 +123,7 @@ func ResourceExtension() *schema.Resource {
 	}
 }
 
-func resourceExtensionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -157,7 +157,7 @@ func resourceExtensionCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceExtensionRead(ctx, d, meta)...)
 }
 
-func resourceExtensionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -184,7 +184,7 @@ func resourceExtensionRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceExtensionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -224,7 +224,7 @@ func resourceExtensionUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceExtensionRead(ctx, d, meta)...)
 }
 
-func resourceExtensionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -245,10 +245,10 @@ func resourceExtensionDelete(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func expandExtensionActions(actionsListRaw interface{}) []awstypes.Action {
+func expandExtensionActions(actionsListRaw any) []awstypes.Action {
 	var actions []awstypes.Action
 	for _, actionRaw := range actionsListRaw.(*schema.Set).List() {
-		actionMap, ok := actionRaw.(map[string]interface{})
+		actionMap, ok := actionRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -267,21 +267,21 @@ func expandExtensionActions(actionsListRaw interface{}) []awstypes.Action {
 	return actions
 }
 
-func expandExtensionActionPoints(actionsPointListRaw []interface{}) map[string][]awstypes.Action {
+func expandExtensionActionPoints(actionsPointListRaw []any) map[string][]awstypes.Action {
 	if len(actionsPointListRaw) == 0 {
 		return map[string][]awstypes.Action{}
 	}
 
 	actionsMap := make(map[string][]awstypes.Action)
 	for _, actionPointRaw := range actionsPointListRaw {
-		actionPointMap := actionPointRaw.(map[string]interface{})
+		actionPointMap := actionPointRaw.(map[string]any)
 		actionsMap[actionPointMap["point"].(string)] = expandExtensionActions(actionPointMap[names.AttrAction])
 	}
 
 	return actionsMap
 }
 
-func expandExtensionParameters(rawParameters []interface{}) map[string]awstypes.Parameter {
+func expandExtensionParameters(rawParameters []any) map[string]awstypes.Parameter {
 	if rawParameters == nil {
 		return nil
 	}
@@ -289,7 +289,7 @@ func expandExtensionParameters(rawParameters []interface{}) map[string]awstypes.
 	parameters := make(map[string]awstypes.Parameter)
 
 	for _, rawParameterMap := range rawParameters {
-		parameterMap, ok := rawParameterMap.(map[string]interface{})
+		parameterMap, ok := rawParameterMap.(map[string]any)
 
 		if !ok {
 			continue
@@ -305,10 +305,10 @@ func expandExtensionParameters(rawParameters []interface{}) map[string]awstypes.
 	return parameters
 }
 
-func flattenExtensionActions(actions []awstypes.Action) []interface{} {
-	var rawActions []interface{}
+func flattenExtensionActions(actions []awstypes.Action) []any {
+	var rawActions []any
 	for _, action := range actions {
-		rawAction := map[string]interface{}{
+		rawAction := map[string]any{
 			names.AttrName:        aws.ToString(action.Name),
 			names.AttrDescription: aws.ToString(action.Description),
 			names.AttrRoleARN:     aws.ToString(action.RoleArn),
@@ -319,14 +319,14 @@ func flattenExtensionActions(actions []awstypes.Action) []interface{} {
 	return rawActions
 }
 
-func flattenExtensionActionPoints(actionPointsMap map[string][]awstypes.Action) []interface{} {
+func flattenExtensionActionPoints(actionPointsMap map[string][]awstypes.Action) []any {
 	if len(actionPointsMap) == 0 {
 		return nil
 	}
 
-	var rawActionPoints []interface{}
+	var rawActionPoints []any
 	for actionPoint, actions := range actionPointsMap {
-		rawActionPoint := map[string]interface{}{
+		rawActionPoint := map[string]any{
 			"point":          actionPoint,
 			names.AttrAction: flattenExtensionActions(actions),
 		}
@@ -336,14 +336,14 @@ func flattenExtensionActionPoints(actionPointsMap map[string][]awstypes.Action) 
 	return rawActionPoints
 }
 
-func flattenExtensionParameters(parameters map[string]awstypes.Parameter) []interface{} {
+func flattenExtensionParameters(parameters map[string]awstypes.Parameter) []any {
 	if len(parameters) == 0 {
 		return nil
 	}
 
-	var rawParameters []interface{}
+	var rawParameters []any
 	for key, parameter := range parameters {
-		rawParameter := map[string]interface{}{
+		rawParameter := map[string]any{
 			names.AttrName:        key,
 			names.AttrDescription: aws.ToString(parameter.Description),
 			"required":            parameter.Required,

--- a/internal/service/appconfig/extension_association.go
+++ b/internal/service/appconfig/extension_association.go
@@ -65,7 +65,7 @@ func ResourceExtensionAssociation() *schema.Resource {
 	}
 }
 
-func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -76,7 +76,7 @@ func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if v, ok := d.GetOk(names.AttrParameters); ok {
-		in.Parameters = flex.ExpandStringValueMap(v.(map[string]interface{}))
+		in.Parameters = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	out, err := conn.CreateExtensionAssociation(ctx, &in)
@@ -94,7 +94,7 @@ func resourceExtensionAssociationCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceExtensionAssociationRead(ctx, d, meta)...)
 }
 
-func resourceExtensionAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -120,7 +120,7 @@ func resourceExtensionAssociationRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
@@ -131,7 +131,7 @@ func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceD
 	}
 
 	if d.HasChange(names.AttrParameters) {
-		in.Parameters = flex.ExpandStringValueMap(d.Get(names.AttrParameters).(map[string]interface{}))
+		in.Parameters = flex.ExpandStringValueMap(d.Get(names.AttrParameters).(map[string]any))
 		requestUpdate = true
 	}
 
@@ -150,7 +150,7 @@ func resourceExtensionAssociationUpdate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceExtensionAssociationRead(ctx, d, meta)...)
 }
 
-func resourceExtensionAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceExtensionAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)

--- a/internal/service/appconfig/hosted_configuration_version.go
+++ b/internal/service/appconfig/hosted_configuration_version.go
@@ -77,7 +77,7 @@ func ResourceHostedConfigurationVersion() *schema.Resource {
 	}
 }
 
-func resourceHostedConfigurationVersionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostedConfigurationVersionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -106,7 +106,7 @@ func resourceHostedConfigurationVersionCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceHostedConfigurationVersionRead(ctx, d, meta)...)
 }
 
-func resourceHostedConfigurationVersionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostedConfigurationVersionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 
@@ -158,7 +158,7 @@ func resourceHostedConfigurationVersionRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceHostedConfigurationVersionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceHostedConfigurationVersionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).AppConfigClient(ctx)
 

--- a/internal/service/apprunner/auto_scaling_configuration_version.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version.go
@@ -94,7 +94,7 @@ func resourceAutoScalingConfigurationVersion() *schema.Resource {
 	}
 }
 
-func resourceAutoScalingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAutoScalingConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -132,7 +132,7 @@ func resourceAutoScalingConfigurationCreate(ctx context.Context, d *schema.Resou
 	return append(diags, resourceAutoScalingConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceAutoScalingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAutoScalingConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -163,12 +163,12 @@ func resourceAutoScalingConfigurationRead(ctx context.Context, d *schema.Resourc
 	return diags
 }
 
-func resourceAutoScalingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAutoScalingConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceAutoScalingConfigurationRead(ctx, d, meta)
 }
 
-func resourceAutoScalingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceAutoScalingConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -263,7 +263,7 @@ const (
 )
 
 func statusAutoScalingConfiguration(ctx context.Context, conn *apprunner.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findAutoScalingConfigurationByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apprunner/connection.go
+++ b/internal/service/apprunner/connection.go
@@ -62,7 +62,7 @@ func resourceConnection() *schema.Resource {
 	}
 }
 
-func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -85,7 +85,7 @@ func resourceConnectionCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceConnectionRead(ctx, d, meta)...)
 }
 
-func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -110,12 +110,12 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceConnectionRead(ctx, d, meta)
 }
 
-func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceConnectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -197,7 +197,7 @@ func findConnections(ctx context.Context, conn *apprunner.Client, input *apprunn
 }
 
 func statusConnection(ctx context.Context, conn *apprunner.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findConnectionByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apprunner/custom_domain_association.go
+++ b/internal/service/apprunner/custom_domain_association.go
@@ -92,7 +92,7 @@ func resourceCustomDomainAssociation() *schema.Resource {
 	}
 }
 
-func resourceCustomDomainAssociationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDomainAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -122,7 +122,7 @@ func resourceCustomDomainAssociationCreate(ctx context.Context, d *schema.Resour
 	return append(diags, resourceCustomDomainAssociationRead(ctx, d, meta)...)
 }
 
-func resourceCustomDomainAssociationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDomainAssociationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -155,7 +155,7 @@ func resourceCustomDomainAssociationRead(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func resourceCustomDomainAssociationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceCustomDomainAssociationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -275,7 +275,7 @@ const (
 )
 
 func statusCustomDomain(ctx context.Context, conn *apprunner.Client, domainName, serviceARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findCustomDomainByTwoPartKey(ctx, conn, domainName, serviceARN)
 
 		if tfresource.NotFound(err) {
@@ -330,11 +330,11 @@ func waitCustomDomainAssociationDeleted(ctx context.Context, conn *apprunner.Cli
 	return nil, err
 }
 
-func flattenCustomDomainCertificateValidationRecords(records []types.CertificateValidationRecord) []interface{} {
-	var results []interface{}
+func flattenCustomDomainCertificateValidationRecords(records []types.CertificateValidationRecord) []any {
+	var results []any
 
 	for _, record := range records {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrName:   aws.ToString(record.Name),
 			names.AttrStatus: record.Status,
 			names.AttrType:   aws.ToString(record.Type),

--- a/internal/service/apprunner/deployment.go
+++ b/internal/service/apprunner/deployment.go
@@ -196,7 +196,7 @@ func findOperations(ctx context.Context, conn *apprunner.Client, input *apprunne
 }
 
 func statusOperation(ctx context.Context, conn *apprunner.Client, serviceARN, operationID string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findOperationByTwoPartKey(ctx, conn, serviceARN, operationID)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apprunner/observability_configuration.go
+++ b/internal/service/apprunner/observability_configuration.go
@@ -78,7 +78,7 @@ func resourceObservabilityConfiguration() *schema.Resource {
 	}
 }
 
-func resourceObservabilityConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObservabilityConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -89,8 +89,8 @@ func resourceObservabilityConfigurationCreate(ctx context.Context, d *schema.Res
 		Tags:                           getTagsIn(ctx),
 	}
 
-	if v, ok := d.GetOk("trace_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.TraceConfiguration = expandTraceConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("trace_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.TraceConfiguration = expandTraceConfiguration(v.([]any))
 	}
 
 	output, err := conn.CreateObservabilityConfiguration(ctx, input)
@@ -108,7 +108,7 @@ func resourceObservabilityConfigurationCreate(ctx context.Context, d *schema.Res
 	return append(diags, resourceObservabilityConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceObservabilityConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObservabilityConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -137,12 +137,12 @@ func resourceObservabilityConfigurationRead(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func resourceObservabilityConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObservabilityConfigurationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceObservabilityConfigurationRead(ctx, d, meta)
 }
 
-func resourceObservabilityConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceObservabilityConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -201,7 +201,7 @@ func findObservabilityConfigurationByARN(ctx context.Context, conn *apprunner.Cl
 }
 
 func statusObservabilityConfiguration(ctx context.Context, conn *apprunner.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findObservabilityConfigurationByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -256,12 +256,12 @@ func waitObservabilityConfigurationDeleted(ctx context.Context, conn *apprunner.
 	return nil, err
 }
 
-func expandTraceConfiguration(l []interface{}) *types.TraceConfiguration {
+func expandTraceConfiguration(l []any) *types.TraceConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	configuration := &types.TraceConfiguration{}
 
@@ -272,14 +272,14 @@ func expandTraceConfiguration(l []interface{}) *types.TraceConfiguration {
 	return configuration
 }
 
-func flattenTraceConfiguration(traceConfiguration *types.TraceConfiguration) []interface{} {
+func flattenTraceConfiguration(traceConfiguration *types.TraceConfiguration) []any {
 	if traceConfiguration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"vendor": string(traceConfiguration.Vendor),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/apprunner/service.go
+++ b/internal/service/apprunner/service.go
@@ -429,7 +429,7 @@ func resourceService() *schema.Resource {
 	}
 }
 
-func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -437,7 +437,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	name := d.Get(names.AttrServiceName).(string)
 	input := &apprunner.CreateServiceInput{
 		ServiceName:         aws.String(name),
-		SourceConfiguration: expandServiceSourceConfiguration(d.Get("source_configuration").([]interface{})),
+		SourceConfiguration: expandServiceSourceConfiguration(d.Get("source_configuration").([]any)),
 		Tags:                getTagsIn(ctx),
 	}
 
@@ -445,27 +445,27 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 		input.AutoScalingConfigurationArn = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk(names.AttrEncryptionConfiguration); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.EncryptionConfiguration = expandServiceEncryptionConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrEncryptionConfiguration); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.EncryptionConfiguration = expandServiceEncryptionConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk("health_check_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.HealthCheckConfiguration = expandServiceHealthCheckConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("health_check_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.HealthCheckConfiguration = expandServiceHealthCheckConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk("instance_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.InstanceConfiguration = expandServiceInstanceConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("instance_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.InstanceConfiguration = expandServiceInstanceConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk(names.AttrNetworkConfiguration); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.NetworkConfiguration = expandNetworkConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk(names.AttrNetworkConfiguration); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.NetworkConfiguration = expandNetworkConfiguration(v.([]any))
 	}
 
-	if v, ok := d.GetOk("observability_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("observability_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(v.([]any))
 	}
 
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidRequestException](ctx, propagationTimeout, func() (interface{}, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.InvalidRequestException](ctx, propagationTimeout, func() (any, error) {
 		return conn.CreateService(ctx, input)
 	}, "Error in assuming instance role")
 
@@ -482,7 +482,7 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
-func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -548,7 +548,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	return diags
 }
 
-func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -563,23 +563,23 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		}
 
 		if d.HasChange("health_check_configuration") {
-			input.HealthCheckConfiguration = expandServiceHealthCheckConfiguration(d.Get("health_check_configuration").([]interface{}))
+			input.HealthCheckConfiguration = expandServiceHealthCheckConfiguration(d.Get("health_check_configuration").([]any))
 		}
 
 		if d.HasChange("instance_configuration") {
-			input.InstanceConfiguration = expandServiceInstanceConfiguration(d.Get("instance_configuration").([]interface{}))
+			input.InstanceConfiguration = expandServiceInstanceConfiguration(d.Get("instance_configuration").([]any))
 		}
 
 		if d.HasChange(names.AttrNetworkConfiguration) {
-			input.NetworkConfiguration = expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]interface{}))
+			input.NetworkConfiguration = expandNetworkConfiguration(d.Get(names.AttrNetworkConfiguration).([]any))
 		}
 
 		if d.HasChange("observability_configuration") {
-			input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(d.Get("observability_configuration").([]interface{}))
+			input.ObservabilityConfiguration = expandServiceObservabilityConfiguration(d.Get("observability_configuration").([]any))
 		}
 
 		if d.HasChange("source_configuration") {
-			input.SourceConfiguration = expandServiceSourceConfiguration(d.Get("source_configuration").([]interface{}))
+			input.SourceConfiguration = expandServiceSourceConfiguration(d.Get("source_configuration").([]any))
 		}
 
 		_, err := conn.UpdateService(ctx, input)
@@ -596,7 +596,7 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	return append(diags, resourceServiceRead(ctx, d, meta)...)
 }
 
-func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceServiceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -655,7 +655,7 @@ func findServiceByARN(ctx context.Context, conn *apprunner.Client, arn string) (
 }
 
 func statusService(ctx context.Context, conn *apprunner.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findServiceByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -730,12 +730,12 @@ func waitServiceDeleted(ctx context.Context, conn *apprunner.Client, arn string)
 	return nil, err
 }
 
-func expandServiceEncryptionConfiguration(l []interface{}) *types.EncryptionConfiguration {
+func expandServiceEncryptionConfiguration(l []any) *types.EncryptionConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -750,12 +750,12 @@ func expandServiceEncryptionConfiguration(l []interface{}) *types.EncryptionConf
 	return result
 }
 
-func expandServiceHealthCheckConfiguration(l []interface{}) *types.HealthCheckConfiguration {
+func expandServiceHealthCheckConfiguration(l []any) *types.HealthCheckConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -790,12 +790,12 @@ func expandServiceHealthCheckConfiguration(l []interface{}) *types.HealthCheckCo
 	return result
 }
 
-func expandServiceInstanceConfiguration(l []interface{}) *types.InstanceConfiguration {
+func expandServiceInstanceConfiguration(l []any) *types.InstanceConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -818,12 +818,12 @@ func expandServiceInstanceConfiguration(l []interface{}) *types.InstanceConfigur
 	return result
 }
 
-func expandNetworkConfiguration(l []interface{}) *types.NetworkConfiguration {
+func expandNetworkConfiguration(l []any) *types.NetworkConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -831,11 +831,11 @@ func expandNetworkConfiguration(l []interface{}) *types.NetworkConfiguration {
 
 	result := &types.NetworkConfiguration{}
 
-	if v, ok := tfMap["ingress_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["ingress_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.IngressConfiguration = expandNetworkIngressConfiguration(v)
 	}
 
-	if v, ok := tfMap["egress_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["egress_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.EgressConfiguration = expandNetworkEgressConfiguration(v)
 	}
 
@@ -846,12 +846,12 @@ func expandNetworkConfiguration(l []interface{}) *types.NetworkConfiguration {
 	return result
 }
 
-func expandServiceObservabilityConfiguration(l []interface{}) *types.ServiceObservabilityConfiguration {
+func expandServiceObservabilityConfiguration(l []any) *types.ServiceObservabilityConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -870,12 +870,12 @@ func expandServiceObservabilityConfiguration(l []interface{}) *types.ServiceObse
 	return result
 }
 
-func expandServiceSourceConfiguration(l []interface{}) *types.SourceConfiguration {
+func expandServiceSourceConfiguration(l []any) *types.SourceConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -883,7 +883,7 @@ func expandServiceSourceConfiguration(l []interface{}) *types.SourceConfiguratio
 
 	result := &types.SourceConfiguration{}
 
-	if v, ok := tfMap["authentication_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["authentication_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.AuthenticationConfiguration = expandServiceAuthenticationConfiguration(v)
 	}
 
@@ -891,23 +891,23 @@ func expandServiceSourceConfiguration(l []interface{}) *types.SourceConfiguratio
 		result.AutoDeploymentsEnabled = aws.Bool(v)
 	}
 
-	if v, ok := tfMap["code_repository"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["code_repository"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.CodeRepository = expandServiceCodeRepository(v)
 	}
 
-	if v, ok := tfMap["image_repository"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["image_repository"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.ImageRepository = expandServiceImageRepository(v)
 	}
 
 	return result
 }
 
-func expandServiceAuthenticationConfiguration(l []interface{}) *types.AuthenticationConfiguration {
+func expandServiceAuthenticationConfiguration(l []any) *types.AuthenticationConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -926,12 +926,12 @@ func expandServiceAuthenticationConfiguration(l []interface{}) *types.Authentica
 	return result
 }
 
-func expandNetworkIngressConfiguration(l []interface{}) *types.IngressConfiguration {
+func expandNetworkIngressConfiguration(l []any) *types.IngressConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -946,12 +946,12 @@ func expandNetworkIngressConfiguration(l []interface{}) *types.IngressConfigurat
 	return result
 }
 
-func expandNetworkEgressConfiguration(l []interface{}) *types.EgressConfiguration {
+func expandNetworkEgressConfiguration(l []any) *types.EgressConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -970,12 +970,12 @@ func expandNetworkEgressConfiguration(l []interface{}) *types.EgressConfiguratio
 	return result
 }
 
-func expandServiceImageConfiguration(l []interface{}) *types.ImageConfiguration {
+func expandServiceImageConfiguration(l []any) *types.ImageConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -987,11 +987,11 @@ func expandServiceImageConfiguration(l []interface{}) *types.ImageConfiguration 
 		result.Port = aws.String(v)
 	}
 
-	if v, ok := tfMap["runtime_environment_secrets"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["runtime_environment_secrets"].(map[string]any); ok && len(v) > 0 {
 		result.RuntimeEnvironmentSecrets = flex.ExpandStringValueMap(v)
 	}
 
-	if v, ok := tfMap["runtime_environment_variables"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["runtime_environment_variables"].(map[string]any); ok && len(v) > 0 {
 		result.RuntimeEnvironmentVariables = flex.ExpandStringValueMap(v)
 	}
 
@@ -1002,12 +1002,12 @@ func expandServiceImageConfiguration(l []interface{}) *types.ImageConfiguration 
 	return result
 }
 
-func expandServiceCodeRepository(l []interface{}) *types.CodeRepository {
+func expandServiceCodeRepository(l []any) *types.CodeRepository {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -1015,11 +1015,11 @@ func expandServiceCodeRepository(l []interface{}) *types.CodeRepository {
 
 	result := &types.CodeRepository{}
 
-	if v, ok := tfMap["source_code_version"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["source_code_version"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.SourceCodeVersion = expandServiceSourceCodeVersion(v)
 	}
 
-	if v, ok := tfMap["code_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["code_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.CodeConfiguration = expandServiceCodeConfiguration(v)
 	}
 
@@ -1034,12 +1034,12 @@ func expandServiceCodeRepository(l []interface{}) *types.CodeRepository {
 	return result
 }
 
-func expandServiceImageRepository(l []interface{}) *types.ImageRepository {
+func expandServiceImageRepository(l []any) *types.ImageRepository {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -1047,7 +1047,7 @@ func expandServiceImageRepository(l []interface{}) *types.ImageRepository {
 
 	result := &types.ImageRepository{}
 
-	if v, ok := tfMap["image_configuration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["image_configuration"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.ImageConfiguration = expandServiceImageConfiguration(v)
 	}
 
@@ -1062,12 +1062,12 @@ func expandServiceImageRepository(l []interface{}) *types.ImageRepository {
 	return result
 }
 
-func expandServiceCodeConfiguration(l []interface{}) *types.CodeConfiguration {
+func expandServiceCodeConfiguration(l []any) *types.CodeConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -1079,19 +1079,19 @@ func expandServiceCodeConfiguration(l []interface{}) *types.CodeConfiguration {
 		result.ConfigurationSource = types.ConfigurationSource(v)
 	}
 
-	if v, ok := tfMap["code_configuration_values"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := tfMap["code_configuration_values"].([]any); ok && len(v) > 0 && v[0] != nil {
 		result.CodeConfigurationValues = expandServiceCodeConfigurationValues(v)
 	}
 
 	return result
 }
 
-func expandServiceCodeConfigurationValues(l []interface{}) *types.CodeConfigurationValues {
+func expandServiceCodeConfigurationValues(l []any) *types.CodeConfigurationValues {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -1111,11 +1111,11 @@ func expandServiceCodeConfigurationValues(l []interface{}) *types.CodeConfigurat
 		result.Runtime = types.Runtime(v)
 	}
 
-	if v, ok := tfMap["runtime_environment_secrets"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["runtime_environment_secrets"].(map[string]any); ok && len(v) > 0 {
 		result.RuntimeEnvironmentSecrets = flex.ExpandStringValueMap(v)
 	}
 
-	if v, ok := tfMap["runtime_environment_variables"].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap["runtime_environment_variables"].(map[string]any); ok && len(v) > 0 {
 		result.RuntimeEnvironmentVariables = flex.ExpandStringValueMap(v)
 	}
 
@@ -1126,12 +1126,12 @@ func expandServiceCodeConfigurationValues(l []interface{}) *types.CodeConfigurat
 	return result
 }
 
-func expandServiceSourceCodeVersion(l []interface{}) *types.SourceCodeVersion {
+func expandServiceSourceCodeVersion(l []any) *types.SourceCodeVersion {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := l[0].(map[string]interface{})
+	tfMap, ok := l[0].(map[string]any)
 
 	if !ok {
 		return nil
@@ -1150,24 +1150,24 @@ func expandServiceSourceCodeVersion(l []interface{}) *types.SourceCodeVersion {
 	return result
 }
 
-func flattenServiceEncryptionConfiguration(config *types.EncryptionConfiguration) []interface{} {
+func flattenServiceEncryptionConfiguration(config *types.EncryptionConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrKMSKey: aws.ToString(config.KmsKey),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceHealthCheckConfiguration(config *types.HealthCheckConfiguration) []interface{} {
+func flattenServiceHealthCheckConfiguration(config *types.HealthCheckConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"healthy_threshold":   config.HealthyThreshold,
 		names.AttrInterval:    config.Interval,
 		names.AttrPath:        aws.ToString(config.Path),
@@ -1176,109 +1176,109 @@ func flattenServiceHealthCheckConfiguration(config *types.HealthCheckConfigurati
 		"unhealthy_threshold": config.UnhealthyThreshold,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceInstanceConfiguration(config *types.InstanceConfiguration) []interface{} {
+func flattenServiceInstanceConfiguration(config *types.InstanceConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"cpu":               aws.ToString(config.Cpu),
 		"instance_role_arn": aws.ToString(config.InstanceRoleArn),
 		"memory":            aws.ToString(config.Memory),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenNetworkConfiguration(config *types.NetworkConfiguration) []interface{} {
+func flattenNetworkConfiguration(config *types.NetworkConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"ingress_configuration": flattenNetworkIngressConfiguration(config.IngressConfiguration),
 		"egress_configuration":  flattenNetworkEgressConfiguration(config.EgressConfiguration),
 		names.AttrIPAddressType: config.IpAddressType,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenNetworkIngressConfiguration(config *types.IngressConfiguration) []interface{} {
+func flattenNetworkIngressConfiguration(config *types.IngressConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"is_publicly_accessible": config.IsPubliclyAccessible,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenNetworkEgressConfiguration(config *types.EgressConfiguration) []interface{} {
+func flattenNetworkEgressConfiguration(config *types.EgressConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"egress_type":       string(config.EgressType),
 		"vpc_connector_arn": aws.ToString(config.VpcConnectorArn),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceObservabilityConfiguration(config *types.ServiceObservabilityConfiguration) []interface{} {
+func flattenServiceObservabilityConfiguration(config *types.ServiceObservabilityConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"observability_configuration_arn": aws.ToString(config.ObservabilityConfigurationArn),
 		"observability_enabled":           config.ObservabilityEnabled,
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceCodeRepository(r *types.CodeRepository) []interface{} {
+func flattenServiceCodeRepository(r *types.CodeRepository) []any {
 	if r == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"code_configuration":  flattenServiceCodeConfiguration(r.CodeConfiguration),
 		"repository_url":      aws.ToString(r.RepositoryUrl),
 		"source_code_version": flattenServiceSourceCodeVersion(r.SourceCodeVersion),
 		"source_directory":    aws.ToString(r.SourceDirectory),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceCodeConfiguration(config *types.CodeConfiguration) []interface{} {
+func flattenServiceCodeConfiguration(config *types.CodeConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"code_configuration_values": flattenServiceCodeConfigurationValues(config.CodeConfigurationValues),
 		"configuration_source":      string(config.ConfigurationSource),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceCodeConfigurationValues(values *types.CodeConfigurationValues) []interface{} {
+func flattenServiceCodeConfigurationValues(values *types.CodeConfigurationValues) []any {
 	if values == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"build_command":                 aws.ToString(values.BuildCommand),
 		names.AttrPort:                  aws.ToString(values.Port),
 		"runtime":                       string(values.Runtime),
@@ -1287,75 +1287,75 @@ func flattenServiceCodeConfigurationValues(values *types.CodeConfigurationValues
 		"start_command":                 aws.ToString(values.StartCommand),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceSourceCodeVersion(v *types.SourceCodeVersion) []interface{} {
+func flattenServiceSourceCodeVersion(v *types.SourceCodeVersion) []any {
 	if v == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrType:  string(v.Type),
 		names.AttrValue: aws.ToString(v.Value),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceSourceConfiguration(config *types.SourceConfiguration) []interface{} {
+func flattenServiceSourceConfiguration(config *types.SourceConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"authentication_configuration": flattenServiceAuthenticationConfiguration(config.AuthenticationConfiguration),
 		"auto_deployments_enabled":     aws.ToBool(config.AutoDeploymentsEnabled),
 		"code_repository":              flattenServiceCodeRepository(config.CodeRepository),
 		"image_repository":             flattenServiceImageRepository(config.ImageRepository),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceAuthenticationConfiguration(config *types.AuthenticationConfiguration) []interface{} {
+func flattenServiceAuthenticationConfiguration(config *types.AuthenticationConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"access_role_arn": aws.ToString(config.AccessRoleArn),
 		"connection_arn":  aws.ToString(config.ConnectionArn),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceImageConfiguration(config *types.ImageConfiguration) []interface{} {
+func flattenServiceImageConfiguration(config *types.ImageConfiguration) []any {
 	if config == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrPort:                  aws.ToString(config.Port),
 		"runtime_environment_secrets":   config.RuntimeEnvironmentSecrets,
 		"runtime_environment_variables": config.RuntimeEnvironmentVariables,
 		"start_command":                 aws.ToString(config.StartCommand),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenServiceImageRepository(r *types.ImageRepository) []interface{} {
+func flattenServiceImageRepository(r *types.ImageRepository) []any {
 	if r == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		"image_configuration":   flattenServiceImageConfiguration(r.ImageConfiguration),
 		"image_identifier":      aws.ToString(r.ImageIdentifier),
 		"image_repository_type": string(r.ImageRepositoryType),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/apprunner/vpc_connector.go
+++ b/internal/service/apprunner/vpc_connector.go
@@ -75,7 +75,7 @@ func resourceVPCConnector() *schema.Resource {
 	}
 }
 
-func resourceVPCConnectorCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCConnectorCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -103,7 +103,7 @@ func resourceVPCConnectorCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceVPCConnectorRead(ctx, d, meta)...)
 }
 
-func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -130,12 +130,12 @@ func resourceVPCConnectorRead(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func resourceVPCConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCConnectorUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceVPCConnectorRead(ctx, d, meta)
 }
 
-func resourceVPCConnectorDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCConnectorDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -194,7 +194,7 @@ func findVPCConnectorByARN(ctx context.Context, conn *apprunner.Client, arn stri
 }
 
 func statusVPCConnector(ctx context.Context, conn *apprunner.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCConnectorByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/apprunner/vpc_ingress_connection.go
+++ b/internal/service/apprunner/vpc_ingress_connection.go
@@ -87,7 +87,7 @@ func resourceVPCIngressConnection() *schema.Resource {
 	}
 }
 
-func resourceVPCIngressConnectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIngressConnectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -99,8 +99,8 @@ func resourceVPCIngressConnectionCreate(ctx context.Context, d *schema.ResourceD
 		VpcIngressConnectionName: aws.String(name),
 	}
 
-	if v, ok := d.GetOk("ingress_vpc_configuration"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-		input.IngressVpcConfiguration = expandIngressVPCConfiguration(v.([]interface{}))
+	if v, ok := d.GetOk("ingress_vpc_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.IngressVpcConfiguration = expandIngressVPCConfiguration(v.([]any))
 	}
 
 	output, err := conn.CreateVpcIngressConnection(ctx, input)
@@ -118,7 +118,7 @@ func resourceVPCIngressConnectionCreate(ctx context.Context, d *schema.ResourceD
 	return append(diags, resourceVPCIngressConnectionRead(ctx, d, meta)...)
 }
 
-func resourceVPCIngressConnectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIngressConnectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -147,12 +147,12 @@ func resourceVPCIngressConnectionRead(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
-func resourceVPCIngressConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIngressConnectionUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	// Tags only.
 	return resourceVPCIngressConnectionRead(ctx, d, meta)
 }
 
-func resourceVPCIngressConnectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVPCIngressConnectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	conn := meta.(*conns.AWSClient).AppRunnerClient(ctx)
@@ -211,7 +211,7 @@ func findVPCIngressConnectionByARN(ctx context.Context, conn *apprunner.Client, 
 }
 
 func statusVPCIngressConnection(ctx context.Context, conn *apprunner.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findVPCIngressConnectionByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {
@@ -265,12 +265,12 @@ func waitVPCIngressConnectionDeleted(ctx context.Context, conn *apprunner.Client
 	return nil, err
 }
 
-func expandIngressVPCConfiguration(l []interface{}) *types.IngressVpcConfiguration {
+func expandIngressVPCConfiguration(l []any) *types.IngressVpcConfiguration {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 
-	m := l[0].(map[string]interface{})
+	m := l[0].(map[string]any)
 
 	configuration := &types.IngressVpcConfiguration{}
 
@@ -285,15 +285,15 @@ func expandIngressVPCConfiguration(l []interface{}) *types.IngressVpcConfigurati
 	return configuration
 }
 
-func flattenIngressVPCConfiguration(ingressVpcConfiguration *types.IngressVpcConfiguration) []interface{} {
+func flattenIngressVPCConfiguration(ingressVpcConfiguration *types.IngressVpcConfiguration) []any {
 	if ingressVpcConfiguration == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrVPCID:         aws.ToString(ingressVpcConfiguration.VpcId),
 		names.AttrVPCEndpointID: aws.ToString(ingressVpcConfiguration.VpcEndpointId),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }

--- a/internal/service/backup/framework.go
+++ b/internal/service/backup/framework.go
@@ -145,7 +145,7 @@ func resourceFramework() *schema.Resource {
 	}
 }
 
-func resourceFrameworkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFrameworkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -176,7 +176,7 @@ func resourceFrameworkCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceFrameworkRead(ctx, d, meta)...)
 }
 
-func resourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -205,7 +205,7 @@ func resourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -217,7 +217,7 @@ func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta i
 			IdempotencyToken:     aws.String(sdkid.UniqueId()),
 		}
 
-		_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func() (interface{}, error) {
+		_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutUpdate), func() (any, error) {
 			return conn.UpdateFramework(ctx, input)
 		})
 
@@ -233,12 +233,12 @@ func resourceFrameworkUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceFrameworkRead(ctx, d, meta)...)
 }
 
-func resourceFrameworkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceFrameworkDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	log.Printf("[DEBUG] Deleting Backup Framework: %s", d.Id())
-	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsA[*awstypes.ConflictException](ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
 		return conn.DeleteFramework(ctx, &backup.DeleteFrameworkInput{
 			FrameworkName: aws.String(d.Id()),
 		})
@@ -289,7 +289,7 @@ func findFramework(ctx context.Context, conn *backup.Client, input *backup.Descr
 }
 
 func statusFramework(ctx context.Context, conn *backup.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findFrameworkByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -363,7 +363,7 @@ func waitFrameworkDeleted(ctx context.Context, conn *backup.Client, name string,
 	return nil, err
 }
 
-func expandFrameworkControls(ctx context.Context, tfList []interface{}) []awstypes.FrameworkControl {
+func expandFrameworkControls(ctx context.Context, tfList []any) []awstypes.FrameworkControl {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -371,7 +371,7 @@ func expandFrameworkControls(ctx context.Context, tfList []interface{}) []awstyp
 	apiObjects := []awstypes.FrameworkControl{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		// on some updates, there is an { ControlName: "" } element in Framework Controls.
 		// this element must be skipped to avoid the "A control name is required." error
@@ -382,7 +382,7 @@ func expandFrameworkControls(ctx context.Context, tfList []interface{}) []awstyp
 
 		apiObject := awstypes.FrameworkControl{
 			ControlName:  aws.String(tfMap[names.AttrName].(string)),
-			ControlScope: expandControlScope(ctx, tfMap[names.AttrScope].([]interface{})),
+			ControlScope: expandControlScope(ctx, tfMap[names.AttrScope].([]any)),
 		}
 
 		if v, ok := tfMap["input_parameter"]; ok && v.(*schema.Set).Len() > 0 {
@@ -395,7 +395,7 @@ func expandFrameworkControls(ctx context.Context, tfList []interface{}) []awstyp
 	return apiObjects
 }
 
-func expandControlInputParameters(tfList []interface{}) []awstypes.ControlInputParameter {
+func expandControlInputParameters(tfList []any) []awstypes.ControlInputParameter {
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -403,7 +403,7 @@ func expandControlInputParameters(tfList []interface{}) []awstypes.ControlInputP
 	apiObjects := []awstypes.ControlInputParameter{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		apiObject := awstypes.ControlInputParameter{}
 
@@ -421,12 +421,12 @@ func expandControlInputParameters(tfList []interface{}) []awstypes.ControlInputP
 	return apiObjects
 }
 
-func expandControlScope(ctx context.Context, tfList []interface{}) *awstypes.ControlScope {
+func expandControlScope(ctx context.Context, tfList []any) *awstypes.ControlScope {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -443,22 +443,22 @@ func expandControlScope(ctx context.Context, tfList []interface{}) *awstypes.Con
 
 	// A maximum of one key-value pair can be provided.
 	// The tag value is optional, but it cannot be an empty string
-	if v, ok := tfMap[names.AttrTags].(map[string]interface{}); ok && len(v) > 0 {
+	if v, ok := tfMap[names.AttrTags].(map[string]any); ok && len(v) > 0 {
 		apiObject.Tags = Tags(tftags.New(ctx, v).IgnoreAWS())
 	}
 
 	return apiObject
 }
 
-func flattenFrameworkControls(ctx context.Context, apiObjects []awstypes.FrameworkControl) []interface{} {
+func flattenFrameworkControls(ctx context.Context, apiObjects []awstypes.FrameworkControl) []any {
 	if apiObjects == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		tfMap["input_parameter"] = flattenControlInputParameters(apiObject.ControlInputParameters)
 		tfMap[names.AttrName] = aws.ToString(apiObject.ControlName)
 		tfMap[names.AttrScope] = flattenControlScope(ctx, apiObject.ControlScope)
@@ -469,15 +469,15 @@ func flattenFrameworkControls(ctx context.Context, apiObjects []awstypes.Framewo
 	return tfList
 }
 
-func flattenControlInputParameters(apiObjects []awstypes.ControlInputParameter) []interface{} {
+func flattenControlInputParameters(apiObjects []awstypes.ControlInputParameter) []any {
 	if apiObjects == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfList := []interface{}{}
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{}
+		tfMap := map[string]any{}
 		tfMap[names.AttrName] = aws.ToString(apiObject.ParameterName)
 		tfMap[names.AttrValue] = aws.ToString(apiObject.ParameterValue)
 
@@ -487,12 +487,12 @@ func flattenControlInputParameters(apiObjects []awstypes.ControlInputParameter) 
 	return tfList
 }
 
-func flattenControlScope(ctx context.Context, apiObject *awstypes.ControlScope) []interface{} {
+func flattenControlScope(ctx context.Context, apiObject *awstypes.ControlScope) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"compliance_resource_ids":   apiObject.ComplianceResourceIds,
 		"compliance_resource_types": apiObject.ComplianceResourceTypes,
 	}
@@ -501,5 +501,5 @@ func flattenControlScope(ctx context.Context, apiObject *awstypes.ControlScope) 
 		tfMap[names.AttrTags] = KeyValueTags(ctx, v).IgnoreAWS().Map()
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/backup/framework_data_source.go
+++ b/internal/service/backup/framework_data_source.go
@@ -104,7 +104,7 @@ func dataSourceFramework() *schema.Resource {
 	}
 }
 
-func dataSourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceFrameworkRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/global_settings.go
+++ b/internal/service/backup/global_settings.go
@@ -38,12 +38,12 @@ func resourceGlobalSettings() *schema.Resource {
 	}
 }
 
-func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	input := &backup.UpdateGlobalSettingsInput{
-		GlobalSettings: flex.ExpandStringValueMap(d.Get("global_settings").(map[string]interface{})),
+		GlobalSettings: flex.ExpandStringValueMap(d.Get("global_settings").(map[string]any)),
 	}
 
 	_, err := conn.UpdateGlobalSettings(ctx, input)
@@ -59,7 +59,7 @@ func resourceGlobalSettingsUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceGlobalSettingsRead(ctx, d, meta)...)
 }
 
-func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalSettingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/logically_air_gapped_vault.go
+++ b/internal/service/backup/logically_air_gapped_vault.go
@@ -220,7 +220,7 @@ func findLogicallyAirGappedBackupVaultByName(ctx context.Context, conn *backup.C
 }
 
 func statusLogicallyAirGappedVault(ctx context.Context, conn *backup.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findLogicallyAirGappedBackupVaultByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/backup/plan.go
+++ b/internal/service/backup/plan.go
@@ -199,7 +199,7 @@ func resourcePlan() *schema.Resource {
 	}
 }
 
-func resourcePlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlanCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -224,7 +224,7 @@ func resourcePlanCreate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourcePlanRead(ctx, d, meta)...)
 }
 
-func resourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlanRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -255,7 +255,7 @@ func resourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interfac
 	return diags
 }
 
-func resourcePlanUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlanUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -279,7 +279,7 @@ func resourcePlanUpdate(ctx context.Context, d *schema.ResourceData, meta interf
 	return append(diags, resourcePlanRead(ctx, d, meta)...)
 }
 
-func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -287,7 +287,7 @@ func resourcePlanDelete(ctx context.Context, d *schema.ResourceData, meta interf
 	const (
 		timeout = 2 * time.Minute
 	)
-	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*awstypes.InvalidRequestException](ctx, timeout, func() (any, error) {
 		return conn.DeleteBackupPlan(ctx, &backup.DeleteBackupPlanInput{
 			BackupPlanId: aws.String(d.Id()),
 		})
@@ -333,11 +333,11 @@ func findPlan(ctx context.Context, conn *backup.Client, input *backup.GetBackupP
 	return output, nil
 }
 
-func expandBackupRuleInputs(ctx context.Context, tfList []interface{}) []awstypes.BackupRuleInput { // nosemgrep:ci.backup-in-func-name
+func expandBackupRuleInputs(ctx context.Context, tfList []any) []awstypes.BackupRuleInput { // nosemgrep:ci.backup-in-func-name
 	apiObjects := []awstypes.BackupRuleInput{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.BackupRuleInput{}
 
 		if v, ok := tfMap["completion_window"].(int); ok {
@@ -349,10 +349,10 @@ func expandBackupRuleInputs(ctx context.Context, tfList []interface{}) []awstype
 		if v, ok := tfMap["enable_continuous_backup"].(bool); ok {
 			apiObject.EnableContinuousBackup = aws.Bool(v)
 		}
-		if v, ok := tfMap["lifecycle"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]interface{}))
+		if v, ok := tfMap["lifecycle"].([]any); ok && len(v) > 0 && v[0] != nil {
+			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]any))
 		}
-		if v, ok := tfMap["recovery_point_tags"].(map[string]interface{}); ok && len(v) > 0 {
+		if v, ok := tfMap["recovery_point_tags"].(map[string]any); ok && len(v) > 0 {
 			apiObject.RecoveryPointTags = Tags(tftags.New(ctx, v).IgnoreAWS())
 		}
 		if v, ok := tfMap["rule_name"].(string); ok && v != "" {
@@ -379,7 +379,7 @@ func expandBackupRuleInputs(ctx context.Context, tfList []interface{}) []awstype
 	return apiObjects
 }
 
-func expandAdvancedBackupSetting(tfList []interface{}) []awstypes.AdvancedBackupSetting { // nosemgrep:ci.backup-in-func-name
+func expandAdvancedBackupSetting(tfList []any) []awstypes.AdvancedBackupSetting { // nosemgrep:ci.backup-in-func-name
 	if len(tfList) == 0 {
 		return nil
 	}
@@ -387,10 +387,10 @@ func expandAdvancedBackupSetting(tfList []interface{}) []awstypes.AdvancedBackup
 	apiObjects := []awstypes.AdvancedBackupSetting{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.AdvancedBackupSetting{}
 
-		if v, ok := tfMap["backup_options"].(map[string]interface{}); ok && v != nil {
+		if v, ok := tfMap["backup_options"].(map[string]any); ok && v != nil {
 			apiObject.BackupOptions = flex.ExpandStringValueMap(v)
 		}
 		if v, ok := tfMap[names.AttrResourceType].(string); ok && v != "" {
@@ -409,17 +409,17 @@ func expandAdvancedBackupSetting(tfList []interface{}) []awstypes.AdvancedBackup
 	return apiObjects
 }
 
-func expandCopyActions(tfList []interface{}) []awstypes.CopyAction {
+func expandCopyActions(tfList []any) []awstypes.CopyAction {
 	apiObjects := []awstypes.CopyAction{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.CopyAction{}
 
 		apiObject.DestinationBackupVaultArn = aws.String(tfMap["destination_vault_arn"].(string))
 
-		if v, ok := tfMap["lifecycle"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]interface{}))
+		if v, ok := tfMap["lifecycle"].([]any); ok && len(v) > 0 && v[0] != nil {
+			apiObject.Lifecycle = expandLifecycle(v[0].(map[string]any))
 		}
 
 		apiObjects = append(apiObjects, apiObject)
@@ -428,7 +428,7 @@ func expandCopyActions(tfList []interface{}) []awstypes.CopyAction {
 	return apiObjects
 }
 
-func expandLifecycle(tfMap map[string]interface{}) *awstypes.Lifecycle {
+func expandLifecycle(tfMap map[string]any) *awstypes.Lifecycle {
 	if tfMap == nil {
 		return nil
 	}
@@ -450,11 +450,11 @@ func expandLifecycle(tfMap map[string]interface{}) *awstypes.Lifecycle {
 	return apiObject
 }
 
-func flattenBackupRules(ctx context.Context, apiObjects []awstypes.BackupRule) []interface{} { // nosemgrep:ci.backup-in-func-name
-	tfList := []interface{}{}
+func flattenBackupRules(ctx context.Context, apiObjects []awstypes.BackupRule) []any { // nosemgrep:ci.backup-in-func-name
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"completion_window":            aws.ToInt64(apiObject.CompletionWindowMinutes),
 			"enable_continuous_backup":     aws.ToBool(apiObject.EnableContinuousBackup),
 			"rule_name":                    aws.ToString(apiObject.RuleName),
@@ -482,11 +482,11 @@ func flattenBackupRules(ctx context.Context, apiObjects []awstypes.BackupRule) [
 	return tfList
 }
 
-func flattenAdvancedBackupSettings(apiObjects []awstypes.AdvancedBackupSetting) []interface{} { // nosemgrep:ci.backup-in-func-name
-	tfList := []interface{}{}
+func flattenAdvancedBackupSettings(apiObjects []awstypes.AdvancedBackupSetting) []any { // nosemgrep:ci.backup-in-func-name
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"backup_options":       apiObject.BackupOptions,
 			names.AttrResourceType: aws.ToString(apiObject.ResourceType),
 		}
@@ -497,15 +497,15 @@ func flattenAdvancedBackupSettings(apiObjects []awstypes.AdvancedBackupSetting) 
 	return tfList
 }
 
-func flattenCopyActions(apiObjects []awstypes.CopyAction) []interface{} {
+func flattenCopyActions(apiObjects []awstypes.CopyAction) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, copyAction := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			"destination_vault_arn": aws.ToString(copyAction.DestinationBackupVaultArn),
 		}
 
@@ -519,16 +519,16 @@ func flattenCopyActions(apiObjects []awstypes.CopyAction) []interface{} {
 	return tfList
 }
 
-func flattenLifecycle(apiObject *awstypes.Lifecycle) []interface{} {
+func flattenLifecycle(apiObject *awstypes.Lifecycle) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"delete_after":       aws.ToInt64(apiObject.DeleteAfterDays),
 		"cold_storage_after": aws.ToInt64(apiObject.MoveToColdStorageAfterDays),
 		"opt_in_to_archive_for_supported_resources": aws.ToBool(apiObject.OptInToArchiveForSupportedResources),
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }

--- a/internal/service/backup/plan_data_source.go
+++ b/internal/service/backup/plan_data_source.go
@@ -132,7 +132,7 @@ func dataSourcePlan() *schema.Resource {
 	}
 }
 
-func dataSourcePlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourcePlanRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/plan_migrate.go
+++ b/internal/service/backup/plan_migrate.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func planStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
-	var tfList []interface{}
-	if v, ok := rawState[names.AttrRule].([]interface{}); ok {
+func planStateUpgradeV0(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	var tfList []any
+	if v, ok := rawState[names.AttrRule].([]any); ok {
 		for _, tfMapRaw := range v {
-			tfMap := tfMapRaw.(map[string]interface{})
+			tfMap := tfMapRaw.(map[string]any)
 			tfMap["schedule_expression_timezone"] = defaultPlanRuleScheduleExpressionTimezone
 			tfList = append(tfList, tfMap)
 		}

--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -44,18 +44,18 @@ func resourceRegionSettings() *schema.Resource {
 	}
 }
 
-func resourceRegionSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegionSettingsUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	input := &backup.UpdateRegionSettingsInput{}
 
-	if v, ok := d.GetOk("resource_type_management_preference"); ok && len(v.(map[string]interface{})) > 0 {
-		input.ResourceTypeManagementPreference = flex.ExpandBoolValueMap(v.(map[string]interface{}))
+	if v, ok := d.GetOk("resource_type_management_preference"); ok && len(v.(map[string]any)) > 0 {
+		input.ResourceTypeManagementPreference = flex.ExpandBoolValueMap(v.(map[string]any))
 	}
 
-	if v, ok := d.GetOk("resource_type_opt_in_preference"); ok && len(v.(map[string]interface{})) > 0 {
-		input.ResourceTypeOptInPreference = flex.ExpandBoolValueMap(v.(map[string]interface{}))
+	if v, ok := d.GetOk("resource_type_opt_in_preference"); ok && len(v.(map[string]any)) > 0 {
+		input.ResourceTypeOptInPreference = flex.ExpandBoolValueMap(v.(map[string]any))
 	}
 
 	_, err := conn.UpdateRegionSettings(ctx, input)
@@ -71,7 +71,7 @@ func resourceRegionSettingsUpdate(ctx context.Context, d *schema.ResourceData, m
 	return append(diags, resourceRegionSettingsRead(ctx, d, meta)...)
 }
 
-func resourceRegionSettingsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceRegionSettingsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/report_plan.go
+++ b/internal/service/backup/report_plan.go
@@ -143,17 +143,17 @@ func resourceReportPlan() *schema.Resource {
 	}
 }
 
-func resourceReportPlanCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReportPlanCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	name := d.Get(names.AttrName).(string)
 	input := &backup.CreateReportPlanInput{
 		IdempotencyToken:      aws.String(sdkid.UniqueId()),
-		ReportDeliveryChannel: expandReportDeliveryChannel(d.Get("report_delivery_channel").([]interface{})),
+		ReportDeliveryChannel: expandReportDeliveryChannel(d.Get("report_delivery_channel").([]any)),
 		ReportPlanName:        aws.String(name),
 		ReportPlanTags:        getTagsIn(ctx),
-		ReportSetting:         expandReportSetting(d.Get("report_setting").([]interface{})),
+		ReportSetting:         expandReportSetting(d.Get("report_setting").([]any)),
 	}
 
 	if v, ok := d.GetOk(names.AttrDescription); ok {
@@ -175,7 +175,7 @@ func resourceReportPlanCreate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceReportPlanRead(ctx, d, meta)...)
 }
 
-func resourceReportPlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReportPlanRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -206,17 +206,17 @@ func resourceReportPlanRead(ctx context.Context, d *schema.ResourceData, meta in
 	return diags
 }
 
-func resourceReportPlanUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReportPlanUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
 		input := &backup.UpdateReportPlanInput{
 			IdempotencyToken:      aws.String(sdkid.UniqueId()),
-			ReportDeliveryChannel: expandReportDeliveryChannel(d.Get("report_delivery_channel").([]interface{})),
+			ReportDeliveryChannel: expandReportDeliveryChannel(d.Get("report_delivery_channel").([]any)),
 			ReportPlanDescription: aws.String(d.Get(names.AttrDescription).(string)),
 			ReportPlanName:        aws.String(d.Id()),
-			ReportSetting:         expandReportSetting(d.Get("report_setting").([]interface{})),
+			ReportSetting:         expandReportSetting(d.Get("report_setting").([]any)),
 		}
 
 		_, err := conn.UpdateReportPlan(ctx, input)
@@ -233,7 +233,7 @@ func resourceReportPlanUpdate(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceReportPlanRead(ctx, d, meta)...)
 }
 
-func resourceReportPlanDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceReportPlanDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -258,12 +258,12 @@ func resourceReportPlanDelete(ctx context.Context, d *schema.ResourceData, meta 
 	return diags
 }
 
-func expandReportDeliveryChannel(tfList []interface{}) *awstypes.ReportDeliveryChannel {
+func expandReportDeliveryChannel(tfList []any) *awstypes.ReportDeliveryChannel {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -283,12 +283,12 @@ func expandReportDeliveryChannel(tfList []interface{}) *awstypes.ReportDeliveryC
 	return apiObject
 }
 
-func expandReportSetting(tfList []interface{}) *awstypes.ReportSetting {
+func expandReportSetting(tfList []any) *awstypes.ReportSetting {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
 
-	tfMap, ok := tfList[0].(map[string]interface{})
+	tfMap, ok := tfList[0].(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -320,12 +320,12 @@ func expandReportSetting(tfList []interface{}) *awstypes.ReportSetting {
 	return apiObject
 }
 
-func flattenReportDeliveryChannel(apiObject *awstypes.ReportDeliveryChannel) []interface{} {
+func flattenReportDeliveryChannel(apiObject *awstypes.ReportDeliveryChannel) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		names.AttrS3BucketName: aws.ToString(apiObject.S3BucketName),
 	}
 
@@ -337,15 +337,15 @@ func flattenReportDeliveryChannel(apiObject *awstypes.ReportDeliveryChannel) []i
 		tfMap[names.AttrS3KeyPrefix] = aws.ToString(v)
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenReportSetting(apiObject *awstypes.ReportSetting) []interface{} {
+func flattenReportSetting(apiObject *awstypes.ReportSetting) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	tfMap := map[string]interface{}{
+	tfMap := map[string]any{
 		"report_template": aws.ToString(apiObject.ReportTemplate),
 	}
 
@@ -367,7 +367,7 @@ func flattenReportSetting(apiObject *awstypes.ReportSetting) []interface{} {
 		tfMap["regions"] = apiObject.Regions
 	}
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
 func findReportPlanByName(ctx context.Context, conn *backup.Client, name string) (*awstypes.ReportPlan, error) {
@@ -400,7 +400,7 @@ func findReportPlan(ctx context.Context, conn *backup.Client, input *backup.Desc
 }
 
 func statusReportPlan(ctx context.Context, conn *backup.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findReportPlanByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/backup/report_plan_data_source.go
+++ b/internal/service/backup/report_plan_data_source.go
@@ -115,7 +115,7 @@ func dataSourceReportPlan() *schema.Resource {
 	}
 }
 
-func dataSourceReportPlanRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceReportPlanRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -187,7 +187,7 @@ func resourceSelection() *schema.Resource {
 	}
 }
 
-func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -207,7 +207,7 @@ func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta i
 
 	// Retry for IAM eventual consistency.
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.CreateBackupSelection(ctx, input)
 		},
 		func(err error) (bool, error) {
@@ -235,7 +235,7 @@ func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta i
 		// Maximum amount of time to wait for Backup changes to propagate.
 		timeout = 2 * time.Minute
 	)
-	_, err = tfresource.RetryWhenNotFound(ctx, timeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, timeout, func() (any, error) {
 		return findSelectionByTwoPartKey(ctx, conn, planID, d.Id())
 	})
 
@@ -246,7 +246,7 @@ func resourceSelectionCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceSelectionRead(ctx, d, meta)...)
 }
 
-func resourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -278,10 +278,10 @@ func resourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta int
 		return sdkdiag.AppendErrorf(diags, "setting resources: %s", err)
 	}
 	if v := output.ListOfTags; v != nil {
-		tfList := make([]interface{}, 0)
+		tfList := make([]any, 0)
 
 		for _, v := range v {
-			tfMap := make(map[string]interface{})
+			tfMap := make(map[string]any)
 
 			tfMap[names.AttrKey] = aws.ToString(v.ConditionKey)
 			tfMap[names.AttrType] = v.ConditionType
@@ -298,7 +298,7 @@ func resourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceSelectionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceSelectionDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -320,7 +320,7 @@ func resourceSelectionDelete(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceSelectionImportState(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceSelectionImportState(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), "|")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected <plan-id>|<selection-id>", d.Id())
@@ -361,11 +361,11 @@ func findSelection(ctx context.Context, conn *backup.Client, input *backup.GetBa
 	return output.BackupSelection, nil
 }
 
-func expandConditionTags(tfList []interface{}) []awstypes.Condition {
+func expandConditionTags(tfList []any) []awstypes.Condition {
 	apiObjects := []awstypes.Condition{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.Condition{}
 
 		apiObject.ConditionKey = aws.String(tfMap[names.AttrKey].(string))
@@ -378,11 +378,11 @@ func expandConditionTags(tfList []interface{}) []awstypes.Condition {
 	return apiObjects
 }
 
-func expandConditions(tfList []interface{}) *awstypes.Conditions {
+func expandConditions(tfList []any) *awstypes.Conditions {
 	apiObject := &awstypes.Conditions{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 
 		if v := expandConditionParameters(tfMap["string_equals"].(*schema.Set).List()); len(v) > 0 {
 			apiObject.StringEquals = v
@@ -401,11 +401,11 @@ func expandConditions(tfList []interface{}) *awstypes.Conditions {
 	return apiObject
 }
 
-func expandConditionParameters(tfList []interface{}) []awstypes.ConditionParameter {
+func expandConditionParameters(tfList []any) []awstypes.ConditionParameter {
 	apiObjects := []awstypes.ConditionParameter{}
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObject := awstypes.ConditionParameter{}
 
 		apiObject.ConditionKey = aws.String(tfMap[names.AttrKey].(string))
@@ -417,26 +417,26 @@ func expandConditionParameters(tfList []interface{}) []awstypes.ConditionParamet
 	return apiObjects
 }
 
-func flattenConditions(apiObject *awstypes.Conditions) []interface{} {
-	tfMap := map[string]interface{}{}
+func flattenConditions(apiObject *awstypes.Conditions) []any {
+	tfMap := map[string]any{}
 
 	tfMap["string_equals"] = flattenConditionParameters(apiObject.StringEquals)
 	tfMap["string_not_equals"] = flattenConditionParameters(apiObject.StringNotEquals)
 	tfMap["string_like"] = flattenConditionParameters(apiObject.StringLike)
 	tfMap["string_not_like"] = flattenConditionParameters(apiObject.StringNotLike)
 
-	return []interface{}{tfMap}
+	return []any{tfMap}
 }
 
-func flattenConditionParameters(apiObjects []awstypes.ConditionParameter) []interface{} {
+func flattenConditionParameters(apiObjects []awstypes.ConditionParameter) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
-		tfMap := map[string]interface{}{
+		tfMap := map[string]any{
 			names.AttrKey:   aws.ToString(apiObject.ConditionKey),
 			names.AttrValue: aws.ToString(apiObject.ConditionValue),
 		}

--- a/internal/service/backup/selection_data_source.go
+++ b/internal/service/backup/selection_data_source.go
@@ -44,7 +44,7 @@ func dataSourceSelection() *schema.Resource {
 	}
 }
 
-func dataSourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceSelectionRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/validate.go
+++ b/internal/service/backup/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/YakDriver/regexache"
 )
 
-func validReportPlanName(v interface{}, k string) (ws []string, errors []error) {
+func validReportPlanName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[A-Za-z]{1}[0-9A-Za-z_]{0,255}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.", k, v))
@@ -18,7 +18,7 @@ func validReportPlanName(v interface{}, k string) (ws []string, errors []error) 
 }
 
 // The pattern for framework and report plan name is the same but separate functions are used in the event that there are future differences
-func validFrameworkName(v interface{}, k string) (ws []string, errors []error) {
+func validFrameworkName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexache.MustCompile(`^[A-Za-z]{1}[0-9A-Za-z_]{0,255}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("%q (%q) must be must be between 1 and 256 characters, starting with a letter, and consisting of letters, numbers, and underscores.", k, v))

--- a/internal/service/backup/vault.go
+++ b/internal/service/backup/vault.go
@@ -84,7 +84,7 @@ func resourceVault() *schema.Resource {
 	}
 }
 
-func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -109,7 +109,7 @@ func resourceVaultCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceVaultRead(ctx, d, meta)...)
 }
 
-func resourceVaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -133,7 +133,7 @@ func resourceVaultRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceVaultUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 
 	// Tags only.
@@ -141,7 +141,7 @@ func resourceVaultUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceVaultRead(ctx, d, meta)...)
 }
 
-func resourceVaultDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -283,7 +283,7 @@ func findRecoveryPoint(ctx context.Context, conn *backup.Client, input *backup.D
 }
 
 func statusRecoveryPoint(ctx context.Context, conn *backup.Client, backupVaultName, recoveryPointARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findRecoveryPointByTwoPartKey(ctx, conn, backupVaultName, recoveryPointARN)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/backup/vault_data_source.go
+++ b/internal/service/backup/vault_data_source.go
@@ -42,7 +42,7 @@ func dataSourceVault() *schema.Resource {
 	}
 }
 
-func dataSourceVaultRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceVaultRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/vault_lock_configuration.go
+++ b/internal/service/backup/vault_lock_configuration.go
@@ -62,7 +62,7 @@ func resourceVaultLockConfiguration() *schema.Resource {
 	}
 }
 
-func resourceVaultLockConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultLockConfigurationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -94,7 +94,7 @@ func resourceVaultLockConfigurationCreate(ctx context.Context, d *schema.Resourc
 	return append(diags, resourceVaultLockConfigurationRead(ctx, d, meta)...)
 }
 
-func resourceVaultLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultLockConfigurationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -118,7 +118,7 @@ func resourceVaultLockConfigurationRead(ctx context.Context, d *schema.ResourceD
 	return diags
 }
 
-func resourceVaultLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultLockConfigurationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/vault_notifications.go
+++ b/internal/service/backup/vault_notifications.go
@@ -67,7 +67,7 @@ func resourceVaultNotifications() *schema.Resource {
 	}
 }
 
-func resourceVaultNotificationsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultNotificationsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -89,7 +89,7 @@ func resourceVaultNotificationsCreate(ctx context.Context, d *schema.ResourceDat
 	return append(diags, resourceVaultNotificationsRead(ctx, d, meta)...)
 }
 
-func resourceVaultNotificationsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultNotificationsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -113,7 +113,7 @@ func resourceVaultNotificationsRead(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func resourceVaultNotificationsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultNotificationsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/vault_policy.go
+++ b/internal/service/backup/vault_policy.go
@@ -52,7 +52,7 @@ func resourceVaultPolicy() *schema.Resource {
 				ValidateFunc:          validation.StringIsJSON,
 				DiffSuppressFunc:      verify.SuppressEquivalentPolicyDiffs,
 				DiffSuppressOnRefresh: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
@@ -61,7 +61,7 @@ func resourceVaultPolicy() *schema.Resource {
 	}
 }
 
-func resourceVaultPolicyPut(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -77,7 +77,7 @@ func resourceVaultPolicyPut(ctx context.Context, d *schema.ResourceData, meta in
 	}
 
 	_, err = tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout,
-		func() (interface{}, error) {
+		func() (any, error) {
 			return conn.PutBackupVaultAccessPolicy(ctx, input)
 		},
 		errCodeInvalidParameterValueException, "Provided principal is not valid",
@@ -92,7 +92,7 @@ func resourceVaultPolicyPut(ctx context.Context, d *schema.ResourceData, meta in
 	return append(diags, resourceVaultPolicyRead(ctx, d, meta)...)
 }
 
-func resourceVaultPolicyRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 
@@ -126,7 +126,7 @@ func resourceVaultPolicyRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceVaultPolicyDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVaultPolicyDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).BackupClient(ctx)
 

--- a/internal/service/backup/vault_test.go
+++ b/internal/service/backup/vault_test.go
@@ -308,7 +308,7 @@ func findJobByID(ctx context.Context, conn *backup.Client, id string) (*backup.D
 }
 
 func statusJobState(ctx context.Context, conn *backup.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findJobByID(ctx, conn, id)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/dynamodb/contributor_insights.go
+++ b/internal/service/dynamodb/contributor_insights.go
@@ -55,7 +55,7 @@ func resourceContributorInsights() *schema.Resource {
 	}
 }
 
-func resourceContributorInsightsCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceContributorInsightsCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -86,7 +86,7 @@ func resourceContributorInsightsCreate(ctx context.Context, d *schema.ResourceDa
 	return append(diags, resourceContributorInsightsRead(ctx, d, meta)...)
 }
 
-func resourceContributorInsightsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceContributorInsightsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -113,7 +113,7 @@ func resourceContributorInsightsRead(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceContributorInsightsDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceContributorInsightsDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -217,7 +217,7 @@ func findContributorInsights(ctx context.Context, conn *dynamodb.Client, input *
 }
 
 func statusContributorInsights(ctx context.Context, conn *dynamodb.Client, tableName, indexName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findContributorInsightsByTwoPartKey(ctx, conn, tableName, indexName)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/dynamodb/forge.go
+++ b/internal/service/dynamodb/forge.go
@@ -7,13 +7,13 @@ import (
 	"github.com/mitchellh/copystructure"
 )
 
-func stripCapacityAttributes(in map[string]interface{}) (map[string]interface{}, error) {
+func stripCapacityAttributes(in map[string]any) (map[string]any, error) {
 	mapCopy, err := copystructure.Copy(in)
 	if err != nil {
 		return nil, err
 	}
 
-	m := mapCopy.(map[string]interface{})
+	m := mapCopy.(map[string]any)
 
 	delete(m, "write_capacity")
 	delete(m, "read_capacity")
@@ -21,26 +21,26 @@ func stripCapacityAttributes(in map[string]interface{}) (map[string]interface{},
 	return m, nil
 }
 
-func stripNonKeyAttributes(in map[string]interface{}) (map[string]interface{}, error) {
+func stripNonKeyAttributes(in map[string]any) (map[string]any, error) {
 	mapCopy, err := copystructure.Copy(in)
 	if err != nil {
 		return nil, err
 	}
 
-	m := mapCopy.(map[string]interface{})
+	m := mapCopy.(map[string]any)
 
 	delete(m, "non_key_attributes")
 
 	return m, nil
 }
 
-func stripOnDemandThroughputAttributes(in map[string]interface{}) (map[string]interface{}, error) {
+func stripOnDemandThroughputAttributes(in map[string]any) (map[string]any, error) {
 	mapCopy, err := copystructure.Copy(in)
 	if err != nil {
 		return nil, err
 	}
 
-	m := mapCopy.(map[string]interface{})
+	m := mapCopy.(map[string]any)
 
 	delete(m, "on_demand_throughput")
 

--- a/internal/service/dynamodb/global_table.go
+++ b/internal/service/dynamodb/global_table.go
@@ -67,7 +67,7 @@ func resourceGlobalTable() *schema.Resource {
 	}
 }
 
-func resourceGlobalTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -92,7 +92,7 @@ func resourceGlobalTableCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceGlobalTableRead(ctx, d, meta)...)
 }
 
-func resourceGlobalTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -117,7 +117,7 @@ func resourceGlobalTableRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func resourceGlobalTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -156,7 +156,7 @@ func resourceGlobalTableUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 // Deleting a DynamoDB Global Table is represented by removing all replicas.
-func resourceGlobalTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceGlobalTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -208,7 +208,7 @@ func findGlobalTableByName(ctx context.Context, conn *dynamodb.Client, name stri
 }
 
 func statusGlobalTable(ctx context.Context, conn *dynamodb.Client, name string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGlobalTableByName(ctx, conn, name)
 
 		if tfresource.NotFound(err) {
@@ -277,18 +277,18 @@ func waitGlobalTableDeleted(ctx context.Context, conn *dynamodb.Client, name str
 	return nil, err
 }
 
-func expandReplicaUpdateCreateReplicas(tfList []interface{}) []awstypes.ReplicaUpdate {
+func expandReplicaUpdateCreateReplicas(tfList []any) []awstypes.ReplicaUpdate {
 	apiObjects := make([]awstypes.ReplicaUpdate, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObjects = append(apiObjects, *expandReplicaUpdateCreateReplica(tfMap))
 	}
 
 	return apiObjects
 }
 
-func expandReplicaUpdateCreateReplica(tfMap map[string]interface{}) *awstypes.ReplicaUpdate {
+func expandReplicaUpdateCreateReplica(tfMap map[string]any) *awstypes.ReplicaUpdate {
 	apiObject := &awstypes.ReplicaUpdate{
 		Create: &awstypes.CreateReplicaAction{
 			RegionName: aws.String(tfMap["region_name"].(string)),
@@ -298,18 +298,18 @@ func expandReplicaUpdateCreateReplica(tfMap map[string]interface{}) *awstypes.Re
 	return apiObject
 }
 
-func expandReplicaUpdateDeleteReplicas(tfList []interface{}) []awstypes.ReplicaUpdate {
+func expandReplicaUpdateDeleteReplicas(tfList []any) []awstypes.ReplicaUpdate {
 	apiObjects := make([]awstypes.ReplicaUpdate, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObjects = append(apiObjects, *expandReplicaUpdateDeleteReplica(tfMap))
 	}
 
 	return apiObjects
 }
 
-func expandReplicaUpdateDeleteReplica(tfMap map[string]interface{}) *awstypes.ReplicaUpdate {
+func expandReplicaUpdateDeleteReplica(tfMap map[string]any) *awstypes.ReplicaUpdate {
 	apiObject := &awstypes.ReplicaUpdate{
 		Delete: &awstypes.DeleteReplicaAction{
 			RegionName: aws.String(tfMap["region_name"].(string)),
@@ -319,18 +319,18 @@ func expandReplicaUpdateDeleteReplica(tfMap map[string]interface{}) *awstypes.Re
 	return apiObject
 }
 
-func expandReplicas(tfList []interface{}) []awstypes.Replica {
+func expandReplicas(tfList []any) []awstypes.Replica {
 	apiObjects := make([]awstypes.Replica, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
-		tfMap := tfMapRaw.(map[string]interface{})
+		tfMap := tfMapRaw.(map[string]any)
 		apiObjects = append(apiObjects, *expandReplica(tfMap))
 	}
 
 	return apiObjects
 }
 
-func expandReplica(tfMap map[string]interface{}) *awstypes.Replica {
+func expandReplica(tfMap map[string]any) *awstypes.Replica {
 	apiObject := &awstypes.Replica{
 		RegionName: aws.String(tfMap["region_name"].(string)),
 	}
@@ -338,8 +338,8 @@ func expandReplica(tfMap map[string]interface{}) *awstypes.Replica {
 	return apiObject
 }
 
-func flattenReplicas(apiObjects []awstypes.ReplicaDescription) []interface{} {
-	tfList := []interface{}{}
+func flattenReplicas(apiObjects []awstypes.ReplicaDescription) []any {
+	tfList := []any{}
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenReplica(&apiObject))
@@ -348,8 +348,8 @@ func flattenReplicas(apiObjects []awstypes.ReplicaDescription) []interface{} {
 	return tfList
 }
 
-func flattenReplica(apiObject *awstypes.ReplicaDescription) map[string]interface{} {
-	tfMap := make(map[string]interface{})
+func flattenReplica(apiObject *awstypes.ReplicaDescription) map[string]any {
+	tfMap := make(map[string]any)
 	tfMap["region_name"] = aws.ToString(apiObject.RegionName)
 
 	return tfMap

--- a/internal/service/dynamodb/kinesis_streaming_destination.go
+++ b/internal/service/dynamodb/kinesis_streaming_destination.go
@@ -64,7 +64,7 @@ func resourceKinesisStreamingDestination() *schema.Resource {
 	}
 }
 
-func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -99,7 +99,7 @@ func resourceKinesisStreamingDestinationCreate(ctx context.Context, d *schema.Re
 	return append(diags, resourceKinesisStreamingDestinationRead(ctx, d, meta)...)
 }
 
-func resourceKinesisStreamingDestinationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKinesisStreamingDestinationRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -128,7 +128,7 @@ func resourceKinesisStreamingDestinationRead(ctx context.Context, d *schema.Reso
 	return diags
 }
 
-func resourceKinesisStreamingDestinationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceKinesisStreamingDestinationDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -225,7 +225,7 @@ func findKinesisDataStreamDestinations(ctx context.Context, conn *dynamodb.Clien
 }
 
 func statusKinesisStreamingDestination(ctx context.Context, conn *dynamodb.Client, streamARN, tableName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		input := &dynamodb.DescribeKinesisStreamingDestinationInput{
 			TableName: aws.String(tableName),
 		}

--- a/internal/service/dynamodb/resource_policy.go
+++ b/internal/service/dynamodb/resource_policy.go
@@ -93,7 +93,7 @@ func (r *resourcePolicyResource) Create(ctx context.Context, request resource.Cr
 	data.RevisionID = fwflex.StringToFramework(ctx, output.RevisionId)
 	data.setID()
 
-	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (interface{}, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findResourcePolicyByARN(ctx, conn, data.ResourceARN.ValueString())
 	})
 

--- a/internal/service/dynamodb/status.go
+++ b/internal/service/dynamodb/status.go
@@ -14,7 +14,7 @@ import (
 )
 
 func statusTable(ctx context.Context, conn *dynamodb.Client, tableName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTableByName(ctx, conn, tableName)
 
 		if tfresource.NotFound(err) {
@@ -30,7 +30,7 @@ func statusTable(ctx context.Context, conn *dynamodb.Client, tableName string) r
 }
 
 func statusImport(ctx context.Context, conn *dynamodb.Client, importARN string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findImportByARN(ctx, conn, importARN)
 
 		if tfresource.NotFound(err) {
@@ -50,7 +50,7 @@ func statusImport(ctx context.Context, conn *dynamodb.Client, importARN string) 
 }
 
 func statusReplicaUpdate(ctx context.Context, conn *dynamodb.Client, tableName, region string, optFns ...func(*dynamodb.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTableByName(ctx, conn, tableName, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -72,7 +72,7 @@ func statusReplicaUpdate(ctx context.Context, conn *dynamodb.Client, tableName, 
 }
 
 func statusReplicaDelete(ctx context.Context, conn *dynamodb.Client, tableName, region string, optFns ...func(*dynamodb.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTableByName(ctx, conn, tableName, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -94,7 +94,7 @@ func statusReplicaDelete(ctx context.Context, conn *dynamodb.Client, tableName, 
 }
 
 func statusGSI(ctx context.Context, conn *dynamodb.Client, tableName, indexName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findGSIByTwoPartKey(ctx, conn, tableName, indexName)
 
 		if tfresource.NotFound(err) {
@@ -114,7 +114,7 @@ func statusGSI(ctx context.Context, conn *dynamodb.Client, tableName, indexName 
 }
 
 func statusPITR(ctx context.Context, conn *dynamodb.Client, tableName string, optFns ...func(*dynamodb.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findPITRByTableName(ctx, conn, tableName, optFns...)
 
 		if tfresource.NotFound(err) {
@@ -134,7 +134,7 @@ func statusPITR(ctx context.Context, conn *dynamodb.Client, tableName string, op
 }
 
 func statusTTL(ctx context.Context, conn *dynamodb.Client, tableName string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTTLByTableName(ctx, conn, tableName)
 
 		if tfresource.NotFound(err) {
@@ -154,7 +154,7 @@ func statusTTL(ctx context.Context, conn *dynamodb.Client, tableName string) ret
 }
 
 func statusSSE(ctx context.Context, conn *dynamodb.Client, tableName string, optFns ...func(*dynamodb.Options)) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTableByName(ctx, conn, tableName, optFns...)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -67,13 +67,13 @@ func resourceTable() *schema.Resource {
 		},
 
 		CustomizeDiff: customdiff.All(
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				return validStreamSpec(diff)
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				return validateTableAttributes(diff)
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				if diff.Id() != "" && diff.HasChange("server_side_encryption") {
 					o, n := diff.GetChange("server_side_encryption")
 					if isTableOptionDisabled(o) && isTableOptionDisabled(n) {
@@ -82,7 +82,7 @@ func resourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				if diff.Id() != "" && diff.HasChange("point_in_time_recovery") {
 					o, n := diff.GetChange("point_in_time_recovery")
 					if isTableOptionDisabled(o) && isTableOptionDisabled(n) {
@@ -91,7 +91,7 @@ func resourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				if diff.Id() != "" && diff.HasChange("stream_enabled") {
 					if err := diff.SetNewComputed(names.AttrStreamARN); err != nil {
 						return fmt.Errorf("setting stream_arn to computed: %s", err)
@@ -99,7 +99,7 @@ func resourceTable() *schema.Resource {
 				}
 				return nil
 			},
-			func(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
 				if v := diff.Get("restore_source_name"); v != "" {
 					return nil
 				}
@@ -118,12 +118,12 @@ func resourceTable() *schema.Resource {
 				}
 				return errors.Join(errs...)
 			},
-			customdiff.ForceNewIfChange("restore_source_name", func(_ context.Context, old, new, meta interface{}) bool {
+			customdiff.ForceNewIfChange("restore_source_name", func(_ context.Context, old, new, meta any) bool {
 				// If they differ force new unless new is cleared
 				// https://github.com/hashicorp/terraform-provider-aws/issues/25214
 				return old.(string) != new.(string) && new.(string) != ""
 			}),
-			customdiff.ForceNewIfChange("restore_source_table_arn", func(_ context.Context, old, new, meta interface{}) bool {
+			customdiff.ForceNewIfChange("restore_source_table_arn", func(_ context.Context, old, new, meta any) bool {
 				return old.(string) != new.(string) && new.(string) != ""
 			}),
 			validateTTLCustomDiff,
@@ -445,7 +445,7 @@ func resourceTable() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				StateFunc: func(v interface{}) string {
+				StateFunc: func(v any) string {
 					value := v.(string)
 					return strings.ToUpper(value)
 				},
@@ -528,12 +528,12 @@ func onDemandThroughputSchema() *schema.Schema {
 	}
 }
 
-func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
 	tableName := d.Get(names.AttrName).(string)
-	keySchemaMap := map[string]interface{}{
+	keySchemaMap := map[string]any{
 		"hash_key": d.Get("hash_key").(string),
 	}
 	if v, ok := d.GetOk("range_key"); ok {
@@ -569,7 +569,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		if _, ok := d.GetOk("write_capacity"); ok {
 			if _, ok := d.GetOk("read_capacity"); ok {
-				capacityMap := map[string]interface{}{
+				capacityMap := map[string]any{
 					"write_capacity": d.Get("write_capacity"),
 					"read_capacity":  d.Get("read_capacity"),
 				}
@@ -587,7 +587,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			gsiSet := v.(*schema.Set)
 
 			for _, gsiObject := range gsiSet.List() {
-				gsi := gsiObject.(map[string]interface{})
+				gsi := gsiObject.(map[string]any)
 				if err := validateGSIProvisionedThroughput(gsi, billingModeOverride); err != nil {
 					return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Get(names.AttrName).(string), err)
 				}
@@ -599,10 +599,10 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if v, ok := d.GetOk("server_side_encryption"); ok {
-			input.SSESpecificationOverride = expandEncryptAtRestOptions(v.([]interface{}))
+			input.SSESpecificationOverride = expandEncryptAtRestOptions(v.([]any))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
 			return conn.RestoreTableToPointInTime(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -621,8 +621,8 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		if err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, tableName, err)
 		}
-	} else if vit, ok := d.GetOk("import_table"); ok && len(vit.([]interface{})) > 0 && vit.([]interface{})[0] != nil {
-		input := expandImportTable(vit.([]interface{})[0].(map[string]interface{}))
+	} else if vit, ok := d.GetOk("import_table"); ok && len(vit.([]any)) > 0 && vit.([]any)[0] != nil {
+		input := expandImportTable(vit.([]any)[0].(map[string]any))
 
 		tcp := &awstypes.TableCreationParameters{
 			TableName:   aws.String(tableName),
@@ -630,7 +630,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			KeySchema:   expandKeySchema(keySchemaMap),
 		}
 
-		capacityMap := map[string]interface{}{
+		capacityMap := map[string]any{
 			"write_capacity": d.Get("write_capacity"),
 			"read_capacity":  d.Get("read_capacity"),
 		}
@@ -645,7 +645,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if v, ok := d.GetOk("server_side_encryption"); ok {
-			tcp.SSESpecification = expandEncryptAtRestOptions(v.([]interface{}))
+			tcp.SSESpecification = expandEncryptAtRestOptions(v.([]any))
 		}
 
 		if v, ok := d.GetOk("global_secondary_index"); ok {
@@ -653,7 +653,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			gsiSet := v.(*schema.Set)
 
 			for _, gsiObject := range gsiSet.List() {
-				gsi := gsiObject.(map[string]interface{})
+				gsi := gsiObject.(map[string]any)
 				if err := validateGSIProvisionedThroughput(gsi, billingMode); err != nil {
 					return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Get(names.AttrName).(string), err)
 				}
@@ -664,13 +664,13 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			tcp.GlobalSecondaryIndexes = globalSecondaryIndexes
 		}
 
-		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			tcp.OnDemandThroughput = expandOnDemandThroughput(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			tcp.OnDemandThroughput = expandOnDemandThroughput(v.([]any)[0].(map[string]any))
 		}
 
 		input.TableCreationParameters = tcp
 
-		importTableOutput, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (interface{}, error) {
+		importTableOutput, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
 			return conn.ImportTable(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -705,7 +705,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 
 		billingMode := awstypes.BillingMode(d.Get("billing_mode").(string))
 
-		capacityMap := map[string]interface{}{
+		capacityMap := map[string]any{
 			"write_capacity": d.Get("write_capacity"),
 			"read_capacity":  d.Get("read_capacity"),
 		}
@@ -731,7 +731,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			gsiSet := v.(*schema.Set)
 
 			for _, gsiObject := range gsiSet.List() {
-				gsi := gsiObject.(map[string]interface{})
+				gsi := gsiObject.(map[string]any)
 				if err := validateGSIProvisionedThroughput(gsi, billingMode); err != nil {
 					return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, tableName, err)
 				}
@@ -742,8 +742,8 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 			input.GlobalSecondaryIndexes = globalSecondaryIndexes
 		}
 
-		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.OnDemandThroughput = expandOnDemandThroughput(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.OnDemandThroughput = expandOnDemandThroughput(v.([]any)[0].(map[string]any))
 		}
 
 		if v, ok := d.GetOk("stream_enabled"); ok {
@@ -754,14 +754,14 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		}
 
 		if v, ok := d.GetOk("server_side_encryption"); ok {
-			input.SSESpecification = expandEncryptAtRestOptions(v.([]interface{}))
+			input.SSESpecification = expandEncryptAtRestOptions(v.([]any))
 		}
 
 		if v, ok := d.GetOk("table_class"); ok {
 			input.TableClass = awstypes.TableClass(v.(string))
 		}
 
-		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (interface{}, error) {
+		_, err := tfresource.RetryWhen(ctx, createTableTimeout, func() (any, error) {
 			return conn.CreateTable(ctx, input)
 		}, func(err error) (bool, error) {
 			if tfawserr.ErrCodeEquals(err, errCodeThrottlingException) {
@@ -794,7 +794,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 		gsiSet := v.(*schema.Set)
 
 		for _, gsiObject := range gsiSet.List() {
-			gsi := gsiObject.(map[string]interface{})
+			gsi := gsiObject.(map[string]any)
 
 			if _, err := waitGSIActive(ctx, conn, d.Id(), gsi[names.AttrName].(string), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionWaitingForCreation, resNameTable, d.Id(), fmt.Errorf("GSI (%s): %w", gsi[names.AttrName].(string), err))
@@ -803,7 +803,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.Get("ttl.0.enabled").(bool) {
-		if err := updateTimeToLive(ctx, conn, d.Id(), d.Get("ttl").([]interface{}), d.Timeout(schema.TimeoutCreate)); err != nil {
+		if err := updateTimeToLive(ctx, conn, d.Id(), d.Get("ttl").([]any), d.Timeout(schema.TimeoutCreate)); err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionCreating, resNameTable, d.Id(), fmt.Errorf("enabling TTL: %w", err))
 		}
 	}
@@ -827,7 +827,7 @@ func resourceTableCreate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceTableRead(ctx, d, meta)...)
 }
 
-func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -956,7 +956,7 @@ func resourceTableRead(ctx context.Context, d *schema.ResourceData, meta interfa
 	return diags
 }
 
-func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -1027,7 +1027,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	if d.HasChanges("billing_mode", "read_capacity", "write_capacity") {
 		hasTableUpdate = true
 
-		capacityMap := map[string]interface{}{
+		capacityMap := map[string]any{
 			"write_capacity": d.Get("write_capacity"),
 			"read_capacity":  d.Get("read_capacity"),
 		}
@@ -1043,8 +1043,8 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 
 	if d.HasChange("on_demand_throughput") {
 		hasTableUpdate = true
-		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]interface{})) > 0 && v.([]interface{})[0] != nil {
-			input.OnDemandThroughput = expandOnDemandThroughput(v.([]interface{})[0].(map[string]interface{}))
+		if v, ok := d.GetOk("on_demand_throughput"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+			input.OnDemandThroughput = expandOnDemandThroughput(v.([]any)[0].(map[string]any))
 		}
 	}
 
@@ -1148,11 +1148,11 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("server_side_encryption") {
-		if replicas, sseSpecification := d.Get("replica").(*schema.Set), expandEncryptAtRestOptions(d.Get("server_side_encryption").([]interface{})); replicas.Len() > 0 && sseSpecification.KMSMasterKeyId != nil {
+		if replicas, sseSpecification := d.Get("replica").(*schema.Set), expandEncryptAtRestOptions(d.Get("server_side_encryption").([]any)); replicas.Len() > 0 && sseSpecification.KMSMasterKeyId != nil {
 			log.Printf("[DEBUG] Using SSE update on replicas")
 			var replicaUpdates []awstypes.ReplicationGroupUpdate
 			for _, replica := range replicas.List() {
-				tfMap, ok := replica.(map[string]interface{})
+				tfMap, ok := replica.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -1208,7 +1208,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 		if replicas := d.Get("replica").(*schema.Set); replicas.Len() > 0 {
 			var replicaRegions []string
 			for _, replica := range replicas.List() {
-				tfMap, ok := replica.(map[string]interface{})
+				tfMap, ok := replica.(map[string]any)
 				if !ok {
 					continue
 				}
@@ -1229,7 +1229,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	if d.HasChange("ttl") {
-		if err := updateTimeToLive(ctx, conn, d.Id(), d.Get("ttl").([]interface{}), d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := updateTimeToLive(ctx, conn, d.Id(), d.Get("ttl").([]any), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return create.AppendDiagError(diags, names.DynamoDB, create.ErrActionUpdating, resNameTable, d.Id(), err)
 		}
 	}
@@ -1264,7 +1264,7 @@ func resourceTableUpdate(ctx context.Context, d *schema.ResourceData, meta inter
 	return append(diags, resourceTableRead(ctx, d, meta)...)
 }
 
-func resourceTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -1298,12 +1298,12 @@ func resourceTableDelete(ctx context.Context, d *schema.ResourceData, meta inter
 
 // custom diff
 
-func isTableOptionDisabled(v interface{}) bool {
-	options := v.([]interface{})
+func isTableOptionDisabled(v any) bool {
+	options := v.([]any)
 	if len(options) == 0 {
 		return true
 	}
-	e := options[0].(map[string]interface{})[names.AttrEnabled]
+	e := options[0].(map[string]any)[names.AttrEnabled]
 	return !e.(bool)
 }
 
@@ -1346,9 +1346,9 @@ func cycleStreamEnabled(ctx context.Context, conn *dynamodb.Client, id string, s
 	return nil
 }
 
-func createReplicas(ctx context.Context, conn *dynamodb.Client, tableName string, tfList []interface{}, create bool, timeout time.Duration) error {
+func createReplicas(ctx context.Context, conn *dynamodb.Client, tableName string, tfList []any, create bool, timeout time.Duration) error {
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1449,9 +1449,9 @@ func createReplicas(ctx context.Context, conn *dynamodb.Client, tableName string
 	return nil
 }
 
-func updateReplicaTags(ctx context.Context, conn *dynamodb.Client, rn string, replicas []interface{}, newTags interface{}) error {
+func updateReplicaTags(ctx context.Context, conn *dynamodb.Client, rn string, replicas []any, newTags any) error {
 	for _, tfMapRaw := range replicas {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1487,8 +1487,8 @@ func updateReplicaTags(ctx context.Context, conn *dynamodb.Client, rn string, re
 	return nil
 }
 
-func updateTimeToLive(ctx context.Context, conn *dynamodb.Client, tableName string, ttlList []interface{}, timeout time.Duration) error {
-	ttlMap := ttlList[0].(map[string]interface{})
+func updateTimeToLive(ctx context.Context, conn *dynamodb.Client, tableName string, ttlList []any, timeout time.Duration) error {
+	ttlMap := ttlList[0].(map[string]any)
 
 	input := &dynamodb.UpdateTimeToLiveInput{
 		TableName: aws.String(tableName),
@@ -1559,16 +1559,16 @@ func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.Resourc
 	removeRaw := o.Difference(n).List()
 	addRaw := n.Difference(o).List()
 
-	var removeFirst []interface{} // replicas to delete before recreating (like ForceNew without recreating table)
-	var toAdd []interface{}
-	var toRemove []interface{}
+	var removeFirst []any // replicas to delete before recreating (like ForceNew without recreating table)
+	var toAdd []any
+	var toRemove []any
 
 	// first pass - add replicas that don't have corresponding remove entry
 	for _, a := range addRaw {
 		add := true
-		ma := a.(map[string]interface{})
+		ma := a.(map[string]any)
 		for _, r := range removeRaw {
-			mr := r.(map[string]interface{})
+			mr := r.(map[string]any)
 
 			if ma["region_name"].(string) == mr["region_name"].(string) {
 				add = false
@@ -1584,9 +1584,9 @@ func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.Resourc
 	// second pass - remove replicas that don't have corresponding add entry
 	for _, r := range removeRaw {
 		remove := true
-		mr := r.(map[string]interface{})
+		mr := r.(map[string]any)
 		for _, a := range addRaw {
-			ma := a.(map[string]interface{})
+			ma := a.(map[string]any)
 
 			if ma["region_name"].(string) == mr["region_name"].(string) {
 				remove = false
@@ -1602,9 +1602,9 @@ func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.Resourc
 	// third pass - for replicas that exist in both add and remove
 	// For true updates, don't remove and add, just update
 	for _, a := range addRaw {
-		ma := a.(map[string]interface{})
+		ma := a.(map[string]any)
 		for _, r := range removeRaw {
-			mr := r.(map[string]interface{})
+			mr := r.(map[string]any)
 
 			if ma["region_name"].(string) != mr["region_name"].(string) {
 				continue
@@ -1651,16 +1651,16 @@ func updateReplica(ctx context.Context, conn *dynamodb.Client, d *schema.Resourc
 	return nil
 }
 
-func updateDiffGSI(oldGsi, newGsi []interface{}, billingMode awstypes.BillingMode) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
+func updateDiffGSI(oldGsi, newGsi []any, billingMode awstypes.BillingMode) ([]awstypes.GlobalSecondaryIndexUpdate, error) {
 	// Transform slices into maps
-	oldGsis := make(map[string]interface{})
+	oldGsis := make(map[string]any)
 	for _, gsidata := range oldGsi {
-		m := gsidata.(map[string]interface{})
+		m := gsidata.(map[string]any)
 		oldGsis[m[names.AttrName].(string)] = m
 	}
-	newGsis := make(map[string]interface{})
+	newGsis := make(map[string]any)
 	for _, gsidata := range newGsi {
-		m := gsidata.(map[string]interface{})
+		m := gsidata.(map[string]any)
 		// validate throughput input early, to avoid unnecessary processing
 		if err := validateGSIProvisionedThroughput(m, billingMode); err != nil {
 			return nil, err
@@ -1671,11 +1671,11 @@ func updateDiffGSI(oldGsi, newGsi []interface{}, billingMode awstypes.BillingMod
 	var ops []awstypes.GlobalSecondaryIndexUpdate
 
 	for _, data := range newGsi {
-		newMap := data.(map[string]interface{})
+		newMap := data.(map[string]any)
 		newName := newMap[names.AttrName].(string)
 
 		if _, exists := oldGsis[newName]; !exists {
-			m := data.(map[string]interface{})
+			m := data.(map[string]any)
 			idxName := m[names.AttrName].(string)
 
 			c := awstypes.CreateGlobalSecondaryIndexAction{
@@ -1696,12 +1696,12 @@ func updateDiffGSI(oldGsi, newGsi []interface{}, billingMode awstypes.BillingMod
 	}
 
 	for _, data := range oldGsi {
-		oldMap := data.(map[string]interface{})
+		oldMap := data.(map[string]any)
 		oldName := oldMap[names.AttrName].(string)
 
 		newData, exists := newGsis[oldName]
 		if exists {
-			newMap := newData.(map[string]interface{})
+			newMap := newData.(map[string]any)
 			idxName := newMap[names.AttrName].(string)
 
 			oldWriteCapacity, oldReadCapacity := oldMap["write_capacity"].(int), oldMap["read_capacity"].(int)
@@ -1802,7 +1802,7 @@ func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) e
 		TableName: aws.String(tableName),
 	}
 
-	_, err := tfresource.RetryWhen(ctx, deleteTableTimeout, func() (interface{}, error) {
+	_, err := tfresource.RetryWhen(ctx, deleteTableTimeout, func() (any, error) {
 		return conn.DeleteTable(ctx, input)
 	}, func(err error) (bool, error) {
 		// Subscriber limit exceeded: Only 10 tables can be created, updated, or deleted simultaneously
@@ -1824,11 +1824,11 @@ func deleteTable(ctx context.Context, conn *dynamodb.Client, tableName string) e
 	return err
 }
 
-func deleteReplicas(ctx context.Context, conn *dynamodb.Client, tableName string, tfList []interface{}, timeout time.Duration) error {
+func deleteReplicas(ctx context.Context, conn *dynamodb.Client, tableName string, tfList []any, timeout time.Duration) error {
 	var g multierror.Group
 
 	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 
 		if !ok {
 			continue
@@ -1933,11 +1933,11 @@ func replicaPITR(ctx context.Context, conn *dynamodb.Client, tableName string, r
 	return enabled, nil
 }
 
-func addReplicaPITRs(ctx context.Context, conn *dynamodb.Client, tableName string, replicas []interface{}) ([]interface{}, error) {
+func addReplicaPITRs(ctx context.Context, conn *dynamodb.Client, tableName string, replicas []any) ([]any, error) {
 	// This non-standard approach is needed because PITR info for a replica
 	// must come from a region-specific connection.
 	for i, replicaRaw := range replicas {
-		replica := replicaRaw.(map[string]interface{})
+		replica := replicaRaw.(map[string]any)
 
 		var enabled bool
 		var err error
@@ -1951,11 +1951,11 @@ func addReplicaPITRs(ctx context.Context, conn *dynamodb.Client, tableName strin
 	return replicas, nil
 }
 
-func enrichReplicas(ctx context.Context, conn *dynamodb.Client, arn, tableName string, tfList []interface{}) ([]interface{}, error) {
+func enrichReplicas(ctx context.Context, conn *dynamodb.Client, arn, tableName string, tfList []any) ([]any, error) {
 	// This non-standard approach is needed because PITR info for a replica
 	// must come from a region-specific connection.
 	for i, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]interface{})
+		tfMap, ok := tfMapRaw.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -1988,7 +1988,7 @@ func enrichReplicas(ctx context.Context, conn *dynamodb.Client, arn, tableName s
 	return tfList, nil
 }
 
-func addReplicaTagPropagates(configReplicas *schema.Set, replicas []interface{}) []interface{} {
+func addReplicaTagPropagates(configReplicas *schema.Set, replicas []any) []any {
 	if configReplicas.Len() == 0 {
 		return replicas
 	}
@@ -1996,12 +1996,12 @@ func addReplicaTagPropagates(configReplicas *schema.Set, replicas []interface{})
 	l := configReplicas.List()
 
 	for i, replicaRaw := range replicas {
-		replica := replicaRaw.(map[string]interface{})
+		replica := replicaRaw.(map[string]any)
 
 		prop := false
 
 		for _, configReplicaRaw := range l {
-			configReplica := configReplicaRaw.(map[string]interface{})
+			configReplica := configReplicaRaw.(map[string]any)
 
 			if v, ok := configReplica["region_name"].(string); ok && v != replica["region_name"].(string) {
 				continue
@@ -2021,12 +2021,12 @@ func addReplicaTagPropagates(configReplicas *schema.Set, replicas []interface{})
 
 // clearSSEDefaultKey sets the kms_key_arn to "" if it is the default key alias/aws/dynamodb.
 // Not clearing the key causes diff problems and sends the key to AWS when it should not be.
-func clearSSEDefaultKey(ctx context.Context, client *conns.AWSClient, sseList []interface{}) []interface{} {
+func clearSSEDefaultKey(ctx context.Context, client *conns.AWSClient, sseList []any) []any {
 	if len(sseList) == 0 {
 		return sseList
 	}
 
-	sse := sseList[0].(map[string]interface{})
+	sse := sseList[0].(map[string]any)
 
 	dk, err := kms.FindDefaultKeyARNForService(ctx, client.KMSClient(ctx), "dynamodb", client.Region(ctx))
 	if err != nil {
@@ -2035,7 +2035,7 @@ func clearSSEDefaultKey(ctx context.Context, client *conns.AWSClient, sseList []
 
 	if v, ok := sse[names.AttrKMSKeyARN].(string); ok && v == dk {
 		sse[names.AttrKMSKeyARN] = ""
-		return []interface{}{sse}
+		return []any{sse}
 	}
 
 	return sseList
@@ -2043,13 +2043,13 @@ func clearSSEDefaultKey(ctx context.Context, client *conns.AWSClient, sseList []
 
 // clearReplicaDefaultKeys sets a replica's kms_key_arn to "" if it is the default key alias/aws/dynamodb for
 // the replica's region. Not clearing the key causes diff problems and sends the key to AWS when it should not be.
-func clearReplicaDefaultKeys(ctx context.Context, client *conns.AWSClient, replicas []interface{}) []interface{} {
+func clearReplicaDefaultKeys(ctx context.Context, client *conns.AWSClient, replicas []any) []any {
 	if len(replicas) == 0 {
 		return replicas
 	}
 
 	for i, replicaRaw := range replicas {
-		replica := replicaRaw.(map[string]interface{})
+		replica := replicaRaw.(map[string]any)
 
 		if v, ok := replica[names.AttrKMSKeyARN].(string); !ok || v == "" {
 			continue
@@ -2076,15 +2076,15 @@ func clearReplicaDefaultKeys(ctx context.Context, client *conns.AWSClient, repli
 
 // flatteners, expanders
 
-func flattenTableAttributeDefinitions(definitions []awstypes.AttributeDefinition) []interface{} {
+func flattenTableAttributeDefinitions(definitions []awstypes.AttributeDefinition) []any {
 	if len(definitions) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var attributes []interface{}
+	var attributes []any
 
 	for _, d := range definitions {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrName: aws.ToString(d.AttributeName),
 			names.AttrType: d.AttributeType,
 		}
@@ -2095,15 +2095,15 @@ func flattenTableAttributeDefinitions(definitions []awstypes.AttributeDefinition
 	return attributes
 }
 
-func flattenTableLocalSecondaryIndex(lsi []awstypes.LocalSecondaryIndexDescription) []interface{} {
+func flattenTableLocalSecondaryIndex(lsi []awstypes.LocalSecondaryIndexDescription) []any {
 	if len(lsi) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var output []interface{}
+	var output []any
 
 	for _, l := range lsi {
-		m := map[string]interface{}{
+		m := map[string]any{
 			names.AttrName: aws.ToString(l.IndexName),
 		}
 
@@ -2124,15 +2124,15 @@ func flattenTableLocalSecondaryIndex(lsi []awstypes.LocalSecondaryIndexDescripti
 	return output
 }
 
-func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescription) []interface{} {
+func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescription) []any {
 	if len(gsi) == 0 {
-		return []interface{}{}
+		return []any{}
 	}
 
-	var output []interface{}
+	var output []any
 
 	for _, g := range gsi {
-		gsi := make(map[string]interface{})
+		gsi := make(map[string]any)
 
 		if g.ProvisionedThroughput != nil {
 			gsi["write_capacity"] = aws.ToInt64(g.ProvisionedThroughput.WriteCapacityUnits)
@@ -2165,23 +2165,23 @@ func flattenTableGlobalSecondaryIndex(gsi []awstypes.GlobalSecondaryIndexDescrip
 	return output
 }
 
-func flattenTableServerSideEncryption(description *awstypes.SSEDescription) []interface{} {
+func flattenTableServerSideEncryption(description *awstypes.SSEDescription) []any {
 	if description == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{
+	m := map[string]any{
 		names.AttrEnabled:   description.Status == awstypes.SSEStatusEnabled,
 		names.AttrKMSKeyARN: aws.ToString(description.KMSMasterKeyArn),
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func expandAttributes(cfg []interface{}) []awstypes.AttributeDefinition {
+func expandAttributes(cfg []any) []awstypes.AttributeDefinition {
 	attributes := make([]awstypes.AttributeDefinition, len(cfg))
 	for i, attribute := range cfg {
-		attr := attribute.(map[string]interface{})
+		attr := attribute.(map[string]any)
 		attributes[i] = awstypes.AttributeDefinition{
 			AttributeName: aws.String(attr[names.AttrName].(string)),
 			AttributeType: awstypes.ScalarAttributeType(attr[names.AttrType].(string)),
@@ -2190,12 +2190,12 @@ func expandAttributes(cfg []interface{}) []awstypes.AttributeDefinition {
 	return attributes
 }
 
-func flattenOnDemandThroughput(apiObject *awstypes.OnDemandThroughput) []interface{} {
+func flattenOnDemandThroughput(apiObject *awstypes.OnDemandThroughput) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if v := apiObject.MaxReadRequestUnits; v != nil {
 		m["max_read_request_units"] = aws.ToInt64(v)
@@ -2205,15 +2205,15 @@ func flattenOnDemandThroughput(apiObject *awstypes.OnDemandThroughput) []interfa
 		m["max_write_request_units"] = aws.ToInt64(v)
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenReplicaDescription(apiObject *awstypes.ReplicaDescription) map[string]interface{} {
+func flattenReplicaDescription(apiObject *awstypes.ReplicaDescription) map[string]any {
 	if apiObject == nil {
 		return nil
 	}
 
-	tfMap := map[string]interface{}{}
+	tfMap := map[string]any{}
 
 	if apiObject.KMSMasterKeyId != nil {
 		tfMap[names.AttrKMSKeyARN] = aws.ToString(apiObject.KMSMasterKeyId)
@@ -2226,12 +2226,12 @@ func flattenReplicaDescription(apiObject *awstypes.ReplicaDescription) map[strin
 	return tfMap
 }
 
-func flattenReplicaDescriptions(apiObjects []awstypes.ReplicaDescription) []interface{} {
+func flattenReplicaDescriptions(apiObjects []awstypes.ReplicaDescription) []any {
 	if len(apiObjects) == 0 {
 		return nil
 	}
 
-	var tfList []interface{}
+	var tfList []any
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenReplicaDescription(&apiObject))
@@ -2240,13 +2240,13 @@ func flattenReplicaDescriptions(apiObjects []awstypes.ReplicaDescription) []inte
 	return tfList
 }
 
-func flattenTTL(ttlOutput *dynamodb.DescribeTimeToLiveOutput) []interface{} {
-	m := map[string]interface{}{
+func flattenTTL(ttlOutput *dynamodb.DescribeTimeToLiveOutput) []any {
+	m := map[string]any{
 		names.AttrEnabled: false,
 	}
 
 	if ttlOutput == nil || ttlOutput.TimeToLiveDescription == nil {
-		return []interface{}{m}
+		return []any{m}
 	}
 
 	ttlDesc := ttlOutput.TimeToLiveDescription
@@ -2254,16 +2254,16 @@ func flattenTTL(ttlOutput *dynamodb.DescribeTimeToLiveOutput) []interface{} {
 	m["attribute_name"] = aws.ToString(ttlDesc.AttributeName)
 	m[names.AttrEnabled] = (ttlDesc.TimeToLiveStatus == awstypes.TimeToLiveStatusEnabled)
 
-	return []interface{}{m}
+	return []any{m}
 }
 
-func flattenPITR(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []interface{} {
-	m := map[string]interface{}{
+func flattenPITR(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []any {
+	m := map[string]any{
 		names.AttrEnabled: false,
 	}
 
 	if pitrDesc == nil {
-		return []interface{}{m}
+		return []any{m}
 	}
 
 	if pitrDesc.ContinuousBackupsDescription != nil {
@@ -2273,16 +2273,16 @@ func flattenPITR(pitrDesc *dynamodb.DescribeContinuousBackupsOutput) []interface
 		}
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 // TODO: Get rid of keySchemaM - the user should just explicitly define
 // this in the config, we shouldn't magically be setting it like this.
 // Removal will however require config change, hence BC. :/
-func expandLocalSecondaryIndexes(cfg []interface{}, keySchemaM map[string]interface{}) []awstypes.LocalSecondaryIndex {
+func expandLocalSecondaryIndexes(cfg []any, keySchemaM map[string]any) []awstypes.LocalSecondaryIndex {
 	indexes := make([]awstypes.LocalSecondaryIndex, len(cfg))
 	for i, lsi := range cfg {
-		m := lsi.(map[string]interface{})
+		m := lsi.(map[string]any)
 		idxName := m[names.AttrName].(string)
 
 		// TODO: See https://github.com/hashicorp/terraform-provider-aws/issues/3176
@@ -2299,7 +2299,7 @@ func expandLocalSecondaryIndexes(cfg []interface{}, keySchemaM map[string]interf
 	return indexes
 }
 
-func expandImportTable(data map[string]interface{}) *dynamodb.ImportTableInput {
+func expandImportTable(data map[string]any) *dynamodb.ImportTableInput {
 	a := &dynamodb.ImportTableInput{
 		ClientToken: aws.String(id.UniqueId()),
 	}
@@ -2312,18 +2312,18 @@ func expandImportTable(data map[string]interface{}) *dynamodb.ImportTableInput {
 		a.InputFormat = awstypes.InputFormat(v)
 	}
 
-	if v, ok := data["input_format_options"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+	if v, ok := data["input_format_options"].([]any); ok && len(v) > 0 && v[0] != nil {
 		a.InputFormatOptions = expandInputFormatOptions(v)
 	}
 
-	if v, ok := data["s3_bucket_source"].([]interface{}); ok && len(v) > 0 {
-		a.S3BucketSource = expandS3BucketSource(v[0].(map[string]interface{}))
+	if v, ok := data["s3_bucket_source"].([]any); ok && len(v) > 0 {
+		a.S3BucketSource = expandS3BucketSource(v[0].(map[string]any))
 	}
 
 	return a
 }
 
-func expandGlobalSecondaryIndex(data map[string]interface{}, billingMode awstypes.BillingMode) *awstypes.GlobalSecondaryIndex {
+func expandGlobalSecondaryIndex(data map[string]any, billingMode awstypes.BillingMode) *awstypes.GlobalSecondaryIndex {
 	output := awstypes.GlobalSecondaryIndex{
 		IndexName:             aws.String(data[names.AttrName].(string)),
 		KeySchema:             expandKeySchema(data),
@@ -2338,11 +2338,11 @@ func expandGlobalSecondaryIndex(data map[string]interface{}, billingMode awstype
 	return &output
 }
 
-func expandProvisionedThroughput(data map[string]interface{}, billingMode awstypes.BillingMode) *awstypes.ProvisionedThroughput {
+func expandProvisionedThroughput(data map[string]any, billingMode awstypes.BillingMode) *awstypes.ProvisionedThroughput {
 	return expandProvisionedThroughputUpdate("", data, billingMode, "")
 }
 
-func expandProvisionedThroughputUpdate(id string, data map[string]interface{}, billingMode, oldBillingMode awstypes.BillingMode) *awstypes.ProvisionedThroughput {
+func expandProvisionedThroughputUpdate(id string, data map[string]any, billingMode, oldBillingMode awstypes.BillingMode) *awstypes.ProvisionedThroughput {
 	if billingMode == awstypes.BillingModePayPerRequest {
 		return nil
 	}
@@ -2353,7 +2353,7 @@ func expandProvisionedThroughputUpdate(id string, data map[string]interface{}, b
 	}
 }
 
-func expandProvisionedThroughputField(id string, data map[string]interface{}, key string, billingMode, oldBillingMode awstypes.BillingMode) int64 {
+func expandProvisionedThroughputField(id string, data map[string]any, key string, billingMode, oldBillingMode awstypes.BillingMode) int64 {
 	v := data[key].(int)
 	if v == 0 && billingMode == awstypes.BillingModeProvisioned && oldBillingMode == awstypes.BillingModePayPerRequest {
 		log.Printf("[WARN] Overriding %[1]s on DynamoDB Table (%[2]s) to %[3]d. Switching from billing mode %[4]q to %[5]q without value for %[1]s. Assuming changes are being ignored.",
@@ -2363,12 +2363,12 @@ func expandProvisionedThroughputField(id string, data map[string]interface{}, ke
 	return int64(v)
 }
 
-func expandProjection(data map[string]interface{}) *awstypes.Projection {
+func expandProjection(data map[string]any) *awstypes.Projection {
 	projection := &awstypes.Projection{
 		ProjectionType: awstypes.ProjectionType(data["projection_type"].(string)),
 	}
 
-	if v, ok := data["non_key_attributes"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := data["non_key_attributes"].([]any); ok && len(v) > 0 {
 		projection.NonKeyAttributes = flex.ExpandStringValueList(v)
 	}
 
@@ -2379,7 +2379,7 @@ func expandProjection(data map[string]interface{}) *awstypes.Projection {
 	return projection
 }
 
-func expandKeySchema(data map[string]interface{}) []awstypes.KeySchemaElement {
+func expandKeySchema(data map[string]any) []awstypes.KeySchemaElement {
 	keySchema := []awstypes.KeySchemaElement{}
 
 	if v, ok := data["hash_key"]; ok && v != nil && v != "" {
@@ -2399,12 +2399,12 @@ func expandKeySchema(data map[string]interface{}) []awstypes.KeySchemaElement {
 	return keySchema
 }
 
-func expandEncryptAtRestOptions(vOptions []interface{}) *awstypes.SSESpecification {
+func expandEncryptAtRestOptions(vOptions []any) *awstypes.SSESpecification {
 	options := &awstypes.SSESpecification{}
 
 	enabled := false
 	if len(vOptions) > 0 {
-		mOptions := vOptions[0].(map[string]interface{})
+		mOptions := vOptions[0].(map[string]any)
 
 		enabled = mOptions[names.AttrEnabled].(bool)
 		if enabled {
@@ -2419,18 +2419,18 @@ func expandEncryptAtRestOptions(vOptions []interface{}) *awstypes.SSESpecificati
 	return options
 }
 
-func expandInputFormatOptions(data []interface{}) *awstypes.InputFormatOptions {
+func expandInputFormatOptions(data []any) *awstypes.InputFormatOptions {
 	if data == nil {
 		return nil
 	}
 
-	m := data[0].(map[string]interface{})
+	m := data[0].(map[string]any)
 	a := &awstypes.InputFormatOptions{}
 
-	if v, ok := m["csv"].([]interface{}); ok && len(v) > 0 {
+	if v, ok := m["csv"].([]any); ok && len(v) > 0 {
 		a.Csv = &awstypes.CsvOptions{}
 
-		csv := v[0].(map[string]interface{})
+		csv := v[0].(map[string]any)
 
 		if s, ok := csv["delimiter"].(string); ok && s != "" {
 			a.Csv.Delimiter = aws.String(s)
@@ -2444,7 +2444,7 @@ func expandInputFormatOptions(data []interface{}) *awstypes.InputFormatOptions {
 	return a
 }
 
-func expandOnDemandThroughput(tfMap map[string]interface{}) *awstypes.OnDemandThroughput {
+func expandOnDemandThroughput(tfMap map[string]any) *awstypes.OnDemandThroughput {
 	if tfMap == nil {
 		return nil
 	}
@@ -2462,7 +2462,7 @@ func expandOnDemandThroughput(tfMap map[string]interface{}) *awstypes.OnDemandTh
 	return apiObject
 }
 
-func expandS3BucketSource(data map[string]interface{}) *awstypes.S3BucketSource {
+func expandS3BucketSource(data map[string]any) *awstypes.S3BucketSource {
 	if data == nil {
 		return nil
 	}
@@ -2499,7 +2499,7 @@ func validateTableAttributes(d *schema.ResourceDiff) error {
 	if v, ok := d.GetOk("local_secondary_index"); ok {
 		indexes := v.(*schema.Set).List()
 		for _, idx := range indexes {
-			index := idx.(map[string]interface{})
+			index := idx.(map[string]any)
 			rangeKey := index["range_key"].(string)
 			indexedAttributes[rangeKey] = true
 		}
@@ -2507,7 +2507,7 @@ func validateTableAttributes(d *schema.ResourceDiff) error {
 	if v, ok := d.GetOk("global_secondary_index"); ok {
 		indexes := v.(*schema.Set).List()
 		for _, idx := range indexes {
-			index := idx.(map[string]interface{})
+			index := idx.(map[string]any)
 
 			hashKey := index["hash_key"].(string)
 			indexedAttributes[hashKey] = true
@@ -2522,7 +2522,7 @@ func validateTableAttributes(d *schema.ResourceDiff) error {
 	attributes := d.Get("attribute").(*schema.Set).List()
 	unindexedAttributes := []string{}
 	for _, attr := range attributes {
-		attribute := attr.(map[string]interface{})
+		attribute := attr.(map[string]any)
 		attrName := attribute[names.AttrName].(string)
 
 		if _, ok := indexedAttributes[attrName]; !ok {
@@ -2550,7 +2550,7 @@ func validateTableAttributes(d *schema.ResourceDiff) error {
 	return errors.Join(errs...)
 }
 
-func validateGSIProvisionedThroughput(data map[string]interface{}, billingMode awstypes.BillingMode) error {
+func validateGSIProvisionedThroughput(data map[string]any, billingMode awstypes.BillingMode) error {
 	// if billing mode is PAY_PER_REQUEST, don't need to validate the throughput settings
 	if billingMode == awstypes.BillingModePayPerRequest {
 		return nil

--- a/internal/service/dynamodb/table_data_source.go
+++ b/internal/service/dynamodb/table_data_source.go
@@ -253,7 +253,7 @@ func dataSourceTable() *schema.Resource {
 	}
 }
 
-func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTableRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 

--- a/internal/service/dynamodb/table_export.go
+++ b/internal/service/dynamodb/table_export.go
@@ -163,7 +163,7 @@ func resourceTableExport() *schema.Resource {
 	}
 }
 
-func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -188,7 +188,7 @@ func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if v, ok := d.GetOk("incremental_export_specification"); ok {
-		input.IncrementalExportSpecification = expandIncrementalExportSpecification(v.([]interface{}))
+		input.IncrementalExportSpecification = expandIncrementalExportSpecification(v.([]any))
 	}
 
 	if v, ok := d.GetOk("s3_bucket_owner"); ok {
@@ -222,7 +222,7 @@ func resourceTableExportCreate(ctx context.Context, d *schema.ResourceData, meta
 	return append(diags, resourceTableExportRead(ctx, d, meta)...)
 }
 
-func resourceTableExportRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableExportRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -265,12 +265,12 @@ func resourceTableExportRead(ctx context.Context, d *schema.ResourceData, meta i
 	return diags
 }
 
-func expandIncrementalExportSpecification(d interface{}) *awstypes.IncrementalExportSpecification {
-	if d.([]interface{}) == nil || len(d.([]interface{})) == 0 {
+func expandIncrementalExportSpecification(d any) *awstypes.IncrementalExportSpecification {
+	if d.([]any) == nil || len(d.([]any)) == 0 {
 		return nil
 	}
 
-	dMap := d.([]interface{})[0].(map[string]interface{})
+	dMap := d.([]any)[0].(map[string]any)
 
 	spec := &awstypes.IncrementalExportSpecification{}
 
@@ -291,12 +291,12 @@ func expandIncrementalExportSpecification(d interface{}) *awstypes.IncrementalEx
 	return spec
 }
 
-func flattenIncrementalExportSpecification(apiObject *awstypes.IncrementalExportSpecification) []interface{} {
+func flattenIncrementalExportSpecification(apiObject *awstypes.IncrementalExportSpecification) []any {
 	if apiObject == nil {
-		return []interface{}{}
+		return []any{}
 	}
 
-	m := map[string]interface{}{}
+	m := map[string]any{}
 
 	if v := apiObject.ExportFromTime; v != nil {
 		m["export_from_time"] = aws.ToTime(v).Format(time.RFC3339)
@@ -310,7 +310,7 @@ func flattenIncrementalExportSpecification(apiObject *awstypes.IncrementalExport
 		m["export_view_type"] = v
 	}
 
-	return []interface{}{m}
+	return []any{m}
 }
 
 func findTableExportByARN(ctx context.Context, conn *dynamodb.Client, arn string) (*awstypes.ExportDescription, error) {
@@ -335,7 +335,7 @@ func findTableExportByARN(ctx context.Context, conn *dynamodb.Client, arn string
 }
 
 func statusTableExport(ctx context.Context, conn *dynamodb.Client, arn string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+	return func() (any, string, error) {
 		output, err := findTableExportByARN(ctx, conn, arn)
 
 		if tfresource.NotFound(err) {

--- a/internal/service/dynamodb/table_item.go
+++ b/internal/service/dynamodb/table_item.go
@@ -60,7 +60,7 @@ func resourceTableItem() *schema.Resource {
 	}
 }
 
-func validateTableItem(v interface{}, k string) (ws []string, errors []error) {
+func validateTableItem(v any, k string) (ws []string, errors []error) {
 	_, err := expandTableItemAttributes(v.(string))
 	if err != nil {
 		errors = append(errors, fmt.Errorf("Invalid format of %q: %s", k, err))
@@ -68,7 +68,7 @@ func validateTableItem(v interface{}, k string) (ws []string, errors []error) {
 	return
 }
 
-func resourceTableItemCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableItemCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -98,7 +98,7 @@ func resourceTableItemCreate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceTableItemRead(ctx, d, meta)...)
 }
 
-func resourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -135,7 +135,7 @@ func resourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta int
 	return diags
 }
 
-func resourceTableItemUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableItemUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -215,7 +215,7 @@ func resourceTableItemUpdate(ctx context.Context, d *schema.ResourceData, meta i
 	return append(diags, resourceTableItemRead(ctx, d, meta)...)
 }
 
-func resourceTableItemDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableItemDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 

--- a/internal/service/dynamodb/table_item_data_source.go
+++ b/internal/service/dynamodb/table_item_data_source.go
@@ -51,7 +51,7 @@ func dataSourceTableItem() *schema.Resource {
 	}
 }
 
-func dataSourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -68,8 +68,8 @@ func dataSourceTableItemRead(ctx context.Context, d *schema.ResourceData, meta i
 		TableName:      aws.String(tableName),
 	}
 
-	if v, ok := d.GetOk("expression_attribute_names"); ok && len(v.(map[string]interface{})) > 0 {
-		input.ExpressionAttributeNames = flex.ExpandStringValueMap(v.(map[string]interface{}))
+	if v, ok := d.GetOk("expression_attribute_names"); ok && len(v.(map[string]any)) > 0 {
+		input.ExpressionAttributeNames = flex.ExpandStringValueMap(v.(map[string]any))
 	}
 
 	if v, ok := d.GetOk("projection_expression"); ok {

--- a/internal/service/dynamodb/table_migrate.go
+++ b/internal/service/dynamodb/table_migrate.go
@@ -6,6 +6,7 @@ package dynamodb
 import (
 	"fmt"
 	"log"
+	"maps"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -13,7 +14,7 @@ import (
 )
 
 func resourceTableMigrateState(
-	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	v int, is *terraform.InstanceState, meta any) (*terraform.InstanceState, error) {
 	switch v {
 	case 0:
 		log.Println("[INFO] Found AWS DynamoDB Table State v0; migrating to v1")
@@ -63,9 +64,7 @@ func migrateStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, 
 	if err := writer.WriteField([]string{prefix}, oldKeys); err != nil {
 		return is, err
 	}
-	for k, v := range writer.Map() {
-		is.Attributes[k] = v
-	}
+	maps.Copy(is.Attributes, writer.Map())
 
 	log.Printf("[DEBUG] DynamoDB Table Attributes after State Migration: %#v", is.Attributes)
 

--- a/internal/service/dynamodb/table_replica.go
+++ b/internal/service/dynamodb/table_replica.go
@@ -98,7 +98,7 @@ func resourceTableReplica() *schema.Resource {
 	}
 }
 
-func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -194,7 +194,7 @@ func resourceTableReplicaCreate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceTableReplicaUpdate(ctx, d, meta)...)
 }
 
-func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -267,7 +267,7 @@ func resourceTableReplicaRead(ctx context.Context, d *schema.ResourceData, meta 
 	return append(diags, resourceTableReplicaReadReplica(ctx, d, meta)...)
 }
 
-func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -313,7 +313,7 @@ func resourceTableReplicaReadReplica(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 
@@ -423,7 +423,7 @@ func resourceTableReplicaUpdate(ctx context.Context, d *schema.ResourceData, met
 	return append(diags, resourceTableReplicaRead(ctx, d, meta)...)
 }
 
-func resourceTableReplicaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceTableReplicaDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).DynamoDBClient(ctx)
 

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -53,13 +53,13 @@ func TestUpdateDiffGSI(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		Old             []interface{}
-		New             []interface{}
+		Old             []any
+		New             []any
 		ExpectedUpdates []awstypes.GlobalSecondaryIndexUpdate
 	}{
 		{ // No-op => no changes
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -67,8 +67,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -79,32 +79,32 @@ func TestUpdateDiffGSI(t *testing.T) {
 			ExpectedUpdates: nil,
 		},
 		{ // No-op => ignore ordering of non_key_attributes
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:       "att1-index",
 					"hash_key":           "att1",
 					"write_capacity":     10,
 					"read_capacity":      10,
 					"projection_type":    "INCLUDE",
-					"non_key_attributes": schema.NewSet(schema.HashString, []interface{}{"attr3", "attr1", "attr2"}),
+					"non_key_attributes": schema.NewSet(schema.HashString, []any{"attr3", "attr1", "attr2"}),
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:       "att1-index",
 					"hash_key":           "att1",
 					"write_capacity":     10,
 					"read_capacity":      10,
 					"projection_type":    "INCLUDE",
-					"non_key_attributes": schema.NewSet(schema.HashString, []interface{}{"attr1", "attr2", "attr3"}),
+					"non_key_attributes": schema.NewSet(schema.HashString, []any{"attr1", "attr2", "attr3"}),
 				},
 			},
 			ExpectedUpdates: nil,
 		},
 
 		{ // Creation
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -112,15 +112,15 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
 					"read_capacity":   10,
 					"projection_type": "ALL",
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrName:    "att2-index",
 					"hash_key":        "att2",
 					"write_capacity":  12,
@@ -151,15 +151,15 @@ func TestUpdateDiffGSI(t *testing.T) {
 		},
 
 		{ // Deletion
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
 					"read_capacity":   10,
 					"projection_type": "ALL",
 				},
-				map[string]interface{}{
+				map[string]any{
 					names.AttrName:    "att2-index",
 					"hash_key":        "att2",
 					"write_capacity":  12,
@@ -167,8 +167,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -186,8 +186,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 		},
 
 		{ // Update
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -195,8 +195,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  20,
@@ -218,8 +218,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 		},
 
 		{ // Update of non-capacity attributes
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -227,15 +227,15 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:       "att1-index",
 					"hash_key":           "att-new",
 					"range_key":          "new-range-key",
 					"write_capacity":     10,
 					"read_capacity":      10,
 					"projection_type":    "KEYS_ONLY",
-					"non_key_attributes": schema.NewSet(schema.HashString, []interface{}{"RandomAttribute"}),
+					"non_key_attributes": schema.NewSet(schema.HashString, []any{"RandomAttribute"}),
 				},
 			},
 			ExpectedUpdates: []awstypes.GlobalSecondaryIndexUpdate{
@@ -271,8 +271,8 @@ func TestUpdateDiffGSI(t *testing.T) {
 		},
 
 		{ // Update of all attributes
-			Old: []interface{}{
-				map[string]interface{}{
+			Old: []any{
+				map[string]any{
 					names.AttrName:    "att1-index",
 					"hash_key":        "att1",
 					"write_capacity":  10,
@@ -280,15 +280,15 @@ func TestUpdateDiffGSI(t *testing.T) {
 					"projection_type": "ALL",
 				},
 			},
-			New: []interface{}{
-				map[string]interface{}{
+			New: []any{
+				map[string]any{
 					names.AttrName:       "att1-index",
 					"hash_key":           "att-new",
 					"range_key":          "new-range-key",
 					"write_capacity":     12,
 					"read_capacity":      12,
 					"projection_type":    "INCLUDE",
-					"non_key_attributes": schema.NewSet(schema.HashString, []interface{}{"RandomAttribute"}),
+					"non_key_attributes": schema.NewSet(schema.HashString, []any{"RandomAttribute"}),
 				},
 			},
 			ExpectedUpdates: []awstypes.GlobalSecondaryIndexUpdate{

--- a/internal/service/dynamodb/validate.go
+++ b/internal/service/dynamodb/validate.go
@@ -12,7 +12,7 @@ import (
 )
 
 // http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_CreateGlobalTable.html
-func validGlobalTableName(v interface{}, k string) (ws []string, errors []error) {
+func validGlobalTableName(v any, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if (len(value) > 255) || (len(value) < 3) {
 		errors = append(errors, fmt.Errorf("%s length must be between 3 and 255 characters: %q", k, value))
@@ -40,7 +40,7 @@ func validStreamSpec(d *schema.ResourceDiff) error {
 }
 
 // checkIfNonKeyAttributesChanged returns true if non_key_attributes between old map and new map are different
-func checkIfNonKeyAttributesChanged(oldMap, newMap map[string]interface{}) bool {
+func checkIfNonKeyAttributesChanged(oldMap, newMap map[string]any) bool {
 	oldNonKeyAttributes, oldNkaExists := oldMap["non_key_attributes"].(*schema.Set)
 	newNonKeyAttributes, newNkaExists := newMap["non_key_attributes"].(*schema.Set)
 


### PR DESCRIPTION
### Description

Modernizing Go code improves readability, maintainability, and aligns with current best practices. Replacing `interface{}` with `any` makes the code more concise and idiomatic in Go 1.18+, reducing verbosity without changing functionality. Similarly, updating loop constructs enhances clarity and leverages Go’s modern syntax where applicable. These changes help keep the codebase up to date, making it easier for new contributors to understand and maintain.

### Relations

Relates #41807


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
