### PR TITLE
Fix aws_route53_resolver_endpoint hangs with 6-10 IPs

### DIFF
--- a/internal/service/route53resolver/service_package_extra_options.go
+++ b/internal/service/route53resolver/service_package_extra_options.go
@@ -1,0 +1,48 @@
+package route53resolver
+
+import (
+	"context"
+	"errors"
+
+	aws_sdkv2 "github.com/aws/aws-sdk-go-v2/aws"
+	retry_sdkv2 "github.com/aws/aws-sdk-go-v2/aws/retry"
+	"github.com/aws/aws-sdk-go-v2/service/route53resolver"
+	smithy "github.com/aws/smithy-go"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+)
+
+// service_package_gen.go is a generated file but the behavior can be extended in another file by defining this
+// function which NewClient will call. Use this to customize error retries.
+func (p *servicePackage) withExtraOptions(
+	_ context.Context,
+	config map[string]any,
+) []func(*route53resolver.Options) {
+	retryer := mustFindRetryer(config)
+	return []func(*route53resolver.Options){func(o *route53resolver.Options) {
+		o.Retryer = conns.AddIsErrorRetryables(retryer, doNotRetryLimitExceededException())
+	}}
+
+}
+
+func mustFindRetryer(config map[string]any) aws_sdkv2.RetryerV2 {
+	if cfg, ok := config["aws_sdkv2_config"]; ok {
+		if cfgp, ok := cfg.(*aws_sdkv2.Config); ok {
+			if r, ok := cfgp.Retryer().(aws_sdkv2.RetryerV2); ok {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func doNotRetryLimitExceededException() retry_sdkv2.IsErrorRetryable {
+	return retry_sdkv2.IsErrorRetryableFunc(func(err error) aws_sdkv2.Ternary {
+		var smithyErr smithy.APIError
+		if ok := errors.As(err, &smithyErr); ok {
+			if smithyErr.ErrorCode() == "LimitExceededException" {
+				return aws_sdkv2.FalseTernary
+			}
+		}
+		return aws_sdkv2.UnknownTernary // Delegate to the configured Retryer.
+	})
+}


### PR DESCRIPTION
### Description

This change prevents retrying LimitExceededException, in particular one returned by CreateResolverEndpoint when an aws_route53_resolver_endpoint resource is provisioned with too many IPs. Instead of appearing to hang indefinitely, such programs now fail fast with an error.

### Relations

Closes #40480


### Output from Acceptance Testing

```console
[130] anton@anton-mbp-m3> TF_ACC=1 go test -test.v -test.run TestAccRoute53ResolverEndpoint_LimitExceededException_failsFast
2025/03/28 10:56:23 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53ResolverEndpoint_LimitExceededException_failsFast
=== PAUSE TestAccRoute53ResolverEndpoint_LimitExceededException_failsFast
=== CONT  TestAccRoute53ResolverEndpoint_LimitExceededException_failsFast
--- PASS: TestAccRoute53ResolverEndpoint_LimitExceededException_failsFast (41.42s)
PASS
```
