### PR TITLE
 r/aws_emr_cluster: kms key test resources should not have open policies

### DIFF
--- a/internal/service/emr/studio_test.go
+++ b/internal/service/emr/studio_test.go
@@ -388,7 +388,7 @@ resource "aws_kms_key" "test" {
       "Sid": "Enable IAM User Permissions",
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       },
       "Action": "kms:*",
       "Resource": "*"


### PR DESCRIPTION
### Description
Part of fixing a bunch of issues I am running into while implementing a few features for EMR. The existing acceptance tests create, in a few cases, world-open KMS keys.

While this is for acceptance testing, and not necessarily a security concern, I do get paged for these at the moment :)

Please close if this is undesired.

### Relations
Relates #41869

### Output from Acceptance Testing

As this is purely a change in test resources, running this only for the three affected tests.

```console
% make testacc PKG=emr TESTS='(TestAccEMRCluster_security|TestAccEMRCluster_s3LogEncryption|TestAccEMRStudio_workspaceStorageEncryption)'
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 35 -run='(TestAccEMRCluster_security|TestAccEMRCluster_s3LogEncryption|TestAccEMRStudio_workspaceStorageEncryption)'  -timeout 360m -vet=off
2025/03/18 09:49:15 Initializing Terraform AWS Provider...
=== RUN   TestAccEMRCluster_security
2025/03/18 09:49:15 [WARN] Invalid log level: "JSON". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR]
=== PAUSE TestAccEMRCluster_security
=== RUN   TestAccEMRCluster_s3LogEncryption
=== PAUSE TestAccEMRCluster_s3LogEncryption
=== RUN   TestAccEMRStudio_workspaceStorageEncryption
=== PAUSE TestAccEMRStudio_workspaceStorageEncryption
=== CONT  TestAccEMRCluster_security
=== CONT  TestAccEMRStudio_workspaceStorageEncryption
=== CONT  TestAccEMRCluster_s3LogEncryption
--- PASS: TestAccEMRStudio_workspaceStorageEncryption (94.91s)
--- PASS: TestAccEMRCluster_security (390.93s)
--- PASS: TestAccEMRCluster_s3LogEncryption (809.60s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        815.322s
```
