### PR TITLE
r/lakeformation_opt_in: fix error when using table `wildcard`

### DIFF
--- a/.changelog/41939.txt
+++ b/.changelog/41939.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lakeformation_opt_in: Fix error when expanding `resource_data.table_wildcard` attribute
+```

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -33,6 +33,7 @@ func BoolToFramework(ctx context.Context, v *bool) types.Bool {
 	return types.BoolPointerValue(v)
 }
 
+// BoolValueToFramework converts a bool value to a Framework Bool value.
 func BoolValueToFramework(ctx context.Context, v bool) types.Bool {
 	return types.BoolValue(v)
 }

--- a/internal/framework/flex/bool.go
+++ b/internal/framework/flex/bool.go
@@ -33,6 +33,10 @@ func BoolToFramework(ctx context.Context, v *bool) types.Bool {
 	return types.BoolPointerValue(v)
 }
 
+func BoolValueToFramework(ctx context.Context, v bool) types.Bool {
+	return types.BoolValue(v)
+}
+
 // BoolToFrameworkLegacy converts a bool pointer to a Framework Bool value.
 // A nil bool pointer is converted to a false Bool.
 func BoolToFrameworkLegacy(_ context.Context, v *bool) types.Bool {

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -33,6 +33,7 @@ func TestAccLakeFormation_serial(t *testing.T) {
 		"OptIn": {
 			acctest.CtBasic:      testAccOptIn_basic,
 			acctest.CtDisappears: testAccOptIn_disappears,
+			"table":              testAccOptIn_table,
 		},
 		"PermissionsBasic": {
 			acctest.CtBasic:         testAccPermissions_basic,

--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -30,6 +30,10 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			acctest.CtBasic:  testAccDataLakeSettingsDataSource_basic,
 			"readOnlyAdmins": testAccDataLakeSettingsDataSource_readOnlyAdmins,
 		},
+		"OptIn": {
+			acctest.CtBasic:      testAccOptIn_basic,
+			acctest.CtDisappears: testAccOptIn_disappears,
+		},
 		"PermissionsBasic": {
 			acctest.CtBasic:         testAccPermissions_basic,
 			"database":              testAccPermissions_database,

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -59,7 +59,7 @@ type resourceOptIn struct {
 
 func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	catalogLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[Catalog](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[catalogOptIn](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrID: schema.StringAttribute{
@@ -70,7 +70,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	dataCellsFilterLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[DataCellsFilter](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[dataCellsFilterOptIn](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrDatabaseName: schema.StringAttribute{
@@ -90,7 +90,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	dataLocationLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[DataLocation](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[dataLocationOptIn](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrResourceARN: schema.StringAttribute{
@@ -105,7 +105,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	databaseLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[Database](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[databaseOptIn](ctx),
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
@@ -126,7 +126,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	lfTagLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[LFTag](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[lfTagOptIn](ctx),
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
@@ -160,7 +160,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	lftagExpressionLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[LFTagExpression](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[lfTagExpressionOptIn](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrCatalogID: catalogIDSchemaOptional(),
@@ -175,7 +175,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	lfTagPolicyLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[LFTagPolicy](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[lfTagPolicyOptIn](ctx),
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				names.AttrResourceType: schema.StringAttribute{
@@ -241,7 +241,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 	}
 
 	tableWCLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[TableWithColumns](ctx),
+		CustomType: fwtypes.NewListNestedObjectTypeOf[tableWithColumnsOptIn](ctx),
 		Validators: []validator.List{
 			listvalidator.SizeAtMost(1),
 		},
@@ -280,7 +280,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 			},
 			Blocks: map[string]schema.Block{
 				"column_wildcard": schema.ListNestedBlock{
-					CustomType: fwtypes.NewListNestedObjectTypeOf[columnWildcardData](ctx),
+					CustomType: fwtypes.NewListNestedObjectTypeOf[columnWildcardDataOptIn](ctx),
 					Validators: []validator.List{
 						listvalidator.SizeAtMost(1),
 						listvalidator.AtLeastOneOf(
@@ -319,7 +319,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 		},
 		Blocks: map[string]schema.Block{
 			names.AttrCondition: schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[Condition](ctx),
+				CustomType: fwtypes.NewListNestedObjectTypeOf[conditionOptIn](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						names.AttrExpression: schema.StringAttribute{
@@ -329,7 +329,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 				},
 			},
 			names.AttrPrincipal: schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[DataLakePrincipal](ctx),
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dataLakePrincipal](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
 				},
@@ -342,7 +342,7 @@ func (r *resourceOptIn) Schema(ctx context.Context, req resource.SchemaRequest, 
 				},
 			},
 			"resource_data": schema.ListNestedBlock{
-				CustomType: fwtypes.NewListNestedObjectTypeOf[ResourceData](ctx),
+				CustomType: fwtypes.NewListNestedObjectTypeOf[resourceData](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
 						"catalog":            catalogLNB,
@@ -619,42 +619,42 @@ type optInResourcer interface {
 }
 
 type catalogResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type dbResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type dcfResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type dlResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type lftagResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type lfteResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type lftpResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type tbResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
 type tbcResource struct {
-	data *ResourceData
+	data *resourceData
 }
 
-func newOptInResourcer(data *ResourceData, diags *diag.Diagnostics) optInResourcer {
+func newOptInResourcer(data *resourceData, diags *diag.Diagnostics) optInResourcer {
 	switch {
 	case !data.Catalog.IsNull():
 		return &catalogResource{data: data}
@@ -844,55 +844,66 @@ func (d *tbcResource) expandOptInResource(ctx context.Context, diags *diag.Diagn
 }
 
 type resourceOptInData struct {
-	Principal     fwtypes.ListNestedObjectValueOf[DataLakePrincipal] `tfsdk:"principal"`
-	Resource      fwtypes.ListNestedObjectValueOf[ResourceData]      `tfsdk:"resource_data"`
-	Condition     fwtypes.ListNestedObjectValueOf[Condition]         `tfsdk:"condition"`
+	Principal     fwtypes.ListNestedObjectValueOf[dataLakePrincipal] `tfsdk:"principal"`
+	Resource      fwtypes.ListNestedObjectValueOf[resourceData]      `tfsdk:"resource_data"`
+	Condition     fwtypes.ListNestedObjectValueOf[conditionOptIn]    `tfsdk:"condition"`
 	LastUpdatedBy types.String                                       `tfsdk:"last_updated_by"`
 	LastModified  timetypes.RFC3339                                  `tfsdk:"last_modified"`
 }
 
-type DataLakePrincipal struct {
+type dataLakePrincipal struct {
 	DataLakePrincipalIdentifier types.String `tfsdk:"data_lake_principal_identifier"`
 }
 
-type ResourceData struct {
-	Catalog          fwtypes.ListNestedObjectValueOf[Catalog]          `tfsdk:"catalog"`
-	DataCellsFilter  fwtypes.ListNestedObjectValueOf[DataCellsFilter]  `tfsdk:"data_cells_filter"`
-	DataLocation     fwtypes.ListNestedObjectValueOf[DataLocation]     `tfsdk:"data_location"`
-	Database         fwtypes.ListNestedObjectValueOf[Database]         `tfsdk:"database"`
-	LFTag            fwtypes.ListNestedObjectValueOf[LFTag]            `tfsdk:"lf_tag"`
-	LFTagExpression  fwtypes.ListNestedObjectValueOf[LFTagExpression]  `tfsdk:"lf_tag_expression"`
-	LFTagPolicy      fwtypes.ListNestedObjectValueOf[LFTagPolicy]      `tfsdk:"lf_tag_policy"`
-	Table            fwtypes.ListNestedObjectValueOf[tableOptIn]       `tfsdk:"table"`
-	TableWithColumns fwtypes.ListNestedObjectValueOf[TableWithColumns] `tfsdk:"table_with_columns"`
+type resourceData struct {
+	Catalog          fwtypes.ListNestedObjectValueOf[catalogOptIn]          `tfsdk:"catalog"`
+	DataCellsFilter  fwtypes.ListNestedObjectValueOf[dataCellsFilterOptIn]  `tfsdk:"data_cells_filter"`
+	DataLocation     fwtypes.ListNestedObjectValueOf[dataLocationOptIn]     `tfsdk:"data_location"`
+	Database         fwtypes.ListNestedObjectValueOf[databaseOptIn]         `tfsdk:"database"`
+	LFTag            fwtypes.ListNestedObjectValueOf[lfTagOptIn]            `tfsdk:"lf_tag"`
+	LFTagExpression  fwtypes.ListNestedObjectValueOf[lfTagExpressionOptIn]  `tfsdk:"lf_tag_expression"`
+	LFTagPolicy      fwtypes.ListNestedObjectValueOf[lfTagPolicyOptIn]      `tfsdk:"lf_tag_policy"`
+	Table            fwtypes.ListNestedObjectValueOf[tableOptIn]            `tfsdk:"table"`
+	TableWithColumns fwtypes.ListNestedObjectValueOf[tableWithColumnsOptIn] `tfsdk:"table_with_columns"`
 }
 
-type Catalog struct {
+type catalogOptIn struct {
 	ID types.String `tfsdk:"id"`
 }
 
-type Condition struct {
+type conditionOptIn struct {
 	Expression types.String `tfsdk:"expression"`
 }
 
-type DataCellsFilter struct {
+type dataCellsFilterOptIn struct {
 	DatabaseName   types.String `tfsdk:"database_name"`
 	Name           types.String `tfsdk:"name"`
 	TableCatalogID types.String `tfsdk:"table_catalog_id"`
 	TableName      types.String `tfsdk:"table_name"`
 }
 
-type DataLocation struct {
+type databaseOptIn struct {
+	CatalogID types.String `tfsdk:"catalog_id"`
+	Name      types.String `tfsdk:"name"`
+}
+
+type dataLocationOptIn struct {
 	ResourceArn types.String `tfsdk:"resource_arn"`
 	CatalogID   types.String `tfsdk:"catalog_id"`
 }
 
-type LFTagExpression struct {
+type lfTagOptIn struct {
+	CatalogID types.String `tfsdk:"catalog_id"`
+	Key       types.String `tfsdk:"key"`
+	Value     types.String `tfsdk:"value"`
+}
+
+type lfTagExpressionOptIn struct {
 	Name      types.String `tfsdk:"name"`
 	CatalogID types.String `tfsdk:"catalog_id"`
 }
 
-type LFTagPolicy struct {
+type lfTagPolicyOptIn struct {
 	ResourceType   fwtypes.StringEnum[awstypes.ResourceType] `tfsdk:"resource_type"`
 	CatalogID      types.String                              `tfsdk:"catalog_id"`
 	Expression     fwtypes.ListValueOf[types.String]         `tfsdk:"expression"`
@@ -943,10 +954,14 @@ func (m *tableOptIn) Flatten(ctx context.Context, input any) (diags diag.Diagnos
 	return diags
 }
 
-type TableWithColumns struct {
-	CatalogID      types.String                                        `tfsdk:"catalog_id"`
-	ColumnNames    fwtypes.SetValueOf[types.String]                    `tfsdk:"column_names"`
-	ColumnWildcard fwtypes.ListNestedObjectValueOf[columnWildcardData] `tfsdk:"column_wildcard"`
-	DatabaseName   types.String                                        `tfsdk:"database_name"`
-	Name           types.String                                        `tfsdk:"name"`
+type tableWithColumnsOptIn struct {
+	CatalogID      types.String                                             `tfsdk:"catalog_id"`
+	ColumnNames    fwtypes.SetValueOf[types.String]                         `tfsdk:"column_names"`
+	ColumnWildcard fwtypes.ListNestedObjectValueOf[columnWildcardDataOptIn] `tfsdk:"column_wildcard"`
+	DatabaseName   types.String                                             `tfsdk:"database_name"`
+	Name           types.String                                             `tfsdk:"name"`
+}
+
+type columnWildcardDataOptIn struct {
+	ExcludedColumnNames fwtypes.SetValueOf[types.String] `tfsdk:"excluded_column_names"`
 }

--- a/internal/service/lakeformation/opt_in_test.go
+++ b/internal/service/lakeformation/opt_in_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccLakeFormationOptIn_basic(t *testing.T) {
+func testAccOptIn_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var optin lakeformation.ListLakeFormationOptInsOutput
@@ -32,7 +32,7 @@ func TestAccLakeFormationOptIn_basic(t *testing.T) {
 	roleName := "aws_iam_role.test"
 	databaseName := "aws_glue_catalog_database.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
@@ -56,14 +56,14 @@ func TestAccLakeFormationOptIn_basic(t *testing.T) {
 	})
 }
 
-func TestAccLakeFormationOptIn_disappears(t *testing.T) {
+func testAccOptIn_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 
 	var optin lakeformation.ListLakeFormationOptInsOutput
 	resourceName := "aws_lakeformation_opt_in.test"
 	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
@@ -206,11 +206,16 @@ func constructOptInResource(rs *terraform.ResourceState) *awstypes.Resource {
 			}
 		},
 		"resource_data.0.table.0.name": func(rs *terraform.ResourceState) *awstypes.Resource {
+			table := awstypes.TableResource{
+				DatabaseName: aws.String(rs.Primary.Attributes["resource_data.0.table.0.database_name"]),
+				Name:         aws.String(rs.Primary.Attributes["resource_data.0.table.0.name"]),
+			}
+			if rs.Primary.Attributes["resource_data.0.table.0.wildcard"] == "true" {
+				table.TableWildcard = &awstypes.TableWildcard{}
+				table.Name = nil
+			}
 			return &awstypes.Resource{
-				Table: &awstypes.TableResource{
-					Name:         aws.String(rs.Primary.Attributes["resource_data.0.table.0.name"]),
-					DatabaseName: aws.String(rs.Primary.Attributes["resource_data.0.table.0.database_name"]),
-				},
+				Table: &table,
 			}
 		},
 		"resource_data.0.table_with_columns.0.name": func(rs *terraform.ResourceState) *awstypes.Resource {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

- Expands `table.wildcard` into AWS structure 
- Run test as serial
- make resource structs local to package

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #41916

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccLakeFormation_serial/OptIn" PKG=lakeformation

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/lakeformation/... -v -count 1 -parallel 20  -run=TestAccLakeFormation_serial/OptIn -timeout 360m -vet=off
2025/03/20 14:10:29 Initializing Terraform AWS Provider...
=== RUN   TestAccLakeFormation_serial
=== PAUSE TestAccLakeFormation_serial
=== CONT  TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/OptIn
=== RUN   TestAccLakeFormation_serial/OptIn/basic
=== RUN   TestAccLakeFormation_serial/OptIn/disappears
=== RUN   TestAccLakeFormation_serial/OptIn/table
--- PASS: TestAccLakeFormation_serial (85.41s)
    --- PASS: TestAccLakeFormation_serial/OptIn (85.41s)
        --- PASS: TestAccLakeFormation_serial/OptIn/basic (24.60s)
        --- PASS: TestAccLakeFormation_serial/OptIn/disappears (23.85s)
        --- PASS: TestAccLakeFormation_serial/OptIn/table (36.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	92.141s
```
