### PR TITLE
[Enhancement] Mark `value` in `aws_api_gateway_usage_plan_key` as sensitive

### DIFF
--- a/internal/service/apigateway/usage_plan_key.go
+++ b/internal/service/apigateway/usage_plan_key.go
@@ -65,8 +65,9 @@ func resourceUsagePlanKey() *schema.Resource {
 				ForceNew: true,
 			},
 			names.AttrValue: {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 		},
 	}

--- a/website/docs/r/api_gateway_usage_plan_key.html.markdown
+++ b/website/docs/r/api_gateway_usage_plan_key.html.markdown
@@ -56,7 +56,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `key_type` - Type of a usage plan key. Currently, the valid key type is API_KEY.
 * `usage_plan_id` - ID of the API resource
 * `name` - Name of a usage plan key.
-* `value` - Value of a usage plan key.
+* `value` - Value of a usage plan key. This value is marked as sensitive in the Terraform plan output.
 
 ## Import
 


### PR DESCRIPTION
### Description
* This PR marks `value` in `aws_api_gateway_usage_plan_key` as sensitive. As a result, the value is not displayed in the terraform plan output.
* Just add "Sensitive: true" to the schema definition of `value`.

### Relations
Closes #26739 


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
