### PR TITLE
r/aws_redshift_cluster: remove `snapshot_copy` attribute

### DIFF
--- a/.changelog/41995.txt
+++ b/.changelog/41995.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_redshift_cluster: The `snapshot_copy` attribute has been removed
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -387,31 +387,6 @@ func resourceCluster() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
-			"snapshot_copy": {
-				Type: schema.TypeList,
-				Deprecated: "snapshot_copy is deprecated. Use the aws_redshift_snapshot_copy resource instead. " +
-					"This argument will be removed in a future major version.",
-				MaxItems: 1,
-				Optional: true,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"destination_region": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"grant_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						names.AttrRetentionPeriod: {
-							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  7,
-						},
-					},
-				},
-			},
 			"snapshot_identifier": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -643,12 +618,6 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		return sdkdiag.AppendErrorf(diags, "creating Redshift Cluster (%s): waiting for relocation: %s", d.Id(), err)
 	}
 
-	if v, ok := d.GetOk("snapshot_copy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-		if err := enableSnapshotCopy(ctx, conn, d.Id(), v.([]any)[0].(map[string]any)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "creating Redshift Cluster (%s): %s", d.Id(), err)
-		}
-	}
-
 	if v, ok := d.GetOk("logging"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		tfMap := v.([]any)[0].(map[string]any)
 
@@ -745,9 +714,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("number_of_nodes", rsc.NumberOfNodes)
 	d.Set(names.AttrPreferredMaintenanceWindow, rsc.PreferredMaintenanceWindow)
 	d.Set(names.AttrPubliclyAccessible, rsc.PubliclyAccessible)
-	if err := d.Set("snapshot_copy", flattenSnapshotCopy(rsc.ClusterSnapshotCopyStatus)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting snapshot_copy: %s", err)
-	}
 	d.Set(names.AttrVPCSecurityGroupIDs, tfslices.ApplyToAll(rsc.VpcSecurityGroups, func(v awstypes.VpcSecurityGroupMembership) string {
 		return aws.ToString(v.VpcSecurityGroupId)
 	}))
@@ -776,7 +742,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).RedshiftClient(ctx)
 
