### PR TITLE
Add `beta-feedback` label

### DIFF
--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -21,6 +21,10 @@ variable "workflow_labels" {
       color       = "844fba", # color:terraform (main)
       description = "Issues that are related to the providers migration to AWS SDK for Go v2."
     },
+    "beta-feedback" = {
+      color       = "844fba", # color:terraform (main)
+      description = "Issues providing feedback on beta releases."
+    },
     "breaking-change" = {
       color       = "ec585d", # color:boundary
       description = "Introduces a breaking change in current functionality; usually deferred to the next major release."
@@ -233,7 +237,6 @@ variable "workflow_labels" {
       color       = "828a90", # color:stale grey
       description = "Issues and PRs that relate to using the provider on the Windows operating system."
     },
-
   }
   description = "Name-color-description mapping of workflow issues."
   type        = map(any)


### PR DESCRIPTION
### Description

Adds a `beta-feedback` label for our receiving feedback on beta releases.
