### PR TITLE
docs: Add 'Example with Delivery Policy' to aws_sns_topic_subscription

### DIFF
--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -225,6 +225,39 @@ resource "aws_sns_topic_subscription" "sns-topic" {
 }
 ```
 
+## Example with Delivery Policy
+
+This example demonstrates how to define a `delivery_policy` for an HTTPS subscription. Unlike the `aws_sns_topic` resource, the `delivery_policy` for `aws_sns_topic_subscription` should not be wrapped in an `"http"` object.
+
+```hcl
+resource "aws_sns_topic_subscription" "example_with_delivery_policy" {
+  topic_arn            = "arn:aws:sns:us-west-2:123456789012:my-topic"
+  protocol             = "https"
+  endpoint             = "https://example.com/endpoint"
+  raw_message_delivery = true
+
+  delivery_policy = <<EOF
+{
+  "healthyRetryPolicy": {
+    "minDelayTarget": 20,
+    "maxDelayTarget": 20,
+    "numRetries": 3,
+    "numMaxDelayRetries": 0,
+    "numNoDelayRetries": 0,
+    "numMinDelayRetries": 0,
+    "backoffFunction": "linear"
+  },
+  "sicklyRetryPolicy": null,
+  "throttlePolicy": null,
+  "requestPolicy": {
+    "headerContentType": "text/plain; application/json"
+  },
+  "guaranteed": false
+}
+EOF
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:


### PR DESCRIPTION
### Description

This PR enhances the `aws_sns_topic_subscription` documentation by adding an **'Example with Delivery Policy'** section. The new example demonstrates how to define a `delivery_policy` for an HTTPS subscription, clarifying that, unlike the `aws_sns_topic` resource, the `delivery_policy` for `aws_sns_topic_subscription` should **not** be wrapped in an `"http"` object.

### Relations

Closes #41885