-	if d.HasChangesExcept("aqua_configuration_status", names.AttrAvailabilityZone, "iam_roles", "logging", "multi_az", "snapshot_copy", names.AttrTags, names.AttrTagsAll, "skip_final_snapshot") {
+	if d.HasChangesExcept("aqua_configuration_status", names.AttrAvailabilityZone, "iam_roles", "logging", "multi_az", names.AttrTags, names.AttrTagsAll, "skip_final_snapshot") {
 		input := &redshift.ModifyClusterInput{
 			ClusterIdentifier: aws.String(d.Id()),
 		}
@@ -962,23 +928,6 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	if d.HasChange("snapshot_copy") {
-		if v, ok := d.GetOk("snapshot_copy"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-			if err := enableSnapshotCopy(ctx, conn, d.Id(), v.([]any)[0].(map[string]any)); err != nil {
-				if !errs.IsA[*awstypes.SnapshotCopyAlreadyEnabledFault](err) {
-					return sdkdiag.AppendErrorf(diags, "updating Redshift Cluster (%s) snapshot_copy: %s", d.Id(), err)
-				}
-				if err := toggleSnapshotCopy(ctx, conn, d.Id(), v.([]any)[0].(map[string]any)); err != nil {
-					return sdkdiag.AppendErrorf(diags, "updating Redshift Cluster (%s) snapshot_copy: %s", d.Id(), err)
-				}
-			}
-		} else {
-			if err := disableSnapshotCopy(ctx, conn, d.Id()); err != nil {
-				return sdkdiag.AppendErrorf(diags, "updating Redshift Cluster (%s) snapshot_copy: %s", d.Id(), err)
-			}
-		}
-	}
-
 	if d.HasChange("logging") {
 		if v, ok := d.GetOk("logging"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			tfMap := v.([]any)[0].(map[string]any)
@@ -1133,58 +1082,6 @@ func disableLogging(ctx context.Context, conn *redshift.Client, clusterID string
 	return nil
 }
 
-func enableSnapshotCopy(ctx context.Context, conn *redshift.Client, clusterID string, tfMap map[string]any) error {
-	input := &redshift.EnableSnapshotCopyInput{
-		ClusterIdentifier: aws.String(clusterID),
-		DestinationRegion: aws.String(tfMap["destination_region"].(string)),
-	}
-
-	if v, ok := tfMap[names.AttrRetentionPeriod]; ok {
-		input.RetentionPeriod = aws.Int32(int32(v.(int)))
-	}
-
-	if v, ok := tfMap["grant_name"]; ok {
-		input.SnapshotCopyGrantName = aws.String(v.(string))
-	}
-
-	_, err := conn.EnableSnapshotCopy(ctx, input)
-	if err != nil {
-		return fmt.Errorf("enabling snapshot copy: %w", err)
-	}
-
-	return nil
-}
-
-func disableSnapshotCopy(ctx context.Context, conn *redshift.Client, clusterID string) error {
-	input := &redshift.DisableSnapshotCopyInput{
-		ClusterIdentifier: aws.String(clusterID),
-	}
-
-	_, err := conn.DisableSnapshotCopy(ctx, input)
-	if err != nil {
-		return fmt.Errorf("disabling snapshot copy: %w", err)
-	}
-
-	return nil
-}
-
-// toggleSnapshotCopy calls disableSnapshotCopy followed by enableSnapshotCopy
-//
-// This workflow is necessary in cases where the existing snapshot copy configuration
-// needs to be updated. Once enabled, `EnableSnapshotCopy` cannot be called to update existing
-// settings. While the `ModifySnapshotCopyRetentionPeriod` API is available to update the
-// `retention_period` argument, there is no mechanism to update other arguments such
-// as `destination_region` or `snapshot_copy_grant_name` without disabling first.
-func toggleSnapshotCopy(ctx context.Context, conn *redshift.Client, clusterID string, tfMap map[string]any) error {
-	if err := disableSnapshotCopy(ctx, conn, clusterID); err != nil {
-		return err
-	}
-	if err := enableSnapshotCopy(ctx, conn, clusterID, tfMap); err != nil {
-		return err
-	}
-	return nil
-}
-
 func flattenClusterNode(apiObject awstypes.ClusterNode) map[string]any {
 	tfMap := map[string]any{}
 
@@ -1262,25 +1159,6 @@ func flattenLogging(ls *redshift.DescribeLoggingStatusOutput) []any {
 
 	if ls.S3KeyPrefix != nil {
 		cfg[names.AttrS3KeyPrefix] = aws.ToString(ls.S3KeyPrefix)
-	}
-
-	return []any{cfg}
-}
-
-func flattenSnapshotCopy(scs *awstypes.ClusterSnapshotCopyStatus) []any {
-	if scs == nil {
-		return []any{}
-	}
-
-	cfg := make(map[string]any)
-	if scs.DestinationRegion != nil {
-		cfg["destination_region"] = aws.ToString(scs.DestinationRegion)
-	}
-	if scs.RetentionPeriod != nil {
-		cfg[names.AttrRetentionPeriod] = aws.ToInt64(scs.RetentionPeriod)
-	}
-	if scs.SnapshotCopyGrantName != nil {
-		cfg["grant_name"] = aws.ToString(scs.SnapshotCopyGrantName)
 	}
 
 	return []any{cfg}

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -98,7 +98,9 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 
 ## resource/aws_redshift_cluster
 
-The `publicly_accessible` attribute now defaults to `false`.
+* The `publicly_accessible` attribute now defaults to `false`.
+* Remove `snapshot_copy` from configuration as it no longer exists. Use the `aws_redshift_snapshot_copy` resource instead.
+
 
 ## resource/aws_redshift_service_account
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -101,7 +101,6 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 * The `publicly_accessible` attribute now defaults to `false`.
 * Remove `snapshot_copy` from configuration as it no longer exists. Use the `aws_redshift_snapshot_copy` resource instead.
 
-
 ## resource/aws_redshift_service_account
 
 The `aws_redshift_service_account` resource has been removed. AWS [recommends](https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions) that a [service principal name](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services) should be used instead of an AWS account ID in any relevant IAM policy.

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -111,7 +111,6 @@ This resource supports the following arguments:
 * `logging` - (Optional, **Deprecated**) Logging, documented below.
 * `maintenance_track_name` - (Optional) The name of the maintenance track for the restored cluster. When you take a snapshot, the snapshot inherits the MaintenanceTrack value from the cluster. The snapshot might be on a different track than the cluster that was the source for the snapshot. For example, suppose that you take a snapshot of  a cluster that is on the current track and then change the cluster to be on the trailing track. In this case, the snapshot and the source cluster are on different tracks. Default value is `current`.
 * `manual_snapshot_retention_period` - (Optional)  The default number of days to retain a manual snapshot. If the value is -1, the snapshot is retained indefinitely. This setting doesn't change the retention period of existing snapshots. Valid values are between `-1` and `3653`. Default value is `-1`.
-* `snapshot_copy` - (Optional, **Deprecated**) Configuration of automatic copy of snapshots from one region to another. Documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Nested Blocks
@@ -126,14 +125,6 @@ For more information on the permissions required for the bucket, please read the
 * `s3_key_prefix` - (Optional) The prefix applied to the log file names.
 * `log_destination_type` - (Optional) The log destination type. An enum with possible values of `s3` and `cloudwatch`.
 * `log_exports` - (Optional) The collection of exported log types. Log types include the connection log, user log and user activity log. Required when `log_destination_type` is `cloudwatch`. Valid log types are `connectionlog`, `userlog`, and `useractivitylog`.
-
-#### `snapshot_copy`
-
-~> The `snapshot_copy` argument is deprecated. Use the [`aws_redshift_snapshot_copy`](./redshift_snapshot_copy.html.markdown) resource instead. This argument will be removed in a future major version.
-
-* `destination_region` - (Required) The destination region that you want to copy snapshots to.
-* `retention_period` - (Optional) The number of days to retain automated snapshots in the destination region after they are copied from the source region. Defaults to `7`.
-* `grant_name` - (Optional) The name of the snapshot copy grant to use when snapshots of an AWS KMS-encrypted cluster are copied to the destination region.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:
--->

Closes #36869

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS="-run=TestAccRedshiftCluster_" PKG=redshift

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.1 test ./internal/service/redshift/... -v -count 1 -parallel 20  -run=TestAccRedshiftCluster_ -timeout 360m -vet=off
2025/03/27 10:39:11 Initializing Terraform AWS Provider...
--- PASS: TestAccRedshiftCluster_masterUsername_invalid (8.21s)
--- PASS: TestAccRedshiftCluster_manageMasterPassword (171.92s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible (174.01s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone_availabilityZoneRelocationNotSet (178.85s)
--- PASS: TestAccRedshiftCluster_iamRoles (186.02s)
--- PASS: TestAccRedshiftCluster_availabilityZoneRelocation (192.54s)
--- PASS: TestAccRedshiftCluster_loggingEnabled (206.66s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZoneAndSetAvailabilityZoneRelocation (309.09s)
--- PASS: TestAccRedshiftCluster_masterUsername (313.85s)
--- PASS: TestAccRedshiftCluster_enhancedVPCRoutingEnabled (343.93s)
--- PASS: TestAccRedshiftCluster_aqua (178.10s)
--- PASS: TestAccRedshiftCluster_kmsKey (414.13s)
--- PASS: TestAccRedshiftCluster_basic (421.89s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshot (458.65s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible (475.16s)
--- PASS: TestAccRedshiftCluster_changeAvailabilityZone (276.58s)
--- PASS: TestAccRedshiftCluster_publiclyAccessible_default (487.62s)
--- PASS: TestAccRedshiftCluster_multiAZ (568.10s)
--- PASS: TestAccRedshiftCluster_disappears (406.82s)
--- PASS: TestAccRedshiftCluster_tags (452.78s)
--- PASS: TestAccRedshiftCluster_withFinalSnapshot (494.35s)
--- PASS: TestAccRedshiftCluster_passwordWriteOnly (684.79s)
--- PASS: TestAccRedshiftCluster_restoreFromSnapshotARN (773.74s)
--- PASS: TestAccRedshiftCluster_changeEncryption2 (1049.14s)
--- PASS: TestAccRedshiftCluster_changeEncryption1 (775.16s)
--- PASS: TestAccRedshiftCluster_updateNodeCount (1161.38s)
--- PASS: TestAccRedshiftCluster_updateNodeType (1621.05s)
PASS
ok	github.com/hashicorp/terraform-provider-aws/internal/service/redshift	1627.885s
```
