### PR TITLE
[Bug] Agent instruction limit does not cater for multi-byte characters

### DIFF
--- a/.changelog/41921.txt
+++ b/.changelog/41921.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_bedrockagent_agent: Fix `instruction` validator to consider multi-byte chars so not to artificially limit instruction length
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -133,7 +133,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(40, 8000),
+					stringvalidator.UTF8LengthBetween(40, 8000),
 				},
 			},
 			"prompt_override_configuration": schema.ListAttribute{ // proto5 Optional+Computed nested block.

--- a/internal/service/bedrockagent/agent_test.go
+++ b/internal/service/bedrockagent/agent_test.go
@@ -444,7 +444,7 @@ func TestAccBedrockAgentAgent_agentCollaboration(t *testing.T) {
 		CheckDestroy:             testAccCheckAgentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAgentConfig_agentCollaboration(rName, "anthropic.claude-v2", "basic claude", string(awstypes.AgentCollaborationSupervisor)),
+				Config: testAccAgentConfig_agentCollaboration(rName, "anthropic.claude-3-5-sonnet-20240620-v1:0", "basic claude", string(awstypes.AgentCollaborationSupervisor)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),
@@ -462,7 +462,7 @@ func TestAccBedrockAgentAgent_agentCollaboration(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"skip_resource_in_use_check", "prepare_agent"},
 			},
 			{
-				Config: testAccAgentConfig_agentCollaboration(rName, "anthropic.claude-v2", "basic claude", string(awstypes.AgentCollaborationSupervisorRouter)),
+				Config: testAccAgentConfig_agentCollaboration(rName, "anthropic.claude-3-5-sonnet-20240620-v1:0", "basic claude", string(awstypes.AgentCollaborationSupervisorRouter)),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAgentExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "agent_name", rName),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fix this issue by using `stringvalidator.UTF8LengthBetween`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41783

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc ACCTEST_PARALLELISM=3 TESTS=TestAccBedrockAgentAgent_ PKG=bedrockagent
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/bedrockagent/... -v -count 1 -parallel 3 -run='TestAccBedrockAgentAgent_'  -timeout 360m -vet=off
2025/03/19 19:55:20 Initializing Terraform AWS Provider...
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== RUN   TestAccBedrockAgentAgent_full
=== PAUSE TestAccBedrockAgentAgent_full
=== RUN   TestAccBedrockAgentAgent_singlePrompt
=== PAUSE TestAccBedrockAgentAgent_singlePrompt
=== RUN   TestAccBedrockAgentAgent_singlePromptUpdate
=== PAUSE TestAccBedrockAgentAgent_singlePromptUpdate
=== RUN   TestAccBedrockAgentAgent_addPrompt
=== PAUSE TestAccBedrockAgentAgent_addPrompt
=== RUN   TestAccBedrockAgentAgent_guardrail
=== PAUSE TestAccBedrockAgentAgent_guardrail
=== RUN   TestAccBedrockAgentAgent_update
=== PAUSE TestAccBedrockAgentAgent_update
=== RUN   TestAccBedrockAgentAgent_tags
=== PAUSE TestAccBedrockAgentAgent_tags
=== RUN   TestAccBedrockAgentAgent_kms
=== PAUSE TestAccBedrockAgentAgent_kms
=== RUN   TestAccBedrockAgentAgent_agentCollaboration
=== PAUSE TestAccBedrockAgentAgent_agentCollaboration
=== CONT  TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_guardrail
=== CONT  TestAccBedrockAgentAgent_singlePromptUpdate
--- PASS: TestAccBedrockAgentAgent_basic (30.18s)
=== CONT  TestAccBedrockAgentAgent_agentCollaboration
--- PASS: TestAccBedrockAgentAgent_singlePromptUpdate (47.98s)
=== CONT  TestAccBedrockAgentAgent_kms
--- PASS: TestAccBedrockAgentAgent_agentCollaboration (42.13s)
=== CONT  TestAccBedrockAgentAgent_tags
--- PASS: TestAccBedrockAgentAgent_guardrail (83.35s)
=== CONT  TestAccBedrockAgentAgent_update
--- PASS: TestAccBedrockAgentAgent_kms (51.80s)
=== CONT  TestAccBedrockAgentAgent_addPrompt
--- PASS: TestAccBedrockAgentAgent_tags (64.11s)
=== CONT  TestAccBedrockAgentAgent_singlePrompt
--- PASS: TestAccBedrockAgentAgent_update (59.84s)
=== CONT  TestAccBedrockAgentAgent_full
--- PASS: TestAccBedrockAgentAgent_singlePrompt (29.05s)
--- PASS: TestAccBedrockAgentAgent_full (29.40s)
--- PASS: TestAccBedrockAgentAgent_addPrompt (84.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       189.366s

```
