### PR TITLE
Fix ELBV2 health check default protocol

### DIFF
--- a/internal/service/elbv2/target_group.go
+++ b/internal/service/elbv2/target_group.go
@@ -126,7 +126,7 @@ func resourceTargetGroup() *schema.Resource {
 						names.AttrProtocol: {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  awstypes.ProtocolEnumHttp,
+							Computed: true,
 							StateFunc: func(v any) string {
 								return strings.ToUpper(v.(string))
 							},
@@ -471,7 +471,11 @@ func resourceTargetGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 			input.HealthCheckTimeoutSeconds = aws.Int32(int32(v))
 		}
 
-		healthCheckProtocol := awstypes.ProtocolEnum(tfMap[names.AttrProtocol].(string))
+		protocol, ok := tfMap[names.AttrProtocol].(string)
+		if !ok || protocol == "" {
+			protocol = string(awstypes.ProtocolEnumHttp)
+		}
+		healthCheckProtocol := awstypes.ProtocolEnum(protocol)
 		if healthCheckProtocol != awstypes.ProtocolEnumTcp {
 			if v, ok := tfMap[names.AttrPath].(string); ok && v != "" {
 				input.HealthCheckPath = aws.String(v)
@@ -685,7 +689,11 @@ func resourceTargetGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 				input.HealthCheckTimeoutSeconds = aws.Int32(int32(v))
 			}
 
-			healthCheckProtocol := awstypes.ProtocolEnum(tfMap[names.AttrProtocol].(string))
+			protocol, ok := tfMap[names.AttrProtocol].(string)
+			if !ok || protocol == "" {
+				protocol = string(awstypes.ProtocolEnumHttp)
+			}
+			healthCheckProtocol := awstypes.ProtocolEnum(protocol)
 			if healthCheckProtocol != awstypes.ProtocolEnumTcp {
 				if v, ok := tfMap["matcher"].(string); ok {
 					if protocolVersion := d.Get("protocol_version").(string); protocolVersion == protocolVersionGRPC {

--- a/internal/service/elbv2/target_group_test.go
+++ b/internal/service/elbv2/target_group_test.go
@@ -4195,7 +4195,7 @@ func TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0(t *testing.T)
 				// Lambda health checks don't take a protocol, but are effectively an HTTP check.
 				// So, they return a `matcher` on read. When Terraform validates the diff, the (incorrectly stored) protocol
 				// `TCP` is checked against the `matcher`, and returns an error.
-				step.ExpectError = regexache.MustCompile(`health_check.matcher is not supported for target_groups with TCP protocol`)
+				step.ExpectError = regexache.MustCompile(`Attribute "health_check\[0\]\.protocol" cannot have value "TCP" when "target_type" is "lambda"`)
 			} else if tc.warning {
 				step.Check = resource.ComposeAggregateTestCheckFunc(
 					testAccCheckTargetGroupExists(ctx, resourceName, &targetGroup),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
- Modify the code to set the default health check protocol to HTTP only when the target type is not lambda.
- Fixes test case TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35457 
### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol PKG=elbv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol'  -timeout 360m -vet=off
2025/03/19 15:28:30 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTP
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTP
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTP
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTPS
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTPS
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/TCP
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTP
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/TCP
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTP
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTPS
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTPS
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/TCP
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTPS
=== RUN   TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/TCP
=== PAUSE TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/TCP
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTP
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/TCP
=== CONT  TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTPS
--- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol (0.00s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/TCP (2.97s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTP (18.11s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol/HTTPS (18.30s)
--- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0 (0.00s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/TCP (22.36s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTPS (44.61s)
    --- PASS: TestAccELBV2TargetGroup_Lambda_HealthCheck_protocol_MigrateV0/HTTP (49.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	54.825s

...
```

I think existing test cases cover the scenarios but please let me know if something has to be added. I did test manually with lambda and IP as target types.