### PR TITLE
Fix CodeQL `Incorrect conversion between integer types` warning

### DIFF
--- a/internal/service/elb/app_cookie_stickiness_policy.go
+++ b/internal/service/elb/app_cookie_stickiness_policy.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/YakDriver/regexache"
@@ -22,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -75,17 +75,17 @@ func resourceAppCookieStickinessPolicyCreate(ctx context.Context, d *schema.Reso
 	conn := meta.(*conns.AWSClient).ELBClient(ctx)
 
 	lbName := d.Get("load_balancer").(string)
-	lbPort := d.Get("lb_port").(int)
+	lbPort := int32(d.Get("lb_port").(int))
 	policyName := d.Get(names.AttrName).(string)
 	id := appCookieStickinessPolicyCreateResourceID(lbName, lbPort, policyName)
 	{
-		input := &elasticloadbalancing.CreateAppCookieStickinessPolicyInput{
+		input := elasticloadbalancing.CreateAppCookieStickinessPolicyInput{
 			CookieName:       aws.String(d.Get("cookie_name").(string)),
 			LoadBalancerName: aws.String(lbName),
 			PolicyName:       aws.String(policyName),
 		}
 
-		_, err := conn.CreateAppCookieStickinessPolicy(ctx, input)
+		_, err := conn.CreateAppCookieStickinessPolicy(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating ELB Classic App Cookie Stickiness Policy (%s): %s", id, err)
@@ -95,13 +95,13 @@ func resourceAppCookieStickinessPolicyCreate(ctx context.Context, d *schema.Reso
 	d.SetId(id)
 
 	{
-		input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
 			LoadBalancerName: aws.String(lbName),
-			LoadBalancerPort: int32(lbPort),
+			LoadBalancerPort: lbPort,
 			PolicyNames:      []string{policyName},
 		}
 
-		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting ELB Classic App Cookie Stickiness Policy (%s): %s", d.Id(), err)
@@ -154,49 +154,54 @@ func resourceAppCookieStickinessPolicyDelete(ctx context.Context, d *schema.Reso
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	// Perversely, if we Set an empty list of PolicyNames, we detach the
-	// policies attached to a listener, which is required to delete the
-	// policy itself.
-	input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
-		LoadBalancerName: aws.String(lbName),
-		LoadBalancerPort: int32(lbPort),
-		PolicyNames:      []string{},
+	{
+		// Perversely, if we Set an empty list of PolicyNames, we detach the
+		// policies attached to a listener, which is required to delete the
+		// policy itself.
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+			LoadBalancerName: aws.String(lbName),
+			LoadBalancerPort: lbPort,
+			PolicyNames:      []string{},
+		}
+
+		_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
+
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting ELB Classic App Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		}
 	}
 
-	_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+	{
+		log.Printf("[DEBUG] Deleting ELB Classic App Cookie Stickiness Policy: %s", d.Id())
+		input := elasticloadbalancing.DeleteLoadBalancerPolicyInput{
+			LoadBalancerName: aws.String(lbName),
+			PolicyName:       aws.String(policyName),
+		}
+		_, err = conn.DeleteLoadBalancerPolicy(ctx, &input)
 
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting ELB Classic App Cookie Stickiness Policy (%s): %s", d.Id(), err)
-	}
-
-	log.Printf("[DEBUG] Deleting ELB Classic App Cookie Stickiness Policy: %s", d.Id())
-	_, err = conn.DeleteLoadBalancerPolicy(ctx, &elasticloadbalancing.DeleteLoadBalancerPolicyInput{
-		LoadBalancerName: aws.String(lbName),
-		PolicyName:       aws.String(policyName),
-	})
-
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting ELB Classic App Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "deleting ELB Classic App Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		}
 	}
 
 	return diags
 }
 
 func findLoadBalancerPolicyByTwoPartKey(ctx context.Context, conn *elasticloadbalancing.Client, lbName, policyName string) (*awstypes.PolicyDescription, error) {
-	input := &elasticloadbalancing.DescribeLoadBalancerPoliciesInput{
+	input := elasticloadbalancing.DescribeLoadBalancerPoliciesInput{
 		LoadBalancerName: aws.String(lbName),
 		PolicyNames:      []string{policyName},
 	}
 
-	output, err := conn.DescribeLoadBalancerPolicies(ctx, input)
+	output, err := conn.DescribeLoadBalancerPolicies(ctx, &input)
 
 	if errs.IsA[*awstypes.PolicyNotFoundException](err) || errs.IsA[*awstypes.AccessPointNotFoundException](err) {
 		return nil, &retry.NotFoundError{
@@ -212,7 +217,7 @@ func findLoadBalancerPolicyByTwoPartKey(ctx context.Context, conn *elasticloadba
 	return tfresource.AssertSingleValueResult(output.PolicyDescriptions)
 }
 
-func findLoadBalancerListenerPolicyByThreePartKey(ctx context.Context, conn *elasticloadbalancing.Client, lbName string, lbPort int, policyName string) (*awstypes.PolicyDescription, error) {
+func findLoadBalancerListenerPolicyByThreePartKey(ctx context.Context, conn *elasticloadbalancing.Client, lbName string, lbPort int32, policyName string) (*awstypes.PolicyDescription, error) {
 	policy, err := findLoadBalancerPolicyByTwoPartKey(ctx, conn, lbName, policyName)
 
 	if err != nil {
@@ -225,12 +230,14 @@ func findLoadBalancerListenerPolicyByThreePartKey(ctx context.Context, conn *ela
 		return nil, err
 	}
 
+	//return tfresource.AssertSingleValueResult(tfslices.)
+
 	for _, v := range lb.ListenerDescriptions {
 		if v.Listener == nil {
 			continue
 		}
 
-		if v.Listener.LoadBalancerPort != int32(lbPort) {
+		if v.Listener.LoadBalancerPort != lbPort {
 			continue
 		}
 
@@ -244,24 +251,18 @@ func findLoadBalancerListenerPolicyByThreePartKey(ctx context.Context, conn *ela
 
 const appCookieStickinessPolicyResourceIDSeparator = ":"
 
-func appCookieStickinessPolicyCreateResourceID(lbName string, lbPort int, policyName string) string {
-	parts := []string{lbName, strconv.Itoa(lbPort), policyName}
+func appCookieStickinessPolicyCreateResourceID(lbName string, lbPort int32, policyName string) string {
+	parts := []string{lbName, flex.Int32ValueToStringValue(lbPort), policyName}
 	id := strings.Join(parts, appCookieStickinessPolicyResourceIDSeparator)
 
 	return id
 }
 
-func appCookieStickinessPolicyParseResourceID(id string) (string, int, string, error) {
+func appCookieStickinessPolicyParseResourceID(id string) (string, int32, string, error) {
 	parts := strings.Split(id, appCookieStickinessPolicyResourceIDSeparator)
 
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
-		v, err := strconv.Atoi(parts[1])
-
-		if err != nil {
-			return "", 0, "", err
-		}
-
-		return parts[0], v, parts[2], nil
+		return parts[0], flex.StringValueToInt32Value(parts[1]), parts[2], nil
 	}
 
 	return "", 0, "", fmt.Errorf("unexpected format for ID (%[1]s), expected LBNAME%[2]sLBPORT%[2]sPOLICYNAME", id, appCookieStickinessPolicyResourceIDSeparator)

--- a/internal/service/elb/app_cookie_stickiness_policy.go
+++ b/internal/service/elb/app_cookie_stickiness_policy.go
@@ -230,8 +230,6 @@ func findLoadBalancerListenerPolicyByThreePartKey(ctx context.Context, conn *ela
 		return nil, err
 	}
 
-	//return tfresource.AssertSingleValueResult(tfslices.)
-
 	for _, v := range lb.ListenerDescriptions {
 		if v.Listener == nil {
 			continue

--- a/internal/service/elb/lb_cookie_stickiness_policy.go
+++ b/internal/service/elb/lb_cookie_stickiness_policy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -61,11 +60,11 @@ func resourceCookieStickinessPolicyCreate(ctx context.Context, d *schema.Resourc
 	conn := meta.(*conns.AWSClient).ELBClient(ctx)
 
 	lbName := d.Get("load_balancer").(string)
-	lbPort := d.Get("lb_port").(int)
+	lbPort := int32(d.Get("lb_port").(int))
 	policyName := d.Get(names.AttrName).(string)
 	id := lbCookieStickinessPolicyCreateResourceID(lbName, lbPort, policyName)
 	{
-		input := &elasticloadbalancing.CreateLBCookieStickinessPolicyInput{
+		input := elasticloadbalancing.CreateLBCookieStickinessPolicyInput{
 			LoadBalancerName: aws.String(lbName),
 			PolicyName:       aws.String(policyName),
 		}
@@ -74,7 +73,7 @@ func resourceCookieStickinessPolicyCreate(ctx context.Context, d *schema.Resourc
 			input.CookieExpirationPeriod = aws.Int64(int64(v.(int)))
 		}
 
-		_, err := conn.CreateLBCookieStickinessPolicy(ctx, input)
+		_, err := conn.CreateLBCookieStickinessPolicy(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating ELB Classic LB Cookie Stickiness Policy (%s): %s", id, err)
@@ -82,13 +81,13 @@ func resourceCookieStickinessPolicyCreate(ctx context.Context, d *schema.Resourc
 	}
 
 	{
-		input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
 			LoadBalancerName: aws.String(lbName),
-			LoadBalancerPort: int32(lbPort),
+			LoadBalancerPort: lbPort,
 			PolicyNames:      []string{policyName},
 		}
 
-		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting ELB Classic LB Cookie Stickiness Policy (%s): %s", id, err)
@@ -142,37 +141,42 @@ func resourceCookieStickinessPolicyDelete(ctx context.Context, d *schema.Resourc
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	// Perversely, if we Set an empty list of PolicyNames, we detach the
-	// policies attached to a listener, which is required to delete the
-	// policy itself.
-	input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
-		LoadBalancerName: aws.String(lbName),
-		LoadBalancerPort: int32(lbPort),
-		PolicyNames:      []string{},
+	{
+		// Perversely, if we Set an empty list of PolicyNames, we detach the
+		// policies attached to a listener, which is required to delete the
+		// policy itself.
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+			LoadBalancerName: aws.String(lbName),
+			LoadBalancerPort: lbPort,
+			PolicyNames:      []string{},
+		}
+
+		_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
+
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting ELB Classic LB Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		}
 	}
 
-	_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+	{
+		log.Printf("[DEBUG] Deleting ELB Classic LB Cookie Stickiness Policy: %s", d.Id())
+		input := elasticloadbalancing.DeleteLoadBalancerPolicyInput{
+			LoadBalancerName: aws.String(lbName),
+			PolicyName:       aws.String(policyName),
+		}
+		_, err = conn.DeleteLoadBalancerPolicy(ctx, &input)
 
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting ELB Classic LB Cookie Stickiness Policy (%s): %s", d.Id(), err)
-	}
-
-	log.Printf("[DEBUG] Deleting ELB Classic LB Cookie Stickiness Policy: %s", d.Id())
-	_, err = conn.DeleteLoadBalancerPolicy(ctx, &elasticloadbalancing.DeleteLoadBalancerPolicyInput{
-		LoadBalancerName: aws.String(lbName),
-		PolicyName:       aws.String(policyName),
-	})
-
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting ELB Classic LB Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "deleting ELB Classic LB Cookie Stickiness Policy (%s): %s", d.Id(), err)
+		}
 	}
 
 	return diags
@@ -180,24 +184,18 @@ func resourceCookieStickinessPolicyDelete(ctx context.Context, d *schema.Resourc
 
 const lbCookieStickinessPolicyResourceIDSeparator = ":"
 
-func lbCookieStickinessPolicyCreateResourceID(lbName string, lbPort int, policyName string) string {
-	parts := []string{lbName, strconv.Itoa(lbPort), policyName}
+func lbCookieStickinessPolicyCreateResourceID(lbName string, lbPort int32, policyName string) string {
+	parts := []string{lbName, flex.Int32ValueToStringValue(lbPort), policyName}
 	id := strings.Join(parts, lbCookieStickinessPolicyResourceIDSeparator)
 
 	return id
 }
 
-func lbCookieStickinessPolicyParseResourceID(id string) (string, int, string, error) {
+func lbCookieStickinessPolicyParseResourceID(id string) (string, int32, string, error) {
 	parts := strings.Split(id, lbCookieStickinessPolicyResourceIDSeparator)
 
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
-		v, err := strconv.Atoi(parts[1])
-
-		if err != nil {
-			return "", 0, "", err
-		}
-
-		return parts[0], v, parts[2], nil
+		return parts[0], flex.StringValueToInt32Value(parts[1]), parts[2], nil
 	}
 
 	return "", 0, "", fmt.Errorf("unexpected format for ID (%[1]s), expected LBNAME%[2]sLBPORT%[2]sPOLICYNAME", id, lbCookieStickinessPolicyResourceIDSeparator)

--- a/internal/service/elb/lb_ssl_negotiation_policy.go
+++ b/internal/service/elb/lb_ssl_negotiation_policy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -76,12 +76,12 @@ func resourceSSLNegotiationPolicyCreate(ctx context.Context, d *schema.ResourceD
 	conn := meta.(*conns.AWSClient).ELBClient(ctx)
 
 	lbName := d.Get("load_balancer").(string)
-	lbPort := d.Get("lb_port").(int)
+	lbPort := int32(d.Get("lb_port").(int))
 	policyName := d.Get(names.AttrName).(string)
 	id := sslNegotiationPolicyCreateResourceID(lbName, lbPort, policyName)
 
 	{
-		input := &elasticloadbalancing.CreateLoadBalancerPolicyInput{
+		input := elasticloadbalancing.CreateLoadBalancerPolicyInput{
 			LoadBalancerName: aws.String(lbName),
 			PolicyName:       aws.String(policyName),
 			PolicyTypeName:   aws.String("SSLNegotiationPolicyType"),
@@ -91,7 +91,7 @@ func resourceSSLNegotiationPolicyCreate(ctx context.Context, d *schema.ResourceD
 			input.PolicyAttributes = expandPolicyAttributes(v.(*schema.Set).List())
 		}
 
-		_, err := conn.CreateLoadBalancerPolicy(ctx, input)
+		_, err := conn.CreateLoadBalancerPolicy(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating ELB Classic SSL Negotiation Policy (%s): %s", id, err)
@@ -99,13 +99,13 @@ func resourceSSLNegotiationPolicyCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	{
-		input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
 			LoadBalancerName: aws.String(lbName),
-			LoadBalancerPort: int32(lbPort),
+			LoadBalancerPort: lbPort,
 			PolicyNames:      []string{policyName},
 		}
 
-		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+		_, err := conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting ELB Classic SSL Negotiation Policy (%s): %s", id, err)
@@ -169,36 +169,42 @@ func resourceSSLNegotiationPolicyDelete(ctx context.Context, d *schema.ResourceD
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	// Perversely, if we Set an empty list of PolicyNames, we detach the
-	// policies attached to a listener, which is required to delete the
-	// policy itself.
-	input := &elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
-		LoadBalancerName: aws.String(lbName),
-		LoadBalancerPort: int32(lbPort),
-		PolicyNames:      []string{},
+	{
+		// Perversely, if we Set an empty list of PolicyNames, we detach the
+		// policies attached to a listener, which is required to delete the
+		// policy itself.
+		input := elasticloadbalancing.SetLoadBalancerPoliciesOfListenerInput{
+			LoadBalancerName: aws.String(lbName),
+			LoadBalancerPort: lbPort,
+			PolicyNames:      []string{},
+		}
+
+		_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, &input)
+
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
+
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting ELB Classic SSL Negotiation Policy (%s): %s", d.Id(), err)
+		}
 	}
 
-	_, err = conn.SetLoadBalancerPoliciesOfListener(ctx, input)
+	{
+		log.Printf("[DEBUG] Deleting ELB Classic SSL Negotiation Policy: %s", d.Id())
+		input := elasticloadbalancing.DeleteLoadBalancerPolicyInput{
+			LoadBalancerName: aws.String(lbName),
+			PolicyName:       aws.String(policyName),
+		}
+		_, err = conn.DeleteLoadBalancerPolicy(ctx, &input)
 
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
+		if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
+			return diags
+		}
 
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting ELB Classic SSL Negotiation Policy (%s): %s", d.Id(), err)
-	}
-
-	_, err = conn.DeleteLoadBalancerPolicy(ctx, &elasticloadbalancing.DeleteLoadBalancerPolicyInput{
-		LoadBalancerName: aws.String(lbName),
-		PolicyName:       aws.String(policyName),
-	})
-
-	if tfawserr.ErrCodeEquals(err, errCodeLoadBalancerNotFound) {
-		return diags
-	}
-
-	if err != nil {
-		return sdkdiag.AppendErrorf(diags, "deleting ELB Classic SSL Negotiation Policy (%s): %s", d.Id(), err)
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "deleting ELB Classic SSL Negotiation Policy (%s): %s", d.Id(), err)
+		}
 	}
 
 	return diags
@@ -206,24 +212,18 @@ func resourceSSLNegotiationPolicyDelete(ctx context.Context, d *schema.ResourceD
 
 const sslNegotiationPolicyResourceIDSeparator = ":"
 
-func sslNegotiationPolicyCreateResourceID(lbName string, lbPort int, policyName string) string {
-	parts := []string{lbName, strconv.Itoa(lbPort), policyName}
+func sslNegotiationPolicyCreateResourceID(lbName string, lbPort int32, policyName string) string {
+	parts := []string{lbName, flex.Int32ValueToStringValue(lbPort), policyName}
 	id := strings.Join(parts, sslNegotiationPolicyResourceIDSeparator)
 
 	return id
 }
 
-func sslNegotiationPolicyParseResourceID(id string) (string, int, string, error) {
+func sslNegotiationPolicyParseResourceID(id string) (string, int32, string, error) {
 	parts := strings.Split(id, sslNegotiationPolicyResourceIDSeparator)
 
 	if len(parts) == 3 && parts[0] != "" && parts[1] != "" && parts[2] != "" {
-		v, err := strconv.Atoi(parts[1])
-
-		if err != nil {
-			return "", 0, "", err
-		}
-
-		return parts[0], v, parts[2], nil
+		return parts[0], flex.StringValueToInt32Value(parts[1]), parts[2], nil
 	}
 
 	return "", 0, "", fmt.Errorf("unexpected format for ID (%[1]s), expected LBNAME%[2]sLBPORT%[2]sPOLICYNAME", id, sslNegotiationPolicyResourceIDSeparator)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/472.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccELBSSLNegotiationPolicy_\|TestAccELBCookieStickinessPolicy_\|TestAccELBAppCookieStickinessPolicy_' PKG=elb ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/elb/... -v -count 1 -parallel 3  -run=TestAccELBSSLNegotiationPolicy_\|TestAccELBCookieStickinessPolicy_\|TestAccELBAppCookieStickinessPolicy_ -timeout 360m -vet=off
2025/03/28 08:56:46 Initializing Terraform AWS Provider...
=== RUN   TestAccELBAppCookieStickinessPolicy_basic
=== PAUSE TestAccELBAppCookieStickinessPolicy_basic
=== RUN   TestAccELBAppCookieStickinessPolicy_disappears
=== PAUSE TestAccELBAppCookieStickinessPolicy_disappears
=== RUN   TestAccELBAppCookieStickinessPolicy_Disappears_elb
=== PAUSE TestAccELBAppCookieStickinessPolicy_Disappears_elb
=== RUN   TestAccELBCookieStickinessPolicy_basic
=== PAUSE TestAccELBCookieStickinessPolicy_basic
=== RUN   TestAccELBCookieStickinessPolicy_disappears
=== PAUSE TestAccELBCookieStickinessPolicy_disappears
=== RUN   TestAccELBCookieStickinessPolicy_Disappears_elb
=== PAUSE TestAccELBCookieStickinessPolicy_Disappears_elb
=== RUN   TestAccELBSSLNegotiationPolicy_basic
=== PAUSE TestAccELBSSLNegotiationPolicy_basic
=== RUN   TestAccELBSSLNegotiationPolicy_update
=== PAUSE TestAccELBSSLNegotiationPolicy_update
=== RUN   TestAccELBSSLNegotiationPolicy_disappears
=== PAUSE TestAccELBSSLNegotiationPolicy_disappears
=== CONT  TestAccELBAppCookieStickinessPolicy_basic
=== CONT  TestAccELBCookieStickinessPolicy_Disappears_elb
=== CONT  TestAccELBCookieStickinessPolicy_basic
--- PASS: TestAccELBCookieStickinessPolicy_Disappears_elb (20.38s)
=== CONT  TestAccELBSSLNegotiationPolicy_update
--- PASS: TestAccELBCookieStickinessPolicy_basic (30.70s)
=== CONT  TestAccELBSSLNegotiationPolicy_disappears
--- PASS: TestAccELBAppCookieStickinessPolicy_basic (36.26s)
=== CONT  TestAccELBCookieStickinessPolicy_disappears
--- PASS: TestAccELBCookieStickinessPolicy_disappears (24.52s)
=== CONT  TestAccELBAppCookieStickinessPolicy_Disappears_elb
--- PASS: TestAccELBSSLNegotiationPolicy_update (49.49s)
=== CONT  TestAccELBSSLNegotiationPolicy_basic
--- PASS: TestAccELBSSLNegotiationPolicy_disappears (47.83s)
=== CONT  TestAccELBAppCookieStickinessPolicy_disappears
--- PASS: TestAccELBAppCookieStickinessPolicy_Disappears_elb (18.33s)
--- PASS: TestAccELBSSLNegotiationPolicy_basic (27.93s)
--- PASS: TestAccELBAppCookieStickinessPolicy_disappears (19.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elb	104.687s
```
