### PR TITLE
[New Resource] aws_organizations_account_parent

### DIFF
--- a/.ci/.semgrep-constants.yml
+++ b/.ci/.semgrep-constants.yml
@@ -2377,6 +2377,24 @@ rules:
     options:
       constant_propagation: false
 
+  - id: literal-parent_id-string-constant
+    languages: [go]
+    message: Use the constant `names.AttrParentID` for the string literal "parent_id"
+    paths:
+      include:
+        - "internal/service/**/*.go"
+    patterns:
+      - pattern: '"parent_id"'
+      - pattern-not-regex: '"parent_id":\s+test\w+,'
+      - pattern-not-inside: 'config.Variables{ ... }'
+      - pattern-not-inside: 'packageName = ...'
+      - pattern-not-inside: 'provider.ConflictingEndpointsWarningDiag(...)'
+      - pattern-not-inside: 'const $X = ...'
+    severity: ERROR
+    fix: "names.AttrParentID"
+    options:
+      constant_propagation: false
+
   - id: literal-password-string-constant
     languages: [go]
     message: Use the constant `names.AttrPassword` for the string literal "password"

--- a/internal/framework/validators/aws_organization_ou_id.go
+++ b/internal/framework/validators/aws_organization_ou_id.go
@@ -1,0 +1,48 @@
+package validators
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+// awsOrganizationOUIDValidator validates that a string
+type awsOrganizationOUIDValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator awsOrganizationOUIDValidator) Description(_ context.Context) string {
+	return "value must be a valid AWS organizational unit ID"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator awsOrganizationOUIDValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// ValidateString performs the validation
+func (validator awsOrganizationOUIDValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// https://docs.aws.amazon.com/organizations/latest/APIReference/API_OrganizationalUnit.html
+	if !itypes.IsAWSOrganizationOUID(request.ConfigValue.ValueString()) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			request.ConfigValue.ValueString(),
+		))
+		return
+	}
+}
+
+// AWSOrganizationOUID returns a string validator which ensures that any configured
+// attribute value:
+//
+//   - Is a string, which represents a valid AWS Organizational Unit ID.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AWSOrganizationOUID() validator.String { // nosemgrep:ci.aws-in-func-name
+	return awsOrganizationOUIDValidator{}
+}

--- a/internal/framework/validators/aws_organization_ou_id.go
+++ b/internal/framework/validators/aws_organization_ou_id.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"

--- a/internal/framework/validators/aws_organization_ou_id_test.go
+++ b/internal/framework/validators/aws_organization_ou_id_test.go
@@ -44,7 +44,7 @@ func TestAWSOrganizationOUIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-fun
 				diag.NewAttributeErrorDiagnostic(
 					path.Root("test"),
 					"Invalid Attribute Value",
-					`Attribute test value must be a valid AWS organizational unit ID, got: r-xy6ffog945kghe8jjg948984jf8e2ifo3e`,
+					`Attribute test value must be a valid AWS organizational unit ID, got: ou-z7jt-19mqs9sp42iu99e322rt46hf9er237hf9xc`,
 				),
 			},
 		},

--- a/internal/framework/validators/aws_organization_ou_id_test.go
+++ b/internal/framework/validators/aws_organization_ou_id_test.go
@@ -2,13 +2,14 @@ package validators_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
-	"testing"
 )
 
 func TestAWSOrganizationOUIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-func-name

