### PR TITLE
r/aws_eks_cluster: modify `compute_config` in place to add `node_role_arn`

### DIFF
--- a/.changelog/41925.txt
+++ b/.changelog/41925.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_eks_cluster: Allow `compute_config.node_role_arn` to update in place when previously unset
+```

--- a/internal/service/eks/cluster.go
+++ b/internal/service/eks/cluster.go
@@ -74,7 +74,8 @@ func resourceCluster() *schema.Resource {
 				oldRoleARN := aws.ToString(oldComputeConfig.NodeRoleArn)
 				newRoleARN := aws.ToString(newComputeConfig.NodeRoleArn)
 
-				if oldRoleARN != newRoleARN {
+				// only force new if an existing role has changed, not if a new role is added
+				if oldRoleARN != "" && oldRoleARN != newRoleARN {
 					if err := rd.ForceNew("compute_config.0.node_role_arn"); err != nil {
 						return err
 					}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adding a new `compute_config.node_role_arn` when previously no configured should update in place, not recreate.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #40549

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccEKSCluster_ComputeConfig_AddARN" PKG=eks

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/eks/... -v -count 1 -parallel 20  -run=TestAccEKSCluster_ComputeConfig_AddARN -timeout 360m -vet=off
2025/03/19 17:31:28 Initializing Terraform AWS Provider...
=== RUN   TestAccEKSCluster_ComputeConfig_AddARN
=== PAUSE TestAccEKSCluster_ComputeConfig_AddARN
=== CONT  TestAccEKSCluster_ComputeConfig_AddARN
--- PASS: TestAccEKSCluster_ComputeConfig_AddARN (810.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	817.598s
```

```console
% make testacc TESTARGS="-run=TestAccEKSCluster_" PKG=eks

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/eks/... -v -count 1 -parallel 20  -run=TestAccEKSCluster_ -timeout 360m -vet=off
2025/03/19 16:44:12 Initializing Terraform AWS Provider...
--- PASS: TestAccEKSCluster_Encryption_create (535.66s)
--- PASS: TestAccEKSCluster_zonalShiftConfig (562.98s)
--- PASS: TestAccEKSCluster_basic (573.52s)
--- PASS: TestAccEKSCluster_tags (577.07s)
--- PASS: TestAccEKSCluster_RemoteNetwork_Pod (585.38s)
--- PASS: TestAccEKSCluster_upgradePolicy (617.68s)
    cluster_test.go:1096: skipping since no Outposts found
--- SKIP: TestAccEKSCluster_Outpost_placement (0.41s)
--- PASS: TestAccEKSCluster_logging (620.69s)
    cluster_test.go:1063: skipping since no Outposts found
--- SKIP: TestAccEKSCluster_Outpost_create (0.14s)
--- PASS: TestAccEKSCluster_ComputeConfig_OnUpdate (864.61s)
--- PASS: TestAccEKSCluster_ComputeConfig_AddARN (823.31s)
--- PASS: TestAccEKSCluster_VPC_publicAccessCIDRs (943.11s)
--- PASS: TestAccEKSCluster_Network_ipFamily (984.23s)
--- PASS: TestAccEKSCluster_version (1045.11s)
--- PASS: TestAccEKSCluster_BootstrapSelfManagedAddons_update (1064.88s)
--- PASS: TestAccEKSCluster_ComputeConfig_OnCreate (1068.12s)
--- PASS: TestAccEKSCluster_Encryption_versionUpdate (1071.54s)
--- PASS: TestAccEKSCluster_Network_serviceIPv4CIDR (1108.10s)
--- PASS: TestAccEKSCluster_AccessConfig_create (547.38s)
--- PASS: TestAccEKSCluster_VPC_securityGroupIDs (573.22s)
--- PASS: TestAccEKSCluster_BootstrapSelfManagedAddons_migrate (601.12s)
--- PASS: TestAccEKSCluster_disappears (590.63s)
--- PASS: TestAccEKSCluster_AccessConfig_update (608.65s)
--- PASS: TestAccEKSCluster_VPC_endpointPublicAccess (1200.45s)
--- PASS: TestAccEKSCluster_RemoteNetwork_Node (609.47s)
--- PASS: TestAccEKSCluster_ComputeConfig_ModifyARN (1442.36s)
--- PASS: TestAccEKSCluster_Encryption_update (1444.88s)
--- PASS: TestAccEKSCluster_VPC_securityGroupIDsAndSubnetIDs_update (1485.03s)
--- PASS: TestAccEKSCluster_VPC_endpointPrivateAccess (1655.65s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	1662.578s
```
