### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-03-21)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -204,7 +204,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rds v1.94.1
 	github.com/aws/aws-sdk-go-v2/service/redshift v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.33.0
-	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.1
+	github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/backup v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/batch v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1
-	github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1
+	github.com/aws/aws-sdk-go-v2/service/bedrock v1.30.0
 	github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/billing v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/budgets v1.30.1

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/acm v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0
 	github.com/aws/aws-sdk-go-v2/service/amp v1.32.1
-	github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0
+	github.com/aws/aws-sdk-go-v2/service/amplify v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.37.1

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/chime v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.21.1
-	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.22.1
+	github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.58.1

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/groundstation v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/guardduty v1.54.1
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.30.1
-	github.com/aws/aws-sdk-go-v2/service/iam v1.40.1
+	github.com/aws/aws-sdk-go-v2/service/iam v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.26.1

--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1
 	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0
-	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1
+	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.70.0
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/mediapackagev2 v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.55.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.2.1
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.180.2
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.182.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.1
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.2

--- a/go.mod
+++ b/go.mod
@@ -165,7 +165,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/lookoutmetrics v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/m2 v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.38.1
+	github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1
 	github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1

--- a/go.mod
+++ b/go.mod
@@ -181,7 +181,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.8.1
-	github.com/aws/aws-sdk-go-v2/service/oam v1.17.1
+	github.com/aws/aws-sdk-go-v2/service/oam v1.17.2
 	github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1
 	github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/opsworks v1.27.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appmesh v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/apprunner v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.45.1
-	github.com/aws/aws-sdk-go-v2/service/appsync v1.44.1
+	github.com/aws/aws-sdk-go-v2/service/appsync v1.45.0
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.1
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.52.1

--- a/go.mod
+++ b/go.mod
@@ -211,7 +211,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/resourcegroups v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.1
-	github.com/aws/aws-sdk-go-v2/service/route53 v1.49.1
+	github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1

--- a/go.mod
+++ b/go.mod
@@ -178,7 +178,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/mwaa v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/neptune v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.2
-	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.46.1
+	github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.47.0
 	github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1
 	github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.8.1
 	github.com/aws/aws-sdk-go-v2/service/oam v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -155,7 +155,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.28.1
 	github.com/aws/aws-sdk-go-v2/service/kms v1.38.1
 	github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0
-	github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1
+	github.com/aws/aws-sdk-go-v2/service/lambda v1.71.0
 	github.com/aws/aws-sdk-go-v2/service/launchwizard v1.9.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/lexmodelsv2 v1.50.1

--- a/go.mod
+++ b/go.mod
@@ -214,7 +214,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2
-	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1
+	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.27.0
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/rum v1.24.0

--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2
-	github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1
+	github.com/aws/aws-sdk-go-v2/service/dlm v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.31.1

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.11.0
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.3.1
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.1
-	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1
+	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1
 	github.com/aws/aws-sdk-go-v2/service/polly v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.34.1

--- a/go.mod
+++ b/go.mod
@@ -102,7 +102,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/drs v1.31.1
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.54.2

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0
-	github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0
+	github.com/aws/aws-sdk-go-v2/service/datazone v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/dax v1.24.1
 	github.com/aws/aws-sdk-go-v2/service/detective v1.32.2
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.30.1

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.1
 	github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.56.0
 	github.com/aws/aws-sdk-go-v2/service/codecatalyst v1.17.18

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/devicefarm v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/devopsguru v1.35.1
 	github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1
-	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.1
+	github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.1

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1
-	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.1
+	github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2
 	github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.1
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/aws/aws-sdk-go-v2/service/pcs v1.3.1 h1:cvNW3PjOsAtjy4NLfXu4aScWPtCYE
 github.com/aws/aws-sdk-go-v2/service/pcs v1.3.1/go.mod h1:CX99CnPyFWfXFOQYf5NhHOzdJjCxhPo39DoChDi32jE=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.1 h1:XOGLlhIF2LTQjzYeuS3qUp7deW0YD2hMCU9MSK0de94=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.1/go.mod h1:O3MV3jUxQNsjM46TGJ4DwPqfuqUgywJpmHua8CCx/zE=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1 h1:CLUjV2mR7ELuh8XMOOyPYIbBeKyMiqCAQs2xrFyONvE=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.1/go.mod h1:UfJ+CG2eqRldWl1lLd2e1/glFbp7Ln3ZZgSkvMHvNh4=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.2 h1:fA+kjwba0PBh8nwtZbMV0OuEzoPGnTHrdIDQr7IUhNA=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.2/go.mod h1:UfJ+CG2eqRldWl1lLd2e1/glFbp7Ln3ZZgSkvMHvNh4=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1 h1:zhU2uG3XkbumH4QATCM7HWyVLGL/P/eoQDAuDCb6XHE=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.1/go.mod h1:2EbU5EjVT3Gu9OevmKa2nLT3daim8GIqnAHtGDcowvw=
 github.com/aws/aws-sdk-go-v2/service/polly v1.47.2 h1:hVy4hlfRSlumXLlkS46iuzhsLfeCp1+TxeEVyjaQ6Fw=