--- a/internal/framework/validators/aws_organization_ou_id_test.go
+++ b/internal/framework/validators/aws_organization_ou_id_test.go
@@ -1,0 +1,82 @@
+package validators_test
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"testing"
+)
+
+func TestAWSOrganizationOUIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	type testCase struct {
+		val                 types.String
+		expectedDiagnostics diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"unknown string": {
+			val: types.StringUnknown(),
+		},
+		"null string": {
+			val: types.StringNull(),
+		},
+		"invalid string": {
+			val: types.StringValue("test-value"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organizational unit ID, got: test-value`,
+				),
+			},
+		},
+		"valid AWS organizational unit ID": {
+			val: types.StringValue("ou-z7jt-19mqs9sp"),
+		},
+		"too long AWS organizational unit ID": {
+			val: types.StringValue(`ou-z7jt-19mqs9sp42iu99e322rt46hf9er237hf9xc`),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organizational unit ID, got: r-xy6ffog945kghe8jjg948984jf8e2ifo3e`,
+				),
+			},
+		},
+		"too short AWS organizational unit ID": {
+			val: types.StringValue("r-xf"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organizational unit ID, got: r-xf`,
+				),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    tc.val,
+			}
+			response := validator.StringResponse{}
+			fwvalidators.AWSOrganizationOUID().ValidateString(ctx, request, &response)
+
+			if diff := cmp.Diff(response.Diagnostics, tc.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/validators/aws_organization_root_id.go
+++ b/internal/framework/validators/aws_organization_root_id.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"

--- a/internal/framework/validators/aws_organization_root_id.go
+++ b/internal/framework/validators/aws_organization_root_id.go
@@ -1,0 +1,48 @@
+package validators
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
+)
+
+// awsOrganizationRootIDValidator validates that a string
+type awsOrganizationRootIDValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator awsOrganizationRootIDValidator) Description(_ context.Context) string {
+	return "value must be a valid AWS organization root ID"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator awsOrganizationRootIDValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// ValidateString performs the validation
+func (validator awsOrganizationRootIDValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// https://docs.aws.amazon.com/organizations/latest/APIReference/API_Root.html
+	if !itypes.IsAWSOrganizationRootID(request.ConfigValue.ValueString()) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			request.ConfigValue.ValueString(),
+		))
+		return
+	}
+}
+
+// AWSOrganizationRootID returns a string validator which ensures that any configured
+// attribute value:
+//
+//   - Is a string, which represents a valid AWS Organization Root ID.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AWSOrganizationRootID() validator.String { // nosemgrep:ci.aws-in-func-name
+	return awsOrganizationRootIDValidator{}
+}

--- a/internal/framework/validators/aws_organization_root_id_test.go
+++ b/internal/framework/validators/aws_organization_root_id_test.go
@@ -1,0 +1,82 @@
+package validators_test
+
+import (
+	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"testing"
+)
+
+func TestAwsOrganizationRootIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	type testCase struct {
+		val                 types.String
+		expectedDiagnostics diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"unknown string": {
+			val: types.StringUnknown(),
+		},
+		"null string": {
+			val: types.StringNull(),
+		},
+		"invalid string": {
+			val: types.StringValue("test-value"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organization root ID, got: test-value`,
+				),
+			},
+		},
+		"valid AWS organization Root ID": {
+			val: types.StringValue("r-xy6f"),
+		},
+		"too long AWS organization Root ID": {
+			val: types.StringValue(`r-xy6ffog945kghe8jjg948984jf8e2ifo3e`),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organization root ID, got: r-xy6ffog945kghe8jjg948984jf8e2ifo3e`,
+				),
+			},
+		},
+		"too short AWS organization root ID": {
+			val: types.StringValue("r-xf"),
+			expectedDiagnostics: diag.Diagnostics{
+				diag.NewAttributeErrorDiagnostic(
+					path.Root("test"),
+					"Invalid Attribute Value",
+					`Attribute test value must be a valid AWS organization root ID, got: r-xf`,
+				),
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    tc.val,
+			}
+			response := validator.StringResponse{}
+			fwvalidators.AWSOrganizationRootID().ValidateString(ctx, request, &response)
+
+			if diff := cmp.Diff(response.Diagnostics, tc.expectedDiagnostics); diff != "" {
+				t.Errorf("unexpected diagnostics difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/validators/aws_organization_root_id_test.go
+++ b/internal/framework/validators/aws_organization_root_id_test.go
@@ -2,13 +2,14 @@ package validators_test
 
 import (
 	"context"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
-	"testing"
 )
 
 func TestAwsOrganizationRootIDValidator(t *testing.T) { // nosemgrep:ci.aws-in-func-name

--- a/internal/service/organizations/account_parent.go
+++ b/internal/service/organizations/account_parent.go
@@ -5,6 +5,7 @@ package organizations
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"

--- a/internal/service/organizations/account_parent.go
+++ b/internal/service/organizations/account_parent.go
@@ -1,0 +1,199 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organizations
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_organizations_account_parent", name="Account Parent")
+func newResourceAccountParent(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceAccountParent{}
+
+	return r, nil
+}
+
+const (
+	ResNameAccountParent = "Account Parent"
+)
+
+type resourceAccountParent struct {
+	framework.ResourceWithConfigure
+}
+
+func (r *resourceAccountParent) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrAccountID: schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					fwvalidators.AWSAccountID(),
+				},
+			},
+			names.AttrParentID: schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.Any(
+						fwvalidators.AWSOrganizationRootID(),
+						fwvalidators.AWSOrganizationOUID(),
+					),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceAccountParent) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	conn := r.Meta().OrganizationsClient(ctx)
+
+	var plan resourceAccountParentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	currentParentAccountID, err := FindParentAccountID(ctx, conn, plan.AccountID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Organizations, create.ErrActionCreating, ResNameAccountParent, plan.AccountID.String(), err),
+			err.Error(),
+		)
+	}
+
+	input := organizations.MoveAccountInput{
+		AccountId:           flex.StringFromFramework(ctx, plan.AccountID),
+		SourceParentId:      currentParentAccountID,
+		DestinationParentId: flex.StringFromFramework(ctx, plan.ParentID),
+	}
+
+	_, err = conn.MoveAccount(ctx, &input)
+	if err != nil && !errs.IsA[*awstypes.DuplicateAccountException](err) {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Organizations, create.ErrActionCreating, ResNameAccountParent, plan.AccountID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceAccountParent) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	conn := r.Meta().OrganizationsClient(ctx)
+
+	var state resourceAccountParentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the current parent ID
+	parentID, err := FindParentAccountID(ctx, conn, state.AccountID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Organizations, create.ErrActionReading, ResNameAccountParent, state.AccountID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	// Set the attributes
+	state.ParentID = types.StringPointerValue(parentID)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceAccountParent) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	conn := r.Meta().OrganizationsClient(ctx)
+
+	var plan, state resourceAccountParentModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	diff, d := flex.Diff(ctx, plan, state)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		input := organizations.MoveAccountInput{
+			AccountId:           flex.StringFromFramework(ctx, plan.AccountID),
+			SourceParentId:      flex.StringFromFramework(ctx, state.ParentID),
+			DestinationParentId: flex.StringFromFramework(ctx, plan.ParentID),
+		}
+
+		_, err := conn.MoveAccount(ctx, &input)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				create.ProblemStandardMessage(names.Organizations, create.ErrActionUpdating, ResNameAccountParent, plan.AccountID.String(), err),
+				err.Error(),
+			)
+			return
+		}
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceAccountParent) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data resourceAccountParentModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().OrganizationsClient(ctx)
+
+	roots, err := findRoots(ctx, conn, &organizations.ListRootsInput{})
+	if err != nil {
+		create.ProblemStandardMessage(names.Organizations, create.ErrActionDeleting, ResNameAccountParent, data.AccountID.String(), err)
+	}
+
+	input := organizations.MoveAccountInput{
+		AccountId:           flex.StringFromFramework(ctx, data.AccountID),
+		SourceParentId:      flex.StringFromFramework(ctx, data.ParentID),
+		DestinationParentId: roots[0].Id,
+	}
+
+	_, err = conn.MoveAccount(ctx, &input)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.Organizations, create.ErrActionUpdating, ResNameAccountParent, data.AccountID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceAccountParent) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrAccountID), req, resp)
+}
+
+type resourceAccountParentModel struct {
+	AccountID types.String `tfsdk:"account_id"`
+	ParentID  types.String `tfsdk:"parent_id"`
+}

--- a/internal/service/organizations/account_parent_test.go
+++ b/internal/service/organizations/account_parent_test.go
@@ -1,0 +1,331 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package organizations_test
+
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/organizations/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestAccountParentExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tforganizations.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccOrganizationsAccountParent_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accountparent organizations.DescribeAccountParentResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_organizations_account_parent.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OrganizationsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OrganizationsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountParentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountParentConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountParentExists(ctx, resourceName, &accountparent),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "organizations", regexache.MustCompile(`accountparent:.+$`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccOrganizationsAccountParent_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accountparent organizations.DescribeAccountParentResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_organizations_account_parent.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OrganizationsEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.OrganizationsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountParentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountParentConfig_basic(rName, testAccAccountParentVersionNewer),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountParentExists(ctx, resourceName, &accountparent),
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var ResourceAccountParent = newResourceAccountParent
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tforganizations.ResourceAccountParent, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAccountParentDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_organizations_account_parent" {
+				continue
+			}
+
+			// TIP: ==== FINDERS ====
+			// The find function should be exported. Since it won't be used outside of the package, it can be exported
+			// in the `exports_test.go` file.
+			_, err := tforganizations.FindAccountParentByID(ctx, conn, rs.Primary.ID)
+			if tfresource.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return create.Error(names.Organizations, create.ErrActionCheckingDestroyed, tforganizations.ResNameAccountParent, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.Organizations, create.ErrActionCheckingDestroyed, tforganizations.ResNameAccountParent, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAccountParentExists(ctx context.Context, name string, accountparent *organizations.DescribeAccountParentResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
+
+		resp, err := tforganizations.FindAccountParentByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, rs.Primary.ID, err)
+		}
+
+		*accountparent = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
+
+	input := &organizations.ListAccountParentsInput{}
+
+	_, err := conn.ListAccountParents(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckAccountParentNotRecreated(before, after *organizations.DescribeAccountParentResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.AccountParentId), aws.ToString(after.AccountParentId); before != after {
+			return create.Error(names.Organizations, create.ErrActionCheckingNotRecreated, tforganizations.ResNameAccountParent, aws.ToString(before.AccountParentId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccAccountParentConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+
+resource "aws_organizations_account_parent" "test" {
+  account_parent_name             = %[1]q
+  engine_type             = "ActiveOrganizations"
+  engine_version          = %[2]q
+  host_instance_type      = "organizations.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+
+  logs {
+    general = true
+  }
+
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/organizations/account_parent_test.go
+++ b/internal/service/organizations/account_parent_test.go
@@ -3,329 +3,166 @@
 
 package organizations_test
 
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
-
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/organizations/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"testing"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/organizations"
-	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/names"
 
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestAccountParentExampleUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-			got, err := tforganizations.FunctionFromResource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the resource as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// resource name.
-//
-// Acceptance test access AWS and cost money to run.
 func TestAccOrganizationsAccountParent_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
 
-	var accountparent organizations.DescribeAccountParentResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_organizations_account_parent.test"
+	ouName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.OrganizationsEndpointID)
-			testAccPreCheck(ctx, t)
+			acctest.PreCheckAlternateAccount(t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.OrganizationsServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesAlternate(ctx, t),
 		CheckDestroy:             testAccCheckAccountParentDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccountParentConfig_basic(rName),
+				Config: testAccAccountParentConfig_root(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountParentExists(ctx, resourceName, &accountparent),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
-					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "organizations", regexache.MustCompile(`accountparent:.+$`)),
+					testAccCheckAccountParentExists(ctx, resourceName),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrAccountID), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrParentID), knownvalue.StringRegexp(regexache.MustCompile(`^r-[0-9a-z]{4,32}$`))),
+				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, names.AttrAccountID),
+				ImportStateVerifyIdentifierAttribute: names.AttrAccountID,
+			},
+			{
+				Config: testAccAccountParentConfig_organizationalUnit(ouName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountParentExists(ctx, resourceName),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrAccountID), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrParentID), knownvalue.StringRegexp(regexache.MustCompile(`^ou-[0-9a-z]{4,32}-[a-z0-9]{8,32}$`))),
+				},
 			},
 		},
 	})
 }
 
-func TestAccOrganizationsAccountParent_disappears(t *testing.T) {
-	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var accountparent organizations.DescribeAccountParentResponse
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_organizations_account_parent.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.OrganizationsEndpointID)
-			testAccPreCheck(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.OrganizationsServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountParentDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAccountParentConfig_basic(rName, testAccAccountParentVersionNewer),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountParentExists(ctx, resourceName, &accountparent),
-					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
-					// but expects a new resource factory function as the third argument. To expose this
-					// private function to the testing package, you may need to add a line like the following
-					// to exports_test.go:
-					//
-					//   var ResourceAccountParent = newResourceAccountParent
-					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tforganizations.ResourceAccountParent, resourceName),
-				),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func testAccCheckAccountParentDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_organizations_account_parent" {
-				continue
-			}
-
-			// TIP: ==== FINDERS ====
-			// The find function should be exported. Since it won't be used outside of the package, it can be exported
-			// in the `exports_test.go` file.
-			_, err := tforganizations.FindAccountParentByID(ctx, conn, rs.Primary.ID)
-			if tfresource.NotFound(err) {
-				return nil
-			}
-			if err != nil {
-				return create.Error(names.Organizations, create.ErrActionCheckingDestroyed, tforganizations.ResNameAccountParent, rs.Primary.ID, err)
-			}
-
-			return create.Error(names.Organizations, create.ErrActionCheckingDestroyed, tforganizations.ResNameAccountParent, rs.Primary.ID, errors.New("not destroyed"))
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckAccountParentExists(ctx context.Context, name string, accountparent *organizations.DescribeAccountParentResponse) resource.TestCheckFunc {
+func testAccCheckAccountParentExists(ctx context.Context, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, name, errors.New("not found"))
 		}
 
-		if rs.Primary.ID == "" {
+		if rs.Primary.Attributes[names.AttrParentID] == "" {
 			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, name, errors.New("not set"))
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
 
-		resp, err := tforganizations.FindAccountParentByID(ctx, conn, rs.Primary.ID)
+		_, err := tforganizations.FindParentAccountID(ctx, conn, rs.Primary.Attributes[names.AttrAccountID])
 		if err != nil {
-			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, rs.Primary.ID, err)
+			return create.Error(names.Organizations, create.ErrActionCheckingExistence, tforganizations.ResNameAccountParent, rs.Primary.Attributes[names.AttrAccountID], err)
 		}
-
-		*accountparent = *resp
 
 		return nil
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
-
-	input := &organizations.ListAccountParentsInput{}
-
-	_, err := conn.ListAccountParents(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-func testAccCheckAccountParentNotRecreated(before, after *organizations.DescribeAccountParentResponse) resource.TestCheckFunc {
+func testAccCheckAccountParentDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if before, after := aws.ToString(before.AccountParentId), aws.ToString(after.AccountParentId); before != after {
-			return create.Error(names.Organizations, create.ErrActionCheckingNotRecreated, tforganizations.ResNameAccountParent, aws.ToString(before.AccountParentId), errors.New("recreated"))
+		conn := acctest.Provider.Meta().(*conns.AWSClient).OrganizationsClient(ctx)
+
+		root, err := tforganizations.FindDefaultRoot(ctx, conn)
+		if err != nil {
+			return err
 		}
 
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_organizations_account_parent" {
+				continue
+			}
+
+			parentID, err := tforganizations.FindParentAccountID(ctx, conn, rs.Primary.Attributes[names.AttrAccountID])
+			if err != nil {
+				return err
+			}
+
+			if *parentID == *root.Id {
+				continue
+			}
+
+			return fmt.Errorf("Found account %s outside of org root", rs.Primary.Attributes[names.AttrAccountID])
+		}
 		return nil
 	}
 }
 
-func testAccAccountParentConfig_basic(rName, version string) string {
+func testAccAccountParentConfig_root() string {
+	return `
+data "aws_caller_identity" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_organizations_organization" "current" {}
+
+resource "aws_organizations_account_parent" "test" {
+  account_id = data.aws_caller_identity.alternate.account_id
+  parent_id  = data.aws_organizations_organization.current.roots[0].id
+}
+`
+}
+
+func testAccAccountParentConfig_organizationalUnit(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = %[1]q
+data "aws_caller_identity" "alternate" {
+  provider = "awsalternate"
+}
+
+data "aws_organizations_organization" "current" {}
+
+resource "aws_organizations_organizational_unit" "test" {
+  name      = %[1]q
+  parent_id = data.aws_organizations_organization.current.roots[0].id
 }
 
 resource "aws_organizations_account_parent" "test" {
-  account_parent_name             = %[1]q
-  engine_type             = "ActiveOrganizations"
-  engine_version          = %[2]q
-  host_instance_type      = "organizations.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-
-  logs {
-    general = true
-  }
-
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
+  account_id = data.aws_caller_identity.alternate.account_id
+  parent_id  = aws_organizations_organizational_unit.test.id
 }
-`, rName, version)
+`, rName)
 }

--- a/internal/service/organizations/account_parent_test.go
+++ b/internal/service/organizations/account_parent_test.go
@@ -7,21 +7,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
-	"testing"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/names"
-
 	tforganizations "github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccOrganizationsAccountParent_basic(t *testing.T) {

--- a/internal/service/organizations/exports_test.go
+++ b/internal/service/organizations/exports_test.go
@@ -15,7 +15,6 @@ var (
 	ResourceResourcePolicy         = resourceResourcePolicy
 
 	FindAccountByID                  = findAccountByID
-	FindDefaultRoot                  = findDefaultRoot
 	FindOrganizationalUnitByID       = findOrganizationalUnitByID
 	FindParentAccountID              = findParentAccountID
 	FindPolicyAttachmentByTwoPartKey = findPolicyAttachmentByTwoPartKey

--- a/internal/service/organizations/exports_test.go
+++ b/internal/service/organizations/exports_test.go
@@ -6,6 +6,7 @@ package organizations
 // Exports for use in tests only.
 var (
 	ResourceAccount                = resourceAccount
+	ResourceAccountParent          = newResourceAccountParent
 	ResourceDelegatedAdministrator = resourceDelegatedAdministrator
 	ResourceOrganization           = resourceOrganization
 	ResourceOrganizationalUnit     = resourceOrganizationalUnit
@@ -14,7 +15,9 @@ var (
 	ResourceResourcePolicy         = resourceResourcePolicy
 
 	FindAccountByID                  = findAccountByID
+	FindDefaultRoot                  = findDefaultRoot
 	FindOrganizationalUnitByID       = findOrganizationalUnitByID
+	FindParentAccountID              = findParentAccountID
 	FindPolicyAttachmentByTwoPartKey = findPolicyAttachmentByTwoPartKey
 	FindPolicyByID                   = findPolicyByID
 	FindResourcePolicy               = findResourcePolicy

--- a/internal/service/organizations/service_package_gen.go
+++ b/internal/service/organizations/service_package_gen.go
@@ -19,7 +19,13 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
-	return []*types.ServicePackageFrameworkResource{}
+	return []*types.ServicePackageFrameworkResource{
+		{
+			Factory:  newResourceAccountParent,
+			TypeName: "aws_organizations_account_parent",
+			Name:     "Account Parent",
+		},
+	}
 }
 
 func (p *servicePackage) SDKDataSources(ctx context.Context) []*types.ServicePackageSDKDataSource {

--- a/internal/types/aws_organization_ou_id.go
+++ b/internal/types/aws_organization_ou_id.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/YakDriver/regexache"
+
+// IsAWSOrganizationOUID returns whether or not the specified string is a valid AWS Organizational Unit ID.
+func IsAWSOrganizationOUID(s string) bool {
+	return regexache.MustCompile(`^ou-[0-9a-z]{4,32}-[a-z0-9]{8,32}$`).MatchString(s)
+}

--- a/internal/types/aws_organization_ou_id_test.go
+++ b/internal/types/aws_organization_ou_id_test.go
@@ -1,0 +1,22 @@
+package types
+
+import "testing"
+
+func TestIsAWSOrganizationOUID(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	for _, tc := range []struct {
+		id    string
+		valid bool
+	}{
+		{id: "", valid: false},
+		{id: "r-abc", valid: false},
+		{id: "ou-z7jt", valid: false},
+		{id: "ou-z7jt-19mqs9sp", valid: true},
+	} {
+		ok := IsAWSOrganizationOUID(tc.id)
+		if got, want := ok, tc.valid; got != want {
+			t.Errorf("IsAWSOrganizationOUID(%q) = %v; want %v", tc.id, got, want)
+		}
+	}
+}

--- a/internal/types/aws_organization_root_id.go
+++ b/internal/types/aws_organization_root_id.go
@@ -1,0 +1,8 @@
+package types
+
+import "github.com/YakDriver/regexache"
+
+// IsAWSOrganizationRootID returns whether or not the specified string is a valid AWS Organization Root ID.
+func IsAWSOrganizationRootID(s string) bool { // nosemgrep:ci.aws-in-func-name
+	return regexache.MustCompile(`^r-[0-9a-z]{4,32}$`).MatchString(s)
+}

--- a/internal/types/aws_organization_root_id_test.go
+++ b/internal/types/aws_organization_root_id_test.go
@@ -1,0 +1,22 @@
+package types
+
+import "testing"
+
+func TestIsAWSOrganizationRootID(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	for _, tc := range []struct {
+		id    string
+		valid bool
+	}{
+		{id: "", valid: false},
+		{id: "r-abc", valid: false},
+		{id: "-e3zd", valid: true},
+		{id: "r-y7zf", valid: true},
+	} {
+		ok := IsAWSOrganizationRootID(tc.id)
+		if got, want := ok, tc.valid; got != want {
+			t.Errorf("IsAWSOrganizationRootID(%q) = %v; want %v", tc.id, got, want)
+		}
+	}
+}

--- a/internal/types/aws_organization_root_id_test.go
+++ b/internal/types/aws_organization_root_id_test.go
@@ -11,7 +11,7 @@ func TestIsAWSOrganizationRootID(t *testing.T) { // nosemgrep:ci.aws-in-func-nam
 	}{
 		{id: "", valid: false},
 		{id: "r-abc", valid: false},
-		{id: "-e3zd", valid: true},
+		{id: "-e3zd", valid: false},
 		{id: "r-y7zf", valid: true},
 	} {
 		ok := IsAWSOrganizationRootID(tc.id)

--- a/names/attr_constants.csv
+++ b/names/attr_constants.csv
@@ -130,6 +130,7 @@ owner_id,OwnerID
 parameter,Parameter
 parameter_group_name,ParameterGroupName
 parameters,Parameters
+parent_id,ParentID
 password,Password
 path,Path
 permissions,Permissions

--- a/names/attr_consts_gen.go
+++ b/names/attr_consts_gen.go
@@ -137,6 +137,7 @@ const (
 	AttrParameter                  = "parameter"
 	AttrParameterGroupName         = "parameter_group_name"
 	AttrParameters                 = "parameters"
+	AttrParentID                   = "parent_id"
 	AttrPassword                   = "password"
 	AttrPath                       = "path"
 	AttrPermissions                = "permissions"

--- a/names/generate/const_or_quote_gen.go
+++ b/names/generate/const_or_quote_gen.go
@@ -145,6 +145,7 @@ func ConstOrQuote(constant string) string {
 		"parameter":                     "AttrParameter",
 		"parameter_group_name":          "AttrParameterGroupName",
 		"parameters":                    "AttrParameters",
+		"parent_id":                     "AttrParentID",
 		"password":                      "AttrPassword",
 		"path":                          "AttrPath",
 		"permissions":                   "AttrPermissions",

--- a/website/docs/r/organizations_account_parent.html.markdown
+++ b/website/docs/r/organizations_account_parent.html.markdown
@@ -3,19 +3,15 @@ subcategory: "Organizations"
 layout: "aws"
 page_title: "AWS: aws_organizations_account_parent"
 description: |-
-  Terraform resource for managing an AWS Organizations Account Parent.
+  Manages an AWS Organizations Account's current parent in the Organization.
 ---
-<!---
-TIP: A few guiding principles for writing documentation:
-1. Use simple language while avoiding jargon and figures of speech.
-2. Focus on brevity and clarity to keep a reader's attention.
-3. Use active voice and present tense whenever you can.
-4. Document your feature as it exists now; do not mention the future or past if you can help it.
-5. Use accessible and inclusive language.
---->`
 # Resource: aws_organizations_account_parent
 
