### PR TITLE
fix: fix #27674 - resource/aws_apigatewayv2_stage default throttling/burst limit

### DIFF
--- a/.changelog/27674.txt
+++ b/.changelog/27674.txt
@@ -1,0 +1,4 @@
+```release-note:bug
+resource/aws_apigatewayv2_stage: default value of `default_route_settings.0.throttling_burst_limit` should be `null` 
+resource/aws_apigatewayv2_stage: default value of `default_route_settings.0.throttling_rate_limit` should be `null` 
+```

--- a/internal/service/apigatewayv2/stage.go
+++ b/internal/service/apigatewayv2/stage.go
@@ -560,7 +560,7 @@ func flattenDefaultRouteSettings(routeSettings *awstypes.RouteSettings) []any {
 		"data_trace_enabled":       aws.ToBool(routeSettings.DataTraceEnabled),
 		"detailed_metrics_enabled": aws.ToBool(routeSettings.DetailedMetricsEnabled),
 		"logging_level":            string(routeSettings.LoggingLevel),
-		"throttling_burst_limit":   int(aws.ToInt32(routeSettings.ThrottlingBurstLimit)),
+		"throttling_burst_limit":   aws.ToInt32(routeSettings.ThrottlingBurstLimit),
 		"throttling_rate_limit":    aws.ToFloat64(routeSettings.ThrottlingRateLimit),
 	}}
 }
@@ -599,14 +599,22 @@ func flattenRouteSettings(settings map[string]awstypes.RouteSettings) []any {
 	vSettings := []any{}
 
 	for k, routeSetting := range settings {
-		vSettings = append(vSettings, map[string]any{
+		vSetting := map[string]any{
 			"data_trace_enabled":       aws.ToBool(routeSetting.DataTraceEnabled),
 			"detailed_metrics_enabled": aws.ToBool(routeSetting.DetailedMetricsEnabled),
 			"logging_level":            routeSetting.LoggingLevel,
 			"route_key":                k,
-			"throttling_burst_limit":   int(aws.ToInt32(routeSetting.ThrottlingBurstLimit)),
-			"throttling_rate_limit":    aws.ToFloat64(routeSetting.ThrottlingRateLimit),
-		})
+		}
+
+		if routeSetting.ThrottlingBurstLimit != nil {
+			vSetting["throttling_burst_limit"] = aws.ToInt32(routeSetting.ThrottlingBurstLimit)
+		}
+
+		if routeSetting.ThrottlingRateLimit != nil {
+			vSetting["throttling_rate_limit"] = aws.ToFloat64(routeSetting.ThrottlingRateLimit)
+		}
+
+		vSettings = append(vSettings, vSetting)
 	}
 
 	return vSettings

--- a/internal/service/apigatewayv2/stage_unit_test.go
+++ b/internal/service/apigatewayv2/stage_unit_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2
+
+import (
+	"encoding/json"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	"github.com/aws/smithy-go/ptr"
+	"testing"
+)
+
+type jsonSerializableRouteSettings struct {
+	DataTraceEnabled       bool     `json:"data_trace_enabled"`
+	DetailedMetricsEnabled bool     `json:"detailed_metrics_enabled"`
+	LoggingLevel           string   `json:"logging_level"`
+	ThrottlingBurstLimit   *int32   `json:"throttling_burst_limit"`
+	ThrottlingRateLimit    *float64 `json:"throttling_rate_limit"`
+}
+
+func assertRouteSettingsEqualTo(t *testing.T, expected jsonSerializableRouteSettings, actual any) {
+	serialized, err := json.Marshal(actual)
+
+	if err != nil {
+		t.Fatal("unexpected JSON serialization error")
+
+		return
+	}
+
+	var deSerialized jsonSerializableRouteSettings
+
+	err = json.Unmarshal(serialized, &deSerialized)
+
+	if err != nil {
+		t.Fatal("unexpected JSON deserialization error")
+
+		return
+	}
+
+	if !(expected.DataTraceEnabled == deSerialized.DataTraceEnabled &&
+		expected.DetailedMetricsEnabled == deSerialized.DetailedMetricsEnabled &&
+		expected.LoggingLevel == deSerialized.LoggingLevel &&
+		((expected.ThrottlingBurstLimit == nil &&
+			deSerialized.ThrottlingBurstLimit == nil) ||
+			*(expected.ThrottlingBurstLimit) == *(deSerialized.ThrottlingBurstLimit)) &&
+		((expected.ThrottlingRateLimit == nil &&
+			deSerialized.ThrottlingRateLimit == nil) ||
+			*(expected.ThrottlingRateLimit) == *(deSerialized.ThrottlingRateLimit))) {
+		t.Fatal("expected/actual route settings differ")
+	}
+}
+
+func TestAPIGatewayV2Stage_flattenDefaultRouteSettings(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default settings given, when nothing is set", func(t *testing.T) {
+		var routeSettings awstypes.RouteSettings
+
+		flattened := flattenRouteSettings(map[string]awstypes.RouteSettings{
+			"example": routeSettings,
+		})
+
+		if len(flattened) != 1 {
+			t.Fatal("expected route settings to contain one item")
+		}
+
+		assertRouteSettingsEqualTo(
+			t,
+			jsonSerializableRouteSettings{
+				DataTraceEnabled:       false,
+				DetailedMetricsEnabled: false,
+				LoggingLevel:           "",
+				ThrottlingBurstLimit:   nil,
+				ThrottlingRateLimit:    nil,
+			},
+			flattened[0],
+		)
+	})
+
+	t.Run("integer throttling is forwarded, when given", func(t *testing.T) {
+		flattened := flattenRouteSettings(map[string]awstypes.RouteSettings{
+			"example": awstypes.RouteSettings{
+				ThrottlingRateLimit:  ptr.Float64(123),
+				ThrottlingBurstLimit: ptr.Int32(456),
+			},
+		})
+
+		if len(flattened) != 1 {
+			t.Fatal("expected route settings to contain one item")
+		}
+
+		assertRouteSettingsEqualTo(
+			t,
+			jsonSerializableRouteSettings{
+				DataTraceEnabled:       false,
+				DetailedMetricsEnabled: false,
+				LoggingLevel:           "",
+				ThrottlingBurstLimit:   ptr.Int32(456),
+				ThrottlingRateLimit:    ptr.Float64(123),
+			},
+			flattened[0],
+		)
+	})
+}


### PR DESCRIPTION
### Description

The burst limit / rate limiting of API Gateway are **not** zero by default, but are rather not provided at all, when absent.

This change is based on suggestions by @krzysztofdrys

Tests provided had to be written as unit-tests from scratch, since I do not have access to an AWS account suitable for running the test suite against.


### Relations

Fixes #27674

### References

Ref: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html
Ref: https://github.com/hashicorp/terraform-provider-aws/issues/27674


### Output from Acceptance Testing

Acceptance testing was not run: do not have a suitable AWS account where it is acceptable to run third-party test suites against.
Added unit tests were provided: existing acceptance tests will be modified according to CI output, if possible. 