--- a/go.sum
+++ b/go.sum
@@ -277,8 +277,8 @@ github.com/aws/aws-sdk-go-v2/service/guardduty v1.54.1 h1:mlUdEGpNH7FASFMzL0zQvH
 github.com/aws/aws-sdk-go-v2/service/guardduty v1.54.1/go.mod h1:wkoiUwZWKpLDnd+m3aY7dJV/IptW/FToDzYYEkd67gw=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.30.1 h1:yAx1IQB3Vqbnnl6g9yi0xzvIyiUEJnbavtpOhYVg+qM=
 github.com/aws/aws-sdk-go-v2/service/healthlake v1.30.1/go.mod h1:JzL32pq/fBeWRbEOAl6IHbnqhyln8GlD92JSk72tjl4=
-github.com/aws/aws-sdk-go-v2/service/iam v1.40.1 h1:PaHCkW8rtLrA89xM/0LsY/NSIQETqmN+f1vt70EmpB8=
-github.com/aws/aws-sdk-go-v2/service/iam v1.40.1/go.mod h1:mPJkGQzeCoPs82ElNILor2JzZgYENr4UaSKUT8K27+c=
+github.com/aws/aws-sdk-go-v2/service/iam v1.40.2 h1:F1hBvOiplp6lHg5clau/reqayZT+K5EBXkFRNrHF+To=
+github.com/aws/aws-sdk-go-v2/service/iam v1.40.2/go.mod h1:mPJkGQzeCoPs82ElNILor2JzZgYENr4UaSKUT8K27+c=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.1 h1:Kqq7JA3EzvgSUIRn8u/EH3hvbfuk1n/T8CrtZWUqw8c=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.1/go.mod h1:7nGvrQXBNp7k5yYpwpmxGucYTPY39d0cxjmANAeWwYE=
 github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.41.1 h1:7XeIbgmGI/Qp5s1qc94PzwGNQRHw1a4/R5wZMVE/o+8=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,8 @@ github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1 h1:wZp9y89ZuA3SXXXMl3k
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.1/go.mod h1:AsHLBZVzMdJOZ6M73hFduNi138902gV4I9T6LWVONtk=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0 h1:vSsDQQASlA7kHu1SnU5KOZ9F9ruhouf0e46aGxnUDh0=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.47.0/go.mod h1:Cl1F1d83JEmNC22jPyRexP6mNnWSpIzQg8gy7lnjIUU=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0 h1:NidFLawkO9aQEQSsQfxuqXkYJ8EWrVX71BitwIqOz7M=
-github.com/aws/aws-sdk-go-v2/service/datazone v1.27.0/go.mod h1:3a69kSZREiFCWUvaV+8wZ6y43trMz2hjCjPjxJHw2Bg=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.28.0 h1:7Q8eMHztb3d6n8tBKmCJ6ahAyqsAfPaTbSE5fVU+rlU=
+github.com/aws/aws-sdk-go-v2/service/datazone v1.28.0/go.mod h1:3a69kSZREiFCWUvaV+8wZ6y43trMz2hjCjPjxJHw2Bg=
 github.com/aws/aws-sdk-go-v2/service/dax v1.24.1 h1:5uBAjTB52126zNRWFCnMs5IDrHbnPggFc+/7cWW42BU=
 github.com/aws/aws-sdk-go-v2/service/dax v1.24.1/go.mod h1:FTMIKMqG/2AiO0P1LSCN6PeY4BNkQcxAzPSpne6oE6w=
 github.com/aws/aws-sdk-go-v2/service/detective v1.32.2 h1:UTirCa+bkiMDMb7sNBSsarvONyA0XADl36pTIOqnvzs=

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/aws/aws-sdk-go-v2/service/neptune v1.36.1 h1:pefQNBwylG7VyrLHhllVvbS9
 github.com/aws/aws-sdk-go-v2/service/neptune v1.36.1/go.mod h1:YMZFVwN7YhwN5uZ1J+wgj8yrmHrksC/OTJScxa6bjdY=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.2 h1:6gzjd8aaSl+AQdGLskTMk0XLVoqY0zOAb4EFn//qj0Q=
 github.com/aws/aws-sdk-go-v2/service/neptunegraph v1.17.2/go.mod h1:y+/vnOi8XZPLM7+4s+70LnVB5I7PK+we8XvjcDvf82Q=
