### PR TITLE
changed param_by_path to return slice of param attributes

### DIFF
--- a/internal/service/ssm/parameters_by_path_data_source.go
+++ b/internal/service/ssm/parameters_by_path_data_source.go
@@ -23,15 +23,29 @@ func dataSourceParametersByPath() *schema.Resource {
 		ReadWithoutTimeout: dataSourceParametersReadByPath,
 
 		Schema: map[string]*schema.Schema{
-			names.AttrARNs: {
-				Type:     schema.TypeList,
+			names.AttrParameters: {
+				Type:     schema.TypeSet,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrNames: {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						names.AttrARN: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrName: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrType: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						names.AttrValue: {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
 			},
 			names.AttrPath: {
 				Type:     schema.TypeString,
@@ -41,17 +55,6 @@ func dataSourceParametersByPath() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
-			},
-			"types": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-			names.AttrValues: {
-				Type:      schema.TypeList,
-				Computed:  true,
-				Sensitive: true,
-				Elem:      &schema.Schema{Type: schema.TypeString},
 			},
 			"with_decryption": {
 				Type:     schema.TypeBool,
@@ -86,17 +89,13 @@ func dataSourceParametersReadByPath(ctx context.Context, d *schema.ResourceData,
 	}
 
 	d.SetId(path)
-	d.Set(names.AttrARNs, tfslices.ApplyToAll(output, func(v awstypes.Parameter) string {
-		return aws.ToString(v.ARN)
-	}))
-	d.Set(names.AttrNames, tfslices.ApplyToAll(output, func(v awstypes.Parameter) string {
-		return aws.ToString(v.Name)
-	}))
-	d.Set("types", tfslices.ApplyToAll(output, func(v awstypes.Parameter) awstypes.ParameterType {
-		return v.Type
-	}))
-	d.Set(names.AttrValues, tfslices.ApplyToAll(output, func(v awstypes.Parameter) string {
-		return aws.ToString(v.Value)
+	d.Set(names.AttrParameters, tfslices.ApplyToAll(output, func(parameter awstypes.Parameter) map[string]any {
+		return map[string]any{
+			names.AttrARN:   aws.ToString(parameter.ARN),
+			names.AttrName:  aws.ToString(parameter.Name),
+			names.AttrType:  parameter.Type,
+			names.AttrValue: aws.ToString(parameter.Value),
+		}
 	}))
 
 	return diags

--- a/internal/service/ssm/parameters_by_path_data_source_test.go
+++ b/internal/service/ssm/parameters_by_path_data_source_test.go
@@ -15,9 +15,20 @@ import (
 
 func TestAccSSMParametersByPathDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	resourceName := "data.aws_ssm_parameters_by_path.test"
+	dataSourceName := "data.aws_ssm_parameters_by_path.test"
+	resourceName1 := "aws_ssm_parameter.test1"
+	resourceName2 := "aws_ssm_parameter.test2"
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	paramsResourceAttrCheck := fmt.Sprintf("%s.#", names.AttrParameters)
+	paramsARNPairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrARN)
+	paramsNamePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrName)
+	paramsTypePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrType)
+	paramsValuePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrValue)
+	paramsARNPairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrARN)
+	paramsNamePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrName)
+	paramsTypePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrType)
+	paramsValuePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrValue)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -27,12 +38,17 @@ func TestAccSSMParametersByPathDataSource_basic(t *testing.T) {
 			{
 				Config: testAccParametersByPathDataSourceConfig_basic(rName1, rName2, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "arns.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "names.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "types.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "with_decryption", acctest.CtFalse),
-					resource.TestCheckResourceAttr(resourceName, "recursive", acctest.CtFalse),
+					resource.TestCheckResourceAttr(dataSourceName, paramsResourceAttrCheck, "2"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsARNPairCheck1, resourceName1, names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsNamePairCheck1, resourceName1, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsTypePairCheck1, resourceName1, names.AttrType),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsValuePairCheck1, resourceName1, names.AttrValue),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsARNPairCheck2, resourceName2, names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsNamePairCheck2, resourceName2, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsTypePairCheck2, resourceName2, names.AttrType),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsValuePairCheck2, resourceName2, names.AttrValue),
+					resource.TestCheckResourceAttr(dataSourceName, "with_decryption", acctest.CtFalse),
+					resource.TestCheckResourceAttr(dataSourceName, "recursive", acctest.CtFalse),
 				),
 			},
 		},
