### PR TITLE
Fix regressions notifier

### DIFF
--- a/.github/workflows/maintainer_helpers.yml
+++ b/.github/workflows/maintainer_helpers.yml
@@ -173,7 +173,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": ":warning: The following has been labeled as a ${{ github.event.label.name }}:",
+                    "text": ":warning: The following ${{ github.event_name == 'issues' && 'issue' || 'pull request' }} has been labeled as a ${{ github.event.label.name }}:",
                     "emoji": true
                   }
                 },

--- a/.github/workflows/maintainer_helpers.yml
+++ b/.github/workflows/maintainer_helpers.yml
@@ -170,18 +170,30 @@ jobs:
               "channel" : "${{ secrets.SLACK_CHANNEL }}",
               "blocks": [
                 {
-                  "type": "section",
+                  "type": "header",
                   "text": {
-                    "type": "mrkdwn",
-                    "text": ":warning: The following has been labeled as a ${{ github.event.label.name }}:"
+                    "type": "plain_text",
+                    "text": ":warning: The following has been labeled as a ${{ github.event.label.name }}:",
+                    "emoji": true
                   }
                 },
                 {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ${{ toJSON(format('<{0}|{1}>', env.ISSUE_URL, env.ISSUE_TITLE)) }}
-                  }
+                  "type": "divider"
+                },
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "link",
+                          "text": ${{ toJSON(env.ISSUE_TITLE) }}
+                          "url": env.ISSUE_URL
+                        }
+                      ]
+                    }
+                  ]
                 }
               ]
             }


### PR DESCRIPTION
### Description

This PR updates the regressions notifier to use a `rich_text` block rather than a `section` with a `mrkdwn` block for linking to the affected item. This helps fix weird quoting issues that let to some items being posted without working links. While I was at it, I made some slight adjustments to formatting.

Whilst writing this PR description, I've started to wonder if the text should be updated to say "The following **(item|Pull Request|Issue)** has been labeled...", (change bolded) so if that reads better to the team, I'm happy to make those changes prior to merge.

### References

- [A recent example of a failure](https://github.com/hashicorp/terraform-provider-aws/actions/runs/14000394430)
- [`rich_text` block reference](https://api.slack.com/reference/block-kit/blocks#rich_text)
- [`header` block reference](https://api.slack.com/reference/block-kit/blocks#header)
- [`divider` block reference](https://api.slack.com/reference/block-kit/blocks#divider)

The following screenshot was the result of previewing these changes in Slack's [block kit builder](https://app.slack.com/block-kit-builder)

<img width="672" alt="Screenshot 2025-03-24 at 11 04 51" src="https://github.com/user-attachments/assets/06be2a9c-7100-4119-abdd-caca598b1970" />