### PR TITLE
Tech debt: Don't export`vpclattice` functions

### DIFF
--- a/internal/sdkv2/suppress.go
+++ b/internal/sdkv2/suppress.go
@@ -14,14 +14,20 @@ import (
 
 // SuppressEquivalentStringCaseInsensitive provides custom difference suppression
 // for strings that are equal under case-insensitivity.
-func SuppressEquivalentStringCaseInsensitive(k, old, new string, d *schema.ResourceData) bool {
+func SuppressEquivalentStringCaseInsensitive(k, old, new string, _ *schema.ResourceData) bool {
 	return strings.EqualFold(old, new)
 }
 
 // SuppressEquivalentJSONDocuments provides custom difference suppression
 // for JSON documents in the given strings that are equivalent.
-func SuppressEquivalentJSONDocuments(k, old, new string, d *schema.ResourceData) bool {
+func SuppressEquivalentJSONDocuments(k, old, new string, _ *schema.ResourceData) bool {
 	return json.EqualStrings(old, new)
+}
+
+// SuppressEquivalentCloudWatchLogsLogGroupARN provides custom difference suppression
+// for strings that represent equal CloudWatch Logs log group ARNs.
+func SuppressEquivalentCloudWatchLogsLogGroupARN(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.TrimSuffix(old, ":*") == strings.TrimSuffix(new, ":*")
 }
 
 // SuppressEquivalentRoundedTime returns a difference suppression function that compares
@@ -40,7 +46,7 @@ func SuppressEquivalentRoundedTime(layout string, d time.Duration) schema.Schema
 
 // SuppressEquivalentIAMPolicyDocuments provides custom difference suppression
 // for IAM policy documents in the given strings that are equivalent.
-func SuppressEquivalentIAMPolicyDocuments(k, old, new string, d *schema.ResourceData) bool {
+func SuppressEquivalentIAMPolicyDocuments(k, old, new string, _ *schema.ResourceData) bool {
 	if equalEmptyJSONStrings(old, new) {
 		return true
 	}

--- a/internal/sdkv2/suppress_test.go
+++ b/internal/sdkv2/suppress_test.go
@@ -8,6 +8,52 @@ import (
 	"time"
 )
 
+func TestSuppressEquivalentCloudWatchLogsLogGroupARN(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		old  string
+		new  string
+		want bool
+	}{
+		{
+			old:  "arn:aws:s3:::tf-acc-test-3740243764086645346", //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:s3:::tf-acc-test-3740243764086645346", //lintignore:AWSAT003,AWSAT005
+			want: true,
+		},
+		{
+			old:  "arn:aws:s3:::tf-acc-test-3740243764086645346",                                                    //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			want: false,
+		},
+		{
+			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			want: true,
+		},
+		{
+			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346",   //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			want: true,
+		},
+		{
+			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645347:*", //lintignore:AWSAT003,AWSAT005
+			want: false,
+		},
+		{
+			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
+			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645347",   //lintignore:AWSAT003,AWSAT005
+			want: false,
+		},
+	}
+	for _, testCase := range testCases {
+		if got, want := SuppressEquivalentCloudWatchLogsLogGroupARN("test_property", testCase.old, testCase.new, nil), testCase.want; got != want {
+			t.Errorf("SuppressEquivalentCloudWatchLogsLogGroupARN(%q, %q) = %v, want %v", testCase.old, testCase.new, got, want)
+		}
+	}
+}
+
 func TestSuppressEquivalentRoundedTime(t *testing.T) {
 	t.Parallel()
 

--- a/internal/service/vpclattice/access_log_subscription.go
+++ b/internal/service/vpclattice/access_log_subscription.go
@@ -6,19 +6,19 @@ package vpclattice
 import (
 	"context"
 	"log"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -49,7 +49,7 @@ func resourceAccessLogSubscription() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				ValidateFunc:     verify.ValidARN,
-				DiffSuppressFunc: suppressEquivalentCloudWatchLogsLogGroupARN,
+				DiffSuppressFunc: sdkv2.SuppressEquivalentCloudWatchLogsLogGroupARN,
 			},
 			names.AttrResourceARN: {
 				Type:     schema.TypeString,
@@ -74,32 +74,28 @@ func resourceAccessLogSubscription() *schema.Resource {
 	}
 }
 
-const (
-	ResNameAccessLogSubscription = "Access Log Subscription"
-)
-
 func resourceAccessLogSubscriptionCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	in := &vpclattice.CreateAccessLogSubscriptionInput{
-		ClientToken:        aws.String(id.UniqueId()),
+	input := vpclattice.CreateAccessLogSubscriptionInput{
+		ClientToken:        aws.String(sdkid.UniqueId()),
 		DestinationArn:     aws.String(d.Get(names.AttrDestinationARN).(string)),
 		ResourceIdentifier: aws.String(d.Get("resource_identifier").(string)),
 		Tags:               getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("service_network_log_type"); ok {
-		in.ServiceNetworkLogType = awstypes.ServiceNetworkLogType(v.(string))
+		input.ServiceNetworkLogType = awstypes.ServiceNetworkLogType(v.(string))
 	}
 
-	out, err := conn.CreateAccessLogSubscription(ctx, in)
+	output, err := conn.CreateAccessLogSubscription(ctx, &input)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameAccessLogSubscription, d.Get(names.AttrDestinationARN).(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Access Log Subscription: %s", err)
 	}
 
-	d.SetId(aws.ToString(out.Id))
+	d.SetId(aws.ToString(output.Id))
 
 	return append(diags, resourceAccessLogSubscriptionRead(ctx, d, meta)...)
 }
@@ -108,23 +104,23 @@ func resourceAccessLogSubscriptionRead(ctx context.Context, d *schema.ResourceDa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	out, err := findAccessLogSubscriptionByID(ctx, conn, d.Id())
+	output, err := findAccessLogSubscriptionByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] VPCLattice AccessLogSubscription (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] VPCLattice Access Log Subscription (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAccessLogSubscription, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Access Log Subscription (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, out.Arn)
-	d.Set(names.AttrDestinationARN, out.DestinationArn)
-	d.Set(names.AttrResourceARN, out.ResourceArn)
-	d.Set("resource_identifier", out.ResourceId)
-	d.Set("service_network_log_type", out.ServiceNetworkLogType)
+	d.Set(names.AttrARN, output.Arn)
+	d.Set(names.AttrDestinationARN, output.DestinationArn)
+	d.Set(names.AttrResourceARN, output.ResourceArn)
+	d.Set("resource_identifier", output.ResourceId)
+	d.Set("service_network_log_type", output.ServiceNetworkLogType)
 
 	return diags
 }
@@ -138,7 +134,7 @@ func resourceAccessLogSubscriptionDelete(ctx context.Context, d *schema.Resource
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	log.Printf("[INFO] Deleting VPCLattice AccessLogSubscription %s", d.Id())
+	log.Printf("[INFO] Deleting VPCLattice Access Log Subscription: %s", d.Id())
 	input := vpclattice.DeleteAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(d.Id()),
 	}
@@ -149,22 +145,36 @@ func resourceAccessLogSubscriptionDelete(ctx context.Context, d *schema.Resource
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameAccessLogSubscription, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Access Log Subscription (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
 func findAccessLogSubscriptionByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetAccessLogSubscriptionOutput, error) {
-	in := &vpclattice.GetAccessLogSubscriptionInput{
+	input := vpclattice.GetAccessLogSubscriptionInput{
 		AccessLogSubscriptionIdentifier: aws.String(id),
 	}
-	out, err := conn.GetAccessLogSubscription(ctx, in)
+	output, err := findAccessLogSubscription(ctx, conn, &input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output.Id == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func findAccessLogSubscription(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetAccessLogSubscriptionInput) (*vpclattice.GetAccessLogSubscriptionOutput, error) {
+	output, err := conn.GetAccessLogSubscription(ctx, input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -172,15 +182,9 @@ func findAccessLogSubscriptionByID(ctx context.Context, conn *vpclattice.Client,
 		return nil, err
 	}
 
-	if out == nil || out.Id == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil || output.Id == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
-}
-
-// suppressEquivalentCloudWatchLogsLogGroupARN provides custom difference suppression
-// for strings that represent equal CloudWatch Logs log group ARNs.
-func suppressEquivalentCloudWatchLogsLogGroupARN(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.TrimSuffix(old, ":*") == strings.TrimSuffix(new, ":*")
+	return output, nil
 }

--- a/internal/service/vpclattice/access_log_subscription_test.go
+++ b/internal/service/vpclattice/access_log_subscription_test.go
@@ -5,7 +5,6 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -17,57 +16,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-
-func TestSuppressEquivalentCloudWatchLogsLogGroupARN(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		old  string
-		new  string
-		want bool
-	}{
-		{
-			old:  "arn:aws:s3:::tf-acc-test-3740243764086645346", //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:s3:::tf-acc-test-3740243764086645346", //lintignore:AWSAT003,AWSAT005
-			want: true,
-		},
-		{
-			old:  "arn:aws:s3:::tf-acc-test-3740243764086645346",                                                    //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			want: false,
-		},
-		{
-			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			want: true,
-		},
-		{
-			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346",   //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			want: true,
-		},
-		{
-			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645347:*", //lintignore:AWSAT003,AWSAT005
-			want: false,
-		},
-		{
-			old:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645346:*", //lintignore:AWSAT003,AWSAT005
-			new:  "arn:aws:logs:us-west-2:123456789012:log-group:/aws/vpclattice/tf-acc-test-3740243764086645347",   //lintignore:AWSAT003,AWSAT005
-			want: false,
-		},
-	}
-	for _, testCase := range testCases {
-		if got, want := tfvpclattice.SuppressEquivalentCloudWatchLogsLogGroupARN("test_property", testCase.old, testCase.new, nil), testCase.want; got != want {
-			t.Errorf("SuppressEquivalentCloudWatchLogsLogGroupARN(%q, %q) = %v, want %v", testCase.old, testCase.new, got, want)
-		}
-	}
-}
 
 func TestAccVPCLatticeAccessLogSubscription_basic(t *testing.T) {
 	ctx := acctest.Context(t)
@@ -359,25 +311,22 @@ func testAccCheckAccessLogSubscriptionDestroy(ctx context.Context) resource.Test
 	}
 }
 
-func testAccCheckAccessLogSubscriptionExists(ctx context.Context, name string, accesslogsubscription *vpclattice.GetAccessLogSubscriptionOutput) resource.TestCheckFunc {
+func testAccCheckAccessLogSubscriptionExists(ctx context.Context, n string, v *vpclattice.GetAccessLogSubscriptionOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAccessLogSubscription, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAccessLogSubscription, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := tfvpclattice.FindAccessLogSubscriptionByID(ctx, conn, rs.Primary.ID)
+
+		output, err := tfvpclattice.FindAccessLogSubscriptionByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*accesslogsubscription = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -6,6 +6,7 @@ package vpclattice
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
@@ -33,6 +34,12 @@ func resourceAuthPolicy() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -5,7 +5,6 @@ package vpclattice
 
 import (
 	"context"
-	"errors"
 	"log"
 	"time"
 
@@ -13,19 +12,20 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_vpclattice_auth_policy", name="Auth Policy")
-func ResourceAuthPolicy() *schema.Resource {
+func resourceAuthPolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceAuthPolicyPut,
 		ReadWithoutTimeout:   resourceAuthPolicyRead,
@@ -43,56 +43,42 @@ func ResourceAuthPolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
-			},
-			names.AttrState: {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
+			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
 			"resource_identifier": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			names.AttrState: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
 
-const (
-	ResNameAuthPolicy = "Auth Policy"
-)
-
 func resourceAuthPolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
-	resourceId := d.Get("resource_identifier").(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get(names.AttrPolicy).(string))
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	in := &vpclattice.PutAuthPolicyInput{
+	resourceID := d.Get("resource_identifier").(string)
+	input := vpclattice.PutAuthPolicyInput{
 		Policy:             aws.String(policy),
-		ResourceIdentifier: aws.String(resourceId),
+		ResourceIdentifier: aws.String(resourceID),
 	}
 
-	log.Printf("[DEBUG] Putting VPCLattice Auth Policy for resource: %s", resourceId)
+	_, err = conn.PutAuthPolicy(ctx, &input)
 
-	_, err = conn.PutAuthPolicy(ctx, in)
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameAuthPolicy, d.Get(names.AttrPolicy).(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Auth Policy (%s): %s", resourceID, err)
 	}
 
-	d.SetId(resourceId)
+	d.SetId(resourceID)
 
 	return append(diags, resourceAuthPolicyRead(ctx, d, meta)...)
 }
@@ -100,34 +86,25 @@ func resourceAuthPolicyPut(ctx context.Context, d *schema.ResourceData, meta any
 func resourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
-	resourceId := d.Id()
 
-	log.Printf("[DEBUG] Reading VPCLattice Auth Policy for resource: %s", resourceId)
+	output, err := findAuthPolicyByID(ctx, conn, d.Id())
 
-	policy, err := findAuthPolicy(ctx, conn, resourceId)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] VPCLattice AuthPolicy (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] VPCLattice Auth Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Auth Policy (%s): %s", d.Id(), err)
 	}
 
-	if policy == nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, d.Id(), err)
-	}
-
-	d.Set("resource_identifier", resourceId)
-
-	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(policy.Policy))
-
+	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(output.Policy))
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameAuthPolicy, aws.ToString(policy.Policy), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
-
 	d.Set(names.AttrPolicy, policyToSet)
+	d.Set("resource_identifier", d.Id())
 
 	return diags
 }
@@ -136,36 +113,48 @@ func resourceAuthPolicyDelete(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	log.Printf("[INFO] Deleting VPCLattice AuthPolicy: %s", d.Id())
+	log.Printf("[INFO] Deleting VPCLattice Auth Policy: %s", d.Id())
 	input := vpclattice.DeleteAuthPolicyInput{
 		ResourceIdentifier: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteAuthPolicy(ctx, &input)
 
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return diags
-		}
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return diags
+	}
 
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameAuthPolicy, d.Id(), err)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Auth Policy (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func findAuthPolicy(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetAuthPolicyOutput, error) {
-	in := &vpclattice.GetAuthPolicyInput{
+func findAuthPolicyByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetAuthPolicyOutput, error) {
+	input := vpclattice.GetAuthPolicyInput{
 		ResourceIdentifier: aws.String(id),
 	}
 
-	out, err := conn.GetAuthPolicy(ctx, in)
+	return findAuthPolicy(ctx, conn, &input)
+}
+
+func findAuthPolicy(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetAuthPolicyInput) (*vpclattice.GetAuthPolicyOutput, error) {
+	output, err := conn.GetAuthPolicy(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
 	if err != nil {
 		return nil, err
 	}
-	if out == nil {
-		return nil, nil
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
 }

--- a/internal/service/vpclattice/auth_policy.go
+++ b/internal/service/vpclattice/auth_policy.go
@@ -6,7 +6,6 @@ package vpclattice
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
@@ -34,12 +33,6 @@ func resourceAuthPolicy() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -6,21 +6,17 @@ package vpclattice
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
 // @SDKDataSource("aws_vpclattice_auth_policy", name="Auth Policy")
-func DataSourceAuthPolicy() *schema.Resource {
+func dataSourceAuthPolicy() *schema.Resource {
 	return &schema.Resource{
-
 		ReadWithoutTimeout: dataSourceAuthPolicyRead,
 
 		Schema: map[string]*schema.Schema{
@@ -29,8 +25,9 @@ func DataSourceAuthPolicy() *schema.Resource {
 				Optional: true,
 			},
 			"resource_identifier": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: verify.ValidARN,
 			},
 			names.AttrState: {
 				Type:     schema.TypeString,
@@ -40,38 +37,20 @@ func DataSourceAuthPolicy() *schema.Resource {
 	}
 }
 
-const (
-	DSNameAuthPolicy = "Auth Policy Data Source"
-)
-
 func dataSourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	resourceID := d.Get("resource_identifier").(string)
-	out, err := findAuthPolicyByID(ctx, conn, resourceID)
+	output, err := findAuthPolicyByID(ctx, conn, resourceID)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, resourceID, err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Auth Policy (%s): %s", resourceID, err)
 	}
 
 	d.SetId(resourceID)
-
-	d.Set(names.AttrPolicy, out.Policy)
+	d.Set(names.AttrPolicy, output.Policy)
 	d.Set("resource_identifier", resourceID)
-
-	// TIP: Setting a JSON string to avoid errorneous diffs.
-	p, err := verify.SecondJSONUnlessEquivalent(d.Get(names.AttrPolicy).(string), aws.ToString(out.Policy))
-	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameAuthPolicy, d.Id(), err)
-	}
-
-	p, err = structure.NormalizeJsonString(p)
-	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, d.Id(), err)
-	}
-
-	d.Set(names.AttrPolicy, p)
 
 	return diags
 }

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -49,7 +49,7 @@ func dataSourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	resourceID := d.Get("resource_identifier").(string)
-	out, err := findAuthPolicy(ctx, conn, resourceID)
+	out, err := findAuthPolicyByID(ctx, conn, resourceID)
 
 	if err != nil {
 		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameAuthPolicy, resourceID, err)

--- a/internal/service/vpclattice/auth_policy_data_source.go
+++ b/internal/service/vpclattice/auth_policy_data_source.go
@@ -6,6 +6,7 @@ package vpclattice
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -48,8 +49,13 @@ func dataSourceAuthPolicyRead(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Auth Policy (%s): %s", resourceID, err)
 	}
 
+	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(output.Policy))
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
+
 	d.SetId(resourceID)
-	d.Set(names.AttrPolicy, output.Policy)
+	d.Set(names.AttrPolicy, policyToSet)
 	d.Set("resource_identifier", resourceID)
 
 	return diags

--- a/internal/service/vpclattice/auth_policy_data_source_test.go
+++ b/internal/service/vpclattice/auth_policy_data_source_test.go
@@ -16,11 +16,6 @@ import (
 
 func TestAccVPCLatticeAuthPolicyDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpclattice_auth_policy.test"
 
@@ -32,7 +27,6 @@ func TestAccVPCLatticeAuthPolicyDataSource_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAuthPolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAuthPolicyDataSourceConfig_basic(rName),

--- a/internal/service/vpclattice/auth_policy_test.go
+++ b/internal/service/vpclattice/auth_policy_test.go
@@ -5,27 +5,23 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccVPCLatticeAuthPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var authpolicy vpclattice.GetAuthPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_auth_policy.test"
@@ -59,7 +55,6 @@ func TestAccVPCLatticeAuthPolicy_basic(t *testing.T) {
 
 func TestAccVPCLatticeAuthPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var authpolicy vpclattice.GetAuthPolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_auth_policy.test"
@@ -95,50 +90,39 @@ func testAccCheckAuthPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			input := vpclattice.GetAuthPolicyInput{
-				ResourceIdentifier: aws.String(rs.Primary.ID),
+			_, err := tfvpclattice.FindAuthPolicyByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
-			policy, err := conn.GetAuthPolicy(ctx, &input)
+
 			if err != nil {
-				var nfe *types.ResourceNotFoundException
-				if errors.As(err, &nfe) {
-					return nil
-				}
 				return err
 			}
 
-			if policy != nil {
-				return create.Error(names.VPCLattice, create.ErrActionCheckingDestroyed, tfvpclattice.ResNameAuthPolicy, rs.Primary.ID, errors.New("Auth Policy not destroyed"))
-			}
+			return fmt.Errorf("VPCLattice Auth Policy %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckAuthPolicyExists(ctx context.Context, name string, authpolicy *vpclattice.GetAuthPolicyOutput) resource.TestCheckFunc {
+func testAccCheckAuthPolicyExists(ctx context.Context, n string, v *vpclattice.GetAuthPolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAuthPolicy, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAuthPolicy, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		input := vpclattice.GetAuthPolicyInput{
-			ResourceIdentifier: aws.String(rs.Primary.ID),
-		}
-		resp, err := conn.GetAuthPolicy(ctx, &input)
+
+		output, err := tfvpclattice.FindAuthPolicyByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			//return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameAuthPolicy, rs.Primary.ID, err)
-			return fmt.Errorf("AuthPolicy (for resource: %s) not found", rs.Primary.ID)
+			return err
 		}
 
-		*authpolicy = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/exports_test.go
+++ b/internal/service/vpclattice/exports_test.go
@@ -11,6 +11,7 @@ var (
 	ResourceListenerRule                      = resourceListenerRule
 	ResourceResourceConfiguration             = newResourceConfigurationResource
 	ResourceResourceGateway                   = newResourceGatewayResource
+	ResourceResourcePolicy                    = resourceResourcePolicy
 	ResourceService                           = resourceService
 	ResourceServiceNetwork                    = resourceServiceNetwork
 	ResourceServiceNetworkResourceAssociation = newServiceNetworkResourceAssociationResource
@@ -25,6 +26,7 @@ var (
 	FindListenerRuleByThreePartKey            = findListenerRuleByThreePartKey
 	FindResourceConfigurationByID             = findResourceConfigurationByID
 	FindResourceGatewayByID                   = findResourceGatewayByID
+	FindResourcePolicyByID                    = findResourcePolicyByID
 	FindServiceByID                           = findServiceByID
 	FindServiceNetworkByID                    = findServiceNetworkByID
 	FindServiceNetworkResourceAssociationByID = findServiceNetworkResourceAssociationByID

--- a/internal/service/vpclattice/exports_test.go
+++ b/internal/service/vpclattice/exports_test.go
@@ -6,6 +6,7 @@ package vpclattice
 // Exports for use in tests only.
 var (
 	ResourceAccessLogSubscription             = resourceAccessLogSubscription
+	ResourceAuthPolicy                        = resourceAuthPolicy
 	ResourceListener                          = resourceListener
 	ResourceResourceConfiguration             = newResourceConfigurationResource
 	ResourceResourceGateway                   = newResourceGatewayResource
@@ -18,6 +19,7 @@ var (
 	ResourceTargetGroupAttachment             = resourceTargetGroupAttachment
 
 	FindAccessLogSubscriptionByID             = findAccessLogSubscriptionByID
+	FindAuthPolicyByID                        = findAuthPolicyByID
 	FindListenerByTwoPartKey                  = findListenerByTwoPartKey
 	FindResourceConfigurationByID             = findResourceConfigurationByID
 	FindResourceGatewayByID                   = findResourceGatewayByID

--- a/internal/service/vpclattice/exports_test.go
+++ b/internal/service/vpclattice/exports_test.go
@@ -31,7 +31,6 @@ var (
 	FindTargetByThreePartKey                  = findTargetByThreePartKey
 	FindTargetGroupByID                       = findTargetGroupByID
 
-	IDFromIDOrARN                               = idFromIDOrARN
-	SuppressEquivalentCloudWatchLogsLogGroupARN = suppressEquivalentCloudWatchLogsLogGroupARN
-	SuppressEquivalentIDOrARN                   = suppressEquivalentIDOrARN
+	IDFromIDOrARN             = idFromIDOrARN
+	SuppressEquivalentIDOrARN = suppressEquivalentIDOrARN
 )

--- a/internal/service/vpclattice/exports_test.go
+++ b/internal/service/vpclattice/exports_test.go
@@ -8,6 +8,7 @@ var (
 	ResourceAccessLogSubscription             = resourceAccessLogSubscription
 	ResourceAuthPolicy                        = resourceAuthPolicy
 	ResourceListener                          = resourceListener
+	ResourceListenerRule                      = resourceListenerRule
 	ResourceResourceConfiguration             = newResourceConfigurationResource
 	ResourceResourceGateway                   = newResourceGatewayResource
 	ResourceService                           = resourceService
@@ -21,6 +22,7 @@ var (
 	FindAccessLogSubscriptionByID             = findAccessLogSubscriptionByID
 	FindAuthPolicyByID                        = findAuthPolicyByID
 	FindListenerByTwoPartKey                  = findListenerByTwoPartKey
+	FindListenerRuleByThreePartKey            = findListenerRuleByThreePartKey
 	FindResourceConfigurationByID             = findResourceConfigurationByID
 	FindResourceGatewayByID                   = findResourceGatewayByID
 	FindServiceByID                           = findServiceByID

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -14,11 +14,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -37,18 +37,8 @@ func resourceListener() *schema.Resource {
 		UpdateWithoutTimeout: resourceListenerUpdate,
 		DeleteWithoutTimeout: resourceListenerDelete,
 
-		// Id returned by GetListener does not contain required service name, use a custom import function
 		Importer: &schema.ResourceImporter{
-			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				idParts := strings.Split(d.Id(), "/")
-				if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
-					return nil, fmt.Errorf("unexpected format of ID (%q), expected SERVICE-ID/LISTENER-ID", d.Id())
-				}
-				d.Set("service_identifier", idParts[0])
-				d.Set("listener_id", idParts[1])
-
-				return []*schema.ResourceData{d}, nil
-			},
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Timeouts: &schema.ResourceTimeout{
@@ -160,54 +150,38 @@ func resourceListener() *schema.Resource {
 	}
 }
 
-const (
-	ResNameListener = "Listener"
-)
-
 func resourceListenerCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	in := &vpclattice.CreateListenerInput{
-		Name:          aws.String(d.Get(names.AttrName).(string)),
+	name := d.Get(names.AttrName).(string)
+	input := vpclattice.CreateListenerInput{
+		ClientToken:   aws.String(sdkid.UniqueId()),
+		Name:          aws.String(name),
 		DefaultAction: expandDefaultAction(d.Get(names.AttrDefaultAction).([]any)),
 		Protocol:      types.ListenerProtocol(d.Get(names.AttrProtocol).(string)),
 		Tags:          getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk(names.AttrPort); ok && v != nil {
-		in.Port = aws.Int32(int32(v.(int)))
+		input.Port = aws.Int32(int32(v.(int)))
 	}
 
 	if v, ok := d.GetOk("service_identifier"); ok {
-		in.ServiceIdentifier = aws.String(v.(string))
+		input.ServiceIdentifier = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("service_arn"); ok {
-		in.ServiceIdentifier = aws.String(v.(string))
+		input.ServiceIdentifier = aws.String(v.(string))
 	}
 
-	if in.ServiceIdentifier == nil {
-		return sdkdiag.AppendErrorf(diags, "must specify either service_arn or service_identifier")
-	}
-
-	out, err := conn.CreateListener(ctx, in)
+	output, err := conn.CreateListener(ctx, &input)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameListener, d.Get(names.AttrName).(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Listener (%s): %s", name, err)
 	}
 
-	// Id returned by GetListener does not contain required service name
-	// Create a composite ID using service ID and listener ID
-	d.Set("listener_id", out.Id)
-	d.Set("service_identifier", out.ServiceId)
-
-	parts := []string{
-		d.Get("service_identifier").(string),
-		d.Get("listener_id").(string),
-	}
-
-	d.SetId(strings.Join(parts, "/"))
+	d.SetId(listenerCreateResourceID(aws.ToString(output.ServiceId), aws.ToString(output.Id)))
 
 	return append(diags, resourceListenerRead(ctx, d, meta)...)
 }
@@ -216,11 +190,12 @@ func resourceListenerRead(ctx context.Context, d *schema.ResourceData, meta any)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	// GetListener requires the ID or Amazon Resource Name (ARN) of the service
-	serviceId := d.Get("service_identifier").(string)
-	listenerId := d.Get("listener_id").(string)
+	serviceID, listenerID, err := listenerParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
 
-	out, err := findListenerByTwoPartKey(ctx, conn, listenerId, serviceId)
+	output, err := findListenerByTwoPartKey(ctx, conn, serviceID, listenerID)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Listener (%s) not found, removing from state", d.Id())
@@ -229,22 +204,21 @@ func resourceListenerRead(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameListener, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Listener (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, out.Arn)
-	d.Set(names.AttrCreatedAt, aws.ToTime(out.CreatedAt).String())
-	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
-	d.Set("listener_id", out.Id)
-	d.Set(names.AttrName, out.Name)
-	d.Set(names.AttrProtocol, out.Protocol)
-	d.Set(names.AttrPort, out.Port)
-	d.Set("service_arn", out.ServiceArn)
-	d.Set("service_identifier", out.ServiceId)
-
-	if err := d.Set(names.AttrDefaultAction, flattenListenerRuleActions(out.DefaultAction)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, ResNameListener, d.Id(), err)
+	d.Set(names.AttrARN, output.Arn)
+	d.Set(names.AttrCreatedAt, aws.ToTime(output.CreatedAt).String())
+	if err := d.Set(names.AttrDefaultAction, flattenListenerRuleActions(output.DefaultAction)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting default_action: %s", err)
 	}
+	d.Set("last_updated_at", aws.ToTime(output.LastUpdatedAt).String())
+	d.Set("listener_id", output.Id)
+	d.Set(names.AttrName, output.Name)
+	d.Set(names.AttrProtocol, output.Protocol)
+	d.Set(names.AttrPort, output.Port)
+	d.Set("service_arn", output.ServiceArn)
+	d.Set("service_identifier", output.ServiceId)
 
 	return diags
 }
@@ -253,24 +227,25 @@ func resourceListenerUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	serviceId := d.Get("service_identifier").(string)
-	listenerId := d.Get("listener_id").(string)
+	serviceID, listenerID, err := listenerParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		in := &vpclattice.UpdateListenerInput{
-			ListenerIdentifier: aws.String(listenerId),
-			ServiceIdentifier:  aws.String(serviceId),
+		input := vpclattice.UpdateListenerInput{
+			ListenerIdentifier: aws.String(listenerID),
+			ServiceIdentifier:  aws.String(serviceID),
 		}
 
-		// Cannot edit listener name, protocol, or port after creation
 		if d.HasChanges(names.AttrDefaultAction) {
-			in.DefaultAction = expandDefaultAction(d.Get(names.AttrDefaultAction).([]any))
+			input.DefaultAction = expandDefaultAction(d.Get(names.AttrDefaultAction).([]any))
 		}
 
-		log.Printf("[DEBUG] Updating VPC Lattice Listener (%s): %#v", d.Id(), in)
-		_, err := conn.UpdateListener(ctx, in)
+		_, err := conn.UpdateListener(ctx, &input)
+
 		if err != nil {
-			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameListener, d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating VPCLattice Listener (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -281,38 +256,73 @@ func resourceListenerDelete(ctx context.Context, d *schema.ResourceData, meta an
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	serviceId := d.Get("service_identifier").(string)
-	listenerId := d.Get("listener_id").(string)
+	serviceID, listenerID, err := listenerParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
 
 	log.Printf("[INFO] Deleting VPCLattice Listener %s", d.Id())
 	input := vpclattice.DeleteListenerInput{
-		ListenerIdentifier: aws.String(listenerId),
-		ServiceIdentifier:  aws.String(serviceId),
+		ListenerIdentifier: aws.String(listenerID),
+		ServiceIdentifier:  aws.String(serviceID),
 	}
-	_, err := conn.DeleteListener(ctx, &input)
+	_, err = conn.DeleteListener(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameListener, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Listener (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
-func findListenerByTwoPartKey(ctx context.Context, conn *vpclattice.Client, listenerID, serviceID string) (*vpclattice.GetListenerOutput, error) {
-	in := &vpclattice.GetListenerInput{
+const listenerResourceIDSeparator = "/"
+
+func listenerCreateResourceID(serviceID, listenerID string) string {
+	parts := []string{serviceID, listenerID}
+	id := strings.Join(parts, listenerResourceIDSeparator)
+
+	return id
+}
+
+func listenerParseResourceID(id string) (string, string, error) {
+	parts := strings.SplitN(id, listenerResourceIDSeparator, 2)
+
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("unexpected format for ID (%[1]s), expected SERVICE-ID%[2]sLISTENER-ID", id, listenerResourceIDSeparator)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func findListenerByTwoPartKey(ctx context.Context, conn *vpclattice.Client, serviceID, listenerID string) (*vpclattice.GetListenerOutput, error) {
+	input := vpclattice.GetListenerInput{
 		ListenerIdentifier: aws.String(listenerID),
 		ServiceIdentifier:  aws.String(serviceID),
 	}
-	out, err := conn.GetListener(ctx, in)
+	output, err := findListener(ctx, conn, &input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output.Id == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+func findListener(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetListenerInput) (*vpclattice.GetListenerOutput, error) {
+	output, err := conn.GetListener(ctx, input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -320,110 +330,104 @@ func findListenerByTwoPartKey(ctx context.Context, conn *vpclattice.Client, list
 		return nil, err
 	}
 
-	if out == nil || out.Id == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
 }
 
-// Flatten function for listener rule actions
-func flattenListenerRuleActions(config types.RuleAction) []any {
-	m := map[string]any{}
-
-	if config == nil {
+func flattenListenerRuleActions(apiObject types.RuleAction) []any {
+	if apiObject == nil {
 		return []any{}
 	}
 
-	switch v := config.(type) {
-	case *types.RuleActionMemberFixedResponse:
-		m["fixed_response"] = flattenFixedResponseAction(&v.Value)
-	case *types.RuleActionMemberForward:
-		m["forward"] = flattenComplexDefaultActionForward(&v.Value)
-	}
-
-	return []any{m}
-}
-
-// Flatten function for fixed_response action
-func flattenFixedResponseAction(response *types.FixedResponseAction) []any {
 	tfMap := map[string]any{}
 
-	if v := response.StatusCode; v != nil {
+	switch v := apiObject.(type) {
+	case *types.RuleActionMemberFixedResponse:
+		tfMap["fixed_response"] = flattenFixedResponseAction(&v.Value)
+	case *types.RuleActionMemberForward:
+		tfMap["forward"] = flattenComplexDefaultActionForward(&v.Value)
+	}
+
+	return []any{tfMap}
+}
+
+func flattenFixedResponseAction(apiObject *types.FixedResponseAction) []any {
+	tfMap := map[string]any{}
+
+	if v := apiObject.StatusCode; v != nil {
 		tfMap[names.AttrStatusCode] = aws.ToInt32(v)
 	}
 
 	return []any{tfMap}
 }
 
-// Flatten function for forward action
-func flattenComplexDefaultActionForward(forwardAction *types.ForwardAction) []any {
-	if forwardAction == nil {
+func flattenComplexDefaultActionForward(apiObject *types.ForwardAction) []any {
+	if apiObject == nil {
 		return []any{}
 	}
 
-	m := map[string]any{
-		"target_groups": flattenDefaultActionForwardTargetGroups(forwardAction.TargetGroups),
+	tfMap := map[string]any{
+		"target_groups": flattenDefaultActionForwardTargetGroups(apiObject.TargetGroups),
 	}
 
-	return []any{m}
+	return []any{tfMap}
 }
 
-// Flatten function for target_groups
-func flattenDefaultActionForwardTargetGroups(groups []types.WeightedTargetGroup) []any {
-	if len(groups) == 0 {
+func flattenDefaultActionForwardTargetGroups(apiObjects []types.WeightedTargetGroup) []any {
+	if len(apiObjects) == 0 {
 		return []any{}
 	}
 
-	var targetGroups []any
+	var tfList []any
 
-	for _, targetGroup := range groups {
-		m := map[string]any{
-			"target_group_identifier": aws.ToString(targetGroup.TargetGroupIdentifier),
-			names.AttrWeight:          aws.ToInt32(targetGroup.Weight),
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{
+			"target_group_identifier": aws.ToString(apiObject.TargetGroupIdentifier),
+			names.AttrWeight:          aws.ToInt32(apiObject.Weight),
 		}
-		targetGroups = append(targetGroups, m)
+		tfList = append(tfList, tfMap)
 	}
 
-	return targetGroups
+	return tfList
 }
 
-// Expand function for default_action
-func expandDefaultAction(l []any) types.RuleAction {
-	if len(l) == 0 || l[0] == nil {
+func expandDefaultAction(tfList []any) types.RuleAction {
+	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
-	lRaw := l[0].(map[string]any)
 
-	if v, ok := lRaw["forward"].([]any); ok && len(v) > 0 {
+	tfMapRaw := tfList[0].(map[string]any)
+
+	if v, ok := tfMapRaw["forward"].([]any); ok && len(v) > 0 {
 		return &types.RuleActionMemberForward{
-			Value: *expandDefaultActionForwardAction(v),
+			Value: expandDefaultActionForwardAction(v),
 		}
-	} else if v, ok := lRaw["fixed_response"].([]any); ok && len(v) > 0 {
+	} else if v, ok := tfMapRaw["fixed_response"].([]any); ok && len(v) > 0 {
 		return &types.RuleActionMemberFixedResponse{
-			Value: *expandDefaultActionFixedResponseStatus(v),
+			Value: expandDefaultActionFixedResponseStatus(v),
 		}
-	} else {
-		return nil
 	}
+
+	return nil
 }
 
-// Expand function for forward action
-func expandDefaultActionForwardAction(l []any) *types.ForwardAction {
-	lRaw := l[0].(map[string]any)
+func expandDefaultActionForwardAction(tfList []any) types.ForwardAction {
+	lRaw := tfList[0].(map[string]any)
 
-	forwardAction := &types.ForwardAction{}
+	apiObject := types.ForwardAction{}
 
 	if v, ok := lRaw["target_groups"].([]any); ok && len(v) > 0 {
-		forwardAction.TargetGroups = expandForwardTargetGroupList(v)
+		apiObject.TargetGroups = expandForwardTargetGroupList(v)
 	}
 
-	return forwardAction
+	return apiObject
 }
 
-// Expand function for target_groups
 func expandForwardTargetGroupList(tfList []any) []types.WeightedTargetGroup {
-	var targetGroups []types.WeightedTargetGroup
+	var apiObjects []types.WeightedTargetGroup
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
@@ -431,26 +435,25 @@ func expandForwardTargetGroupList(tfList []any) []types.WeightedTargetGroup {
 			continue
 		}
 
-		targetGroup := &types.WeightedTargetGroup{
+		apiObject := types.WeightedTargetGroup{
 			TargetGroupIdentifier: aws.String((tfMap["target_group_identifier"].(string))),
 			Weight:                aws.Int32(int32(tfMap[names.AttrWeight].(int))),
 		}
 
-		targetGroups = append(targetGroups, *targetGroup)
+		apiObjects = append(apiObjects, apiObject)
 	}
 
-	return targetGroups
+	return apiObjects
 }
 
-// Expand function for fixed_response action
-func expandDefaultActionFixedResponseStatus(l []any) *types.FixedResponseAction {
-	lRaw := l[0].(map[string]any)
+func expandDefaultActionFixedResponseStatus(tfList []any) types.FixedResponseAction {
+	tfMapRaw := tfList[0].(map[string]any)
 
-	fixedResponseAction := &types.FixedResponseAction{}
+	apiObject := types.FixedResponseAction{}
 
-	if v, ok := lRaw[names.AttrStatusCode].(int); ok {
-		fixedResponseAction.StatusCode = aws.Int32(int32(v))
+	if v, ok := tfMapRaw[names.AttrStatusCode].(int); ok {
+		apiObject.StatusCode = aws.Int32(int32(v))
 	}
 
-	return fixedResponseAction
+	return apiObject
 }

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
@@ -38,6 +39,12 @@ func resourceListener() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
@@ -39,12 +38,6 @@ func resourceListener() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
-			Update: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/vpclattice/listener.go
+++ b/internal/service/vpclattice/listener.go
@@ -254,7 +254,7 @@ func resourceListenerDelete(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	log.Printf("[INFO] Deleting VPCLattice Listener %s", d.Id())
+	log.Printf("[INFO] Deleting VPCLattice Listener: %s", d.Id())
 	input := vpclattice.DeleteListenerInput{
 		ListenerIdentifier: aws.String(listenerID),
 		ServiceIdentifier:  aws.String(serviceID),

--- a/internal/service/vpclattice/listener_data_source.go
+++ b/internal/service/vpclattice/listener_data_source.go
@@ -5,24 +5,20 @@ package vpclattice
 
 import (
 	"context"
-	"errors"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for datasource registration to the Provider. DO NOT EDIT.
 // @SDKDataSource("aws_vpclattice_listener", name="Listener")
-func DataSourceListener() *schema.Resource {
+// @Tags(identifierAttribute="arn")
+// @Testing(tagsTest=false)
+func dataSourceListener() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceListenerRead,
 
@@ -120,136 +116,31 @@ func DataSourceListener() *schema.Resource {
 	}
 }
 
-const (
-	DSNameListener = "Listener Data Source"
-)
-
 func dataSourceListenerRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	serviceId := d.Get("service_identifier").(string)
-	listenerId := d.Get("listener_identifier").(string)
+	serviceID, listenerID := d.Get("service_identifier").(string), d.Get("listener_identifier").(string)
 
-	out, err := findListenerByListenerIdAndServiceId(ctx, conn, listenerId, serviceId)
-	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
-	}
-
-	// Set simple arguments
-	d.SetId(aws.ToString(out.Id))
-	d.Set(names.AttrARN, out.Arn)
-	d.Set(names.AttrCreatedAt, aws.ToTime(out.CreatedAt).String())
-	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
-	d.Set("listener_id", out.Id)
-	d.Set(names.AttrName, out.Name)
-	d.Set(names.AttrPort, out.Port)
-	d.Set(names.AttrProtocol, out.Protocol)
-	d.Set("service_arn", out.ServiceArn)
-	d.Set("service_id", out.ServiceId)
-
-	// Flatten complex default_action attribute - uses flatteners from listener.go
-	if err := d.Set(names.AttrDefaultAction, flattenListenerRuleActionsDataSource(out.DefaultAction)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
-	}
-
-	// Set tags
-	ignoreTagsConfig := meta.(*conns.AWSClient).IgnoreTagsConfig(ctx)
-	tags, err := listTags(ctx, conn, aws.ToString(out.Arn))
+	output, err := findListenerByTwoPartKey(ctx, conn, serviceID, listenerID)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameListener, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Listener (%s): %s", listenerCreateResourceID(serviceID, listenerID), err)
 	}
 
-	if err := d.Set(names.AttrTags, tags.IgnoreAWS().IgnoreConfig(ignoreTagsConfig).Map()); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionSetting, DSNameListener, d.Id(), err)
+	d.SetId(aws.ToString(output.Id))
+	d.Set(names.AttrARN, output.Arn)
+	d.Set(names.AttrCreatedAt, aws.ToTime(output.CreatedAt).String())
+	if err := d.Set(names.AttrDefaultAction, flattenListenerRuleActions(output.DefaultAction)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting default_action: %s", err)
 	}
+	d.Set("last_updated_at", aws.ToTime(output.LastUpdatedAt).String())
+	d.Set("listener_id", output.Id)
+	d.Set(names.AttrName, output.Name)
+	d.Set(names.AttrPort, output.Port)
+	d.Set(names.AttrProtocol, output.Protocol)
+	d.Set("service_arn", output.ServiceArn)
+	d.Set("service_id", output.ServiceId)
 
 	return diags
-}
-
-func findListenerByListenerIdAndServiceId(ctx context.Context, conn *vpclattice.Client, listener_id string, service_id string) (*vpclattice.GetListenerOutput, error) {
-	in := &vpclattice.GetListenerInput{
-		ListenerIdentifier: aws.String(listener_id),
-		ServiceIdentifier:  aws.String(service_id),
-	}
-
-	out, err := conn.GetListener(ctx, in)
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
-
-		return nil, err
-	}
-
-	if out == nil || out.Id == nil {
-		return nil, tfresource.NewEmptyResultError(in)
-	}
-
-	return out, nil
-}
-
-func flattenListenerRuleActionsDataSource(config types.RuleAction) []any {
-	m := map[string]any{}
-
-	if config == nil {
-		return []any{}
-	}
-
-	switch v := config.(type) {
-	case *types.RuleActionMemberFixedResponse:
-		m["fixed_response"] = flattenRuleActionMemberFixedResponseDataSource(&v.Value)
-	case *types.RuleActionMemberForward:
-		m["forward"] = flattenComplexDefaultActionForwardDataSource(&v.Value)
-	}
-
-	return []any{m}
-}
-
-// Flatten function for fixed_response action
-func flattenRuleActionMemberFixedResponseDataSource(response *types.FixedResponseAction) []any {
-	tfMap := map[string]any{}
-
-	if v := response.StatusCode; v != nil {
-		tfMap[names.AttrStatusCode] = aws.ToInt32(v)
-	}
-
-	return []any{tfMap}
-}
-
-// Flatten function for forward action
-func flattenComplexDefaultActionForwardDataSource(forwardAction *types.ForwardAction) []any {
-	if forwardAction == nil {
-		return []any{}
-	}
-
-	m := map[string]any{
-		"target_groups": flattenDefaultActionForwardTargetGroupsDataSource(forwardAction.TargetGroups),
-	}
-
-	return []any{m}
-}
-
-// Flatten function for target_groups
-func flattenDefaultActionForwardTargetGroupsDataSource(groups []types.WeightedTargetGroup) []any {
-	if len(groups) == 0 {
-		return []any{}
-	}
-
-	var targetGroups []any
-
-	for _, targetGroup := range groups {
-		m := map[string]any{
-			"target_group_identifier": aws.ToString(targetGroup.TargetGroupIdentifier),
-			names.AttrWeight:          aws.ToInt32(targetGroup.Weight),
-		}
-		targetGroups = append(targetGroups, m)
-	}
-
-	return targetGroups
 }

--- a/internal/service/vpclattice/listener_data_source_test.go
+++ b/internal/service/vpclattice/listener_data_source_test.go
@@ -16,10 +16,6 @@ import (
 
 func TestAccVPCLatticeListenerDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpclattice_listener.test"
 
@@ -47,10 +43,6 @@ func TestAccVPCLatticeListenerDataSource_basic(t *testing.T) {
 
 func TestAccVPCLatticeListenerDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpclattice_listener.test_tags"
 	tag_name := "tag0"
@@ -78,13 +70,8 @@ func TestAccVPCLatticeListenerDataSource_tags(t *testing.T) {
 
 func TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	targetGroupName1 := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
-
 	targetGroupResourceName := "aws_vpclattice_target_group.test"
 	targetGroup1ResourceName := "aws_vpclattice_target_group.test1"
 	dataSourceName := "data.aws_vpclattice_listener.test_multi_target"

--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
@@ -38,6 +39,12 @@ func resourceListenerRule() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/vpclattice/listener_rule_test.go
+++ b/internal/service/vpclattice/listener_rule_test.go
@@ -34,7 +34,7 @@ func TestAccVPCLatticeListenerRule_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccChecklistenerRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccListenerRuleConfig_basic(rName),
@@ -67,7 +67,7 @@ func TestAccVPCLatticeListenerRule_fixedResponse(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccChecklistenerRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccListenerRuleConfig_fixedResponse(rName),
@@ -97,7 +97,7 @@ func TestAccVPCLatticeListenerRule_methodMatch(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccChecklistenerRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccListenerRuleConfig_methodMatch(rName),
@@ -126,7 +126,7 @@ func TestAccVPCLatticeListenerRule_tags(t *testing.T) {
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccChecklistenerRuleDestroy(ctx),
+		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccListenerRuleConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
@@ -154,7 +154,7 @@ func TestAccVPCLatticeListenerRule_tags(t *testing.T) {
 	})
 }
 
-func testAccChecklistenerRuleDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckListenerRuleDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
 
@@ -163,7 +163,7 @@ func testAccChecklistenerRuleDestroy(ctx context.Context) resource.TestCheckFunc
 				continue
 			}
 
-			_, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["rule_id"])
+			_, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_identifier"], rs.Primary.Attributes["rule_id"])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -189,7 +189,7 @@ func testAccCheckListenerRuleExists(ctx context.Context, n string, v *vpclattice
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
 
-		output, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["rule_id"])
+		output, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_identifier"], rs.Primary.Attributes["rule_id"])
 
 		if err != nil {
 			return err

--- a/internal/service/vpclattice/listener_rule_test.go
+++ b/internal/service/vpclattice/listener_rule_test.go
@@ -5,21 +5,18 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -157,38 +154,6 @@ func TestAccVPCLatticeListenerRule_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckListenerRuleExists(ctx context.Context, name string, rule *vpclattice.GetRuleOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListenerRule, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListenerRule, name, errors.New("not set"))
-		}
-
-		serviceIdentifier := rs.Primary.Attributes["service_identifier"]
-		listenerIdentifier := rs.Primary.Attributes["listener_identifier"]
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		input := vpclattice.GetRuleInput{
-			RuleIdentifier:     aws.String(rs.Primary.Attributes[names.AttrARN]),
-			ListenerIdentifier: aws.String(listenerIdentifier),
-			ServiceIdentifier:  aws.String(serviceIdentifier),
-		}
-		resp, err := conn.GetRule(ctx, &input)
-
-		if err != nil {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListenerRule, rs.Primary.ID, err)
-		}
-
-		*rule = *resp
-
-		return nil
-	}
-}
-
 func testAccChecklistenerRuleDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
@@ -198,25 +163,39 @@ func testAccChecklistenerRuleDestroy(ctx context.Context) resource.TestCheckFunc
 				continue
 			}
 
-			listenerIdentifier := rs.Primary.Attributes["listener_identifier"]
-			serviceIdentifier := rs.Primary.Attributes["service_identifier"]
+			_, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["rule_id"])
 
-			input := vpclattice.GetRuleInput{
-				RuleIdentifier:     aws.String(rs.Primary.Attributes[names.AttrARN]),
-				ListenerIdentifier: aws.String(listenerIdentifier),
-				ServiceIdentifier:  aws.String(serviceIdentifier),
+			if tfresource.NotFound(err) {
+				continue
 			}
-			_, err := conn.GetRule(ctx, &input)
+
 			if err != nil {
-				var nfe *types.ResourceNotFoundException
-				if errors.As(err, &nfe) {
-					return nil
-				}
 				return err
 			}
 
-			return create.Error(names.VPCLattice, create.ErrActionCheckingDestroyed, tfvpclattice.ResNameListenerRule, rs.Primary.ID, errors.New("not destroyed"))
+			return fmt.Errorf("VPC Lattice Listener Rule %s still exists", rs.Primary.ID)
 		}
+
+		return nil
+	}
+}
+
+func testAccCheckListenerRuleExists(ctx context.Context, n string, v *vpclattice.GetRuleOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
+
+		output, err := tfvpclattice.FindListenerRuleByThreePartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["rule_id"])
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/listener_test.go
+++ b/internal/service/vpclattice/listener_test.go
@@ -5,7 +5,6 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,7 +22,6 @@ import (
 
 func TestAccVPCLatticeListener_defaultActionUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -77,7 +74,6 @@ func TestAccVPCLatticeListener_defaultActionUpdate(t *testing.T) {
 
 func TestAccVPCLatticeListener_fixedResponseHTTP(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -116,7 +112,6 @@ func TestAccVPCLatticeListener_fixedResponseHTTP(t *testing.T) {
 
 func TestAccVPCLatticeListener_fixedResponseHTTPS(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -155,7 +150,6 @@ func TestAccVPCLatticeListener_fixedResponseHTTPS(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardTLSPassthrough(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -196,7 +190,6 @@ func TestAccVPCLatticeListener_forwardTLSPassthrough(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardHTTPTargetGroup(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -237,7 +230,6 @@ func TestAccVPCLatticeListener_forwardHTTPTargetGroup(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -278,7 +270,6 @@ func TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -320,7 +311,6 @@ func TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -362,10 +352,9 @@ func TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort(t *testing.T) {
 
 func TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups(t *testing.T) {
 	ctx := acctest.Context(t)
-	targetGroupName1 := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	targetGroupName1 := fmt.Sprintf("testtargetgroup-%s", sdkacctest.RandString(10))
 	resourceName := "aws_vpclattice_listener.test"
 	serviceName := "aws_vpclattice_service.test"
 	targetGroupResourceName := "aws_vpclattice_target_group.test"
@@ -407,10 +396,6 @@ func TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups(t *testing.T) {
 
 func TestAccVPCLatticeListener_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -439,7 +424,6 @@ func TestAccVPCLatticeListener_disappears(t *testing.T) {
 
 func TestAccVPCLatticeListener_tags(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var listener vpclattice.GetListenerOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_listener.test"
@@ -498,7 +482,7 @@ func testAccCheckListenerDestroy(ctx context.Context) resource.TestCheckFunc {
 				continue
 			}
 
-			_, err := tfvpclattice.FindListenerByTwoPartKey(ctx, conn, rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["service_identifier"])
+			_, err := tfvpclattice.FindListenerByTwoPartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -515,25 +499,22 @@ func testAccCheckListenerDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckListenerExists(ctx context.Context, name string, listener *vpclattice.GetListenerOutput) resource.TestCheckFunc {
+func testAccCheckListenerExists(ctx context.Context, n string, v *vpclattice.GetListenerOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListener, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameListener, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := tfvpclattice.FindListenerByTwoPartKey(ctx, conn, rs.Primary.Attributes["listener_id"], rs.Primary.Attributes["service_identifier"])
+
+		output, err := tfvpclattice.FindListenerByTwoPartKey(ctx, conn, rs.Primary.Attributes["service_identifier"], rs.Primary.Attributes["listener_id"])
 
 		if err != nil {
 			return err
 		}
 
-		*listener = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/resource_policy.go
+++ b/internal/service/vpclattice/resource_policy.go
@@ -5,7 +5,6 @@ package vpclattice
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,19 +14,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @SDKResource("aws_vpclattice_resource_policy", name="Resource Policy")
 // @Testing(tagsTest=false)
-func ResourceResourcePolicy() *schema.Resource {
+func resourceResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceResourcePolicyPut,
 		ReadWithoutTimeout:   resourceResourcePolicyRead,
@@ -39,16 +37,7 @@ func ResourceResourcePolicy() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			names.AttrPolicy: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringIsJSON,
-				DiffSuppressFunc: verify.SuppressEquivalentPolicyDiffs,
-				StateFunc: func(v any) string {
-					json, _ := structure.NormalizeJsonString(v)
-					return json
-				},
-			},
+			names.AttrPolicy: sdkv2.IAMPolicyDocumentSchemaRequired(),
 			names.AttrResourceARN: {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -59,33 +48,30 @@ func ResourceResourcePolicy() *schema.Resource {
 	}
 }
 
-const (
-	ResNameResourcePolicy = "Resource Policy"
-)
-
 func resourceResourcePolicyPut(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
-	resourceArn := d.Get(names.AttrResourceARN).(string)
 
 	policy, err := structure.NormalizeJsonString(d.Get(names.AttrPolicy).(string))
-
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "policy (%s) is invalid JSON: %s", policy, err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	in := &vpclattice.PutResourcePolicyInput{
-		ResourceArn: aws.String(resourceArn),
+	resourceARN := d.Get(names.AttrResourceARN).(string)
+	input := vpclattice.PutResourcePolicyInput{
 		Policy:      aws.String(policy),
+		ResourceArn: aws.String(resourceARN),
 	}
 
-	_, err = conn.PutResourcePolicy(ctx, in)
+	_, err = conn.PutResourcePolicy(ctx, &input)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameResourcePolicy, d.Get(names.AttrPolicy).(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Resource Policy (%s): %s", resourceARN, err)
 	}
 
-	d.SetId(resourceArn)
+	if d.IsNewResource() {
+		d.SetId(resourceARN)
+	}
 
 	return append(diags, resourceResourcePolicyRead(ctx, d, meta)...)
 }
@@ -94,32 +80,24 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	resourceArn := d.Id()
+	output, err := findResourcePolicyByID(ctx, conn, d.Id())
 
-	policy, err := findResourcePolicyByID(ctx, conn, resourceArn)
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] VPCLattice ResourcePolicy (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] VPCLattice Resource Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Resource Policy (%s): %s", d.Id(), err)
 	}
 
-	if policy == nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameResourcePolicy, d.Id(), err)
-	}
-
-	d.Set(names.AttrResourceARN, resourceArn)
-
-	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(policy.Policy))
-
+	policyToSet, err := verify.PolicyToSet(d.Get(names.AttrPolicy).(string), aws.ToString(output.Policy))
 	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting policy %s: %s", aws.ToString(policy.Policy), err)
+		return sdkdiag.AppendFromErr(diags, err)
 	}
-
 	d.Set(names.AttrPolicy, policyToSet)
+	d.Set(names.AttrResourceARN, d.Id())
 
 	return diags
 }
@@ -128,40 +106,48 @@ func resourceResourcePolicyDelete(ctx context.Context, d *schema.ResourceData, m
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	log.Printf("[INFO] Deleting VPCLattice ResourcePolicy: %s", d.Id())
+	log.Printf("[INFO] Deleting VPCLattice Resource Policy: %s", d.Id())
 	input := vpclattice.DeleteResourcePolicyInput{
 		ResourceArn: aws.String(d.Id()),
 	}
 	_, err := conn.DeleteResourcePolicy(ctx, &input)
 
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return diags
-		}
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return diags
+	}
 
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameResourcePolicy, d.Id(), err)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Resource Policy (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
 func findResourcePolicyByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetResourcePolicyOutput, error) {
-	in := &vpclattice.GetResourcePolicyInput{
+	input := vpclattice.GetResourcePolicyInput{
 		ResourceArn: aws.String(id),
 	}
-	out, err := conn.GetResourcePolicy(ctx, in)
-	if err != nil {
-		var nfe *types.ResourceNotFoundException
-		if errors.As(err, &nfe) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
 
+	return findResourcePolicy(ctx, conn, &input)
+}
+
+func findResourcePolicy(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetResourcePolicyInput) (*vpclattice.GetResourcePolicyOutput, error) {
+	output, err := conn.GetResourcePolicy(ctx, input)
+
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
 		return nil, err
 	}
 
-	return out, nil
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
 }

--- a/internal/service/vpclattice/resource_policy_data_source.go
+++ b/internal/service/vpclattice/resource_policy_data_source.go
@@ -9,13 +9,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKDataSource("aws_vpclattice_resource_policy", name="Resource Policy")
-func DataSourceResourcePolicy() *schema.Resource {
+func dataSourceResourcePolicy() *schema.Resource {
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceResourcePolicyRead,
 
@@ -33,27 +33,19 @@ func DataSourceResourcePolicy() *schema.Resource {
 	}
 }
 
-const (
-	DSNameResourcePolicy = "Resource Policy Data Source"
-)
-
 func dataSourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	resourceArn := d.Get(names.AttrResourceARN).(string)
+	resourceARN := d.Get(names.AttrResourceARN).(string)
+	output, err := findResourcePolicyByID(ctx, conn, resourceARN)
 
-	out, err := findResourcePolicyByID(ctx, conn, resourceArn)
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Resource Policy (%s): %s", resourceARN, err)
 	}
 
-	if out == nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, DSNameResourcePolicy, d.Id(), err)
-	}
-
-	d.SetId(resourceArn)
-	d.Set(names.AttrPolicy, out.Policy)
+	d.SetId(resourceARN)
+	d.Set(names.AttrPolicy, output.Policy)
 
 	return diags
 }

--- a/internal/service/vpclattice/resource_policy_data_source_test.go
+++ b/internal/service/vpclattice/resource_policy_data_source_test.go
@@ -16,7 +16,6 @@ import (
 
 func TestAccVPCLatticeResourcePolicyDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_vpclattice_resource_policy.test"
 
@@ -28,7 +27,6 @@ func TestAccVPCLatticeResourcePolicyDataSource_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyDataSourceConfig_basic(rName),

--- a/internal/service/vpclattice/resource_policy_test.go
+++ b/internal/service/vpclattice/resource_policy_test.go
@@ -5,27 +5,23 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
-	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccVPCLatticeResourcePolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var resourcepolicy vpclattice.GetResourcePolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_resource_policy.test"
@@ -59,7 +55,6 @@ func TestAccVPCLatticeResourcePolicy_basic(t *testing.T) {
 
 func TestAccVPCLatticeResourcePolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var resourcepolicy vpclattice.GetResourcePolicyOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_resource_policy.test"
@@ -95,49 +90,39 @@ func testAccCheckResourcePolicyDestroy(ctx context.Context) resource.TestCheckFu
 				continue
 			}
 
-			input := vpclattice.GetResourcePolicyInput{
-				ResourceArn: aws.String(rs.Primary.ID),
+			_, err := tfvpclattice.FindResourcePolicyByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
 			}
-			policy, err := conn.GetResourcePolicy(ctx, &input)
+
 			if err != nil {
-				var nfe *types.ResourceNotFoundException
-				if errors.As(err, &nfe) {
-					return nil
-				}
 				return err
 			}
 
-			if policy != nil {
-				return create.Error(names.VPCLattice, create.ErrActionCheckingDestroyed, tfvpclattice.ResNameResourcePolicy, rs.Primary.ID, errors.New("Resource Policy not destroyed"))
-			}
+			return fmt.Errorf("VPCLattice Resource Policy %s still exists", rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckResourcePolicyExists(ctx context.Context, name string, resourcepolicy *vpclattice.GetResourcePolicyOutput) resource.TestCheckFunc {
+func testAccCheckResourcePolicyExists(ctx context.Context, n string, v *vpclattice.GetResourcePolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameResourcePolicy, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameResourcePolicy, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		input := vpclattice.GetResourcePolicyInput{
-			ResourceArn: aws.String(rs.Primary.ID),
-		}
-		resp, err := conn.GetResourcePolicy(ctx, &input)
+
+		output, err := tfvpclattice.FindResourcePolicyByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameResourcePolicy, rs.Primary.ID, err)
+			return err
 		}
 
-		*resourcepolicy = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/service_network.go
+++ b/internal/service/vpclattice/service_network.go
@@ -12,14 +12,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -62,31 +62,28 @@ func resourceServiceNetwork() *schema.Resource {
 	}
 }
 
-const (
-	ResNameServiceNetwork = "Service Network"
-)
-
 func resourceServiceNetworkCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	in := &vpclattice.CreateServiceNetworkInput{
-		ClientToken: aws.String(id.UniqueId()),
-		Name:        aws.String(d.Get(names.AttrName).(string)),
+	name := d.Get(names.AttrName).(string)
+	input := vpclattice.CreateServiceNetworkInput{
+		ClientToken: aws.String(sdkid.UniqueId()),
+		Name:        aws.String(name),
 		Tags:        getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("auth_type"); ok {
-		in.AuthType = types.AuthType(v.(string))
+		input.AuthType = types.AuthType(v.(string))
 	}
 
-	out, err := conn.CreateServiceNetwork(ctx, in)
+	output, err := conn.CreateServiceNetwork(ctx, &input)
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetwork, d.Get(names.AttrName).(string), err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Service Network (%s): %s", name, err)
 	}
 
-	d.SetId(aws.ToString(out.Id))
+	d.SetId(aws.ToString(output.Id))
 
 	return append(diags, resourceServiceNetworkRead(ctx, d, meta)...)
 }
@@ -95,21 +92,21 @@ func resourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	out, err := findServiceNetworkByID(ctx, conn, d.Id())
+	output, err := findServiceNetworkByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
-		log.Printf("[WARN] VPCLattice ServiceNetwork (%s) not found, removing from state", d.Id())
+		log.Printf("[WARN] VPCLattice Service Network (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameServiceNetwork, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, out.Arn)
-	d.Set("auth_type", out.AuthType)
-	d.Set(names.AttrName, out.Name)
+	d.Set(names.AttrARN, output.Arn)
+	d.Set("auth_type", output.AuthType)
+	d.Set(names.AttrName, output.Name)
 
 	return diags
 }
@@ -119,18 +116,18 @@ func resourceServiceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		in := &vpclattice.UpdateServiceNetworkInput{
+		input := vpclattice.UpdateServiceNetworkInput{
 			ServiceNetworkIdentifier: aws.String(d.Id()),
 		}
 
 		if d.HasChanges("auth_type") {
-			in.AuthType = types.AuthType(d.Get("auth_type").(string))
+			input.AuthType = types.AuthType(d.Get("auth_type").(string))
 		}
 
-		_, err := conn.UpdateServiceNetwork(ctx, in)
+		_, err := conn.UpdateServiceNetwork(ctx, &input)
 
 		if err != nil {
-			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetwork, d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating VPCLattice Service Network (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -152,22 +149,27 @@ func resourceServiceNetworkDelete(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetwork, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Service Network (%s): %s", d.Id(), err)
 	}
 
 	return diags
 }
 
 func findServiceNetworkByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkOutput, error) {
-	in := &vpclattice.GetServiceNetworkInput{
+	input := vpclattice.GetServiceNetworkInput{
 		ServiceNetworkIdentifier: aws.String(id),
 	}
-	out, err := conn.GetServiceNetwork(ctx, in)
+
+	return findServiceNetwork(ctx, conn, &input)
+}
+
+func findServiceNetwork(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetServiceNetworkInput) (*vpclattice.GetServiceNetworkOutput, error) {
+	output, err := conn.GetServiceNetwork(ctx, input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -175,11 +177,11 @@ func findServiceNetworkByID(ctx context.Context, conn *vpclattice.Client, id str
 		return nil, err
 	}
 
-	if out == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
 }
 
 // idFromIDOrARN return a resource ID from an ID or ARN.

--- a/internal/service/vpclattice/service_network_data_source.go
+++ b/internal/service/vpclattice/service_network_data_source.go
@@ -75,22 +75,22 @@ func dataSourceServiceNetworkRead(ctx context.Context, d *schema.ResourceData, m
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
 	serviceNetworkID := d.Get("service_network_identifier").(string)
-	out, err := findServiceNetworkByID(ctx, conn, serviceNetworkID)
+	output, err := findServiceNetworkByID(ctx, conn, serviceNetworkID)
 
 	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network (%s): %s", serviceNetworkID, err)
 	}
 
-	d.SetId(aws.ToString(out.Id))
-	serviceNetworkARN := aws.ToString(out.Arn)
+	d.SetId(aws.ToString(output.Id))
+	serviceNetworkARN := aws.ToString(output.Arn)
 	d.Set(names.AttrARN, serviceNetworkARN)
-	d.Set("auth_type", out.AuthType)
-	d.Set(names.AttrCreatedAt, aws.ToTime(out.CreatedAt).String())
-	d.Set("last_updated_at", aws.ToTime(out.LastUpdatedAt).String())
-	d.Set(names.AttrName, out.Name)
-	d.Set("number_of_associated_services", out.NumberOfAssociatedServices)
-	d.Set("number_of_associated_vpcs", out.NumberOfAssociatedVPCs)
-	d.Set("service_network_identifier", out.Id)
+	d.Set("auth_type", output.AuthType)
+	d.Set(names.AttrCreatedAt, aws.ToTime(output.CreatedAt).String())
+	d.Set("last_updated_at", aws.ToTime(output.LastUpdatedAt).String())
+	d.Set(names.AttrName, output.Name)
+	d.Set("number_of_associated_services", output.NumberOfAssociatedServices)
+	d.Set("number_of_associated_vpcs", output.NumberOfAssociatedVPCs)
+	d.Set("service_network_identifier", output.Id)
 
 	return crossAccountSetTags(ctx, conn, diags, serviceNetworkARN, meta.(*conns.AWSClient).AccountID(ctx), "Service Network")
 }

--- a/internal/service/vpclattice/service_network_service_association.go
+++ b/internal/service/vpclattice/service_network_service_association.go
@@ -5,7 +5,7 @@ package vpclattice
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -13,11 +13,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
@@ -97,34 +96,27 @@ func resourceServiceNetworkServiceAssociation() *schema.Resource {
 	}
 }
 
-const (
-	ResNameServiceNetworkAssociation = "ServiceNetworkAssociation"
-)
-
 func resourceServiceNetworkServiceAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	in := &vpclattice.CreateServiceNetworkServiceAssociationInput{
-		ClientToken:              aws.String(id.UniqueId()),
+	input := vpclattice.CreateServiceNetworkServiceAssociationInput{
+		ClientToken:              aws.String(sdkid.UniqueId()),
 		ServiceIdentifier:        aws.String(d.Get("service_identifier").(string)),
 		ServiceNetworkIdentifier: aws.String(d.Get("service_network_identifier").(string)),
 		Tags:                     getTagsIn(ctx),
 	}
 
-	out, err := conn.CreateServiceNetworkServiceAssociation(ctx, in)
+	output, err := conn.CreateServiceNetworkServiceAssociation(ctx, &input)
+
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Service Network Service Association: %s", err)
 	}
 
-	if out == nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkAssociation, "", errors.New("empty output"))
-	}
-
-	d.SetId(aws.ToString(out.Id))
+	d.SetId(aws.ToString(output.Id))
 
 	if _, err := waitServiceNetworkServiceAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for VPCLattice Service Network Service Association (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceServiceNetworkServiceAssociationRead(ctx, d, meta)...)
@@ -134,7 +126,7 @@ func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	out, err := findServiceNetworkServiceAssociationByID(ctx, conn, d.Id())
+	output, err := findServiceNetworkServiceAssociationByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Service Network Association (%s) not found, removing from state", d.Id())
@@ -143,22 +135,22 @@ func resourceServiceNetworkServiceAssociationRead(ctx context.Context, d *schema
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network Service Association (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, out.Arn)
-	d.Set("created_by", out.CreatedBy)
-	d.Set("custom_domain_name", out.CustomDomainName)
-	if out.DnsEntry != nil {
-		if err := d.Set("dns_entry", []any{flattenDNSEntry(out.DnsEntry)}); err != nil {
+	d.Set(names.AttrARN, output.Arn)
+	d.Set("created_by", output.CreatedBy)
+	d.Set("custom_domain_name", output.CustomDomainName)
+	if output.DnsEntry != nil {
+		if err := d.Set("dns_entry", []any{flattenDNSEntry(output.DnsEntry)}); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting dns_entry: %s", err)
 		}
 	} else {
 		d.Set("dns_entry", nil)
 	}
-	d.Set("service_identifier", out.ServiceId)
-	d.Set("service_network_identifier", out.ServiceNetworkId)
-	d.Set(names.AttrStatus, out.Status)
+	d.Set("service_identifier", output.ServiceId)
+	d.Set("service_network_identifier", output.ServiceNetworkId)
+	d.Set(names.AttrStatus, output.Status)
 
 	return diags
 }
@@ -172,8 +164,7 @@ func resourceServiceNetworkServiceAssociationDelete(ctx context.Context, d *sche
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	log.Printf("[INFO] Deleting VPCLattice Service Network Association %s", d.Id())
-
+	log.Printf("[INFO] Deleting VPCLattice Service Network Service Association: %s", d.Id())
 	input := vpclattice.DeleteServiceNetworkServiceAssociationInput{
 		ServiceNetworkServiceAssociationIdentifier: aws.String(d.Id()),
 	}
@@ -184,26 +175,31 @@ func resourceServiceNetworkServiceAssociationDelete(ctx context.Context, d *sche
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Service Network Service Association (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitServiceNetworkServiceAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for VPCLattice Service Network Service Association (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
 func findServiceNetworkServiceAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkServiceAssociationOutput, error) {
-	in := &vpclattice.GetServiceNetworkServiceAssociationInput{
+	input := vpclattice.GetServiceNetworkServiceAssociationInput{
 		ServiceNetworkServiceAssociationIdentifier: aws.String(id),
 	}
-	out, err := conn.GetServiceNetworkServiceAssociation(ctx, in)
+
+	return findServiceNetworkServiceAssociation(ctx, conn, &input)
+}
+
+func findServiceNetworkServiceAssociation(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetServiceNetworkServiceAssociationInput) (*vpclattice.GetServiceNetworkServiceAssociationOutput, error) {
+	output, err := conn.GetServiceNetworkServiceAssociation(ctx, input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -211,11 +207,27 @@ func findServiceNetworkServiceAssociationByID(ctx context.Context, conn *vpclatt
 		return nil, err
 	}
 
-	if out == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
+}
+
+func statusServiceNetworkServiceAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		output, err := findServiceNetworkServiceAssociationByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
 }
 
 func waitServiceNetworkServiceAssociationCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkServiceAssociationOutput, error) {
@@ -224,13 +236,17 @@ func waitServiceNetworkServiceAssociationCreated(ctx context.Context, conn *vpcl
 		Target:                    enum.Slice(types.ServiceNetworkVpcAssociationStatusActive),
 		Refresh:                   statusServiceNetworkServiceAssociation(ctx, conn, id),
 		Timeout:                   timeout,
-		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkServiceAssociationOutput); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*vpclattice.GetServiceNetworkServiceAssociationOutput); ok {
+		if output.Status == types.ServiceNetworkServiceAssociationStatusCreateFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
@@ -245,24 +261,14 @@ func waitServiceNetworkServiceAssociationDeleted(ctx context.Context, conn *vpcl
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkServiceAssociationOutput); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*vpclattice.GetServiceNetworkServiceAssociationOutput); ok {
+		if output.Status == types.ServiceNetworkServiceAssociationStatusDeleteFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
-}
-
-func statusServiceNetworkServiceAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
-		out, err := findServiceNetworkServiceAssociationByID(ctx, conn, id)
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return out, string(out.Status), nil
-	}
 }

--- a/internal/service/vpclattice/service_network_service_association_test.go
+++ b/internal/service/vpclattice/service_network_service_association_test.go
@@ -5,7 +5,6 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,7 +22,6 @@ import (
 
 func TestAccVPCLatticeServiceNetworkServiceAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkasc vpclattice.GetServiceNetworkServiceAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_service_association.test"
@@ -57,7 +54,6 @@ func TestAccVPCLatticeServiceNetworkServiceAssociation_basic(t *testing.T) {
 
 func TestAccVPCLatticeServiceNetworkServiceAssociation_arn(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkasc vpclattice.GetServiceNetworkServiceAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_service_association.test"
@@ -90,7 +86,6 @@ func TestAccVPCLatticeServiceNetworkServiceAssociation_arn(t *testing.T) {
 
 func TestAccVPCLatticeServiceNetworkServiceAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkasc vpclattice.GetServiceNetworkServiceAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_service_association.test"
@@ -193,25 +188,22 @@ func testAccCheckServiceNetworkServiceAssociationDestroy(ctx context.Context) re
 	}
 }
 
-func testAccCheckServiceNetworkServiceAssociationExists(ctx context.Context, name string, service *vpclattice.GetServiceNetworkServiceAssociationOutput) resource.TestCheckFunc {
+func testAccCheckServiceNetworkServiceAssociationExists(ctx context.Context, n string, v *vpclattice.GetServiceNetworkServiceAssociationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := tfvpclattice.FindServiceNetworkServiceAssociationByID(ctx, conn, rs.Primary.ID)
+
+		output, err := tfvpclattice.FindServiceNetworkServiceAssociationByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*service = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/service_network_test.go
+++ b/internal/service/vpclattice/service_network_test.go
@@ -5,7 +5,6 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -257,39 +255,26 @@ func testAccCheckServiceNetworkDestroy(ctx context.Context) resource.TestCheckFu
 	}
 }
 
-func testAccCheckServiceNetworkExists(ctx context.Context, name string, servicenetwork *vpclattice.GetServiceNetworkOutput) resource.TestCheckFunc {
+func testAccCheckServiceNetworkExists(ctx context.Context, n string, v *vpclattice.GetServiceNetworkOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameServiceNetwork, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameServiceNetwork, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := tfvpclattice.FindServiceNetworkByID(ctx, conn, rs.Primary.ID)
+
+		output, err := tfvpclattice.FindServiceNetworkByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*servicenetwork = *resp
+		*v = *output
 
 		return nil
 	}
 }
-
-// func testAccCheckServiceNetworkNotRecreated(before, after *vpclattice.DescribeServiceNetworkResponse) resource.TestCheckFunc {
-// 	return func(s *terraform.State) error {
-// 		if before, after := aws.StringValue(before.ServiceNetworkId), aws.StringValue(after.ServiceNetworkId); before != after {
-// 			return create.Error(names.VPCLattice, create.ErrActionCheckingNotRecreated, tfvpclattice.ResNameServiceNetwork, aws.StringValue(before.ServiceNetworkId), errors.New("recreated"))
-// 		}
-
-// 		return nil
-// 	}
-// }
 
 func testAccServiceNetworkConfig_basic(rName string) string {
 	return fmt.Sprintf(`

--- a/internal/service/vpclattice/service_network_vpc_association.go
+++ b/internal/service/vpclattice/service_network_vpc_association.go
@@ -5,7 +5,7 @@ package vpclattice
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"log"
 	"time"
 
@@ -13,13 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -71,49 +71,42 @@ func resourceServiceNetworkVPCAssociation() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"vpc_identifier": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }
-
-const (
-	ResNameServiceNetworkVPCAssociation = "ServiceNetworkVPCAssociation"
-)
 
 func resourceServiceNetworkVPCAssociationCreate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	in := &vpclattice.CreateServiceNetworkVpcAssociationInput{
-		ClientToken:              aws.String(id.UniqueId()),
+	input := vpclattice.CreateServiceNetworkVpcAssociationInput{
+		ClientToken:              aws.String(sdkid.UniqueId()),
 		ServiceNetworkIdentifier: aws.String(d.Get("service_network_identifier").(string)),
-		VpcIdentifier:            aws.String(d.Get("vpc_identifier").(string)),
 		Tags:                     getTagsIn(ctx),
+		VpcIdentifier:            aws.String(d.Get("vpc_identifier").(string)),
 	}
 
 	if v, ok := d.GetOk(names.AttrSecurityGroupIDs); ok {
-		in.SecurityGroupIds = flex.ExpandStringValueList(v.([]any))
+		input.SecurityGroupIds = flex.ExpandStringValueList(v.([]any))
 	}
 
-	out, err := conn.CreateServiceNetworkVpcAssociation(ctx, in)
+	output, err := conn.CreateServiceNetworkVpcAssociation(ctx, &input)
+
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVPCAssociation, "", err)
+		return sdkdiag.AppendErrorf(diags, "creating VPCLattice Service Network VPC Association: %s", err)
 	}
 
-	if out == nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionCreating, ResNameServiceNetworkVPCAssociation, "", errors.New("empty output"))
-	}
-
-	d.SetId(aws.ToString(out.Id))
+	d.SetId(aws.ToString(output.Id))
 
 	if _, err := waitServiceNetworkVPCAssociationCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForCreation, ResNameServiceNetworkVPCAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for VPCLattice Service Network VPC Association (%s) create: %s", d.Id(), err)
 	}
 
 	return append(diags, resourceServiceNetworkVPCAssociationRead(ctx, d, meta)...)
@@ -123,7 +116,7 @@ func resourceServiceNetworkVPCAssociationRead(ctx context.Context, d *schema.Res
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	out, err := findServiceNetworkVPCAssociationByID(ctx, conn, d.Id())
+	output, err := findServiceNetworkVPCAssociationByID(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] VPCLattice Service Network VPC Association (%s) not found, removing from state", d.Id())
@@ -132,15 +125,15 @@ func resourceServiceNetworkVPCAssociationRead(ctx context.Context, d *schema.Res
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionReading, ResNameServiceNetworkVPCAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "reading VPCLattice Service Network VPC Association (%s): %s", d.Id(), err)
 	}
 
-	d.Set(names.AttrARN, out.Arn)
-	d.Set("created_by", out.CreatedBy)
-	d.Set("vpc_identifier", out.VpcId)
-	d.Set("service_network_identifier", out.ServiceNetworkId)
-	d.Set(names.AttrSecurityGroupIDs, out.SecurityGroupIds)
-	d.Set(names.AttrStatus, out.Status)
+	d.Set(names.AttrARN, output.Arn)
+	d.Set("created_by", output.CreatedBy)
+	d.Set(names.AttrSecurityGroupIDs, output.SecurityGroupIds)
+	d.Set("service_network_identifier", output.ServiceNetworkId)
+	d.Set(names.AttrStatus, output.Status)
+	d.Set("vpc_identifier", output.VpcId)
 
 	return diags
 }
@@ -148,19 +141,20 @@ func resourceServiceNetworkVPCAssociationRead(ctx context.Context, d *schema.Res
 func resourceServiceNetworkVPCAssociationUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
+
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
-		in := &vpclattice.UpdateServiceNetworkVpcAssociationInput{
+		input := vpclattice.UpdateServiceNetworkVpcAssociationInput{
 			ServiceNetworkVpcAssociationIdentifier: aws.String(d.Id()),
 		}
 
 		if d.HasChange(names.AttrSecurityGroupIDs) {
-			in.SecurityGroupIds = flex.ExpandStringValueList(d.Get(names.AttrSecurityGroupIDs).([]any))
+			input.SecurityGroupIds = flex.ExpandStringValueList(d.Get(names.AttrSecurityGroupIDs).([]any))
 		}
 
-		log.Printf("[DEBUG] Updating VPCLattice ServiceNetwork VPC Association (%s): %#v", d.Id(), in)
-		_, err := conn.UpdateServiceNetworkVpcAssociation(ctx, in)
+		_, err := conn.UpdateServiceNetworkVpcAssociation(ctx, &input)
+
 		if err != nil {
-			return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionUpdating, ResNameServiceNetworkVPCAssociation, d.Id(), err)
+			return sdkdiag.AppendErrorf(diags, "updating VPCLattice Service Network VPC Association (%s): %s", d.Id(), err)
 		}
 	}
 
@@ -171,8 +165,7 @@ func resourceServiceNetworkVPCAssociationDelete(ctx context.Context, d *schema.R
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	log.Printf("[INFO] Deleting VPCLattice Service Network VPC Association %s", d.Id())
-
+	log.Printf("[INFO] Deleting VPCLattice Service Network VPC Association: %s", d.Id())
 	input := vpclattice.DeleteServiceNetworkVpcAssociationInput{
 		ServiceNetworkVpcAssociationIdentifier: aws.String(d.Id()),
 	}
@@ -183,26 +176,31 @@ func resourceServiceNetworkVPCAssociationDelete(ctx context.Context, d *schema.R
 	}
 
 	if err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionDeleting, ResNameServiceNetworkVPCAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "deleting VPCLattice Service Network VPC Association (%s): %s", d.Id(), err)
 	}
 
 	if _, err := waitServiceNetworkVPCAssociationDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
-		return create.AppendDiagError(diags, names.VPCLattice, create.ErrActionWaitingForDeletion, ResNameServiceNetworkVPCAssociation, d.Id(), err)
+		return sdkdiag.AppendErrorf(diags, "waiting for VPCLattice Service Network VPC Association (%s) delete: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
 func findServiceNetworkVPCAssociationByID(ctx context.Context, conn *vpclattice.Client, id string) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
-	in := &vpclattice.GetServiceNetworkVpcAssociationInput{
+	input := vpclattice.GetServiceNetworkVpcAssociationInput{
 		ServiceNetworkVpcAssociationIdentifier: aws.String(id),
 	}
-	out, err := conn.GetServiceNetworkVpcAssociation(ctx, in)
+
+	return findServiceNetworkVPCAssociation(ctx, conn, &input)
+}
+
+func findServiceNetworkVPCAssociation(ctx context.Context, conn *vpclattice.Client, input *vpclattice.GetServiceNetworkVpcAssociationInput) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
+	output, err := conn.GetServiceNetworkVpcAssociation(ctx, input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
-			LastRequest: in,
+			LastRequest: input,
 		}
 	}
 
@@ -210,11 +208,27 @@ func findServiceNetworkVPCAssociationByID(ctx context.Context, conn *vpclattice.
 		return nil, err
 	}
 
-	if out == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
+	return output, nil
+}
+
+func statusServiceNetworkVPCAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		output, err := findServiceNetworkVPCAssociationByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
 }
 
 func waitServiceNetworkVPCAssociationCreated(ctx context.Context, conn *vpclattice.Client, id string, timeout time.Duration) (*vpclattice.GetServiceNetworkVpcAssociationOutput, error) {
@@ -223,13 +237,17 @@ func waitServiceNetworkVPCAssociationCreated(ctx context.Context, conn *vpclatti
 		Target:                    enum.Slice(types.ServiceNetworkVpcAssociationStatusActive),
 		Refresh:                   statusServiceNetworkVPCAssociation(ctx, conn, id),
 		Timeout:                   timeout,
-		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
+		if output.Status == types.ServiceNetworkVpcAssociationStatusCreateFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
@@ -244,24 +262,14 @@ func waitServiceNetworkVPCAssociationDeleted(ctx context.Context, conn *vpclatti
 	}
 
 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-	if out, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
-		return out, err
+
+	if output, ok := outputRaw.(*vpclattice.GetServiceNetworkVpcAssociationOutput); ok {
+		if output.Status == types.ServiceNetworkVpcAssociationStatusDeleteFailed {
+			tfresource.SetLastError(err, fmt.Errorf("%s: %s", aws.ToString(output.FailureCode), aws.ToString(output.FailureMessage)))
+		}
+
+		return output, err
 	}
 
 	return nil, err
-}
-
-func statusServiceNetworkVPCAssociation(ctx context.Context, conn *vpclattice.Client, id string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
-		out, err := findServiceNetworkVPCAssociationByID(ctx, conn, id)
-		if tfresource.NotFound(err) {
-			return nil, "", nil
-		}
-
-		if err != nil {
-			return nil, "", err
-		}
-
-		return out, string(out.Status), nil
-	}
 }

--- a/internal/service/vpclattice/service_network_vpc_association_test.go
+++ b/internal/service/vpclattice/service_network_vpc_association_test.go
@@ -5,7 +5,6 @@ package vpclattice_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfvpclattice "github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -24,7 +22,6 @@ import (
 
 func TestAccVPCLatticeServiceNetworkVPCAssociation_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_vpc_association.test"
@@ -57,7 +54,6 @@ func TestAccVPCLatticeServiceNetworkVPCAssociation_basic(t *testing.T) {
 
 func TestAccVPCLatticeServiceNetworkVPCAssociation_arn(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_vpc_association.test"
@@ -91,7 +87,6 @@ func TestAccVPCLatticeServiceNetworkVPCAssociation_arn(t *testing.T) {
 
 func TestAccVPCLatticeServiceNetworkVPCAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_vpc_association.test"
@@ -120,7 +115,6 @@ func TestAccVPCLatticeServiceNetworkVPCAssociation_disappears(t *testing.T) {
 
 func TestAccVPCLatticeServiceNetworkVPCAssociation_full(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var servicenetworkvpcasc vpclattice.GetServiceNetworkVpcAssociationOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_vpclattice_service_network_vpc_association.test"
@@ -230,25 +224,22 @@ func testAccCheckServiceNetworkVPCAssociationDestroy(ctx context.Context) resour
 	}
 }
 
-func testAccCheckServiceNetworkVPCAssociationExists(ctx context.Context, name string, service *vpclattice.GetServiceNetworkVpcAssociationOutput) resource.TestCheckFunc {
+func testAccCheckServiceNetworkVPCAssociationExists(ctx context.Context, n string, v *vpclattice.GetServiceNetworkVpcAssociationOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.VPCLattice, create.ErrActionCheckingExistence, tfvpclattice.ResNameService, name, errors.New("not set"))
+			return fmt.Errorf("Not found: %s", n)
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).VPCLatticeClient(ctx)
-		resp, err := tfvpclattice.FindServiceNetworkVPCAssociationByID(ctx, conn, rs.Primary.ID)
+
+		output, err := tfvpclattice.FindServiceNetworkVPCAssociationByID(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err
 		}
 
-		*service = *resp
+		*v = *output
 
 		return nil
 	}

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -63,7 +63,7 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			},
 		},
 		{
-			Factory:  DataSourceResourcePolicy,
+			Factory:  dataSourceResourcePolicy,
 			TypeName: "aws_vpclattice_resource_policy",
 			Name:     "Resource Policy",
 		},

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -55,9 +55,12 @@ func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePac
 			Name:     "Auth Policy",
 		},
 		{
-			Factory:  DataSourceListener,
+			Factory:  dataSourceListener,
 			TypeName: "aws_vpclattice_listener",
 			Name:     "Listener",
+			Tags: &types.ServicePackageResourceTags{
+				IdentifierAttribute: names.AttrARN,
+			},
 		},
 		{
 			Factory:  DataSourceResourcePolicy,

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -50,7 +50,7 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.Servic
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {
 	return []*types.ServicePackageSDKDataSource{
 		{
-			Factory:  DataSourceAuthPolicy,
+			Factory:  dataSourceAuthPolicy,
 			TypeName: "aws_vpclattice_auth_policy",
 			Name:     "Auth Policy",
 		},

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -106,7 +106,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceListenerRule,
+			Factory:  resourceListenerRule,
 			TypeName: "aws_vpclattice_listener_rule",
 			Name:     "Listener Rule",
 			Tags: &types.ServicePackageResourceTags{

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -114,7 +114,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceResourcePolicy,
+			Factory:  resourceResourcePolicy,
 			TypeName: "aws_vpclattice_resource_policy",
 			Name:     "Resource Policy",
 		},

--- a/internal/service/vpclattice/service_package_gen.go
+++ b/internal/service/vpclattice/service_package_gen.go
@@ -90,7 +90,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*types.ServicePacka
 			},
 		},
 		{
-			Factory:  ResourceAuthPolicy,
+			Factory:  resourceAuthPolicy,
 			TypeName: "aws_vpclattice_auth_policy",
 			Name:     "Auth Policy",
 		},

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -145,9 +145,11 @@ func resourceTargetGroupAttachmentDelete(ctx context.Context, d *schema.Resource
 	input := vpclattice.DeregisterTargetsInput{
 		TargetGroupIdentifier: aws.String(targetGroupID),
 		Targets: []types.Target{{
-			Id:   aws.String(targetID),
-			Port: aws.Int32(targetPort),
+			Id: aws.String(targetID),
 		}},
+	}
+	if targetPort > 0 {
+		input.Targets[0].Port = aws.Int32(targetPort)
 	}
 	_, err = conn.DeregisterTargets(ctx, &input)
 

--- a/internal/service/vpclattice/target_group_attachment.go
+++ b/internal/service/vpclattice/target_group_attachment.go
@@ -6,8 +6,8 @@ package vpclattice
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -80,14 +81,14 @@ func resourceTargetGroupAttachmentCreate(ctx context.Context, d *schema.Resource
 	targetGroupID := d.Get("target_group_identifier").(string)
 	target := expandTarget(d.Get(names.AttrTarget).([]any)[0].(map[string]any))
 	targetID := aws.ToString(target.Id)
-	targetPort := int(aws.ToInt32(target.Port))
-	id := strings.Join([]string{targetGroupID, targetID, strconv.Itoa(targetPort)}, "/")
-	input := &vpclattice.RegisterTargetsInput{
+	targetPort := aws.ToInt32(target.Port)
+	id := targetGroupAttachmentCreateResourceID(targetGroupID, targetID, targetPort)
+	input := vpclattice.RegisterTargetsInput{
 		TargetGroupIdentifier: aws.String(targetGroupID),
 		Targets:               []types.Target{target},
 	}
 
-	_, err := conn.RegisterTargets(ctx, input)
+	_, err := conn.RegisterTargets(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating VPC Lattice Target Group Attachment (%s): %s", id, err)
@@ -106,10 +107,10 @@ func resourceTargetGroupAttachmentRead(ctx context.Context, d *schema.ResourceDa
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	targetGroupID := d.Get("target_group_identifier").(string)
-	target := expandTarget(d.Get(names.AttrTarget).([]any)[0].(map[string]any))
-	targetID := aws.ToString(target.Id)
-	targetPort := int(aws.ToInt32(target.Port))
+	targetGroupID, targetID, targetPort, err := targetGroupAttachmentParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
 
 	output, err := findTargetByThreePartKey(ctx, conn, targetGroupID, targetID, targetPort)
 
@@ -135,17 +136,20 @@ func resourceTargetGroupAttachmentDelete(ctx context.Context, d *schema.Resource
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).VPCLatticeClient(ctx)
 
-	targetGroupID := d.Get("target_group_identifier").(string)
-	target := expandTarget(d.Get(names.AttrTarget).([]any)[0].(map[string]any))
-	targetID := aws.ToString(target.Id)
-	targetPort := int(aws.ToInt32(target.Port))
+	targetGroupID, targetID, targetPort, err := targetGroupAttachmentParseResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendFromErr(diags, err)
+	}
 
 	log.Printf("[INFO] Deleting VPC Lattice Target Group Attachment: %s", d.Id())
 	input := vpclattice.DeregisterTargetsInput{
 		TargetGroupIdentifier: aws.String(targetGroupID),
-		Targets:               []types.Target{target},
+		Targets: []types.Target{{
+			Id:   aws.String(targetID),
+			Port: aws.Int32(targetPort),
+		}},
 	}
-	_, err := conn.DeregisterTargets(ctx, &input)
+	_, err = conn.DeregisterTargets(ctx, &input)
 
 	if errs.IsA[*types.ResourceNotFoundException](err) {
 		return diags
@@ -162,20 +166,55 @@ func resourceTargetGroupAttachmentDelete(ctx context.Context, d *schema.Resource
 	return diags
 }
 
-func findTargetByThreePartKey(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int) (*types.TargetSummary, error) {
-	input := &vpclattice.ListTargetsInput{
+const targetGroupAttachmentResourceIDSeparator = "/"
+
+func targetGroupAttachmentCreateResourceID(targetGroupID, targetID string, targetPort int32) string {
+	parts := []string{targetGroupID, targetID, flex.Int32ValueToStringValue(targetPort)}
+	id := strings.Join(parts, targetGroupAttachmentResourceIDSeparator)
+
+	return id
+}
+
+func targetGroupAttachmentParseResourceID(id string) (string, string, int32, error) {
+	parts := strings.SplitN(id, targetGroupAttachmentResourceIDSeparator, 3)
+
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", 0, fmt.Errorf("unexpected format for ID (%[1]s), expected TARGET-GROUP-ID%[2]sTARGET-ID%[2]sTARGET-PORT", id, targetGroupAttachmentResourceIDSeparator)
+	}
+
+	return parts[0], parts[1], flex.StringValueToInt32Value(parts[2]), nil
+}
+
+func findTargetByThreePartKey(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32) (*types.TargetSummary, error) {
+	input := vpclattice.ListTargetsInput{
 		TargetGroupIdentifier: aws.String(targetGroupID),
 		Targets: []types.Target{{
 			Id: aws.String(targetID),
 		}},
 	}
 	if targetPort > 0 {
-		input.Targets[0].Port = aws.Int32(int32(targetPort))
+		input.Targets[0].Port = aws.Int32(targetPort)
 	}
+
+	return findTarget(ctx, conn, &input)
+}
+
+func findTarget(ctx context.Context, conn *vpclattice.Client, input *vpclattice.ListTargetsInput) (*types.TargetSummary, error) {
+	output, err := findTargets(ctx, conn, input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return tfresource.AssertSingleValueResult(output)
+}
+
+func findTargets(ctx context.Context, conn *vpclattice.Client, input *vpclattice.ListTargetsInput) ([]types.TargetSummary, error) {
+	var output []types.TargetSummary
 
 	paginator := vpclattice.NewListTargetsPaginator(conn, input)
 	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(ctx)
+		page, err := paginator.NextPage(ctx)
 
 		if errs.IsA[*types.ResourceNotFoundException](err) {
 			return nil, &retry.NotFoundError{
@@ -188,15 +227,13 @@ func findTargetByThreePartKey(ctx context.Context, conn *vpclattice.Client, targ
 			return nil, err
 		}
 
-		if output != nil && len(output.Items) == 1 {
-			return &(output.Items[0]), nil
-		}
+		output = append(output, page.Items...)
 	}
 
-	return nil, &retry.NotFoundError{}
+	return output, nil
 }
 
-func statusTarget(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int) retry.StateRefreshFunc {
+func statusTarget(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		output, err := findTargetByThreePartKey(ctx, conn, targetGroupID, targetID, targetPort)
 
@@ -212,13 +249,12 @@ func statusTarget(ctx context.Context, conn *vpclattice.Client, targetGroupID, t
 	}
 }
 
-func waitTargetGroupAttachmentCreated(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int, timeout time.Duration) (*types.TargetSummary, error) {
+func waitTargetGroupAttachmentCreated(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32, timeout time.Duration) (*types.TargetSummary, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending:                   enum.Slice(types.TargetStatusInitial),
 		Target:                    enum.Slice(types.TargetStatusHealthy, types.TargetStatusUnhealthy, types.TargetStatusUnused, types.TargetStatusUnavailable),
 		Refresh:                   statusTarget(ctx, conn, targetGroupID, targetID, targetPort),
 		Timeout:                   timeout,
-		NotFoundChecks:            20,
 		ContinuousTargetOccurence: 2,
 	}
 
@@ -233,7 +269,7 @@ func waitTargetGroupAttachmentCreated(ctx context.Context, conn *vpclattice.Clie
 	return nil, err
 }
 
-func waitTargetGroupAttachmentDeleted(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int, timeout time.Duration) (*types.TargetSummary, error) {
+func waitTargetGroupAttachmentDeleted(ctx context.Context, conn *vpclattice.Client, targetGroupID, targetID string, targetPort int32, timeout time.Duration) (*types.TargetSummary, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(types.TargetStatusDraining, types.TargetStatusInitial),
 		Target:  []string{},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Prevent `vpclattice` functions from being exported directly.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccVPCLattice' PKG=vpclattice ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/vpclattice/... -v -count 1 -parallel 3  -run=TestAccVPCLattice -timeout 360m -vet=off
2025/03/20 12:07:08 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCLatticeAccessLogSubscription_basic
=== PAUSE TestAccVPCLatticeAccessLogSubscription_basic
=== RUN   TestAccVPCLatticeAccessLogSubscription_disappears
=== PAUSE TestAccVPCLatticeAccessLogSubscription_disappears
=== RUN   TestAccVPCLatticeAccessLogSubscription_arn
=== PAUSE TestAccVPCLatticeAccessLogSubscription_arn
=== RUN   TestAccVPCLatticeAccessLogSubscription_tags
=== PAUSE TestAccVPCLatticeAccessLogSubscription_tags
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== PAUSE TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
=== RUN   TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== PAUSE TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
=== RUN   TestAccVPCLatticeAuthPolicyDataSource_basic
=== PAUSE TestAccVPCLatticeAuthPolicyDataSource_basic
=== RUN   TestAccVPCLatticeAuthPolicy_basic
=== PAUSE TestAccVPCLatticeAuthPolicy_basic
=== RUN   TestAccVPCLatticeAuthPolicy_disappears
=== PAUSE TestAccVPCLatticeAuthPolicy_disappears
=== RUN   TestAccVPCLatticeListenerDataSource_basic
=== PAUSE TestAccVPCLatticeListenerDataSource_basic
=== RUN   TestAccVPCLatticeListenerDataSource_tags
=== PAUSE TestAccVPCLatticeListenerDataSource_tags
=== RUN   TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
=== PAUSE TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
=== RUN   TestAccVPCLatticeListenerRule_basic
=== PAUSE TestAccVPCLatticeListenerRule_basic
=== RUN   TestAccVPCLatticeListenerRule_fixedResponse
=== PAUSE TestAccVPCLatticeListenerRule_fixedResponse
=== RUN   TestAccVPCLatticeListenerRule_methodMatch
=== PAUSE TestAccVPCLatticeListenerRule_methodMatch
=== RUN   TestAccVPCLatticeListenerRule_tags
=== PAUSE TestAccVPCLatticeListenerRule_tags
=== RUN   TestAccVPCLatticeListener_defaultActionUpdate
=== PAUSE TestAccVPCLatticeListener_defaultActionUpdate
=== RUN   TestAccVPCLatticeListener_fixedResponseHTTP
=== PAUSE TestAccVPCLatticeListener_fixedResponseHTTP
=== RUN   TestAccVPCLatticeListener_fixedResponseHTTPS
=== PAUSE TestAccVPCLatticeListener_fixedResponseHTTPS
=== RUN   TestAccVPCLatticeListener_forwardTLSPassthrough
=== PAUSE TestAccVPCLatticeListener_forwardTLSPassthrough
=== RUN   TestAccVPCLatticeListener_forwardHTTPTargetGroup
=== PAUSE TestAccVPCLatticeListener_forwardHTTPTargetGroup
=== RUN   TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
=== PAUSE TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
=== RUN   TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
=== PAUSE TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
=== RUN   TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
=== PAUSE TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
=== RUN   TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
=== PAUSE TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
=== RUN   TestAccVPCLatticeListener_disappears
=== PAUSE TestAccVPCLatticeListener_disappears
=== RUN   TestAccVPCLatticeListener_tags
=== PAUSE TestAccVPCLatticeListener_tags
=== RUN   TestAccVPCLatticeResourceConfiguration_tags
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_null
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_null
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeResourceConfiguration_basic
=== PAUSE TestAccVPCLatticeResourceConfiguration_basic
=== RUN   TestAccVPCLatticeResourceConfiguration_update
=== PAUSE TestAccVPCLatticeResourceConfiguration_update
=== RUN   TestAccVPCLatticeResourceConfiguration_ipAddress
=== PAUSE TestAccVPCLatticeResourceConfiguration_ipAddress
=== RUN   TestAccVPCLatticeResourceConfiguration_parentChild
=== PAUSE TestAccVPCLatticeResourceConfiguration_parentChild
=== RUN   TestAccVPCLatticeResourceConfiguration_arnResource
=== PAUSE TestAccVPCLatticeResourceConfiguration_arnResource
=== RUN   TestAccVPCLatticeResourceConfiguration_disappears
=== PAUSE TestAccVPCLatticeResourceConfiguration_disappears
=== RUN   TestAccVPCLatticeResourceGateway_tags
=== PAUSE TestAccVPCLatticeResourceGateway_tags
=== RUN   TestAccVPCLatticeResourceGateway_tags_null
=== PAUSE TestAccVPCLatticeResourceGateway_tags_null
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyMap
=== RUN   TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeResourceGateway_basic
=== PAUSE TestAccVPCLatticeResourceGateway_basic
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeDualstack
=== RUN   TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== PAUSE TestAccVPCLatticeResourceGateway_addressTypeIPv6
=== RUN   TestAccVPCLatticeResourceGateway_multipleSubnets
=== PAUSE TestAccVPCLatticeResourceGateway_multipleSubnets
=== RUN   TestAccVPCLatticeResourceGateway_update
=== PAUSE TestAccVPCLatticeResourceGateway_update
=== RUN   TestAccVPCLatticeResourceGateway_disappears
=== PAUSE TestAccVPCLatticeResourceGateway_disappears
=== RUN   TestAccVPCLatticeResourcePolicyDataSource_basic
=== PAUSE TestAccVPCLatticeResourcePolicyDataSource_basic
=== RUN   TestAccVPCLatticeResourcePolicy_basic
=== PAUSE TestAccVPCLatticeResourcePolicy_basic
=== RUN   TestAccVPCLatticeResourcePolicy_disappears
=== PAUSE TestAccVPCLatticeResourcePolicy_disappears
=== RUN   TestAccVPCLatticeServiceDataSource_basic
=== PAUSE TestAccVPCLatticeServiceDataSource_basic
=== RUN   TestAccVPCLatticeServiceDataSource_byName
=== PAUSE TestAccVPCLatticeServiceDataSource_byName
=== RUN   TestAccVPCLatticeServiceDataSource_shared
=== PAUSE TestAccVPCLatticeServiceDataSource_shared
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_basic
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_basic
=== RUN   TestAccVPCLatticeServiceNetworkDataSource_shared
=== PAUSE TestAccVPCLatticeServiceNetworkDataSource_shared
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkServiceAssociation_tags
=== RUN   TestAccVPCLatticeServiceNetwork_basic
=== PAUSE TestAccVPCLatticeServiceNetwork_basic
=== RUN   TestAccVPCLatticeServiceNetwork_disappears
=== PAUSE TestAccVPCLatticeServiceNetwork_disappears
=== RUN   TestAccVPCLatticeServiceNetwork_full
=== PAUSE TestAccVPCLatticeServiceNetwork_full
=== RUN   TestAccVPCLatticeServiceNetwork_tags
=== PAUSE TestAccVPCLatticeServiceNetwork_tags
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_arn
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_full
=== RUN   TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== PAUSE TestAccVPCLatticeServiceNetworkVPCAssociation_tags
=== RUN   TestAccVPCLatticeService_basic
=== PAUSE TestAccVPCLatticeService_basic
=== RUN   TestAccVPCLatticeService_disappears
=== PAUSE TestAccVPCLatticeService_disappears
=== RUN   TestAccVPCLatticeService_full
=== PAUSE TestAccVPCLatticeService_full
=== RUN   TestAccVPCLatticeService_tags
=== PAUSE TestAccVPCLatticeService_tags
=== RUN   TestAccVPCLatticeTargetGroupAttachment_instance
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_instance
=== RUN   TestAccVPCLatticeTargetGroupAttachment_ip
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_ip
=== RUN   TestAccVPCLatticeTargetGroupAttachment_lambda
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_lambda
=== RUN   TestAccVPCLatticeTargetGroupAttachment_alb
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_alb
=== RUN   TestAccVPCLatticeTargetGroupAttachment_disappears
=== PAUSE TestAccVPCLatticeTargetGroupAttachment_disappears
=== RUN   TestAccVPCLatticeTargetGroup_basic
=== PAUSE TestAccVPCLatticeTargetGroup_basic
=== RUN   TestAccVPCLatticeTargetGroup_disappears
=== PAUSE TestAccVPCLatticeTargetGroup_disappears
=== RUN   TestAccVPCLatticeTargetGroup_tags
=== PAUSE TestAccVPCLatticeTargetGroup_tags
=== RUN   TestAccVPCLatticeTargetGroup_lambda
=== PAUSE TestAccVPCLatticeTargetGroup_lambda
=== RUN   TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
=== PAUSE TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
=== RUN   TestAccVPCLatticeTargetGroup_ip
=== PAUSE TestAccVPCLatticeTargetGroup_ip
=== RUN   TestAccVPCLatticeTargetGroup_alb
=== PAUSE TestAccVPCLatticeTargetGroup_alb
=== CONT  TestAccVPCLatticeAccessLogSubscription_basic
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeAccessLogSubscription_basic (19.70s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag (63.45s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Replace (96.54s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeListener_forwardHTTPSTargetGroupCustomPort (77.38s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag (62.55s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace (54.48s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add (59.18s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate (40.45s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag (36.59s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingResourceTag (37.02s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTag (37.41s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag (36.93s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnly (51.82s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnly (51.83s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping (74.26s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping (73.63s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace (49.36s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly (93.37s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add (66.72s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_EmptyMap
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate (52.29s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags_null
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate (58.53s)
=== CONT  TestAccVPCLatticeResourceConfiguration_tags
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_EmptyMap (36.56s)
=== CONT  TestAccVPCLatticeListener_tags
--- PASS: TestAccVPCLatticeResourceConfiguration_tags_null (36.91s)
=== CONT  TestAccVPCLatticeListener_disappears
--- PASS: TestAccVPCLatticeResourceConfiguration_tags (86.09s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups
--- PASS: TestAccVPCLatticeListener_disappears (69.37s)
=== CONT  TestAccVPCLatticeServiceNetwork_full
--- PASS: TestAccVPCLatticeServiceNetwork_full (13.53s)
=== CONT  TestAccVPCLatticeTargetGroup_alb
--- PASS: TestAccVPCLatticeListener_tags (103.14s)
=== CONT  TestAccVPCLatticeTargetGroup_ip
--- PASS: TestAccVPCLatticeListener_forwardHTTPMultipleTargetGroups (97.43s)
=== CONT  TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion
--- PASS: TestAccVPCLatticeTargetGroup_alb (71.15s)
=== CONT  TestAccVPCLatticeTargetGroup_lambda
--- PASS: TestAccVPCLatticeTargetGroup_lambdaEventStructureVersion (16.12s)
=== CONT  TestAccVPCLatticeTargetGroup_tags
--- PASS: TestAccVPCLatticeTargetGroup_lambda (17.91s)
=== CONT  TestAccVPCLatticeTargetGroup_disappears
--- PASS: TestAccVPCLatticeTargetGroup_ip (87.06s)
=== CONT  TestAccVPCLatticeTargetGroup_basic
--- PASS: TestAccVPCLatticeTargetGroup_tags (33.24s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_disappears
--- PASS: TestAccVPCLatticeTargetGroup_disappears (63.90s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_alb
--- PASS: TestAccVPCLatticeTargetGroup_basic (70.67s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_lambda
--- PASS: TestAccVPCLatticeTargetGroupAttachment_disappears (177.26s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_ip
--- PASS: TestAccVPCLatticeTargetGroupAttachment_lambda (31.83s)
=== CONT  TestAccVPCLatticeTargetGroupAttachment_instance
--- PASS: TestAccVPCLatticeTargetGroupAttachment_instance (156.94s)
=== CONT  TestAccVPCLatticeService_tags
--- PASS: TestAccVPCLatticeService_tags (33.24s)
=== CONT  TestAccVPCLatticeService_full
--- PASS: TestAccVPCLatticeService_full (16.73s)
=== CONT  TestAccVPCLatticeService_disappears
--- PASS: TestAccVPCLatticeTargetGroupAttachment_alb (242.23s)
=== CONT  TestAccVPCLatticeService_basic
--- PASS: TestAccVPCLatticeTargetGroupAttachment_ip (176.66s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_tags
--- PASS: TestAccVPCLatticeService_disappears (14.88s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_full
--- PASS: TestAccVPCLatticeService_basic (33.82s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_full (146.90s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_tags (160.67s)
=== CONT  TestAccVPCLatticeServiceNetworkVPCAssociation_basic
=== CONT  TestAccVPCLatticeServiceNetwork_tags
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_disappears (135.43s)
--- PASS: TestAccVPCLatticeServiceNetwork_tags (29.93s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_arn
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_arn (23.40s)
=== CONT  TestAccVPCLatticeServiceNetwork_disappears
--- PASS: TestAccVPCLatticeServiceNetwork_disappears (11.49s)
=== CONT  TestAccVPCLatticeServiceNetwork_basic
--- PASS: TestAccVPCLatticeServiceNetwork_basic (13.85s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_tags (41.17s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_basic (139.56s)
=== CONT  TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_disappears (24.36s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN
--- PASS: TestAccVPCLatticeServiceNetworkVPCAssociation_arn (159.58s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort
--- PASS: TestAccVPCLatticeListenerDataSource_forwardMultiTargetGroupHTTP (85.83s)
=== CONT  TestAccVPCLatticeListener_forwardHTTPTargetGroup
--- PASS: TestAccVPCLatticeListener_forwardHTTPSTargetGroupARN (89.25s)
=== CONT  TestAccVPCLatticeListener_forwardTLSPassthrough
--- PASS: TestAccVPCLatticeListener_forwardHTTPTargetGroupCustomPort (88.81s)
=== CONT  TestAccVPCLatticeListener_fixedResponseHTTPS
--- PASS: TestAccVPCLatticeListener_forwardHTTPTargetGroup (77.33s)
=== CONT  TestAccVPCLatticeListener_fixedResponseHTTP
--- PASS: TestAccVPCLatticeListener_fixedResponseHTTPS (75.35s)
=== CONT  TestAccVPCLatticeListener_defaultActionUpdate
--- PASS: TestAccVPCLatticeListener_forwardTLSPassthrough (78.43s)
=== CONT  TestAccVPCLatticeListenerRule_tags
--- PASS: TestAccVPCLatticeListener_fixedResponseHTTP (75.58s)
=== CONT  TestAccVPCLatticeListenerRule_methodMatch
--- PASS: TestAccVPCLatticeListener_defaultActionUpdate (97.91s)
=== CONT  TestAccVPCLatticeListenerRule_fixedResponse
--- PASS: TestAccVPCLatticeListenerRule_tags (96.26s)
=== CONT  TestAccVPCLatticeListenerRule_basic
--- PASS: TestAccVPCLatticeListenerRule_methodMatch (87.78s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeListenerRule_fixedResponse (96.61s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add (51.89s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeListenerRule_basic (97.60s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_Add (98.32s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate (91.22s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate (97.55s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap (92.53s)
=== CONT  TestAccVPCLatticeServiceNetworkServiceAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkServiceAssociation_basic (23.34s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_disappears
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null (92.82s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_basic
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Replace (89.55s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_disappears (88.90s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_basic (92.43s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_ResourceTag (92.29s)
=== CONT  TestAccVPCLatticeListenerDataSource_tags
--- PASS: TestAccVPCLatticeAccessLogSubscription_serviceNetworkLogType (33.82s)
=== CONT  TestAccVPCLatticeListenerDataSource_basic
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_DefaultTag (90.17s)
=== CONT  TestAccVPCLatticeAuthPolicy_disappears
--- PASS: TestAccVPCLatticeAuthPolicy_disappears (15.95s)
=== CONT  TestAccVPCLatticeAuthPolicy_basic
--- PASS: TestAccVPCLatticeListenerDataSource_tags (75.08s)
=== CONT  TestAccVPCLatticeAuthPolicyDataSource_basic
--- PASS: TestAccVPCLatticeListenerDataSource_basic (73.15s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeAuthPolicyDataSource_basic (15.62s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeAuthPolicy_basic (17.63s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourceTag (40.12s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate (51.30s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add (62.42s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTag (34.67s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag (35.34s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag (34.91s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly (48.00s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly (48.19s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping (70.26s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping (69.49s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace (47.88s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly (86.58s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyResourceTag (93.06s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdate_Add (90.25s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreate (96.44s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNonOverlappingResourceTag (95.12s)
=== CONT  TestAccVPCLatticeResourceConfiguration_disappears
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyProviderOnlyTag (93.47s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate
--- PASS: TestAccVPCLatticeResourceConfiguration_disappears (33.83s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOverlappingResourceTag (124.07s)
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_shared
    service_network_data_source_test.go:57: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCLatticeServiceNetworkDataSource_shared (0.00s)
=== CONT  TestAccVPCLatticeServiceNetworkDataSource_basic
--- PASS: TestAccVPCLatticeServiceNetworkDataSource_basic (11.58s)
=== CONT  TestAccVPCLatticeServiceDataSource_shared
    service_data_source_test.go:90: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccVPCLatticeServiceDataSource_shared (0.00s)
=== CONT  TestAccVPCLatticeServiceDataSource_byName
--- PASS: TestAccVPCLatticeServiceDataSource_byName (15.36s)
=== CONT  TestAccVPCLatticeServiceDataSource_basic
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate (50.40s)
=== CONT  TestAccVPCLatticeResourcePolicy_disappears
--- PASS: TestAccVPCLatticeServiceDataSource_basic (15.36s)
=== CONT  TestAccVPCLatticeResourcePolicy_basic
--- PASS: TestAccVPCLatticeResourcePolicy_disappears (12.97s)
=== CONT  TestAccVPCLatticeResourcePolicyDataSource_basic
--- PASS: TestAccVPCLatticeResourcePolicy_basic (14.41s)
=== CONT  TestAccVPCLatticeResourceGateway_disappears
--- PASS: TestAccVPCLatticeResourcePolicyDataSource_basic (11.98s)
=== CONT  TestAccVPCLatticeResourceGateway_update
--- PASS: TestAccVPCLatticeResourceGateway_disappears (31.55s)
=== CONT  TestAccVPCLatticeResourceGateway_multipleSubnets
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags (115.46s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeIPv6
--- PASS: TestAccVPCLatticeResourceGateway_update (61.35s)
=== CONT  TestAccVPCLatticeResourceGateway_addressTypeDualstack
--- PASS: TestAccVPCLatticeResourceGateway_multipleSubnets (35.07s)
=== CONT  TestAccVPCLatticeResourceGateway_basic
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeIPv6 (34.16s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccVPCLatticeResourceGateway_addressTypeDualstack (34.88s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccVPCLatticeResourceGateway_basic (34.27s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag (58.31s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_null
--- PASS: TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag (54.95s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_EmptyMap
--- PASS: TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace (51.71s)
=== CONT  TestAccVPCLatticeResourceGateway_tags
--- PASS: TestAccVPCLatticeResourceGateway_tags_null (34.76s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccVPCLatticeResourceGateway_tags_EmptyMap (34.70s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping
--- PASS: TestAccVPCLatticeResourceGateway_tags (82.16s)
=== CONT  TestAccVPCLatticeResourceGateway_tags_AddOnUpdate
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToResourceOnly (98.28s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_tags
--- PASS: TestAccVPCLatticeResourceGateway_tags_AddOnUpdate (47.58s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOverlapping (105.12s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchWildcard (15.58s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_disappears
--- PASS: TestAccVPCLatticeAccessLogSubscription_tags (45.47s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard
--- PASS: TestAccVPCLatticeAccessLogSubscription_disappears (22.30s)
=== CONT  TestAccVPCLatticeResourceConfiguration_ipAddress
--- PASS: TestAccVPCLatticeAccessLogSubscription_cloudwatchNoWildcard (15.42s)
=== CONT  TestAccVPCLatticeResourceConfiguration_arnResource
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateToProviderOnly (98.85s)
=== CONT  TestAccVPCLatticeResourceConfiguration_update
--- PASS: TestAccVPCLatticeResourceConfiguration_ipAddress (52.50s)
=== CONT  TestAccVPCLatticeResourceConfiguration_parentChild
--- PASS: TestAccVPCLatticeResourceConfiguration_parentChild (39.95s)
=== CONT  TestAccVPCLatticeResourceConfiguration_basic
--- PASS: TestAccVPCLatticeResourceConfiguration_update (53.24s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly
--- PASS: TestAccVPCLatticeResourceConfiguration_basic (36.18s)
=== CONT  TestAccVPCLatticeAccessLogSubscription_arn
--- PASS: TestAccVPCLatticeAccessLogSubscription_arn (19.48s)
=== CONT  TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_providerOnly (123.10s)
--- PASS: TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlapping (104.51s)
--- PASS: TestAccVPCLatticeResourceConfiguration_arnResource (1225.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice	3983.180s
```
