### PR TITLE
r/aws_codepipeline: support removal of `trigger` arguments

### DIFF
--- a/.changelog/42008.txt
+++ b/.changelog/42008.txt
@@ -1,0 +1,6 @@
+```release-note:enhancement
+resource/aws_codepipeline: Removal of `trigger` argument now properly removes custom trigger definitions
+```
+```release-note:enhancement
+resource/aws_codepipeline:  Adds `trigger_all` attribute
+```

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -147,6 +148,215 @@ func resourcePipeline() *schema.Resource {
 									Optional:     true,
 									ValidateFunc: validation.IntBetween(5, 86400),
 								},
+							},
+						},
+					},
+				}
+			}
+
+			triggerSchema := func() *schema.Schema {
+				return &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 50,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"git_configuration": {
+								Type:     schema.TypeList,
+								Required: true,
+								MaxItems: 1,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"pull_request": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 1,
+											MaxItems: 3,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"branches": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"excludes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+																"includes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+															},
+														},
+													},
+													"events": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MinItems: 1,
+														MaxItems: 3,
+														Elem: &schema.Schema{
+															Type:             schema.TypeString,
+															ValidateDiagFunc: enum.Validate[types.GitPullRequestEventType](),
+														},
+													},
+													"file_paths": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"excludes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+																"includes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"push": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MinItems: 1,
+											MaxItems: 3,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"branches": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"excludes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+																"includes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+															},
+														},
+													},
+													"file_paths": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"excludes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+																"includes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+															},
+														},
+													},
+													names.AttrTags: {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 1,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"excludes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+																"includes": {
+																	Type:     schema.TypeList,
+																	Optional: true,
+																	MinItems: 1,
+																	MaxItems: 8,
+																	Elem: &schema.Schema{
+																		Type:         schema.TypeString,
+																		ValidateFunc: validation.StringLenBetween(1, 255),
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+										"source_action_name": {
+											Type:     schema.TypeString,
+											Required: true,
+											ValidateFunc: validation.All(
+												validation.StringLenBetween(1, 100),
+												validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.@-]+`), ""),
+											),
+										},
+									},
+								},
+							},
+							"provider_type": {
+								Type:             schema.TypeString,
+								Required:         true,
+								ValidateDiagFunc: enum.Validate[types.PipelineTriggerProviderType](),
 							},
 						},
 					},
@@ -400,213 +610,8 @@ func resourcePipeline() *schema.Resource {
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
-				"trigger": {
-					Type:     schema.TypeList,
-					Optional: true,
-					Computed: true,
-					MaxItems: 50,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"git_configuration": {
-								Type:     schema.TypeList,
-								Required: true,
-								MaxItems: 1,
-								Elem: &schema.Resource{
-									Schema: map[string]*schema.Schema{
-										"pull_request": {
-											Type:     schema.TypeList,
-											Optional: true,
-											MinItems: 1,
-											MaxItems: 3,
-											Elem: &schema.Resource{
-												Schema: map[string]*schema.Schema{
-													"branches": {
-														Type:     schema.TypeList,
-														Optional: true,
-														MaxItems: 1,
-														Elem: &schema.Resource{
-															Schema: map[string]*schema.Schema{
-																"excludes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-																"includes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-															},
-														},
-													},
-													"events": {
-														Type:     schema.TypeList,
-														Optional: true,
-														MinItems: 1,
-														MaxItems: 3,
-														Elem: &schema.Schema{
-															Type:             schema.TypeString,
-															ValidateDiagFunc: enum.Validate[types.GitPullRequestEventType](),
-														},
-													},
-													"file_paths": {
-														Type:     schema.TypeList,
-														Optional: true,
-														MaxItems: 1,
-														Elem: &schema.Resource{
-															Schema: map[string]*schema.Schema{
-																"excludes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-																"includes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-										"push": {
-											Type:     schema.TypeList,
-											Optional: true,
-											MinItems: 1,
-											MaxItems: 3,
-											Elem: &schema.Resource{
-												Schema: map[string]*schema.Schema{
-													"branches": {
-														Type:     schema.TypeList,
-														Optional: true,
-														MaxItems: 1,
-														Elem: &schema.Resource{
-															Schema: map[string]*schema.Schema{
-																"excludes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-																"includes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-															},
-														},
-													},
-													"file_paths": {
-														Type:     schema.TypeList,
-														Optional: true,
-														MaxItems: 1,
-														Elem: &schema.Resource{
-															Schema: map[string]*schema.Schema{
-																"excludes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-																"includes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-															},
-														},
-													},
-													names.AttrTags: {
-														Type:     schema.TypeList,
-														Optional: true,
-														MaxItems: 1,
-														Elem: &schema.Resource{
-															Schema: map[string]*schema.Schema{
-																"excludes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-																"includes": {
-																	Type:     schema.TypeList,
-																	Optional: true,
-																	MinItems: 1,
-																	MaxItems: 8,
-																	Elem: &schema.Schema{
-																		Type:         schema.TypeString,
-																		ValidateFunc: validation.StringLenBetween(1, 255),
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-										"source_action_name": {
-											Type:     schema.TypeString,
-											Required: true,
-											ValidateFunc: validation.All(
-												validation.StringLenBetween(1, 100),
-												validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z_.@-]+`), ""),
-											),
-										},
-									},
-								},
-							},
-							"provider_type": {
-								Type:             schema.TypeString,
-								Required:         true,
-								ValidateDiagFunc: enum.Validate[types.PipelineTriggerProviderType](),
-							},
-						},
-					},
-				},
+				"trigger":         triggerSchema(),
+				"trigger_all":     sdkv2.DataSourcePropertyFromResourceProperty(triggerSchema()),
 				"variable": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -698,8 +703,9 @@ func resourcePipelineRead(ctx context.Context, d *schema.ResourceData, meta any)
 	if err := d.Set(names.AttrStage, flattenStageDeclarations(d, pipeline.Stages)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting stage: %s", err)
 	}
