### PR TITLE
docs: add valid range for schedule_offset in aws_ssm_maintenance_window

### DIFF
--- a/website/docs/r/ssm_maintenance_window.html.markdown
+++ b/website/docs/r/ssm_maintenance_window.html.markdown
@@ -34,7 +34,7 @@ This resource supports the following arguments:
 * `enabled` - (Optional) Whether the maintenance window is enabled. Default: `true`.
 * `end_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to no longer run the maintenance window.
 * `schedule_timezone` - (Optional) Timezone for schedule in [Internet Assigned Numbers Authority (IANA) Time Zone Database format](https://www.iana.org/time-zones). For example: `America/Los_Angeles`, `etc/UTC`, or `Asia/Seoul`.
-* `schedule_offset` - (Optional) The number of days to wait after the date and time specified by a CRON expression before running the maintenance window.
+* `schedule_offset` - (Optional) The number of days to wait after the date and time specified by a CRON expression before running the maintenance window. Valid range is `1` to `6`.
 * `start_date` - (Optional) Timestamp in [ISO-8601 extended format](https://www.iso.org/iso-8601-date-and-time-format.html) when to begin the maintenance window.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
### Description

While working on [SSM maintenance windows](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window) (for OS patching inside EC2s) I noticed that  a `terraform plan` failed with an error  message related to `schedule_offset`. 

The reason: my configuration contained a value of `12` for `schedule_offset`, the provider reported that only 1-6 are allowed.

This pull request adds the allowed range for the attribute to the documentation. In section _References_ I added a link to the validation in the provider source file.

### Relations

### References

- [Current attribute documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_maintenance_window#schedule_offset-1)
- [Validation in resource source code](https://github.com/hashicorp/terraform-provider-aws/blob/58002c3eaeaf92bde0991e113e2b1ccc4ba7d189/internal/service/ssm/maintenance_window.go#L77)

### Output from Acceptance Testing

Not applicable, only resource documentation is updated.