### PR TITLE
internal/sdkv2: rename `DataSourcePropertyFromResourceProperty`

### DIFF
--- a/internal/sdkv2/schema.go
+++ b/internal/sdkv2/schema.go
@@ -10,59 +10,62 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// ComputedOnlyFromSchema is a recursive function that converts an
+// existing Resource schema to a computed-only schema
+//
+// This may be used to create computed-only variants of a resource attribute,
+// or to copy a resource schema into a corresponding data source. All schema
+// elements are copied, but certain attributes are ignored or changed:
+// - All attributes have Computed = true
+// - All attributes have ForceNew, Required = false
+// - Validation functions and attributes (e.g. MaxItems) are not copied
+//
 // Adapted from https://github.com/hashicorp/terraform-provider-google/google/datasource_helpers.go. Thanks!
-
-// DataSourcePropertyFromResourceProperty is a recursive func that
-// converts an existing Resource property schema to a Datasource property schema.
-// All schema elements are copied, but certain attributes are ignored or changed:
-// - all attributes have Computed = true
-// - all attributes have ForceNew, Required = false
-// - Validation funcs and attributes (e.g. MaxItems) are not copied
-func DataSourcePropertyFromResourceProperty(rs *schema.Schema) *schema.Schema {
-	ds := &schema.Schema{
+func ComputedOnlyFromSchema(s *schema.Schema) *schema.Schema {
+	cs := &schema.Schema{
 		Computed:    true,
-		Description: rs.Description,
-		Type:        rs.Type,
+		Description: s.Description,
+		Type:        s.Type,
 	}
 
-	switch rs.Type {
+	switch s.Type {
 	case schema.TypeSet:
-		ds.Set = rs.Set
+		cs.Set = s.Set
 		fallthrough
 	case schema.TypeList, schema.TypeMap:
 		// List & Set types are generally used for 2 cases:
 		// - a list/set of simple primitive values (e.g. list of strings)
 		// - a sub resource
 		// Maps are usually used for maps of simple primitives
-		switch elem := rs.Elem.(type) {
+		switch elem := s.Elem.(type) {
 		case *schema.Resource:
 			// handle the case where the Element is a sub-resource
-			ds.Elem = DataSourceElemFromResourceElem(elem)
+			cs.Elem = ComputedOnlyFromResource(elem)
 		case *schema.Schema:
 			// handle simple primitive case
-			ds.Elem = &schema.Schema{Type: elem.Type}
+			cs.Elem = &schema.Schema{Type: elem.Type}
 		}
 	}
 
-	return ds
+	return cs
 }
 
-func DataSourceElemFromResourceElem(rs *schema.Resource) *schema.Resource {
-	ds := &schema.Resource{
-		Schema: DataSourceSchemaFromResourceSchema(rs.Schema),
+func ComputedOnlyFromResource(r *schema.Resource) *schema.Resource {
+	cs := &schema.Resource{
+		Schema: ComputedOnlyFromResourceSchema(r.Schema),
 	}
 
-	return ds
+	return cs
 }
 
-func DataSourceSchemaFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
-	ds := make(map[string]*schema.Schema, len(rs))
+func ComputedOnlyFromResourceSchema(rs map[string]*schema.Schema) map[string]*schema.Schema {
+	cs := make(map[string]*schema.Schema, len(rs))
 
 	for k, v := range rs {
-		ds[k] = DataSourcePropertyFromResourceProperty(v)
+		cs[k] = ComputedOnlyFromSchema(v)
 	}
 
-	return ds
+	return cs
 }
 
 // JSONDocumentSchemaRequired returns the standard schema for a required JSON document.

--- a/internal/sdkv2/schema_test.go
+++ b/internal/sdkv2/schema_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func TestDataSourceElemFromResourceElem(t *testing.T) {
+func TestComputedOnlyFromResource(t *testing.T) {
 	t.Parallel()
 
 	input := &schema.Resource{
@@ -67,7 +67,7 @@ func TestDataSourceElemFromResourceElem(t *testing.T) {
 		},
 	}
 
-	got := DataSourceElemFromResourceElem(input)
+	got := ComputedOnlyFromResource(input)
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("unexpected diff (+want, -got): %s", diff)

--- a/internal/service/appmesh/gateway_route_data_source.go
+++ b/internal/service/appmesh/gateway_route_data_source.go
@@ -56,7 +56,7 @@ func dataSourceGatewayRoute() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceGatewayRouteSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceGatewayRouteSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 				"virtual_gateway_name": {
 					Type:     schema.TypeString,

--- a/internal/service/appmesh/mesh_data_source.go
+++ b/internal/service/appmesh/mesh_data_source.go
@@ -52,7 +52,7 @@ func dataSourceMesh() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceMeshSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceMeshSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
 		},

--- a/internal/service/appmesh/route_data_source.go
+++ b/internal/service/appmesh/route_data_source.go
@@ -56,7 +56,7 @@ func dataSourceRoute() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceRouteSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceRouteSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 				"virtual_router_name": {
 					Type:     schema.TypeString,

--- a/internal/service/appmesh/virtual_gateway_data_source.go
+++ b/internal/service/appmesh/virtual_gateway_data_source.go
@@ -55,7 +55,7 @@ func dataSourceVirtualGateway() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceVirtualGatewaySpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceVirtualGatewaySpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
 		},

--- a/internal/service/appmesh/virtual_node_data_source.go
+++ b/internal/service/appmesh/virtual_node_data_source.go
@@ -56,7 +56,7 @@ func dataSourceVirtualNode() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceVirtualNodeSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceVirtualNodeSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
 		},

--- a/internal/service/appmesh/virtual_router_data_source.go
+++ b/internal/service/appmesh/virtual_router_data_source.go
@@ -56,7 +56,7 @@ func dataSourceVirtualRouter() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceVirtualRouterSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceVirtualRouterSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
 		},

--- a/internal/service/appmesh/virtual_service_data_source.go
+++ b/internal/service/appmesh/virtual_service_data_source.go
@@ -56,7 +56,7 @@ func dataSourceVirtualService() *schema.Resource {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"spec":         sdkv2.DataSourcePropertyFromResourceProperty(resourceVirtualServiceSpecSchema()),
+				"spec":         sdkv2.ComputedOnlyFromSchema(resourceVirtualServiceSpecSchema()),
 				names.AttrTags: tftags.TagsSchemaComputed(),
 			}
 		},

--- a/internal/service/ce/cost_category_data_source.go
+++ b/internal/service/ce/cost_category_data_source.go
@@ -68,7 +68,7 @@ func dataSourceCostCategory() *schema.Resource {
 							names.AttrRule: {
 								Type:     schema.TypeList,
 								Computed: true,
-								Elem:     sdkv2.DataSourceElemFromResourceElem(expressionElem(costCategoryRuleRootElementSchemaLevel)),
+								Elem:     sdkv2.ComputedOnlyFromResource(expressionElem(costCategoryRuleRootElementSchemaLevel)),
 							},
 							names.AttrType: {
 								Type:     schema.TypeString,

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -611,7 +611,7 @@ func resourcePipeline() *schema.Resource {
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
 				"trigger":         triggerSchema(),
-				"trigger_all":     sdkv2.DataSourcePropertyFromResourceProperty(triggerSchema()),
+				"trigger_all":     sdkv2.ComputedOnlyFromSchema(triggerSchema()),
 				"variable": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/internal/service/connect/user_hierarchy_structure_data_source.go
+++ b/internal/service/connect/user_hierarchy_structure_data_source.go
@@ -27,11 +27,11 @@ func dataSourceUserHierarchyStructure() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
-							"level_one":   sdkv2.DataSourcePropertyFromResourceProperty(hierarchyStructureLevelSchema()),
-							"level_two":   sdkv2.DataSourcePropertyFromResourceProperty(hierarchyStructureLevelSchema()),
-							"level_three": sdkv2.DataSourcePropertyFromResourceProperty(hierarchyStructureLevelSchema()),
-							"level_four":  sdkv2.DataSourcePropertyFromResourceProperty(hierarchyStructureLevelSchema()),
-							"level_five":  sdkv2.DataSourcePropertyFromResourceProperty(hierarchyStructureLevelSchema()),
+							"level_one":   sdkv2.ComputedOnlyFromSchema(hierarchyStructureLevelSchema()),
+							"level_two":   sdkv2.ComputedOnlyFromSchema(hierarchyStructureLevelSchema()),
+							"level_three": sdkv2.ComputedOnlyFromSchema(hierarchyStructureLevelSchema()),
+							"level_four":  sdkv2.ComputedOnlyFromSchema(hierarchyStructureLevelSchema()),
+							"level_five":  sdkv2.ComputedOnlyFromSchema(hierarchyStructureLevelSchema()),
 						},
 					},
 				},

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -92,7 +92,7 @@ func dataSourceFirewallPolicy() *schema.Resource {
 									},
 								},
 							},
-							"stateless_custom_action": sdkv2.DataSourcePropertyFromResourceProperty(customActionSchema()),
+							"stateless_custom_action": sdkv2.ComputedOnlyFromSchema(customActionSchema()),
 							"stateless_default_actions": {
 								Type:     schema.TypeSet,
 								Computed: true,

--- a/internal/service/quicksight/schema/analysis.go
+++ b/internal/service/quicksight/schema/analysis.go
@@ -106,7 +106,7 @@ func AnalysisDefinitionSchema() *schema.Schema {
 }
 
 func AnalysisDefinitionDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(AnalysisDefinitionSchema())
+	return sdkv2.ComputedOnlyFromSchema(AnalysisDefinitionSchema())
 }
 
 func AnalysisSourceEntitySchema() *schema.Schema {

--- a/internal/service/quicksight/schema/data_set.go
+++ b/internal/service/quicksight/schema/data_set.go
@@ -48,7 +48,7 @@ func DataSetColumnGroupsSchema() *schema.Schema {
 }
 
 func DataSetColumnGroupsSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetColumnGroupsSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetColumnGroupsSchema())
 }
 
 func DataSetColumnLevelPermissionRulesSchema() *schema.Schema {
@@ -77,7 +77,7 @@ func DataSetColumnLevelPermissionRulesSchema() *schema.Schema {
 }
 
 func DataSetColumnLevelPermissionRulesSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetColumnLevelPermissionRulesSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetColumnLevelPermissionRulesSchema())
 }
 
 func DataSetUsageConfigurationSchema() *schema.Schema {
@@ -104,7 +104,7 @@ func DataSetUsageConfigurationSchema() *schema.Schema {
 }
 
 func DataSetUsageConfigurationSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetUsageConfigurationSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetUsageConfigurationSchema())
 }
 
 func DataSetFieldFoldersSchema() *schema.Schema {
@@ -131,7 +131,7 @@ func DataSetFieldFoldersSchema() *schema.Schema {
 }
 
 func DataSetFieldFoldersSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetFieldFoldersSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetFieldFoldersSchema())
 }
 
 func DataSetLogicalTableMapSchema() *schema.Schema {
@@ -352,7 +352,7 @@ func DataSetLogicalTableMapSchema() *schema.Schema {
 }
 
 func DataSetLogicalTableMapSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetLogicalTableMapSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetLogicalTableMapSchema())
 }
 
 func DataSetOutputColumnsSchema() *schema.Schema {
@@ -497,7 +497,7 @@ func DataSetPhysicalTableMapSchema() *schema.Schema {
 }
 
 func DataSetPhysicalTableMapSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetPhysicalTableMapSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetPhysicalTableMapSchema())
 }
 
 func DataSetRowLevelPermissionDataSetSchema() *schema.Schema {
@@ -518,7 +518,7 @@ func DataSetRowLevelPermissionDataSetSchema() *schema.Schema {
 }
 
 func DataSetRowLevelPermissionDataSetSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetRowLevelPermissionDataSetSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetRowLevelPermissionDataSetSchema())
 }
 
 func DataSetRowLevelPermissionTagConfigurationSchema() *schema.Schema {
@@ -553,7 +553,7 @@ func DataSetRowLevelPermissionTagConfigurationSchema() *schema.Schema {
 }
 
 func DataSetRowLevelPermissionTagConfigurationSchemaDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(DataSetRowLevelPermissionTagConfigurationSchema())
+	return sdkv2.ComputedOnlyFromSchema(DataSetRowLevelPermissionTagConfigurationSchema())
 }
 
 func DataSetRefreshPropertiesSchema() *schema.Schema {

--- a/internal/service/quicksight/schema/theme.go
+++ b/internal/service/quicksight/schema/theme.go
@@ -161,7 +161,7 @@ func ThemeConfigurationSchema() *schema.Schema {
 }
 
 func ThemeConfigurationDataSourceSchema() *schema.Schema {
-	return sdkv2.DataSourcePropertyFromResourceProperty(ThemeConfigurationSchema())
+	return sdkv2.ComputedOnlyFromSchema(ThemeConfigurationSchema())
 }
 
 func ExpandThemeConfiguration(tfList []any) *awstypes.ThemeConfiguration {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This series of helper functions are being renamed to `ComputedOnlyFrom[Schema|Resource|SchemaResource]` to better describe their usage given it is mixed between both data sources and managed resources.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42012


### Output from Unit Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 ./internal/sdkv2/...
ok      github.com/hashicorp/terraform-provider-aws/internal/sdkv2      0.323s
ok      github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types        0.639s
ok      github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable       0.453s
```
