### PR TITLE
[Bug Fix] Attribute not_resources from aws_backup_selection should be removed from plan if removed from configuration

### DIFF
--- a/internal/service/backup/selection.go
+++ b/internal/service/backup/selection.go
@@ -143,7 +143,6 @@ func resourceSelection() *schema.Resource {
 			"not_resources": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
### Description
#### Description of the bug
As for now, when removing a not_resources attribute from aws_backup_selection resource where it was previously configured, this attribute is not removed, but is kept in Terraform State and active on AWS side.
#### To reproduce
Configure an AWS Backup with Backup Selection and Backup Plan. Apply with a non empty not_resources list, then configure it as an empty list and display Terraform Plan. The previously configured not_resources attribute is planned to be kept in place.
```
resource "aws_backup_vault" "example" {
  name = "example_backup_vault"

}

resource "aws_backup_selection" "example" {
  iam_role_arn = aws_iam_role.example.arn
  name         = "tf_example_backup_selection"
  plan_id      = aws_backup_plan.example.id

  selection_tag {
    type  = "STRINGEQUALS"
    key   = "example_tag_key"
    value = "example_tag_value"
  }

  #   not_resources = ["arn:aws:s3:::*"]
  #   not_resources = []
}

resource "aws_backup_plan" "example" {
  name = "tf_example_backup_plan"

  rule {
    rule_name         = "tf_example_backup_rule"
    target_vault_name = aws_backup_vault.example.name
    schedule          = "cron(0 12 * * ? *)"

    lifecycle {
      delete_after = 14
    }
  }
}

resource "aws_iam_role" "example" {
  name = "example_role"

  assume_role_policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Action = "sts:AssumeRole"
        Effect = "Allow"
        Principal = {
          Service = "backup.amazonaws.com"
        }
      },
    ]
  })
}

resource "aws_iam_role_policy" "example" {
  name = "example_policy"
  role = aws_iam_role.example.id

  policy = jsonencode({
    Version = "2012-10-17"
    Statement = [
      {
        Action = [
          "ec2:DescribeInstances",
          "ec2:DescribeVolumes",
          "rds:DescribeDBInstances",
          "rds:DescribeDBClusters",
          "dynamodb:DescribeTable",
          "dynamodb:ListTables",
          "dynamodb:ListTagsOfResource",
          "efs:DescribeFileSystems",
          "tag:GetResources"
        ]
        Effect   = "Allow"
        Resource = "*"
      },
    ]
  })
}
```

### Relations
This pull request is related to the [issue #41098](https://github.com/hashicorp/terraform-provider-aws/issues/41098).

### References
This pull request modifies the schema of the not_resources by removing the `Computed` property that was set to `true` in this [pull request](https://github.com/hashicorp/terraform-provider-aws/pull/22882).
Working around this previous pull request, no reason was found to keep setting `Computed` to `true` and it is likely to be related to another previous issue that was fixed on its side. Removing `Computed` from not_resources schema implies that we set it to its default value, which is `false`. All acceptance tests are passing with this update of the schema of not_resources.

### Output from Acceptance Testing
Adding an acceptance test that checks that the attribute not_resources is removed from plan once it is removed from configuration.
```console
% make testacc TESTS=TestAccBackupSelection PKG=backup
...
=== RUN   TestAccBackupSelectionDataSource_basic
=== PAUSE TestAccBackupSelectionDataSource_basic
=== RUN   TestAccBackupSelection_basic
=== PAUSE TestAccBackupSelection_basic
=== RUN   TestAccBackupSelection_disappears
=== PAUSE TestAccBackupSelection_disappears
=== RUN   TestAccBackupSelection_withTags
=== PAUSE TestAccBackupSelection_withTags
=== RUN   TestAccBackupSelection_conditionsWithTags
=== PAUSE TestAccBackupSelection_conditionsWithTags
=== RUN   TestAccBackupSelection_withResources
=== PAUSE TestAccBackupSelection_withResources
=== RUN   TestAccBackupSelection_withNotResources
=== PAUSE TestAccBackupSelection_withNotResources
=== RUN   TestAccBackupSelection_withNotResourcesRemoved
=== PAUSE TestAccBackupSelection_withNotResourcesRemoved
=== RUN   TestAccBackupSelection_updateTag
=== PAUSE TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelectionDataSource_basic
=== CONT  TestAccBackupSelection_withResources
=== CONT  TestAccBackupSelection_withTags
=== CONT  TestAccBackupSelection_conditionsWithTags
=== CONT  TestAccBackupSelection_withNotResourcesRemoved
=== CONT  TestAccBackupSelection_updateTag
=== CONT  TestAccBackupSelection_withNotResources
=== CONT  TestAccBackupSelection_disappears
=== CONT  TestAccBackupSelection_basic
--- PASS: TestAccBackupSelectionDataSource_basic (23.67s)
--- PASS: TestAccBackupSelection_disappears (26.92s)
--- PASS: TestAccBackupSelection_basic (30.52s)
--- PASS: TestAccBackupSelection_withNotResources (30.52s)
--- PASS: TestAccBackupSelection_conditionsWithTags (30.92s)
--- PASS: TestAccBackupSelection_withTags (30.98s)
--- PASS: TestAccBackupSelection_withNotResourcesRemoved (41.03s)
--- PASS: TestAccBackupSelection_updateTag (45.30s)
--- PASS: TestAccBackupSelection_withResources (50.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/backup     55.021s
```