### PR TITLE
d/aws_lambda_event_source_mapping improve 'enabled' parameter description

### DIFF
--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -161,7 +161,7 @@ resource "aws_lambda_event_source_mapping" "example" {
 * `bisect_batch_on_function_error`: - (Optional) If the function returns an error, split the batch in two and retry. Only available for stream sources (DynamoDB and Kinesis). Defaults to `false`.
 * `destination_config`: - (Optional) An Amazon SQS queue, Amazon SNS topic or Amazon S3 bucket (only available for Kafka sources) destination for failed records. Only available for stream sources (DynamoDB and Kinesis) and Kafka sources (Amazon MSK and Self-managed Apache Kafka). Detailed below.
 * `document_db_event_source_config`: - (Optional) Configuration settings for a DocumentDB event source. Detailed below.
-* `enabled` - (Optional) Determines if the mapping will be enabled on creation. Defaults to `true`.
+* `enabled` - (Optional) Determines if the mapping is enabled. This parameter can be used to enable or disable the mapping, both during resource creation and for already created resources. Defaults to `true`.
 * `event_source_arn` - (Optional) The event source ARN - this is required for Kinesis stream, DynamoDB stream, SQS queue, MQ broker, MSK cluster or DocumentDB change stream.  It is incompatible with a Self Managed Kafka source.
 * `filter_criteria` - (Optional) The criteria to use for [event filtering](https://docs.aws.amazon.com/lambda/latest/dg/invocation-eventfiltering.html) Kinesis stream, DynamoDB stream, SQS queue event sources. Detailed below.
 * `function_name` - (Required) The name or the ARN of the Lambda function that will be subscribing to events.


### PR DESCRIPTION
### Description

Improve the `enabled` parameter on aws_lambda_event_source_mapping resource.

The `enabled` parameter is described as:
```
enabled - (Optional) Determines if the mapping will be enabled on creation. Defaults to true.
```

This parameter not only applies on the resource creation. It also works for already created resources.
I have updated the documentation to:
```
enabled - (Optional) Determines if the mapping is enabled. This parameter can be used to enable or disable the mapping, both during resource creation and for already created resources. Defaults to true.
```

### Relations

Closes [#41999](https://github.com/hashicorp/terraform-provider-aws/issues/41999)