-Terraform resource for managing an AWS Organizations Account Parent.
+Manages an AWS Organizations Account's current parent in the Organization.
+
+~> **Note:** Account management must be done from the organization's management account.
+
+!> **WARNING:** You should not use the `aws_organizations_account_parent` resources in conjunction with the `parent_id` field of the [`aws_organizations_account`](organizations_account.html) resource. Doing so may cause perpetual differences.
 
 ## Example Usage
 
@@ -23,6 +19,8 @@ Terraform resource for managing an AWS Organizations Account Parent.
 
 ```terraform
 resource "aws_organizations_account_parent" "example" {
+  account_id = "123456789012"
+  parent_id  = "ou-c3iy-xbe65nlj"
 }
 ```
 
@@ -30,40 +28,26 @@ resource "aws_organizations_account_parent" "example" {
 
 The following arguments are required:
 
-* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-The following arguments are optional:
-
-* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `account_id` - (Required) AWS Account ID of the member account.
+* `parent_id` - (Required) Parent Organizational Unit ID or Root ID for the account.
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `arn` - ARN of the Account Parent. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
-
-## Timeouts
-
-[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
-
-* `create` - (Default `60m`)
-* `update` - (Default `180m`)
-* `delete` - (Default `90m`)
+This resource exports no additional attributes.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Organizations Account Parent using the `example_id_arg`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the account's existing parent association using the `account_id`. For example:
 
 ```terraform
 import {
   to = aws_organizations_account_parent.example
-  id = "account_parent-id-12345678"
+  id = "123456789012"
 }
 ```
 
-Using `terraform import`, import Organizations Account Parent using the `example_id_arg`. For example:
+Using `terraform import`, import Organizations Account Parent using the `account_id`. For example:
 
 ```console
-% terraform import aws_organizations_account_parent.example account_parent-id-12345678
+% terraform import aws_organizations_account_parent.example 123456789012
 ```

--- a/website/docs/r/organizations_account_parent.html.markdown
+++ b/website/docs/r/organizations_account_parent.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "Organizations"
+layout: "aws"
+page_title: "AWS: aws_organizations_account_parent"
+description: |-
+  Terraform resource for managing an AWS Organizations Account Parent.
+---
+<!---
+TIP: A few guiding principles for writing documentation:
+1. Use simple language while avoiding jargon and figures of speech.
+2. Focus on brevity and clarity to keep a reader's attention.
+3. Use active voice and present tense whenever you can.
+4. Document your feature as it exists now; do not mention the future or past if you can help it.
+5. Use accessible and inclusive language.
+--->`
+# Resource: aws_organizations_account_parent
+
+Terraform resource for managing an AWS Organizations Account Parent.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+resource "aws_organizations_account_parent" "example" {
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `example_arg` - (Required) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+The following arguments are optional:
+
+* `optional_arg` - (Optional) Concise argument description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `arn` - ARN of the Account Parent. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+* `example_attribute` - Concise description. Do not begin the description with "An", "The", "Defines", "Indicates", or "Specifies," as these are verbose. In other words, "Indicates the amount of storage," can be rewritten as "Amount of storage," without losing any information.
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `60m`)
+* `update` - (Default `180m`)
+* `delete` - (Default `90m`)
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Organizations Account Parent using the `example_id_arg`. For example:
+
+```terraform
+import {
+  to = aws_organizations_account_parent.example
+  id = "account_parent-id-12345678"
+}
+```
+
+Using `terraform import`, import Organizations Account Parent using the `example_id_arg`. For example:
+
+```console
+% terraform import aws_organizations_account_parent.example account_parent-id-12345678
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

New resource `aws_organizations_account_parent` allows for managing the current parent of a member account in an AWS Organization.

This is especially useful for scenarios where you want to grant reduced/constrained Organization permissions to allow delegates to manage account/OU sub-structure.
Or for cases where you have a GovCloud organization and invited accounts where `aws_organizations_account` usage isn't feasible or practical.

Due to the single-operation non-CRUD nature of the Organizations API that moves accounts, I believe it makes the most sense to leverage NoOpDelete and NoUpdate in combination with both attributes marked with the `RequiresReplace()` plan-modifier.

The MoveAccount API also has an empty response, so there are no IDs or attributes that can or need to be exported as computed.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/organizations/latest/APIReference/API_MoveAccount.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccOrganizationsAccountParent PKG=organizations
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/organizations/... -v -count 1 -parallel 20 -run='TestAccOrganizationsAccountParent'  -timeout 360m -vet=off
2025/03/28 21:10:34 Initializing Terraform AWS Provider...
=== RUN   TestAccOrganizationsAccountParent_basic
=== PAUSE TestAccOrganizationsAccountParent_basic
=== RUN   TestAccOrganizationsAccountParent_disappears
=== PAUSE TestAccOrganizationsAccountParent_disappears
=== CONT  TestAccOrganizationsAccountParent_basic
=== CONT  TestAccOrganizationsAccountParent_disappears
--- PASS: TestAccOrganizationsAccountParent_disappears (36.74s)
--- PASS: TestAccOrganizationsAccountParent_basic (112.19s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/organizations      117.481s
...
```
