### PR TITLE
docs(aws_api_gateway_rest_api_policy): Fix example IAM policy document to work correctly

### DIFF
--- a/website/docs/r/api_gateway_rest_api_policy.html.markdown
+++ b/website/docs/r/api_gateway_rest_api_policy.html.markdown
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "test" {
     }
 
     actions   = ["execute-api:Invoke"]
-    resources = [aws_api_gateway_rest_api.test.execution_arn]
+    resources = ["${aws_api_gateway_rest_api.test.execution_arn}/*"]
 
     condition {
       test     = "IpAddress"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`/*` is required after execution ARN of REST API if you want to allow arbitary stage, HTTP verb, resource path of API.

<!---
### Relations
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html#api-gateway-iam-policy-resource-format-for-executing-api

<!--
### Output from Acceptance Testing
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
-->
