### PR TITLE
r/aws_elasticache_cluster: add configurable timeouts

### DIFF
--- a/.changelog/41940.txt
+++ b/.changelog/41940.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_elasticache_cluster: Add configurable timeouts for create, update, and delete operations
+```


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The registry documentation for the `aws_elasticache_cluster` resource already includes a `Timeouts` section, however, these were hardcoded into the Create, Update, and Delete methods and not configurable. This change adds configurable timeouts using the pre-existing hardcoded values, allowing practitioners to adjust the timeout values as needed (and as the registry documentation already implies).



### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#timeouts

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheCluster_" ACCTEST_PARALLELISM=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elasticache/... -v -count 1 -parallel 10 -run='TestAccElastiCacheCluster_'  -timeout 360m -vet=off
2025/03/20 13:44:04 Initializing Terraform AWS Provider...

=== NAME  TestAccElastiCacheCluster_outpost_memcached
    cluster_test.go:1320: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpost_memcached (0.80s)
=== CONT  TestAccElastiCacheCluster_Redis_finalSnapshot
=== CONT  TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (2.83s)
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (2.91s)
=== CONT  TestAccElastiCacheCluster_outpostID_memcached
    cluster_test.go:1400: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpostID_memcached (0.18s)
=== CONT  TestAccElastiCacheCluster_outpostID_redis
    cluster_test.go:1433: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpostID_redis (0.16s)
=== CONT  TestAccElastiCacheCluster_NodeTypeResize_redis
--- PASS: TestAccElastiCacheCluster_TransitEncryption (664.26s)
=== CONT  TestAccElastiCacheCluster_outpost_redis
    cluster_test.go:1360: skipping since no Outposts found
--- SKIP: TestAccElastiCacheCluster_outpost_redis (0.37s)
=== CONT  TestAccElastiCacheCluster_snapshotsWithUpdates
--- PASS: TestAccElastiCacheCluster_Engine_memcached (701.37s)
=== CONT  TestAccElastiCacheCluster_EngineVersion_memcached
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (741.18s)
=== CONT  TestAccElastiCacheCluster_AZMode_redis
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (926.29s)
=== CONT  TestAccElastiCacheCluster_AZMode_memcached
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1329.27s)
=== CONT  TestAccElastiCacheCluster_multiAZInVPC
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (746.31s)
=== CONT  TestAccElastiCacheCluster_vpc
--- PASS: TestAccElastiCacheCluster_AZMode_redis (687.70s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (1553.48s)
=== CONT  TestAccElastiCacheCluster_tagWithOtherModification
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1553.57s)
=== CONT  TestAccElastiCacheCluster_tags
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (657.97s)
=== CONT  TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (1632.56s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_decrease
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1660.13s)
=== CONT  TestAccElastiCacheCluster_PortRedis_default
--- PASS: TestAccElastiCacheCluster_vpc (716.44s)
=== CONT  TestAccElastiCacheCluster_port
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1429.03s)
=== CONT  TestAccElastiCacheCluster_ipDiscovery
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (893.01s)
=== CONT  TestAccElastiCacheCluster_ParameterGroupName_default
--- PASS: TestAccElastiCacheCluster_tags (675.42s)
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
--- PASS: TestAccElastiCacheCluster_PortRedis_default (646.85s)
=== CONT  TestAccElastiCacheCluster_Engine_None
--- PASS: TestAccElastiCacheCluster_Engine_None (0.80s)
=== CONT  TestAccElastiCacheCluster_disappears
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (952.99s)
=== CONT  TestAccElastiCacheCluster_Engine_redis
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (1268.32s)
=== CONT  TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
--- PASS: TestAccElastiCacheCluster_port (667.96s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increase
--- PASS: TestAccElastiCacheCluster_ipDiscovery (676.03s)
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1249.72s)
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (656.93s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (687.92s)
--- PASS: TestAccElastiCacheCluster_disappears (675.04s)
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (1598.06s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (708.80s)
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (1400.32s)
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption (1593.31s)
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (4688.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        4695.074s
```