@@ -74,8 +90,19 @@ data "aws_ssm_parameters_by_path" "test" {
 
 func TestAccSSMParametersByPathDataSource_withRecursion(t *testing.T) {
 	ctx := acctest.Context(t)
-	resourceName := "data.aws_ssm_parameters_by_path.recursive"
+	dataSourceName := "data.aws_ssm_parameters_by_path.recursive"
+	resourceName1 := "aws_ssm_parameter.top_level"
+	resourceName2 := "aws_ssm_parameter.nested"
 	pathPrefix := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	paramsResourceAttrCheck := fmt.Sprintf("%s.#", names.AttrParameters)
+	paramsARNPairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrARN)
+	paramsNamePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrName)
+	paramsTypePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrType)
+	paramsValuePairCheck1 := fmt.Sprintf("%s.0.%s", names.AttrParameters, names.AttrValue)
+	paramsARNPairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrARN)
+	paramsNamePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrName)
+	paramsTypePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrType)
+	paramsValuePairCheck2 := fmt.Sprintf("%s.1.%s", names.AttrParameters, names.AttrValue)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -85,11 +112,16 @@ func TestAccSSMParametersByPathDataSource_withRecursion(t *testing.T) {
 			{
 				Config: testAccParametersByPathDataSourceConfig_recursion(pathPrefix),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "arns.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "names.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "types.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "values.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "recursive", acctest.CtTrue),
+					resource.TestCheckResourceAttr(dataSourceName, paramsResourceAttrCheck, "2"),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsARNPairCheck1, resourceName1, names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsNamePairCheck1, resourceName1, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsTypePairCheck1, resourceName1, names.AttrType),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsValuePairCheck1, resourceName1, names.AttrValue),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsARNPairCheck2, resourceName2, names.AttrARN),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsNamePairCheck2, resourceName2, names.AttrName),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsTypePairCheck2, resourceName2, names.AttrType),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, paramsValuePairCheck2, resourceName2, names.AttrValue),
+					resource.TestCheckResourceAttr(dataSourceName, "recursive", acctest.CtTrue),
 				),
 			},
 		},

--- a/website/docs/d/ssm_parameters_by_path.html.markdown
+++ b/website/docs/d/ssm_parameters_by_path.html.markdown
@@ -34,7 +34,11 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `arns` - A list that contains the Amazon Resource Names (ARNs) of the retrieved parameters.
-* `names` - A list that contains the names of the retrieved parameters.
-* `types` - A list that contains the types (`String`, `StringList`, or `SecureString`) of retrieved parameters.
-* `values` - A list that contains the retrieved parameter values. **Note:** This value is always marked as sensitive in the Terraform plan output, regardless of whether any retrieved parameters are of `SecureString` type. Use the [`nonsensitive` function](https://developer.hashicorp.com/terraform/language/functions/nonsensitive) to override the behavior at your own risk and discretion, if you are certain that there are no sensitive values being retrieved.
+* `parameters` - A list of the parameters discovered in the requested `path`.
+
+The elements of the `parameters` are exported with the following attributes:
+
+* `arn` - The Amazon Resource Name (ARN) of the retrieved parameter.
+* `name` - The name of the retrieved parameter.
+* `type` - The type (`String`, `StringList`, or `SecureString`) of the retrieved parameter.
+* `value` - The value of the retrieved parameter. **Note:** This value is always marked as sensitive in the Terraform plan output, regardless of whether any retrieved parameters are of `SecureString` type. Use the [`nonsensitive` function](https://developer.hashicorp.com/terraform/language/functions/nonsensitive) to override the behavior at your own risk and discretion, if you are certain that there are no sensitive values being retrieved.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
As mentioned in #40965 the `aws_ssm_parameters_by_path` data source should return information in a manner where parameters have the value associated with the other known attributes of the parameter. 

TO-DO: add more details

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40965

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
 terraform-provider-aws (f-ssm-parameter-by-path-output-enhancement) ✗ AWS_PROFILE=default make testacc TESTS=TestAccSSMParametersByPathDataSource_ PKG=ssm
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParametersByPathDataSource_'  -timeout 360m -vet=off
2025/03/26 07:20:26 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMParametersByPathDataSource_basic
=== PAUSE TestAccSSMParametersByPathDataSource_basic
=== RUN   TestAccSSMParametersByPathDataSource_withRecursion
=== PAUSE TestAccSSMParametersByPathDataSource_withRecursion
=== CONT  TestAccSSMParametersByPathDataSource_basic
=== CONT  TestAccSSMParametersByPathDataSource_withRecursion
--- PASS: TestAccSSMParametersByPathDataSource_withRecursion (11.83s)
--- PASS: TestAccSSMParametersByPathDataSource_basic (12.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        12.086s
...
```