-github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.46.1 h1:xlX9afI6ymc3sbuP09k5NafMHjN7X9d/zC7/3ZmbPaI=
-github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.46.1/go.mod h1:hffD6JfzixDLvqjd04wInnfXHkxquWl3whXOQrL0HVE=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.47.0 h1:51o+OB3oWHw9JeHGUH+ZaKm169OG15GxBHoT7RjqE6k=
+github.com/aws/aws-sdk-go-v2/service/networkfirewall v1.47.0/go.mod h1:hffD6JfzixDLvqjd04wInnfXHkxquWl3whXOQrL0HVE=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1 h1:SnAltMepoUUyR0cvYnMbpjXMb6caFlAtoJJE51SYQHw=
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1/go.mod h1:nBlWp17qsAWgDvhH3/oI2PPqrk/3pcsqLXEPvCzb1Ic=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.8.1 h1:TPwENjY/u19L9fkTFYVkEqY6SwOttqlKjEAkgDraawM=

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1 h1:2/mUnq64vJOLSKMv29
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1/go.mod h1:vWnhJx6FbXnQ08eGSBGt8/3wrrcKKfLA+s6oUm3kXag=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2 h1:0x7ntPzNXdJXGDsJwcj6X69Om5kYOFvqCRdmWxJ5f+4=
 github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2/go.mod h1:tEo7//RLL8seYrcxyD9aQba6Pk8dhPqDDw7iDZm5oe8=
-github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1 h1:IabU8yoOLucAQHHqZbQXkFsHfsfmM7yQylOalltC6e8=
-github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1/go.mod h1:FXvDBITG/lDpC7D5PgwJ99RcFg9sk0UwQ2gaC+LnSo0=
+github.com/aws/aws-sdk-go-v2/service/dlm v1.30.2 h1:AzAb4F82u9CSTRlH/Vbf9fLvPHZ/17yfP1erMUFTDy4=
+github.com/aws/aws-sdk-go-v2/service/dlm v1.30.2/go.mod h1:FXvDBITG/lDpC7D5PgwJ99RcFg9sk0UwQ2gaC+LnSo0=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.41.1 h1:KxSpigaQoHsAcRHuhcFAtqishNM/waI2iaU5Zf8hEYg=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.41.1/go.mod h1:Ft+c7KOTOwfkPKQrPRm5wfEFWXq9oHtFi0yGszwYAgg=
 github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.1 h1:9UzWNUFphpsb2OfRs7DHW51pf8QRKypTRHHjXRgTayg=

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ github.com/aws/aws-sdk-go-v2/service/m2 v1.20.1 h1:r1LtXDDt2Ok0qmzD8Ba5TLXtNr9e7
 github.com/aws/aws-sdk-go-v2/service/m2 v1.20.1/go.mod h1:I5ZhRbxMlWV+HVO6ZtyEfXP2NMTqp9OvYB5Hs0shDsA=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1 h1:CR8WNR4DAYMkHi6VPfP8cJM9sw99mj04UbIPseSlaxw=
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1/go.mod h1:unKjikT3mzu065/bTZ5l9DkgXtLex9H/gmT0urCpSJM=
-github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.38.1 h1:tOJSWB1fN7M4b3UhoNMcWF/ub6iCEyBGd+uMUfPGAMg=
-github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.38.1/go.mod h1:lnMLmJLMKn3wTWwROeiVEkxPXnrHl63/4E5/j2ObgL4=
+github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0 h1:hWzEaAbAO75Tt4OPDjosOdY8gmPPyoPgJmrhGnLnENY=
+github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0/go.mod h1:lnMLmJLMKn3wTWwROeiVEkxPXnrHl63/4E5/j2ObgL4=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1 h1:ik4b+Emp07he9CSy5o5Gn6AfNdxSaZyLbLGHKxD0qTw=
 github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1/go.mod h1:tUZaCc4SfNwVz/S4SE6d4YDOHk8zZ+B5Mz2EzG9vrQE=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0 h1:4EeXWfRdetoYVB9QJXOd0kujK9kWzPWeXThIyzKGkQQ=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/aws/aws-sdk-go-v2/service/apprunner v1.33.1 h1:yGo0QsWiHTqUG1zI9Jxmdm
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.33.1/go.mod h1:n2SfHFPzudurc0eFmGYySXmaY1WqNeENkjQ9sLKy7bg=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.45.1 h1:pn1qPaC7LIOeejLwi3jZQovaEeeGlUMCgmA45wkGyNA=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.45.1/go.mod h1:a6REBrYjpxK+KhuoE6BWRqZSRq2GkkdZC0R+2952zzw=
-github.com/aws/aws-sdk-go-v2/service/appsync v1.44.1 h1:h/xv39ESQd5C2DcIScPxoesL7PoSjd1x0FNTSjzVvjs=
-github.com/aws/aws-sdk-go-v2/service/appsync v1.44.1/go.mod h1:dBOElCuVeW4co3zVZq9tFDiqyeM6BCqd5+HQTE5JPts=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.45.0 h1:BecG6GLE0NZ8ywd6bleMchNXGbL/6RRMpdsInMPY8M8=
+github.com/aws/aws-sdk-go-v2/service/appsync v1.45.0/go.mod h1:dBOElCuVeW4co3zVZq9tFDiqyeM6BCqd5+HQTE5JPts=
 github.com/aws/aws-sdk-go-v2/service/athena v1.50.1 h1:6J4Er9sph4EQQJxe0RUxqhdQOM9EMeY4odwZ0GiIy/k=
 github.com/aws/aws-sdk-go-v2/service/athena v1.50.1/go.mod h1:xsG8Y2fMenmHTdukyknTUO1uQhEZ/entaNHvPmD1klE=
 github.com/aws/aws-sdk-go-v2/service/auditmanager v1.38.1 h1:ooIKCxCHH3WFdwVRuQdRcalRfzJR5/VnKB663jbqDsk=

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0 h1:+F0tG/QIUuKdkCP/H+AOvu0E4
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.0/go.mod h1:v0S5xoRSVzO4z09Fyqm6zkpeYU20qRBXwVS+BOejpcE=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1 h1:NlS3vXebXaVo+HmeSebbV3/yrHSHoRMbLJsTjr8WegA=
 github.com/aws/aws-sdk-go-v2/service/amp v1.32.1/go.mod h1:5NwZKMNRuC5UHuOShamjhZa0lw9vKY8jacSqUegSuYk=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0 h1:s4GtSn4fxLee82Hjwg8wGuw63OV63Wqd2fb5FV1vLBY=
