### PR TITLE
docs: add missing required "stage" argument to data.aws_cloudfront_function example

### DIFF
--- a/website/docs/d/cloudfront_function.html.markdown
+++ b/website/docs/d/cloudfront_function.html.markdown
@@ -18,7 +18,8 @@ variable "function_name" {
 }
 
 data "aws_cloudfront_function" "existing" {
-  name = var.function_name
+  name  = var.function_name
+  stage = "LIVE"
 }
 ```
 


### PR DESCRIPTION
### Description

Fix the example for `data.aws_cloudfront_function` by adding a required `stage` argument.