### PR TITLE
docs: fix table and namespace name of s3tables-related examples

### DIFF
--- a/website/docs/cdktf/python/r/s3tables_namespace.html.markdown
+++ b/website/docs/cdktf/python/r/s3tables_namespace.html.markdown
@@ -33,7 +33,7 @@ class MyConvertedCode(TerraformStack):
             name="example-bucket"
         )
         aws_s3_tables_namespace_example = S3TablesNamespace(self, "example_1",
-            namespace="example-namespace",
+            namespace="example_namespace",
             table_bucket_arn=example.arn
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.

--- a/website/docs/cdktf/python/r/s3tables_table.html.markdown
+++ b/website/docs/cdktf/python/r/s3tables_table.html.markdown
@@ -34,14 +34,14 @@ class MyConvertedCode(TerraformStack):
             name="example-bucket"
         )
         aws_s3_tables_namespace_example = S3TablesNamespace(self, "example_1",
-            namespace="example-namespace",
+            namespace="example_namespace",
             table_bucket_arn=example.arn
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.
         aws_s3_tables_namespace_example.override_logical_id("example")
         aws_s3_tables_table_example = S3TablesTable(self, "example_2",
             format="ICEBERG",
-            name="example-table",
+            name="example_table",
             namespace=Token.as_string(aws_s3_tables_namespace_example.namespace),
             table_bucket_arn=Token.as_string(aws_s3_tables_namespace_example.table_bucket_arn)
         )

--- a/website/docs/cdktf/python/r/s3tables_table_policy.html.markdown
+++ b/website/docs/cdktf/python/r/s3tables_table_policy.html.markdown
@@ -41,14 +41,14 @@ class MyConvertedCode(TerraformStack):
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.
         data_aws_iam_policy_document_example.override_logical_id("example")
         aws_s3_tables_namespace_example = S3TablesNamespace(self, "example_2",
-            namespace=["example-namespace"],
+            namespace=["example_namespace"],
             table_bucket_arn=example.arn
         )
         # This allows the Terraform resource name to match the original name. You can remove the call if you don't need them to match.
         aws_s3_tables_namespace_example.override_logical_id("example")
         aws_s3_tables_table_example = S3TablesTable(self, "example_3",
             format="ICEBERG",
-            name="example-table",
+            name="example_table",
             namespace=aws_s3_tables_namespace_example,
             table_bucket_arn=Token.as_string(aws_s3_tables_namespace_example.table_bucket_arn)
         )

--- a/website/docs/cdktf/typescript/r/s3tables_namespace.html.markdown
+++ b/website/docs/cdktf/typescript/r/s3tables_namespace.html.markdown
@@ -36,7 +36,7 @@ class MyConvertedCode extends TerraformStack {
       this,
       "example_1",
       {
-        namespace: "example-namespace",
+        namespace: "example_namespace",
         tableBucketArn: example.arn,
       }
     );

--- a/website/docs/cdktf/typescript/r/s3tables_table.html.markdown
+++ b/website/docs/cdktf/typescript/r/s3tables_table.html.markdown
@@ -37,7 +37,7 @@ class MyConvertedCode extends TerraformStack {
       this,
       "example_1",
       {
-        namespace: "example-namespace",
+        namespace: "example_namespace",
         tableBucketArn: example.arn,
       }
     );
@@ -45,7 +45,7 @@ class MyConvertedCode extends TerraformStack {
     awsS3TablesNamespaceExample.overrideLogicalId("example");
     const awsS3TablesTableExample = new S3TablesTable(this, "example_2", {
       format: "ICEBERG",
-      name: "example-table",
+      name: "example_table",
       namespace: Token.asString(awsS3TablesNamespaceExample.namespace),
       tableBucketArn: Token.asString(
         awsS3TablesNamespaceExample.tableBucketArn

--- a/website/docs/cdktf/typescript/r/s3tables_table_policy.html.markdown
+++ b/website/docs/cdktf/typescript/r/s3tables_table_policy.html.markdown
@@ -48,7 +48,7 @@ class MyConvertedCode extends TerraformStack {
       this,
       "example_2",
       {
-        namespace: ["example-namespace"],
+        namespace: ["example_namespace"],
         tableBucketArn: example.arn,
       }
     );
@@ -56,7 +56,7 @@ class MyConvertedCode extends TerraformStack {
     awsS3TablesNamespaceExample.overrideLogicalId("example");
     const awsS3TablesTableExample = new S3TablesTable(this, "example_3", {
       format: "ICEBERG",
-      name: "example-table",
+      name: "example_table",
       namespace: awsS3TablesNamespaceExample,
       tableBucketArn: Token.asString(
         awsS3TablesNamespaceExample.tableBucketArn

--- a/website/docs/r/s3tables_namespace.html.markdown
+++ b/website/docs/r/s3tables_namespace.html.markdown
@@ -16,7 +16,7 @@ Terraform resource for managing an Amazon S3 Tables Namespace.
 
 ```terraform
 resource "aws_s3tables_namespace" "example" {
-  namespace        = "example-namespace"
+  namespace        = "example_namespace"
   table_bucket_arn = aws_s3tables_table_bucket.example.arn
 }
 

--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -16,14 +16,14 @@ Terraform resource for managing an Amazon S3 Tables Table.
 
 ```terraform
 resource "aws_s3tables_table" "example" {
-  name             = "example-table"
+  name             = "example_table"
   namespace        = aws_s3tables_namespace.example.namespace
   table_bucket_arn = aws_s3tables_namespace.example.table_bucket_arn
   format           = "ICEBERG"
 }
 
 resource "aws_s3tables_namespace" "example" {
-  namespace        = "example-namespace"
+  namespace        = "example_namespace"
   table_bucket_arn = aws_s3tables_table_bucket.example.arn
 }
 

--- a/website/docs/r/s3tables_table_policy.html.markdown
+++ b/website/docs/r/s3tables_table_policy.html.markdown
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "example" {
 }
 
 resource "aws_s3tables_table" "example" {
-  name             = "example-table"
+  name             = "example_table"
   namespace        = aws_s3tables_namespace.example
   table_bucket_arn = aws_s3tables_namespace.example.table_bucket_arn
   format           = "ICEBERG"


### PR DESCRIPTION
### Description

Fix S3Tables-related examples.
On S3 Tables, table name and namespace name cannot include hyphens (`-`). So I replaced it with underscore (`_`).

### References

table naming rules can be found in:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets-naming.html#naming-rules-table