-github.com/aws/aws-sdk-go-v2/service/amplify v1.31.0/go.mod h1:f8HNneMWkB/Gs6U9yQX5CMNWSk7wS7Lg9YU1AKLLn1w=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.32.0 h1:wqCRyN5XXLaGW9cvzpM5k5hAiS1uqGDA1qXVbGiTir0=
+github.com/aws/aws-sdk-go-v2/service/amplify v1.32.0/go.mod h1:f8HNneMWkB/Gs6U9yQX5CMNWSk7wS7Lg9YU1AKLLn1w=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1 h1:H0reXa+fsC4kFCy3M18UKccJhdZZDTr4mKMype1rx3U=
 github.com/aws/aws-sdk-go-v2/service/apigateway v1.29.1/go.mod h1:C9suuW30sexkILV5QRkNexNeRUtYs98agpG5nZ+zh0k=
 github.com/aws/aws-sdk-go-v2/service/apigatewayv2 v1.26.1 h1:HlFEMjDOjCzrmgO6ckPLbS8unpfp25nNPSEqtPqTX1g=

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,8 @@ github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.1 h1:emvw6/2
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.26.1/go.mod h1:cgPfPTC/V3JqwCKed7Q6d0FrgarV7ltz4Bz6S4Q+Dqk=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.1 h1:GgJySVnqtzgEjnf6FF3OwPT92LWhPmeS7fszgWgOGZ8=
 github.com/aws/aws-sdk-go-v2/service/rolesanywhere v1.17.1/go.mod h1:NW+LcIadUUlDgM3gb8+97lr6zSKExHR58NRRWSWkXl8=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.49.1 h1:krDhGq5RpSgpfPB9riTYLLSoCB8bNBhtdva6t1HDEWc=
-github.com/aws/aws-sdk-go-v2/service/route53 v1.49.1/go.mod h1:kGYOjvTa0Vw0qxrqrOLut1vMnui6qLxqv/SX3vYeM8Y=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0 h1:/nkJHXtJXJeelXHqG0898+fWKgvfaXBhGzbCsSmn9j8=
+github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0/go.mod h1:kGYOjvTa0Vw0qxrqrOLut1vMnui6qLxqv/SX3vYeM8Y=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1 h1:IrIEdVMa+karAtPCMxdOy37/Ibrvso26EeinvHUXHpM=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1/go.mod h1:l41whGvS6dfDuxh6RMNo3+MOvpk7zDx+bOHelpeBbuU=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.1 h1:WHuUg4EpL/d1hWslYJZDCXavwOLtNvm1e4bWXpf1EKE=

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2 h1:kkug2EBxwHbzlH9HeaAD2
 github.com/aws/aws-sdk-go-v2/service/cloudtrail v1.48.2/go.mod h1:/BibEr5ksr34abqBTQN213GrNG6GCKCB6WG7CH4zH2w=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1 h1:ac0UBlcUK+tFcFiAuNbtKqUEtM+iyQgmffEhUACGwD0=
 github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.44.1/go.mod h1:HJlcOk+S/wjJuR/8jPa8GhnEKdKqqiQ5wjsE1PjuO1o=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0 h1:lLkvA+uOu/nB/UeAUoldkSPGIzZANxpEEHA+iP6kvQs=
