### PR TITLE
[Bug fix] Remove warning when the filter argument in aws_s3_bucket_lifecycle_configuration is empty

### DIFF
--- a/.changelog/41917.txt
+++ b/.changelog/41917.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: remove warning when filter is empty
+```

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -115,7 +115,7 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 							Computed:           true, // Because of Legacy value handling
 							DeprecationMessage: "Use filter instead",
 							Validators: []validator.String{
-								warnExactlyOneOf(
+								warnAtMostOneOf(
 									path.MatchRelative().AtParent().AtName(names.AttrFilter),
 								),
 							},
@@ -197,11 +197,12 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 										Optional: true,
 										Computed: true, // Because of Legacy value handling
 										Validators: []validator.String{
-											warnExactlyOneOf(
+											warnAtMostOneOf(
 												path.MatchRelative().AtParent().AtName("object_size_greater_than"),
 												path.MatchRelative().AtParent().AtName("object_size_less_than"),
 												path.MatchRelative().AtParent().AtName("and"),
 												path.MatchRelative().AtParent().AtName("tag"),
+												path.MatchRelative().AtParent().AtName(names.AttrPrefix),
 											),
 										},
 									},

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -220,6 +220,53 @@ func TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix(t *testing.T) {
 	})
 }
 
+func TestAccS3BucketLifecycleConfiguration_emptyFilter(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+	currTime := time.Now()
+	date := time.Date(currTime.Year(), currTime.Month()+1, currTime.Day(), 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketLifecycleConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_emptyFilter(rName, date),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrBucket), "aws_s3_bucket.test", tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrExpectedBucketOwner), knownvalue.StringExact("")),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRule), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
+							"expiration":                        checkExpiration_Date(date),
+							names.AttrFilter:                    checkFilter_Prefix(""),
+							names.AttrID:                        knownvalue.StringExact(rName),
+							"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+							"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+							names.AttrPrefix:                    knownvalue.StringExact(""),
+							names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+							"transition":                        checkTransitions(),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("transition_default_minimum_object_size"), knownvalue.StringExact("all_storage_classes_128K")),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -2471,6 +2518,28 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
     filter {
       prefix = ""
     }
+  }
+}
+`, rName, date)
+}
+
+func testAccBucketLifecycleConfigurationConfig_emptyFilter(rName, date string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+  rule {
+    id     = %[1]q
+    status = "Enabled"
+
+    expiration {
+      date = %[2]q
+    }
+
+    filter {}
   }
 }
 `, rName, date)


### PR DESCRIPTION
### Description
This fixes the bug reported by [[Bug]: aws_s3_bucket_lifecycle_configuration using recommended empty filter issues warning #41710](https://github.com/hashicorp/terraform-provider-aws/issues/41710 ) 

- Remove the warning triggered when the filter is empty and add an acceptance test for this case.
- Improve the warning message when the filter contains multiple fields, making it more user-friendly.

### Relations
Closes #41710

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccS3BucketLifecycleConfiguration_ PKG=s3                     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketLifecycleConfiguration_'  -timeout 360m -vet=off
2025/03/19 14:29:42 Initializing Terraform AWS Provider...
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_disappears
=== PAUSE TestAccS3BucketLifecycleConfiguration_disappears
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_emptyFilter
=== PAUSE TestAccS3BucketLifecycleConfiguration_emptyFilter
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd
=== RUN   TestAccS3BucketLifecycleConfiguration_disableRule
=== PAUSE TestAccS3BucketLifecycleConfiguration_disableRule
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules
=== RUN   TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== PAUSE TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== RUN   TestAccS3BucketLifecycleConfiguration_RulePrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_RulePrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter
=== PAUSE TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter
=== RUN   TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_noChange
=== RUN   TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_migrate_withChange
=== RUN   TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_directoryBucket
=== PAUSE TestAccS3BucketLifecycleConfiguration_directoryBucket
=== RUN   TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update
=== PAUSE TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update
=== RUN   TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove
=== PAUSE TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering
=== RUN   TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering
=== PAUSE TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_RulePrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock
=== CONT  TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate
=== CONT  TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd
=== CONT  TestAccS3BucketLifecycleConfiguration_emptyFilter
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithPrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_disappears
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan
=== CONT  TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (59.60s)
=== CONT  TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (66.55s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (67.46s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (68.42s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (70.11s)
=== CONT  TestAccS3BucketLifecycleConfiguration_multipleRules
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (70.13s)
=== CONT  TestAccS3BucketLifecycleConfiguration_disableRule
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (70.55s)
=== CONT  TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (70.57s)
=== CONT  TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (70.64s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_emptyFilter (71.62s)
=== CONT  TestAccS3BucketLifecycleConfiguration_directoryBucket
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_basic (106.79s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd (114.23s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (55.54s)
=== CONT  TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (124.28s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (54.39s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (55.57s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (56.59s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (128.53s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (137.31s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (138.28s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (149.61s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (156.89s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (104.40s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (167.45s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (57.88s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (107.87s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (108.42s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (114.05s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_basic (181.09s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (114.30s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (59.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (103.18s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (152.27s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (105.63s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (103.46s)
=== CONT  TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (106.19s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (57.16s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (57.98s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (102.07s)
=== CONT  TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (58.82s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (106.22s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (100.31s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (123.30s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (97.64s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (94.79s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_withChange
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (95.35s)
=== CONT  TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (117.01s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (165.68s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (112.01s)
=== CONT  TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (117.62s)
=== CONT  TestAccS3BucketLifecycleConfiguration_migrate_noChange
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (59.17s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (117.01s)
=== CONT  TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (93.05s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (92.77s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_withChange (71.32s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (93.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (95.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter (106.53s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (114.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (52.17s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (99.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (104.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (147.72s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (103.68s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (95.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (117.43s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrate_noChange (66.46s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (117.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (109.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (104.22s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (106.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate (129.30s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 422.653s
```
