### PR TITLE
r/aws_elasticache_replication_group: retry `InvalidReplicationGroupStateFault` errors in tag operations

### DIFF
--- a/.changelog/41954.txt
+++ b/.changelog/41954.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Retry `InvalidReplicationGroupState` exceptions during tagging operations
+```

--- a/internal/generate/tags/main.go
+++ b/internal/generate/tags/main.go
@@ -65,6 +65,12 @@ var (
 	listTagsOpPaginated        = flag.Bool("ListTagsOpPaginated", false, "whether ListTagsOp is paginated")
 	listTagsOutTagsElem        = flag.String("ListTagsOutTagsElem", "Tags", "listTagsOutTagsElem")
 
+	retryErrorCode        = flag.String("RetryErrorCode", "", "error code to retry, must be used with RetryTagOps")
+	retryErrorMessage     = flag.String("RetryErrorMessage", "", "error message to retry, must be used with RetryTagOps")
+	retryTagOps           = flag.Bool("RetryTagOps", false, "whether to retry tag operations")
+	retryTagsListTagsType = flag.String("RetryTagsListTagsType", "", "type of the first ListTagsOp return value such as ListTagsForResourceOutput, must be used with RetryTagOps")
+	retryTimeout          = flag.Duration("RetryTimeout", 1*time.Minute, "amount of time tag operations should retry")
+
 	tagInCustomVal        = flag.String("TagInCustomVal", "", "tagInCustomVal")
 	tagInIDElem           = flag.String("TagInIDElem", "ResourceArn", "tagInIDElem")
 	tagInIDNeedValueSlice = flag.Bool("TagInIDNeedValueSlice", false, "tagInIDNeedValueSlice")
@@ -152,6 +158,11 @@ type TemplateData struct {
 	ListTagsOutTagsElem        string
 	ParentNotFoundErrCode      string
 	ParentNotFoundErrMsg       string
+	RetryErrorCode             string
+	RetryErrorMessage          string
+	RetryTagOps                bool
+	RetryTagsListTagsType      string
+	RetryTimeout               string
 	ServiceTagsMap             bool
 	SetTagsOutFunc             string
 	TagInCustomVal             string
@@ -247,6 +258,11 @@ func main() {
 		ListTagsOutTagsElem:        *listTagsOutTagsElem,
 		ParentNotFoundErrCode:      *parentNotFoundErrCode,
 		ParentNotFoundErrMsg:       *parentNotFoundErrMsg,
+		RetryErrorCode:             *retryErrorCode,
+		RetryErrorMessage:          *retryErrorMessage,
+		RetryTagOps:                *retryTagOps,
+		RetryTagsListTagsType:      *retryTagsListTagsType,
+		RetryTimeout:               formatDuration(*retryTimeout),
 		ServiceTagsMap:             *serviceTagsMap,
 		SetTagsOutFunc:             *setTagsOutFunc,
 		TagInCustomVal:             *tagInCustomVal,

--- a/internal/generate/tags/templates/get_tag_body.gtpl
+++ b/internal/generate/tags/templates/get_tag_body.gtpl
@@ -22,7 +22,16 @@ func {{ .GetTagFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier{{
 		},
 	}
 
+	{{ if .RetryTagOps }}
+	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
+			return conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
+		},
+		"{{ .RetryErrorMessage }}",
+	)
+	{{ else }}
 	output, err := conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
+	{{- end }}
 
 	if err != nil {
 		return nil, err

--- a/internal/generate/tags/templates/list_tags_body.gtpl
+++ b/internal/generate/tags/templates/list_tags_body.gtpl
@@ -26,6 +26,43 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		{{- end }}
 	}
 {{- if .ListTagsOpPaginated }}
+    {{ if .RetryTagOps }}
+	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
+			var output []awstypes.{{ or .TagType2 .TagType }}
+
+			pages := {{ .TagPackage  }}.New{{ .ListTagsOp }}Paginator(conn, &input)
+			for pages.HasMorePages() {
+				page, err := pages.NextPage(ctx, optFns...)
+
+			{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}
+					if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {
+						return nil, &retry.NotFoundError{
+							LastError:   err,
+							LastRequest: &input,
+						}
+					}
+			{{- else if ( .ParentNotFoundErrCode ) }}
+					if tfawserr.ErrCodeEquals(err, "{{ .ParentNotFoundErrCode }}") {
+						return nil, &retry.NotFoundError{
+							LastError:   err,
+							LastRequest: &input,
+						}
+					}
+			{{- end }}
+
+				if err != nil {
+					return tftags.New(ctx, nil), err
+				}
+
+				for _, v := range page.{{ .ListTagsOutTagsElem }} {
+					output = append(output, v)
+				}
+			}
+		},
+		"{{ .RetryErrorMessage }}",
+	)
+	{{ else }}
 	var output []awstypes.{{ or .TagType2 .TagType }}
 
 	pages := {{ .TagPackage  }}.New{{ .ListTagsOp }}Paginator(conn, &input)
@@ -56,11 +93,21 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 			output = append(output, v)
 		}
 	}
+	{{- end }}
 
 	return {{ .KeyValueTagsFunc }}(ctx, output{{ if .TagTypeIDElem }}, identifier{{ if .TagResTypeElem }}, resourceType{{ end }}{{ end }}), nil
 {{- else }}
 
+    {{ if .RetryTagOps }}
+	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
+			return conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
+		},
+		"{{ .RetryErrorMessage }}",
+	)
+	{{- else }}
 	output, err := conn.{{ .ListTagsOp }}(ctx, &input, optFns...)
+	{{- end }}
 
 	{{ if and ( .ParentNotFoundErrCode ) ( .ParentNotFoundErrMsg ) }}
 			if tfawserr.ErrMessageContains(err, "{{ .ParentNotFoundErrCode }}", "{{ .ParentNotFoundErrMsg }}") {

--- a/internal/generate/tags/templates/list_tags_body.gtpl
+++ b/internal/generate/tags/templates/list_tags_body.gtpl
@@ -26,7 +26,7 @@ func {{ .ListTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifier
 		{{- end }}
 	}
 {{- if .ListTagsOpPaginated }}
-    {{ if .RetryTagOps }}
+    {{- if .RetryTagOps }}
 	output, err := tfresource.RetryGWhenIsAErrorMessageContains[*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, *{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
 		func() (*{{ .TagPackage  }}.{{ .RetryTagsListTagsType }}, error) {
 			var output []awstypes.{{ or .TagType2 .TagType }}

--- a/internal/generate/tags/templates/update_tags_body.gtpl
+++ b/internal/generate/tags/templates/update_tags_body.gtpl
@@ -61,8 +61,16 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 		input.{{ .UntagInTagsElem }} = removedTags.Keys()
 		{{- end }}
 	}
-
+	{{ if .RetryTagOps }}
+	_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+		func() (any, error) {
+			return conn.{{ .TagOp }}(ctx, &input, optFns...)
+		},
+		"{{ .RetryErrorMessage }}",
+	)
+	{{ else }}
 	_, err := conn.{{ .TagOp }}(ctx, &input, optFns...)
+	{{- end }}
 
 	if err != nil {
 		return fmt.Errorf("tagging resource (%s): %w", identifier, err)
@@ -103,8 +111,16 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{ .UntagInTagsElem }}:       removedTags.Keys(),
 			{{- end }}
 		}
-
+		{{ if .RetryTagOps }}
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+			func() (any, error) {
+				return conn.{{ .UntagOp }}(ctx, &input, optFns...)
+			},
+			"{{ .RetryErrorMessage }}",
+		)
+		{{ else }}
 		_, err := conn.{{ .UntagOp }}(ctx, &input, optFns...)
+		{{- end }}
 
 		if err != nil {
 			return fmt.Errorf("untagging resource (%s): %w", identifier, err)
@@ -144,7 +160,16 @@ func {{ .UpdateTagsFunc }}(ctx context.Context, conn {{ .ClientType }}, identifi
 			{{- end }}
 		}
 
+		{{ if .RetryTagOps }}
+		_, err := tfresource.RetryWhenIsAErrorMessageContains[*{{ .RetryErrorCode }}](ctx, {{ .RetryTimeout }},
+			func() (any, error) {
+				return conn.{{ .TagOp }}(ctx, &input, optFns...)
+			},
+			"{{ .RetryErrorMessage }}",
+		)
+		{{ else }}
 		_, err := conn.{{ .TagOp }}(ctx, &input, optFns...)
+		{{- end }}
 
 		if err != nil {
 			return fmt.Errorf("tagging resource (%s): %w", identifier, err)

--- a/internal/service/elasticache/generate.go
+++ b/internal/service/elasticache/generate.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:generate go run ../../generate/tags/main.go -CreateTags -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags
+//go:generate go run ../../generate/tags/main.go -CreateTags -ListTags -ListTagsInIDElem=ResourceName -ListTagsOutTagsElem=TagList -ServiceTagsSlice -TagOp=AddTagsToResource -TagInIDElem=ResourceName -UntagOp=RemoveTagsFromResource -UpdateTags -RetryTagOps -RetryTagsListTagsType=ListTagsForResourceOutput -RetryErrorCode=awstypes.InvalidReplicationGroupStateFault "-RetryErrorMessage=not in available state" -RetryTimeout=15m
 //go:generate go run ../../generate/servicepackage/main.go
 // ONLY generate directives and package declaration! Do not add anything else to this file.
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -186,6 +186,16 @@ func RetryWhenIsAErrorMessageContains[T errs.ErrorWithErrorMessage](ctx context.
 	})
 }
 
+func RetryGWhenIsAErrorMessageContains[T any, E errs.ErrorWithErrorMessage](ctx context.Context, timeout time.Duration, f func() (T, error), needle string) (T, error) {
+	return RetryGWhen(ctx, timeout, f, func(err error) (bool, error) {
+		if errs.IsAErrorMessageContains[E](err, needle) {
+			return true, err
+		}
+
+		return false, err
+	})
+}
+
 // RetryUntilEqual retries the specified function until it returns a value equal to `t`.
 func RetryUntilEqual[T comparable](ctx context.Context, timeout time.Duration, t T, f func() (T, error)) (T, error) {
 	var output T


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This fixes a regression introduced during the AWS SDK for Go V2 migration of Elasticache. Previously, the generated tagging logic for AWS SDK for Go V1 included retry logic around the list, tag, and untag operations. These were inadvertently dropped during the SDK migration, and have been added back here using the AWS SDK V2 form of retry handling which accepts error types as an argument. As with the previous implementation tagging operations will have a retry timeout of 15 minutes.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35952 
Closes #40948 
Relates #36310 (Initial implementation of tag operation retries, `v5.41.0`)
Relates #38046  (AWS SDK migration which removed retries and caused the regression, `v5.59.0`)


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS="TestAccElastiCacheReplicationGroup_tag|TestAccElastiCacheReplicationGroup_Tag"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_tag|TestAccElastiCacheReplicationGroup_Tag'  -timeout 360m -vet=off
2025/03/21 16:34:22 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheReplicationGroup_tags (914.17s)
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (1375.71s)
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (2089.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        2096.440s
```