-github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.0/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.1 h1:IKznEkCo7L8VHkQ3tC1e50F1eudenoQ7BTHJhMOswtE=
+github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.47.1/go.mod h1:uo14VBn5cNk/BPGTPz3kyLBxgpgOObgO8lmz+H7Z4Ck=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1 h1:7kG4zaTjHxWRkU+CZSgdPM2Yv9aLYJTbp99IVwbWN3Q=
 github.com/aws/aws-sdk-go-v2/service/codeartifact v1.34.1/go.mod h1:QPTNJjlY2i7XZhMDb7vX3Hxg2YtLucSU4kzDYxXm3k4=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.56.0 h1:mZ5hgyvj5Ryql9xywBONA4zS68oyImYfwHQ8VX+Pirs=

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0 h1:/nkJHXtJXJeelXHqG0898+fW
 github.com/aws/aws-sdk-go-v2/service/route53 v1.50.0/go.mod h1:kGYOjvTa0Vw0qxrqrOLut1vMnui6qLxqv/SX3vYeM8Y=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1 h1:IrIEdVMa+karAtPCMxdOy37/Ibrvso26EeinvHUXHpM=
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1/go.mod h1:l41whGvS6dfDuxh6RMNo3+MOvpk7zDx+bOHelpeBbuU=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.1 h1:WHuUg4EpL/d1hWslYJZDCXavwOLtNvm1e4bWXpf1EKE=
-github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.1/go.mod h1:W44ZP9L/gf9lfyUYPJ0NsZlGIGe5aC82+qDvmrmWrv4=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2 h1:zeBZzAMbxTH27SutG8rAM4INPHzKw1AzpFofSI4u0jI=
+github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2/go.mod h1:W44ZP9L/gf9lfyUYPJ0NsZlGIGe5aC82+qDvmrmWrv4=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1 h1:GYCcz4TTUF+G2Dk2gqNpxQ89C4Zy5cu+G3lMUG5NAaE=
 github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1/go.mod h1:yccYWfGd7VeSZfgL2bjd/cKwNnFU3hagBBcZyvIuh0g=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.1 h1:pwXMSbQbkBgMPx7qcffrXUvlLEWyhnw7Gc8pWxASS6s=

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,8 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.54.1 h1:atHdz2zvGf9wC7NfaOvPh3d
 github.com/aws/aws-sdk-go-v2/service/redshift v1.54.1/go.mod h1:TC8pNvjiikrjpX2MEzX/cEJ4/T4XIoSY4BskVvHj8bk=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.33.0 h1:l8vdpEf98yQZqYTcISRlOCsocjL9KIb6cgDMrAMPDoE=
 github.com/aws/aws-sdk-go-v2/service/redshiftdata v1.33.0/go.mod h1:pe1ZJmqbvJOw0SYKoeR/JIypaIlftRUqkDxt4gLXiA8=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.1 h1:BaVYzvKVffMqiqg0GQ8Sz0nOOGyhkn3Afazz7+bZufk=
-github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.1/go.mod h1:gpRsJN3qxZbsj1NhAoCNX02zJ4RZUB5v/7o4QrnGTcA=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.2 h1:AEbYG7hfFhpnluiF3SKX2GPNAnc+HP/h7lPwRFWX50Y=
+github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.26.2/go.mod h1:gpRsJN3qxZbsj1NhAoCNX02zJ4RZUB5v/7o4QrnGTcA=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.46.1 h1:CtkGvqA22++pHQf2E3vVi5vOOQmm4uZ1EqYBZNiXEtQ=
 github.com/aws/aws-sdk-go-v2/service/rekognition v1.46.1/go.mod h1:swfmNjrxdah48vufQIKufR9NF0KK5aK53svDXO/KZcw=
 github.com/aws/aws-sdk-go-v2/service/resiliencehub v1.30.1 h1:FSIpVo71iGOwSsr6tOIFUEMdf54TBInvFxYkZT/5wAQ=

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,8 @@ github.com/aws/aws-sdk-go-v2/service/devopsguru v1.35.1 h1:wMPTUzQtkBm2pSOL4tk3t
 github.com/aws/aws-sdk-go-v2/service/devopsguru v1.35.1/go.mod h1:Sfi6J5tjI+OVzG/LcCuGzMDPEP214r2tlPRDnJPbgGc=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1 h1:2/mUnq64vJOLSKMv29DoN+CHezcgK4fzqJ1LpFOs/fA=
 github.com/aws/aws-sdk-go-v2/service/directconnect v1.31.1/go.mod h1:vWnhJx6FbXnQ08eGSBGt8/3wrrcKKfLA+s6oUm3kXag=
