### PR TITLE
fix: mark aws_iot_domain_configuration domain_name attribute as computed

### DIFF
--- a/internal/service/iot/domain_configuration.go
+++ b/internal/service/iot/domain_configuration.go
@@ -63,6 +63,7 @@ func resourceDomainConfiguration() *schema.Resource {
 			names.AttrDomainName: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 			"domain_type": {


### PR DESCRIPTION
### Description

As mentioned in #41819 a `terraform plan` on the resource `aws_iot_domain_configuration`

```hcl
resource "aws_iot_domain_configuration" "iot" {
  name         = "iot-"
  service_type = "DATA"
}
```

shows always a diff/ destroy even when there is no change.

```hcl
❯ terraform plan
aws_iot_domain_configuration.iot: Refreshing state... [id=iot-]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_iot_domain_configuration.iot must be replaced
-/+ resource "aws_iot_domain_configuration" "iot" {
      ~ arn                        = "arn:aws:iot:eu-central-1:544871327925:domainconfiguration/iot-/roaws" -> (known after apply)
      - domain_name                = "d0774346294xp3mx7udo9-ats.iot.eu-central-1.amazonaws.com" -> null # forces replacement
      ~ domain_type                = "AWS_MANAGED" -> (known after apply)
      ~ id                         = "iot-" -> (known after apply)
        name                       = "iot-"
      - server_certificate_arns    = [] -> null
      - tags                       = {} -> null
      ~ tags_all                   = {} -> (known after apply)
        # (3 unchanged attributes hidden)

      ~ tls_config (known after apply)
      - tls_config {
          - security_policy = "IoTSecurityPolicy_TLS13_1_2_2022_10" -> null
        }
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

Please note that the  configuration above does not contain a `domain_name` argument. This causes the resource replacement in the current provider version.

AWS provides in the API response (part of resource creation) a value for the domain name. Hence,  `Computed` should be set to `true`  for `names.AttrDomainName` to reflect this.

### Relations

Closes #41819 

### References

- [Resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iot_domain_configuration)

### Output from Acceptance Testing

* There is a general issue with the tests as the resource deletion is not working (seven days grace period)
* The relevant test was already existing. Before its execution I ran

  ```shell
  export IOT_DOMAIN_CONFIGURATION_TEST_AWS_MANAGED=1
  ```
* Current provider code, showing the replacement and failed resource deletion

```shell
❯ make testacc TESTS=TestAccIoTDomainConfiguration_awsManaged PKG=iot
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTDomainConfiguration_awsManaged'  -timeout 360m -vet=off
2025/03/25 21:09:14 Initializing Terraform AWS Provider...
=== RUN   TestAccIoTDomainConfiguration_awsManaged
=== PAUSE TestAccIoTDomainConfiguration_awsManaged
=== CONT  TestAccIoTDomainConfiguration_awsManaged
    domain_configuration_test.go:185: Step 1/1 error: After applying this test step, the non-refresh plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # aws_iot_domain_configuration.test must be replaced
        -/+ resource "aws_iot_domain_configuration" "test" {
              ~ arn                        = "arn:aws:iot:us-west-2:544871327925:domainconfiguration/tf-acc-test-1560740263101395234/1cnjv" -> (known after apply)
              - domain_name                = "d08070241hvxf13d81hbs-ats.iot.us-west-2.amazonaws.com" -> null # forces replacement
              ~ domain_type                = "AWS_MANAGED" -> (known after apply)
              ~ id                         = "tf-acc-test-1560740263101395234" -> (known after apply)
                name                       = "tf-acc-test-1560740263101395234"
              ~ tags_all                   = {} -> (known after apply)
                # (3 unchanged attributes hidden)
        
              ~ tls_config (known after apply)
              - tls_config {
                  - security_policy = "IoTSecurityPolicy_TLS13_1_2_2022_10" -> null
                }
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
    panic.go:635: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting IoT Domain Configuration (tf-acc-test-1560740263101395234): operation error IoT: DeleteDomainConfiguration, https response error StatusCode: 400, RequestID: e047f556-338d-43b5-a624-eb2d2db2f968, InvalidRequestException: AWS Managed Domain Configuration must be disabled for at least 7 days before it can be deleted
        
--- FAIL: TestAccIoTDomainConfiguration_awsManaged (23.25s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iot        23.457s
FAIL
make: *** [GNUmakefile:624: testacc] Error 1
```


* Same test executed with the updated provider code, only the resource deletion fails. All checks that are part of the test succeed.

```shell
❯ make testacc TESTS=TestAccIoTDomainConfiguration_awsManaged PKG=iot
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/iot/... -v -count 1 -parallel 20 -run='TestAccIoTDomainConfiguration_awsManaged'  -timeout 360m -vet=off
2025/03/25 21:14:13 Initializing Terraform AWS Provider...
=== RUN   TestAccIoTDomainConfiguration_awsManaged
=== PAUSE TestAccIoTDomainConfiguration_awsManaged
=== CONT  TestAccIoTDomainConfiguration_awsManaged
    domain_configuration_test.go:185: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: deleting IoT Domain Configuration (tf-acc-test-2550001995689639671): operation error IoT: DeleteDomainConfiguration, https response error StatusCode: 400, RequestID: e236bbe9-1e12-4f97-9a6f-465ae7f2cbfe, InvalidRequestException: AWS Managed Domain Configuration must be disabled for at least 7 days before it can be deleted
        
--- FAIL: TestAccIoTDomainConfiguration_awsManaged (26.63s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/iot        26.855s
FAIL
make: *** [GNUmakefile:624: testacc] Error 1
```

Please let me know if I should also look into this grace period issue - at present I am not sure how to approach it.