### PR TITLE
fix: allow update of database_insights_mode for db_instance

### DIFF
--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -2514,6 +2514,8 @@ func dbInstancePopulateModify(input *rds.ModifyDBInstanceInput, d *schema.Resour
 
 	if d.HasChange("database_insights_mode") {
 		input.DatabaseInsightsMode = types.DatabaseInsightsMode(d.Get("database_insights_mode").(string))
+		input.EnablePerformanceInsights = aws.Bool(d.Get("performance_insights_enabled").(bool))
+		input.PerformanceInsightsRetentionPeriod = aws.Int32(int32(d.Get("performance_insights_retention_period").(int)))
 	}
 
 	if d.HasChange("db_subnet_group_name") {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -5065,6 +5065,38 @@ func TestAccRDSInstance_PerformanceInsights_databaseInsightsMode(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("performance_insights_enabled"), knownvalue.Bool(false)),
 				},
 			},
+			{
+				Config: testAccInstanceConfig_databaseInsightsMode(rName, "standard", true, "465"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("database_insights_mode"), knownvalue.StringExact("standard")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("performance_insights_enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("performance_insights_retention_period"), knownvalue.Int64Exact(465)),
+				},
+			},
+			{
+				Config: testAccInstanceConfig_databaseInsightsMode(rName, "advanced", true, "465"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("database_insights_mode"), knownvalue.StringExact("advanced")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("performance_insights_enabled"), knownvalue.Bool(true)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("performance_insights_retention_period"), knownvalue.Int64Exact(465)),
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
### Description

When updating the `database_insights_mode` for a `db_instance`, additional details about the performance insights configuration needs to be passed along (`performance_insights_enabled` and `performance_insights_retention_period`)  to the AWS API.

At the moment this additional information is missing, causing the error message

```plain
 InvalidParameterCombination: To enable the Advanced mode of Database Insights, modify your instance to enable Performance Insights and set the retention period for Performance Insights to at least 465 days.
```

This pull request focuses on adding the details for `db_instance`, but it looks like the `cluster` is also affected (link to source code in _References_ section).

### Relations

* Relates #41792 
* Closes #41952 

### References

* [`cluster` resource](https://github.com/hashicorp/terraform-provider-aws/blob/2a7d1f5ccff1ec4a67a58131dfe9005b2cb25171/internal/service/rds/cluster.go#L1615), here only `performance_insights_enabled` is added to the input.


### Output from Acceptance Testing

```shell
❯ make testacc TESTS=TestAccRDSInstance_PerformanceInsights_databaseInsightsMode PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/rds/... -v -count 1 -parallel 20 -run='TestAccRDSInstance_PerformanceInsights_databaseInsightsMode'  -timeout 360m -vet=off
2025/03/22 17:59:30 Initializing Terraform AWS Provider...
=== RUN   TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== PAUSE TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
=== CONT  TestAccRDSInstance_PerformanceInsights_databaseInsightsMode
--- PASS: TestAccRDSInstance_PerformanceInsights_databaseInsightsMode (1161.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rds        1161.645s
```