### PR TITLE
r/aws_ssm_parameter: remove `overwrite` deprecation

### DIFF
--- a/.changelog/42030.txt
+++ b/.changelog/42030.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_ssm_parameter: The `overwrite` argument is no longer deprecated
+```

--- a/internal/service/ssm/parameter.go
+++ b/internal/service/ssm/parameter.go
@@ -95,9 +95,8 @@ func resourceParameter() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 2048),
 			},
 			"overwrite": {
-				Type:       schema.TypeBool,
-				Optional:   true,
-				Deprecated: "overwrite is deprecated. This argument will be removed in a future major version.",
+				Type:     schema.TypeBool,
+				Optional: true,
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -212,7 +211,7 @@ func resourceParameterCreate(ctx context.Context, d *schema.ResourceData, meta a
 	}
 
 	// AWS SSM Service only supports PutParameter requests with Tags
-	// iff Overwrite is not provided or is false; in this resource's case,
+	// if Overwrite is not provided or is false; in this resource's case,
 	// the Overwrite value is always set in the paramInput so we check for the value
 	tags := getTagsIn(ctx)
 	if !aws.ToBool(input.Overwrite) {

--- a/website/docs/r/ssm_parameter.html.markdown
+++ b/website/docs/r/ssm_parameter.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an SSM Parameter resource.
 
-~> **Note:** `overwrite` also makes it possible to overwrite an existing SSM Parameter that's not created by Terraform before. This argument has been deprecated and will be removed in v6.0.0 of the provider. For more information on how this affects the behavior of this resource, see [this issue comment](https://github.com/hashicorp/terraform-provider-aws/issues/25636#issuecomment-1623661159).
+~> **Note:** The `overwrite` argument makes it possible to overwrite an existing SSM Parameter created outside of Terraform.
 
 -> **Note:** Write-Only argument `value_wo` is available to use in place of `value`. Write-Only arguments are supported in HashiCorp Terraform 1.11.0 and later. [Learn more](https://developer.hashicorp.com/terraform/language/v1.11.x/resources/ephemeral#write-only-arguments).
 
@@ -71,7 +71,7 @@ The following arguments are optional:
 * `description` - (Optional) Description of the parameter.
 * `insecure_value` - (Optional, exactly one of `value`, `value_wo`  or `insecure_value` is required) Value of the parameter. **Use caution:** This value is _never_ marked as sensitive in the Terraform plan output. This argument is not valid with a `type` of `SecureString`.
 * `key_id` - (Optional) KMS key ID or ARN for encrypting a SecureString.
-* `overwrite` - (Optional, **Deprecated**) Overwrite an existing parameter. If not specified, defaults to `false` if the resource has not been created by Terraform to avoid overwrite of existing resource, and will default to `true` otherwise (Terraform lifecycle rules should then be used to manage the update behavior).
+* `overwrite` - (Optional) Overwrite an existing parameter. If not specified, defaults to `false` during create operations to avoid overwriting existing resources and then `true` for all subsequent operations once the resource is managed by Terraform. [Lifecycle rules](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle) should be used to manage non-standard update behavior.
 * `tags` - (Optional) Map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `tier` - (Optional) Parameter tier to assign to the parameter. If not specified, will use the default parameter tier for the region. Valid tiers are `Standard`, `Advanced`, and `Intelligent-Tiering`. Downgrading an `Advanced` tier parameter to `Standard` will recreate the resource. For more information on parameter tiers, see the [AWS SSM Parameter tier comparison and guide](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html).
 * `value` - (Optional, exactly one of `value`, `value_wo` or `insecure_value` is required) Value of the parameter. This value is always marked as sensitive in the Terraform plan output, regardless of `type`. In Terraform CLI version 0.15 and later, this may require additional configuration handling for certain scenarios. For more information, see the [Terraform v0.15 Upgrade Guide](https://www.terraform.io/upgrade-guides/0-15.html#sensitive-output-values).


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
After assessing community feedback on the intended removal, we have determined the impact to existing use cases relying on this behavior would be too significant to move forward with in `v6`. The deprecation message is now removed from the resource schema and registry documentation, and the argument can continue to be used with the pre-existing behavior.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #25636
Relates #31566


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssm TESTS=TestAccSSMParameter_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter_'  -timeout 360m -vet=off
2025/03/28 11:46:27 Initializing Terraform AWS Provider...

--- PASS: TestAccSSMParameter_DataType_ssmIntegration (31.88s)
=== CONT  TestAccSSMParameter_tags_ComputedTag_OnCreate
--- PASS: TestAccSSMParameter_basic (35.43s)
=== CONT  TestAccSSMParameter_Secure_basic
--- PASS: TestAccSSMParameter_tags_DefaultTags_nullOverlappingResourceTag (45.68s)
=== CONT  TestAccSSMParameter_updateType
--- PASS: TestAccSSMParameter_DataType_ec2Image (52.45s)
=== CONT  TestAccSSMParameter_Overwrite_updateDescription
--- PASS: TestAccSSMParameter_tags_DefaultTags_emptyProviderOnlyTag (54.39s)
=== CONT  TestAccSSMParameter_Overwrite_removeAttribute
--- PASS: TestAccSSMParameter_Overwrite_updateToTags (55.79s)
=== CONT  TestAccSSMParameter_fullPath
--- PASS: TestAccSSMParameter_updateValue (57.60s)
=== CONT  TestAccSSMParameter_changeNameForcesNew
--- PASS: TestAccSSMParameter_tags_DefaultTags_emptyResourceTag (57.73s)
=== CONT  TestAccSSMParameter_importByARN
--- PASS: TestAccSSMParameter_tags_DefaultTags_nullNonOverlappingResourceTag (57.86s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringOnUpdate
=== CONT  TestAccSSMParameter_Overwrite_noOverwriteTags
--- PASS: TestAccSSMParameter_multiple (62.77s)
--- PASS: TestAccSSMParameter_DataType_update (64.29s)
=== CONT  TestAccSSMParameter_Overwrite_tags
--- PASS: TestAccSSMParameter_updateDescription (64.41s)
=== CONT  TestAccSSMParameter_Overwrite_cascade
--- PASS: TestAccSSMParameter_Secure_insecureChangeSecure (66.03s)
=== CONT  TestAccSSMParameter_Overwrite_basic
--- PASS: TestAccSSMParameter_Secure_insecure (67.81s)
=== CONT  TestAccSSMParameter_disappears
--- PASS: TestAccSSMParameter_Secure_basic (38.88s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringToStandard
--- PASS: TestAccSSMParameter_Secure_keyUpdate (76.81s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringOnCreation
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnCreate (46.89s)
=== CONT  TestAccSSMParameter_Tier_intelligentTieringToAdvanced
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnUpdate_Add (84.48s)
=== CONT  TestAccSSMParameter_tier
--- PASS: TestAccSSMParameter_tags_ComputedTag_OnUpdate_Replace (90.52s)
=== CONT  TestAccSSMParameter_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccSSMParameter_fullPath (39.24s)
=== CONT  TestAccSSMParameter_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccSSMParameter_importByARN (38.86s)
=== CONT  TestAccSSMParameter_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSSMParameter_disappears (33.03s)
=== CONT  TestAccSSMParameter_tags_DefaultTags_overlapping
--- PASS: TestAccSSMParameter_tags_IgnoreTags_Overlap_DefaultTag (101.46s)
=== CONT  TestAccSSMParameter_tags_DefaultTags_nonOverlapping
--- PASS: TestAccSSMParameter_Overwrite_noOverwriteTags (40.37s)
=== CONT  TestAccSSMParameter_tags_DefaultTags_providerOnly
--- PASS: TestAccSSMParameter_updateType (59.22s)
=== CONT  TestAccSSMParameter_writeOnly
    parameter_test.go:209: Terraform CLI version 1.10.5 is below minimum version 1.11.0: skipping test
--- SKIP: TestAccSSMParameter_writeOnly (0.08s)
=== CONT  TestAccSSMParameter_tags_AddOnUpdate
--- PASS: TestAccSSMParameter_Overwrite_tags (41.22s)
=== CONT  TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccSSMParameter_Overwrite_updateDescription (58.94s)
=== CONT  TestAccSSMParameter_tags_EmptyTag_OnCreate
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnUpdate (53.54s)
=== CONT  TestAccSSMParameter_tags_EmptyMap
--- PASS: TestAccSSMParameter_Tier_intelligentTieringOnCreation (37.04s)
=== CONT  TestAccSSMParameter_tags_null
=== CONT  TestAccSSMParameter_Secure_key
--- PASS: TestAccSSMParameter_tags_IgnoreTags_Overlap_ResourceTag (116.42s)
--- PASS: TestAccSSMParameter_Overwrite_removeAttribute (64.38s)
--- PASS: TestAccSSMParameter_changeNameForcesNew (64.70s)
--- PASS: TestAccSSMParameter_Overwrite_cascade (66.10s)
--- PASS: TestAccSSMParameter_Overwrite_basic (84.49s)
--- PASS: TestAccSSMParameter_Secure_key (36.09s)
=== NAME  TestAccSSMParameter_Tier_intelligentTieringToStandard
    parameter_test.go:285: Error running post-test destroy, there may be dangling resources: SSM Parameter TestAccSSMParameter_Tier_intelligentTieringToStandard_18ukiu4kt4 still exists
--- FAIL: TestAccSSMParameter_Tier_intelligentTieringToStandard (82.27s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnUpdate_Replace (66.30s)
--- PASS: TestAccSSMParameter_tags (158.23s)
--- PASS: TestAccSSMParameter_tags_EmptyMap (47.21s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_updateToResourceOnly (64.37s)
--- PASS: TestAccSSMParameter_tags_null (46.99s)
--- PASS: TestAccSSMParameter_Tier_intelligentTieringToAdvanced (82.91s)
--- PASS: TestAccSSMParameter_tier (77.26s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_updateToProviderOnly (65.92s)
--- PASS: TestAccSSMParameter_tags_AddOnUpdate (59.24s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnCreate (58.32s)
--- PASS: TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add (72.40s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_overlapping (78.93s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_nonOverlapping (79.45s)
--- PASS: TestAccSSMParameter_tags_DefaultTags_providerOnly (92.19s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/ssm        202.216s
```

Failure is transient and passed on the same branch in a subsequent run.

```console
% make testacc PKG=ssm TESTS=TestAccSSMParameter_Tier_intelligentTieringToStandard
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMParameter_Tier_intelligentTieringToStandard'  -timeout 360m -vet=off
2025/03/28 11:44:26 Initializing Terraform AWS Provider...

--- PASS: TestAccSSMParameter_Tier_intelligentTieringToStandard (31.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ssm        38.262s
```