-github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.1 h1:DbJKosYJ0PIJkGVdIe+IERU2WB370rOG3AYGP07M3jI=
-github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.1/go.mod h1:tEo7//RLL8seYrcxyD9aQba6Pk8dhPqDDw7iDZm5oe8=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2 h1:0x7ntPzNXdJXGDsJwcj6X69Om5kYOFvqCRdmWxJ5f+4=
+github.com/aws/aws-sdk-go-v2/service/directoryservice v1.31.2/go.mod h1:tEo7//RLL8seYrcxyD9aQba6Pk8dhPqDDw7iDZm5oe8=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1 h1:IabU8yoOLucAQHHqZbQXkFsHfsfmM7yQylOalltC6e8=
 github.com/aws/aws-sdk-go-v2/service/dlm v1.30.1/go.mod h1:FXvDBITG/lDpC7D5PgwJ99RcFg9sk0UwQ2gaC+LnSo0=
 github.com/aws/aws-sdk-go-v2/service/docdb v1.41.1 h1:KxSpigaQoHsAcRHuhcFAtqishNM/waI2iaU5Zf8hEYg=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.22.1 h1:5og4C/pzg
 github.com/aws/aws-sdk-go-v2/service/chimesdkmediapipelines v1.22.1/go.mod h1:F3f2vY0B6WEwL6AEVq1Uhj3nvgPFedsLU406lNDnNEU=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.21.1 h1:pZ6WXOfsNgEg2gajo0ew3iYlG7JpYj6MLJdWF24X2fk=
 github.com/aws/aws-sdk-go-v2/service/chimesdkvoice v1.21.1/go.mod h1:x2+uX7b1cMAgJOe6pYtE20AbgY293XuJFrtob8vqksg=
-github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.22.1 h1:73dD57WMeISugx7wUdMkHj0AyRyQqJPoE/3o4O9dUxI=
-github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.22.1/go.mod h1:m/MJKAtrhYP3Pdp++jqY+LxIKjV1ZlDEB9GsphTecRg=
+github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.23.2 h1:8L3zoSuex56zQtlr7+ekuchXqOYXnIUaJqvp28i/bW8=
+github.com/aws/aws-sdk-go-v2/service/cleanrooms v1.23.2/go.mod h1:m/MJKAtrhYP3Pdp++jqY+LxIKjV1ZlDEB9GsphTecRg=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.29.1 h1:rDM7tyn0nZH4I0k8jEeNySHhdQVzYmdPGaRj/3jZx5o=
 github.com/aws/aws-sdk-go-v2/service/cloud9 v1.29.1/go.mod h1:50svqK10lFEj+ui5Jkp87TbIFt4R4mv1ie6dleijEwI=
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.24.1 h1:pjX6Yr5YZKHC9jxSV0N8aOuB4BPHuovnta96aAoxvog=

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1 h1:qtgPTDjxMcq3LaRv2vMiE
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.1/go.mod h1:P3QWrLPDXyc8813o8b7WnBpw7mwoo2LRyOYdxMVT++Y=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.2.1 h1:eC3wvBcMvY8syeN35Lb/k6qsxNdv1d16j1BjobG0DU8=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.2.1/go.mod h1:u8pFMlyM6roXU/RRPYKb+07R+OoyVKO1Gu1AGlDODQk=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.180.2 h1:abthkPjYZEXZg4RSpaE+TMYJ9/lwAatF3O6qlNP02ts=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.180.2/go.mod h1:fp2LcfhQkz90js0Bkg5nXdCGCRy4y/FGgc14uvZ97eA=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.182.0 h1:tmXdwXsGDe3ml6nw0wL2Wn26BKQxVv7rQ+y3r0u8MY8=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.182.0/go.mod h1:fp2LcfhQkz90js0Bkg5nXdCGCRy4y/FGgc14uvZ97eA=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.1 h1:M+dSxFS/ZCxnHg2ZlDtCgPYhsvQmGhhQZJBrlK9IjdY=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.1/go.mod h1:DyWRoXzh5uB79qixa/wH8VBAfH06+sHGBLDR97B7Roo=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.29.1 h1:ZBa3qWVOVN/S3PjVuFn6Q9B28UJ13qCJbm9g67x80Lo=

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1 h1:IrIEdVMa+karAtPCM
 github.com/aws/aws-sdk-go-v2/service/route53domains v1.29.1/go.mod h1:l41whGvS6dfDuxh6RMNo3+MOvpk7zDx+bOHelpeBbuU=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2 h1:zeBZzAMbxTH27SutG8rAM4INPHzKw1AzpFofSI4u0jI=
 github.com/aws/aws-sdk-go-v2/service/route53profiles v1.5.2/go.mod h1:W44ZP9L/gf9lfyUYPJ0NsZlGIGe5aC82+qDvmrmWrv4=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1 h1:GYCcz4TTUF+G2Dk2gqNpxQ89C4Zy5cu+G3lMUG5NAaE=
