### PR TITLE
Further regressions notifier fixes

### DIFF
--- a/.github/workflows/maintainer_helpers.yml
+++ b/.github/workflows/maintainer_helpers.yml
@@ -188,8 +188,8 @@ jobs:
                       "elements": [
                         {
                           "type": "link",
-                          "text": ${{ toJSON(env.ISSUE_TITLE) }}
-                          "url": ${{ env.ISSUE_URL }}
+                          "text": ${{ toJSON(env.ISSUE_TITLE) }},
+                          "url": ${{ toJSON(env.ISSUE_URL) }}
                         }
                       ]
                     }


### PR DESCRIPTION
### Description

Adds a missing comma and wraps the URL in `toJSON` to ensure it's wrapped in quotes

