### PR TITLE
fix: include region to lookup global replication group member on destroy

### DIFF
--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1082,11 +1082,11 @@ func resourceReplicationGroupDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID, region string, timeout time.Duration) error {
+func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID, replicationGroupRegion string, timeout time.Duration) error {
 	input := &elasticache.DisassociateGlobalReplicationGroupInput{
 		GlobalReplicationGroupId: aws.String(globalReplicationGroupID),
 		ReplicationGroupId:       aws.String(replicationGroupID),
-		ReplicationGroupRegion:   aws.String(region),
+		ReplicationGroupRegion:   aws.String(replicationGroupRegion),
 	}
 
 	_, err := tfresource.RetryWhenIsA[*awstypes.InvalidGlobalReplicationGroupStateFault](ctx, timeout, func() (any, error) {
@@ -1105,7 +1105,7 @@ func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		return fmt.Errorf("disassociating ElastiCache Replication Group (%s) from Global Replication Group (%s): %w", replicationGroupID, globalReplicationGroupID, err)
 	}
 
-	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, region, timeout); err != nil {
+	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, replicationGroupRegion, timeout); err != nil {
 		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) detach: %w", replicationGroupID, err)
 	}
 

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -1105,7 +1105,7 @@ func disassociateReplicationGroup(ctx context.Context, conn *elasticache.Client,
 		return fmt.Errorf("disassociating ElastiCache Replication Group (%s) from Global Replication Group (%s): %w", replicationGroupID, globalReplicationGroupID, err)
 	}
 
-	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, timeout); err != nil {
+	if _, err := waitGlobalReplicationGroupMemberDetached(ctx, conn, globalReplicationGroupID, replicationGroupID, region, timeout); err != nil {
 		return fmt.Errorf("waiting for ElastiCache Replication Group (%s) detach: %w", replicationGroupID, err)
 	}
 

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -4601,7 +4601,7 @@ func testAccReplicationGroupConfig_globalIDBasic(rName string) string {
 		testAccVPCBaseWithProvider(rName, "primary", acctest.ProviderNameAlternate, 1),
 		fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
-  replication_group_id        = "%[1]s-s"
+  replication_group_id        = %[1]q
   description                 = "secondary"
   global_replication_group_id = aws_elasticache_global_replication_group.test.global_replication_group_id
   subnet_group_name           = aws_elasticache_subnet_group.test.name
@@ -4617,7 +4617,7 @@ resource "aws_elasticache_global_replication_group" "test" {
 resource "aws_elasticache_replication_group" "primary" {
   provider = awsalternate
 
-  replication_group_id = "%[1]s-p"
+  replication_group_id = %[1]q
   description          = "primary"
   subnet_group_name    = aws_elasticache_subnet_group.primary.name
   node_type            = "cache.m5.large"


### PR DESCRIPTION
### Description

Replication groups associated with a global datastore in ElastiCache are allowed to have the same name since they are in distinct regions. This means when looking up members of a global datastore that the `ReplicationGroupId` can be the same for multiple members and that the only way to distinguish between them is by `ReplicationGroupRegion`.

This is a bug when destroying the secondary member because it will wait indefinitely for it to disassociate, mistaking the primary member for itself.

### Relations

Closes #38919

### Output from Acceptance Testing

With the old logic + modified "basic" test case that makes the primary + secondary replication group have the same name, it hangs indefinitely (I canceled it since I didn't want to wait for 6 hours):

```console
terraform-provider-aws % make testacc TESTS=TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears'  -timeout 360m -vet=off
2025/03/26 11:19:38 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
^Csignal: interrupt
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        4115.209s
make: *** [testacc] Error 1
```

With the new logic + modified test case:
```console
make testacc TESTS=TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears'  -timeout 360m -vet=off
2025/03/26 12:24:30 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (2880.36s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        2887.154s
```