-github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.26.1/go.mod h1:yccYWfGd7VeSZfgL2bjd/cKwNnFU3hagBBcZyvIuh0g=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.27.0 h1:zB5EmEBKgxA4C0YsxqafRfz5AEYwb0qkZ1vb2qE92Rg=
+github.com/aws/aws-sdk-go-v2/service/route53recoverycontrolconfig v1.27.0/go.mod h1:yccYWfGd7VeSZfgL2bjd/cKwNnFU3hagBBcZyvIuh0g=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.1 h1:pwXMSbQbkBgMPx7qcffrXUvlLEWyhnw7Gc8pWxASS6s=
 github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.1/go.mod h1:Wp2pFlYX10D02Ze9xLe9/hC5xIb0nawvfB9u9quQOeA=
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.1 h1:Ge3aBKjW5Pbvmxy0E8t53tMz/dOtq6ThN9fKEnz/f+s=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/aws/aws-sdk-go-v2/service/batch v1.51.1 h1:vP+Mma3uVDnydU3yjVI5rjU6Qe
 github.com/aws/aws-sdk-go-v2/service/batch v1.51.1/go.mod h1:F8tHrowT/XPtWMERTbDvJDUILrZgUV8W2lg4MmiuMtc=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1 h1:ll+yMQBP4zDYVR5g7OYI92OotFZx3runteOtwRvVs5Q=
 github.com/aws/aws-sdk-go-v2/service/bcmdataexports v1.8.1/go.mod h1:py9ul1V8YOAOcDtYs9mXfyhWr/tYaJm8kZ5ycgR0SR4=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1 h1:TajmkfP6PeFhZbyg+LRS+F2fAbrQ4FYa40Yn8jDrKOo=
-github.com/aws/aws-sdk-go-v2/service/bedrock v1.28.1/go.mod h1:rZOgAxQVRg9v5ZEQHrrKw0Gkb9DBAASeeRiwUmmXcG0=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.30.0 h1:5FAOmc63q+NuSH2B2KkviABl/0T2XVOPsbBffrI/RYQ=
+github.com/aws/aws-sdk-go-v2/service/bedrock v1.30.0/go.mod h1:rZOgAxQVRg9v5ZEQHrrKw0Gkb9DBAASeeRiwUmmXcG0=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0 h1:f2ydyCtj8E5e1eaQXBBhaaWpeDUfl5bcNS3VrjIezko=
 github.com/aws/aws-sdk-go-v2/service/bedrockagent v1.39.0/go.mod h1:WlMBqEPeaBywfaXoMAfpitHvwezq555o8waYL3cCPqo=
 github.com/aws/aws-sdk-go-v2/service/billing v1.2.1 h1:T7zx2zhdm5ZFRhv2QlJC9PtnFGO8E34bRwyLz9ARzsA=

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ github.com/aws/aws-sdk-go-v2/service/kms v1.38.1 h1:tecq7+mAav5byF+Mr+iONJnCBf4B
 github.com/aws/aws-sdk-go-v2/service/kms v1.38.1/go.mod h1:cQn6tAF77Di6m4huxovNM7NVAozWTZLsDRp9t8Z/WYk=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0 h1:hTw4cXL81wZQ/jrUw8GBxqxmq2ry3SjlSXEryola0lI=
 github.com/aws/aws-sdk-go-v2/service/lakeformation v1.41.0/go.mod h1:GicrlTk25ZC3c5WVMuffJLoFEJosQUmagR/WRuhFebM=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1 h1:EabaKQAptxXAeSL0sXKqfupPe/CpH965wqoloUK0aMM=
-github.com/aws/aws-sdk-go-v2/service/lambda v1.70.1/go.mod h1:c27kk10S36lBYgbG1jR3opn4OAS5Y/4wjJa1GiHK/X4=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.71.0 h1:8PjrcaqDZKar6ivI8c6vwNADOURebrRZQms3SxggRgU=
+github.com/aws/aws-sdk-go-v2/service/lambda v1.71.0/go.mod h1:c27kk10S36lBYgbG1jR3opn4OAS5Y/4wjJa1GiHK/X4=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.9.1 h1:k9tiuuhl/W6WKdmfy3QGpb8XqbPjwE6sYKZQOADFgZ4=
 github.com/aws/aws-sdk-go-v2/service/launchwizard v1.9.1/go.mod h1:asxJTcb67KxNsJ9qNb94FXKK/MScBbCpHNpco3sief0=
 github.com/aws/aws-sdk-go-v2/service/lexmodelbuildingservice v1.29.1 h1:3GTbxUa5mbszQHKRBqgJRo3a2yqr8dcaaUfSdgcTm3E=

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1 h1:h2YbGqsnzL36l2B/Bd/dvrHfrKo/
 github.com/aws/aws-sdk-go-v2/service/dsql v1.1.1/go.mod h1:StDU/D7R42LhrKp24PGzvxyKjjDm0lwo9JMwuy2qbo4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0 h1:EJXx6zb+lOe/Do2bO0d0dwVnIRGoP5J5xZ0BTn3LbqM=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.42.0/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0 h1:EXSJVsts7D18nt4A2Ii9HlpqDB7/mk9RDqG7+Aqc5Ls=