-	if err := d.Set("trigger", flattenTriggerDeclarations(pipeline.Triggers)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting trigger: %s", err)
+	d.Set("trigger", d.Get("trigger"))
+	if err := d.Set("trigger_all", flattenTriggerDeclarations(pipeline.Triggers)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting trigger_all: %s", err)
 	}
 	if err := d.Set("variable", flattenVariableDeclarations(pipeline.Variables)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting variable: %s", err)
@@ -828,7 +834,13 @@ func hashGitHubToken(token string) string {
 }
 
 func expandPipelineDeclaration(d *schema.ResourceData) (*types.PipelineDeclaration, error) {
-	apiObject := &types.PipelineDeclaration{}
+	pipelineType := types.PipelineType(d.Get("pipeline_type").(string))
+	apiObject := &types.PipelineDeclaration{
+		Name:         aws.String(d.Get(names.AttrName).(string)),
+		PipelineType: pipelineType,
+		RoleArn:      aws.String(d.Get(names.AttrRoleARN).(string)),
+		Stages:       expandStageDeclarations(d.Get(names.AttrStage).([]any)),
+	}
 
 	if v, ok := d.GetOk("artifact_store"); ok && v.(*schema.Set).Len() > 0 {
 		artifactStores := expandArtifactStores(v.(*schema.Set).List())
@@ -859,23 +871,9 @@ func expandPipelineDeclaration(d *schema.ResourceData) (*types.PipelineDeclarati
 		apiObject.ExecutionMode = types.ExecutionMode(v.(string))
 	}
 
-	if v, ok := d.GetOk(names.AttrName); ok {
-		apiObject.Name = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("pipeline_type"); ok {
-		apiObject.PipelineType = types.PipelineType(v.(string))
-	}
-
-	if v, ok := d.GetOk(names.AttrRoleARN); ok {
-		apiObject.RoleArn = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk(names.AttrStage); ok && len(v.([]any)) > 0 {
-		apiObject.Stages = expandStageDeclarations(v.([]any))
-	}
-
-	if v, ok := d.GetOk("trigger"); ok && len(v.([]any)) > 0 {
+	// explicitly send trigger for all V2 pipelines (even when unset) to ensure
+	// removed custom triggers are handled correctly
+	if v, ok := d.GetOk("trigger"); (ok && len(v.([]any)) > 0) || pipelineType == types.PipelineTypeV2 {
 		apiObject.Triggers = expandTriggerDeclarations(v.([]any))
 	}
 
@@ -1391,10 +1389,6 @@ func expandTriggerDeclaration(tfMap map[string]any) *types.PipelineTriggerDeclar
 }
 
 func expandTriggerDeclarations(tfList []any) []types.PipelineTriggerDeclaration {
-	if len(tfList) == 0 {
-		return nil
-	}
-
 	var apiObjects []types.PipelineTriggerDeclaration
 
 	for _, tfMapRaw := range tfList {

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -595,7 +596,7 @@ func TestAccCodePipeline_ecr(t *testing.T) {
 	})
 }
 
-func TestAccCodePipeline_pipelinetype(t *testing.T) {
+func TestAccCodePipeline_pipelineType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var p types.PipelineDeclaration
 	rName := sdkacctest.RandString(10)
@@ -613,7 +614,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCodePipelineConfig_pipelinetype(rName, "V1"),
+				Config: testAccCodePipelineConfig_pipelineType(rName, "V1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.codepipeline_role", names.AttrARN),
@@ -800,6 +801,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"stage.0.action.0.configuration.%",
 					"stage.0.action.0.configuration.OAuthToken",
+					"trigger",
 				},
 			},
 			{
@@ -875,6 +877,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"stage.0.action.0.configuration.%",
 					"stage.0.action.0.configuration.OAuthToken",
+					"trigger",
 				},
 			},
 			{
@@ -908,7 +911,8 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "variable.1.name", "test_var2"),
 					resource.TestCheckResourceAttr(resourceName, "variable.1.description", "This is test pipeline variable 2."),
 					resource.TestCheckResourceAttr(resourceName, "variable.1.default_value", acctest.CtValue2),
-					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.git_configuration.#", "1"),
 				),
 			},
 			{
@@ -921,7 +925,7 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccCodePipelineConfig_pipelinetype(rName, "V2"),
+				Config: testAccCodePipelineConfig_pipelineType(rName, "V2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPipelineExists(ctx, resourceName, &p),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.codepipeline_role", names.AttrARN),
@@ -962,7 +966,8 @@ func TestAccCodePipeline_pipelinetype(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
-					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.git_configuration.#", "1"),
 				),
 			},
 			{
@@ -1205,6 +1210,60 @@ func TestAccCodePipeline_conditions(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCodePipeline_trigger(t *testing.T) {
+	ctx := acctest.Context(t)
+	var p types.PipelineDeclaration
+	rName := sdkacctest.RandString(10)
+	resourceName := "aws_codepipeline.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodePipelineServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCodePipelineConfig_trigger(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.provider_type", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger.0.git_configuration.0.source_action_name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.provider_type", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.git_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.git_configuration.0.source_action_name", "Source"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"trigger"},
+			},
+			{
+				Config: testAccCodePipelineConfig_pipelineType(rName, string(types.PipelineTypeV2)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttr(resourceName, "trigger.#", "0"),
+					// For V2 pipelines, AWS will inject a default trigger block when a custom one is removed
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "trigger_all.0.git_configuration.#", "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -1528,7 +1587,104 @@ resource "aws_codestarconnections_connection" "test" {
 `, rName))
 }
 
-func testAccCodePipelineConfig_pipelinetype(rName, pipelineType string) string { // nosemgrep:ci.codepipeline-in-func-name
+func testAccCodePipelineConfig_trigger(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%[1]s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.test.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "lifesum-terraform/test"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+    }
+  }
+
+  pipeline_type = "V2"
+
+  trigger {
+    provider_type = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+      push {
+        branches {
+          includes = ["main"]
+          excludes = ["feature/test1"]
+        }
+        file_paths {
+          includes = ["src/production1"]
+          excludes = ["test/production1"]
+        }
+        tags {
+          includes = ["tag1"]
+          excludes = ["tag11"]
+        }
+      }
+      pull_request {
+        events = ["OPEN", "UPDATED", "CLOSED"]
+        branches {
+          includes = ["main", "sub11"]
+          excludes = ["feature/test11", "feature/test12"]
+        }
+        file_paths {
+          includes = ["src/production11", "src/production12"]
+          excludes = ["test/production11", "test/production12"]
+        }
+      }
+    }
+  }
+}
+
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_pipelineType(rName, pipelineType string) string { // nosemgrep:ci.codepipeline-in-func-name
 	return acctest.ConfigCompose(
 		testAccS3DefaultBucket(rName),
 		testAccServiceIAMRole(rName),

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -185,6 +185,8 @@ This resource supports the following arguments:
 * `trigger` - (Optional) A trigger block. Valid only when `pipeline_type` is `V2`. Triggers are documented below.
 * `variable` - (Optional) A pipeline-level variable block. Valid only when `pipeline_type` is `V2`. Variable are documented below.
 
+### `artifact_store`
+
 An `artifact_store` block supports the following arguments:
 
 * `location` - (Required) The location where AWS CodePipeline stores artifacts for a pipeline; currently only `S3` is supported.
@@ -192,10 +194,14 @@ An `artifact_store` block supports the following arguments:
 * `encryption_key` - (Optional) The encryption key block AWS CodePipeline uses to encrypt the data in the artifact store, such as an AWS Key Management Service (AWS KMS) key. If you don't specify a key, AWS CodePipeline uses the default key for Amazon Simple Storage Service (Amazon S3). An `encryption_key` block is documented below.
 * `region` - (Optional) The region where the artifact store is located. Required for a cross-region CodePipeline, do not provide for a single-region CodePipeline.
 
+#### `encryption_key`
+
 An `encryption_key` block supports the following arguments:
 
 * `id` - (Required) The KMS key ARN or ID
 * `type` - (Required) The type of key; currently only `KMS` is supported
+
+### `stage`
 
 A `stage` block supports the following arguments:
 
@@ -205,46 +211,9 @@ A `stage` block supports the following arguments:
 * `on_success` - (Optional) The method to use when a stage has succeeded. For example, configuring this field for conditions will allow the stage to succeed when the conditions are met.
 * `on_failure` - (Optional) The method to use when a stage has not completed successfully. For example, configuring this field for rollback will roll back a failed stage automatically to the last successful pipeline execution in the stage.
 
-A `before_entry` block supports the following arguments:
+#### `action`
 
-* `condition` - (Required) The conditions that are configured as entry condition. Defined as a `condition` block below.
-
-A `on_success` block supports the following arguments:
-
-* `condition` - (Required) The conditions that are success conditions. Defined as a `condition` block below.
-
-A `on_failure` block supports the following arguments:
-
-* `condition` - (Optional) The conditions that are failure conditions. Defined as a `condition` block below.
-* `result` - (Optional) The conditions that are configured as failure conditions. Possible values are `ROLLBACK`,  `FAIL`, `RETRY` and `SKIP`.
-* `retry_configuration` - (Optional) The retry configuration specifies automatic retry for a failed stage, along with the configured retry mode. Defined as a `retry_configuration` block below.
-
-A `condition` block supports the following arguments:
-
-* `result` - (Optional) The action to be done when the condition is met. For example, rolling back an execution for a failure condition. Possible values are `ROLLBACK`, `FAIL`, `RETRY` and `SKIP`.
-* `rule` - (Optional) The rules that make up the condition. Defined as a `rule` block below.
-
-A `rule` block supports the following arguments:
-
-* `name` - (Required) The name of the rule that is created for the condition, such as `VariableCheck`.
-* `rule_type_id` - (Required) The ID for the rule type, which is made up of the combined values for `category`, `owner`, `provider`, and `version`. Defined as an `rule_type_id` block below.
-* `commands` - (Optional) The shell commands to run with your commands rule in CodePipeline. All commands are supported except multi-line formats.
-* `configuration` - (Optional) The action configuration fields for the rule. Configurations options for rule types and providers can be found in the [Rule structure reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/rule-reference.html).
-* `input_artifacts` - (Optional) The list of the input artifacts fields for the rule, such as specifying an input file for the rule.
-* `region` - (Optional) The Region for the condition associated with the rule.
-* `role_arn` - (Optional) The pipeline role ARN associated with the rule.
-* `timeout_in_minutes` - (Optional) The action timeout for the rule.
-
-A `rule_type_id` block supports the following arguments:
-
-* `category` - (Required) A category defines what kind of rule can be run in the stage, and constrains the provider type for the rule. The valid category is `Rule`.
-* `provider` - (Required) The rule provider, such as the DeploymentWindow rule. For a list of rule provider names, see the rules listed in the [AWS CodePipeline rule reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/rule-reference.html).
-* `owner` - (Optional) The creator of the rule being called. The valid value for the Owner field in the rule category is `AWS`.
-* `version` - (Optional) A string that describes the rule version.
-
-A `retry_configuration` block supports the following arguments:
-
-* `retry_mode` - (Optional) The method that you want to configure for automatic stage retry on stage failure. You can specify to retry only failed action in the stage or all actions in the stage. Possible values are `FAILED_ACTIONS` and `ALL_ACTIONS`.
+~> The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.
 
 An `action` block supports the following arguments:
 
@@ -261,10 +230,69 @@ An `action` block supports the following arguments:
 * `region` - (Optional) The region in which to run the action.
 * `namespace` - (Optional) The namespace all output variables will be accessed from.
 
+#### `before_entry`
+
+A `before_entry` block supports the following arguments:
+
+* `condition` - (Required) The conditions that are configured as entry condition. Defined as a `condition` block below.
+
+#### `on_success`
+
+A `on_success` block supports the following arguments:
+
+* `condition` - (Required) The conditions that are success conditions. Defined as a `condition` block below.
+
+#### `on_failure`
+
+A `on_failure` block supports the following arguments:
+
+* `condition` - (Optional) The conditions that are failure conditions. Defined as a `condition` block below.
+* `result` - (Optional) The conditions that are configured as failure conditions. Possible values are `ROLLBACK`,  `FAIL`, `RETRY` and `SKIP`.
+* `retry_configuration` - (Optional) The retry configuration specifies automatic retry for a failed stage, along with the configured retry mode. Defined as a `retry_configuration` block below.
+
+##### `condition`
+
+A `condition` block supports the following arguments:
+
+* `result` - (Optional) The action to be done when the condition is met. For example, rolling back an execution for a failure condition. Possible values are `ROLLBACK`, `FAIL`, `RETRY` and `SKIP`.
+* `rule` - (Optional) The rules that make up the condition. Defined as a `rule` block below.
+
+##### `rule`
+
+A `rule` block supports the following arguments:
+
+* `name` - (Required) The name of the rule that is created for the condition, such as `VariableCheck`.
+* `rule_type_id` - (Required) The ID for the rule type, which is made up of the combined values for `category`, `owner`, `provider`, and `version`. Defined as an `rule_type_id` block below.
+* `commands` - (Optional) The shell commands to run with your commands rule in CodePipeline. All commands are supported except multi-line formats.
+* `configuration` - (Optional) The action configuration fields for the rule. Configurations options for rule types and providers can be found in the [Rule structure reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/rule-reference.html).
+* `input_artifacts` - (Optional) The list of the input artifacts fields for the rule, such as specifying an input file for the rule.
+* `region` - (Optional) The Region for the condition associated with the rule.
+* `role_arn` - (Optional) The pipeline role ARN associated with the rule.
+* `timeout_in_minutes` - (Optional) The action timeout for the rule.
+
+##### `rule_type_id`
+
+A `rule_type_id` block supports the following arguments:
+
+* `category` - (Required) A category defines what kind of rule can be run in the stage, and constrains the provider type for the rule. The valid category is `Rule`.
+* `provider` - (Required) The rule provider, such as the DeploymentWindow rule. For a list of rule provider names, see the rules listed in the [AWS CodePipeline rule reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/rule-reference.html).
+* `owner` - (Optional) The creator of the rule being called. The valid value for the Owner field in the rule category is `AWS`.
+* `version` - (Optional) A string that describes the rule version.
+
+##### `retry_configuration`
+
+A `retry_configuration` block supports the following arguments:
+
+* `retry_mode` - (Optional) The method that you want to configure for automatic stage retry on stage failure. You can specify to retry only failed action in the stage or all actions in the stage. Possible values are `FAILED_ACTIONS` and `ALL_ACTIONS`.
+
+### `trigger`
+
 A `trigger` block supports the following arguments:
 
 * `provider_type` - (Required) The source provider for the event. Possible value is `CodeStarSourceConnection`.
 * `git_configuration` - (Required) Provides the filter criteria and the source stage for the repository event that starts the pipeline. For more information, refer to the [AWS documentation](https://docs.aws.amazon.com/codepipeline/latest/userguide/pipelines-filter.html). A `git_configuration` block is documented below.
+
+#### `git_configuration`
 
 A `git_configuration` block supports the following arguments:
 
@@ -272,11 +300,15 @@ A `git_configuration` block supports the following arguments:
 * `pull_request` - (Optional) The field where the repository event that will start the pipeline is specified as pull requests. A `pull_request` block is documented below.
 * `push` - (Optional) The field where the repository event that will start the pipeline, such as pushing Git tags, is specified with details. A `push` block is documented below.
 
+##### `pull_request`
+
 A `pull_request` block supports the following arguments:
 
 * `events` - (Optional) A list that specifies which pull request events to filter on (opened, updated, closed) for the trigger configuration. Possible values are `OPEN`, `UPDATED ` and `CLOSED`.
 * `branches` - (Optional) The field that specifies to filter on branches for the pull request trigger configuration. A `branches` block is documented below.
 * `file_paths` - (Optional) The field that specifies to filter on file paths for the pull request trigger configuration. A `file_paths` block is documented below.
+
+##### `push`
 
 A `push` block supports the following arguments:
 
@@ -284,20 +316,28 @@ A `push` block supports the following arguments:
 * `file_paths` - (Optional) The field that specifies to filter on file paths for the push trigger configuration. A `file_paths` block is documented below.
 * `tags` - (Optional) The field that contains the details for the Git tags trigger configuration. A `tags` block is documented below.
 
+##### `branches`
+
 A `branches` block supports the following arguments:
 
 * `includes` - (Optional) A list of patterns of Git branches that, when a commit is pushed, are to be included as criteria that starts the pipeline.
 * `excludes` - (Optional) A list of patterns of Git branches that, when a commit is pushed, are to be excluded from starting the pipeline.
+
+##### `file_paths`
 
 A `file_paths` block supports the following arguments:
 
 * `includes` - (Optional) A list of patterns of Git repository file paths that, when a commit is pushed, are to be included as criteria that starts the pipeline.
 * `excludes` - (Optional) A list of patterns of Git repository file paths that, when a commit is pushed, are to be excluded from starting the pipeline.
 
+##### `tags`
+
 A `tags` block supports the following arguments:
 
 * `includes` - (Optional) A list of patterns of Git tags that, when pushed, are to be included as criteria that starts the pipeline.
 * `excludes` - (Optional) A list of patterns of Git tags that, when pushed, are to be excluded from starting the pipeline.
+
+### `variable`
 
 A `variable` block supports the following arguments:
 
@@ -305,29 +345,28 @@ A `variable` block supports the following arguments:
 * `default_value` - (Optional) The default value of a pipeline-level variable.
 * `description` - (Optional) The description of a pipeline-level variable.
 
-~> **Note:** The input artifact of an action must exactly match the output artifact declared in a preceding action, but the input artifact does not have to be the next action in strict sequence from the action that provided the output artifact. Actions in parallel can declare different output artifacts, which are in turn consumed by different following actions.
-
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The codepipeline ID.
-* `arn` - The codepipeline ARN.
+* `id` - Codepipeline ID.
+* `arn` - Codepipeline ARN.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
+* `trigger_all` - A list of all triggers present on the pipeline, including default triggers added by AWS for `V2` pipelines which omit an explicit `trigger` definition.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodePipelines using the name. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import CodePipelines using the `name`. For example:
 
 ```terraform
 import {
-  to = aws_codepipeline.foo
-  id = "example"
+  to = aws_codepipeline.example
+  id = "example-pipeline"
 }
 ```
 
-Using `terraform import`, import CodePipelines using the name. For example:
+Using `terraform import`, import CodePipelines using the `name`. For example:
 
 ```console
-% terraform import aws_codepipeline.foo example
+% terraform import aws_codepipeline.example example-pipeline
 ```


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the `trigger` argument was optional and computed, meaning that removal of a configured trigger definition would not result in planned changes as the value would be interpreted as computed only. This change switches the `trigger` argument back to optional only, and adds a computed `trigger_all` block which is used to track both custom trigger configurations provided by the user and default configurations added by AWS for `V2` pipelines. The downside of this approach is that drift between the remote and configured `trigger` definition can no longer be detected. This was deemed an acceptable trade-off in order to ensure trigger removals operate as intended without manual intervention.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39347 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_CreatePipeline.html
- https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_UpdatePipeline.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=codepipeline TESTS="TestAccCodePipeline_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/codepipeline/... -v -count 1 -parallel 20 -run='TestAccCodePipeline_'  -timeout 360m -vet=off
2025/03/27 11:28:59 Initializing Terraform AWS Provider...

--- PASS: TestAccCodePipeline_disappears (36.97s)
--- PASS: TestAccCodePipeline_withNamespace (37.27s)
--- PASS: TestAccCodePipeline_deployWithServiceRole (42.22s)
--- PASS: TestAccCodePipeline_emptyStageArtifacts (42.87s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (46.63s)
--- PASS: TestAccCodePipeline_trigger (50.36s)
--- PASS: TestAccCodePipeline_manualApprovalTimeoutInMinutes (59.18s)
--- PASS: TestAccCodePipeline_conditions (59.98s)
--- PASS: TestAccCodePipeline_basic (60.17s)
--- PASS: TestAccCodePipeline_MultiRegion_update (64.77s)
--- PASS: TestAccCodePipeline_ecr (71.32s)
--- PASS: TestAccCodePipeline_tags (77.72s)
--- PASS: TestAccCodePipeline_MultiRegion_convertSingleRegion (79.22s)
--- PASS: TestAccCodePipeline_pipelineType (100.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       107.207s
```