-github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1 h1:+4A9SDduLZFlDeXWRmfQ6r8kyEJZQfK6lcg+KwdvWrI=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.210.1/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0 h1:Ak4Ggvvbg8WYxPLoyLOtes1cIMQePvCAi/dUGqm8hOY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.0/go.mod h1:iQ1skgw1XRK+6Lgkb0I9ODatAP72WoTILh0zXQ5DtbU=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.1 h1:Tgvq4EuB0AcM2Au4kOmEHt/sm2BSwKrOzsM402g3iwg=

--- a/go.sum
+++ b/go.sum
@@ -383,8 +383,8 @@ github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1 h1:SnAltMepoUUyR0cvY
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.33.1/go.mod h1:nBlWp17qsAWgDvhH3/oI2PPqrk/3pcsqLXEPvCzb1Ic=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.8.1 h1:TPwENjY/u19L9fkTFYVkEqY6SwOttqlKjEAkgDraawM=
 github.com/aws/aws-sdk-go-v2/service/networkmonitor v1.8.1/go.mod h1:pC3ZHIWCZGExYbsbC+ODkIQ8iLUNJ1F9XaQbiEVjhF8=
-github.com/aws/aws-sdk-go-v2/service/oam v1.17.1 h1:dPBrSLkxb0V7seGamP8Qmmva2glA3wN/s5nlbo8OFp0=
-github.com/aws/aws-sdk-go-v2/service/oam v1.17.1/go.mod h1:LBtiDaQEt3JcbaEW6eY5S5b28i0yF66RYqwUnGVOGns=
+github.com/aws/aws-sdk-go-v2/service/oam v1.17.2 h1:JOMzNYnnKMTZ2gao0Uu3c5fxch2j5q0itlT8L4Y3VoU=
+github.com/aws/aws-sdk-go-v2/service/oam v1.17.2/go.mod h1:LBtiDaQEt3JcbaEW6eY5S5b28i0yF66RYqwUnGVOGns=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1 h1:PJPORR5Y+Vdvz+JzR7P5BA/i+lHpGQOhtpuJyvDdK00=
 github.com/aws/aws-sdk-go-v2/service/opensearch v1.46.1/go.mod h1:51rUy2+lDiOQVlekScV044he709HMMhCdUDHqSBojgg=
 github.com/aws/aws-sdk-go-v2/service/opensearchserverless v1.19.1 h1:4SayOJY5j+eqeo6nJXEaw3ysfRnoK39y/bPNSfpgXIw=

--- a/go.sum
+++ b/go.sum
@@ -353,8 +353,8 @@ github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1 h1:CR8WNR4DAYMkHi6VPfP8cJM9s
 github.com/aws/aws-sdk-go-v2/service/macie2 v1.45.1/go.mod h1:unKjikT3mzu065/bTZ5l9DkgXtLex9H/gmT0urCpSJM=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0 h1:hWzEaAbAO75Tt4OPDjosOdY8gmPPyoPgJmrhGnLnENY=
 github.com/aws/aws-sdk-go-v2/service/mediaconnect v1.39.0/go.mod h1:lnMLmJLMKn3wTWwROeiVEkxPXnrHl63/4E5/j2ObgL4=
-github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1 h1:ik4b+Emp07he9CSy5o5Gn6AfNdxSaZyLbLGHKxD0qTw=
-github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.69.1/go.mod h1:tUZaCc4SfNwVz/S4SE6d4YDOHk8zZ+B5Mz2EzG9vrQE=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.70.0 h1:mtBmLovGmCwptKFzM62blzimDgKzS5MVKs1WPJfugFc=
+github.com/aws/aws-sdk-go-v2/service/mediaconvert v1.70.0/go.mod h1:tUZaCc4SfNwVz/S4SE6d4YDOHk8zZ+B5Mz2EzG9vrQE=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0 h1:4EeXWfRdetoYVB9QJXOd0kujK9kWzPWeXThIyzKGkQQ=
 github.com/aws/aws-sdk-go-v2/service/medialive v1.71.0/go.mod h1:LQyji2EWloKipI5Yu/lc2pqIKz8/9T3nDm/2+cbFFo0=
 github.com/aws/aws-sdk-go-v2/service/mediapackage v1.35.1 h1:CoCjkzEn/bk5lUB7G4HinZDTZFEv9hzAgsJoowkq0ok=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [`Release 2025-03-21`](https://github.com/aws/aws-sdk-go-v2/commit/d96b0023dfa1379858d52722c3626466afa26896) due to dependabot failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/41898.