### PR TITLE
Fix SQS Queue Timeout When Waiting for KMS Data Key Reuse Period Propagation

### DIFF
--- a/.changelog/42062.txt
+++ b/.changelog/42062.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_sqs_queue: Fix `waiting for SQS Queue... attributes create: timeout while waiting` errors when `sqs_managed_sse_enabled = false` or omitted and `kms_master_key_id` is not set but `kms_data_key_reuse_period_seconds` is set to a non-default value.
+```

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -550,7 +550,8 @@ func statusQueueAttributeState(ctx context.Context, conn *sqs.Client, url string
 
 					sse, sseOK := got[types.QueueAttributeNameSqsManagedSseEnabled]
 					kmsMaster, kmsOK := got[types.QueueAttributeNameKmsMasterKeyId]
-					if k == types.QueueAttributeNameKmsDataKeyReusePeriodSeconds && (!sseOK || sseOK && sse == "false") && (!kmsOK || kmsOK && kmsMaster == "") {
+					if k == types.QueueAttributeNameKmsDataKeyReusePeriodSeconds &&
+						((!sseOK || (sseOK && sse == "false")) && (!kmsOK || (kmsOK && kmsMaster == ""))) {
 						// API won't set if not encrypted
 						continue
 					}

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -79,7 +79,7 @@ var (
 			Computed:     true,
 			ValidateFunc: validation.IntBetween(60, 86_400),
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// KmsDataKeyReusePeriodSeconds is only valid for SqsManagedSseEnabled queues.
+				// KmsDataKeyReusePeriodSeconds is only valid for encrypted queues.
 				return !d.Get("sqs_managed_sse_enabled").(bool) && d.Get("kms_master_key_id").(string) == ""
 			},
 		},
@@ -551,7 +551,7 @@ func statusQueueAttributeState(ctx context.Context, conn *sqs.Client, url string
 					sse, sseOK := got[types.QueueAttributeNameSqsManagedSseEnabled]
 					kmsMaster, kmsOK := got[types.QueueAttributeNameKmsMasterKeyId]
 					if k == types.QueueAttributeNameKmsDataKeyReusePeriodSeconds && (!sseOK || sseOK && sse == "false") && (!kmsOK || kmsOK && kmsMaster == "") {
-						// Won't be set if SqsManagedSseEnabled is false.
+						// API won't set if not encrypted
 						continue
 					}
 

--- a/internal/service/sqs/queue.go
+++ b/internal/service/sqs/queue.go
@@ -79,7 +79,7 @@ var (
 			Computed:     true,
 			ValidateFunc: validation.IntBetween(60, 86_400),
 			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// KmsDataKeyReusePeriodSeconds is only valid for encrypted queues.
+				// Only valid for encrypted queues, not returned by SQS
 				return !d.Get("sqs_managed_sse_enabled").(bool) && d.Get("kms_master_key_id").(string) == ""
 			},
 		},

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -869,7 +869,7 @@ func TestAccSQSQueue_timeouts(t *testing.T) {
 // SQS does not return kms_data_key_reuse_period_seconds when not using encryption, even if it is sent in the
 // request, causing hanging when statusQueueAttributeState() waited for the attributes to propagate.
 // https://github.com/hashicorp/terraform-provider-aws/pull/41234
-func TestAccSQSQueue_noManagedEncryptionKMSDataKeyReusePeriodSeconds(t *testing.T) {
+func TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds(t *testing.T) {
 	ctx := acctest.Context(t)
 	var queueAttributes map[types.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
@@ -885,6 +885,9 @@ func TestAccSQSQueue_noManagedEncryptionKMSDataKeyReusePeriodSeconds(t *testing.
 				Config: testAccQueueConfig_noManagedEncryptionKMSDataKeyReusePeriodSeconds(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueueExists(ctx, resourceName, &queueAttributes),
+					resource.TestCheckResourceAttr(resourceName, "sqs_managed_sse_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "kms_master_key_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_data_key_reuse_period_seconds", "300"),
 				),
 			},
 		},

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -866,10 +866,9 @@ func TestAccSQSQueue_timeouts(t *testing.T) {
 	})
 }
 
-// SQS does not return the KMS Data Key Reuse Period Seconds attribute when not using managed encryption,
-// even if it is sent in the request. This causes hanging when statusQueueAttributeState() waits for the
-// attributes to propagate.
-// https://github.com/hashicorp/terraform-provider-aws/pull/41590
+// SQS does not return kms_data_key_reuse_period_seconds when not using encryption, even if it is sent in the
+// request, causing hanging when statusQueueAttributeState() waited for the attributes to propagate.
+// https://github.com/hashicorp/terraform-provider-aws/pull/41234
 func TestAccSQSQueue_noManagedEncryptionKMSDataKeyReusePeriodSeconds(t *testing.T) {
 	ctx := acctest.Context(t)
 	var queueAttributes map[types.QueueAttributeName]string

--- a/website/docs/r/sqs_queue.html.markdown
+++ b/website/docs/r/sqs_queue.html.markdown
@@ -12,8 +12,6 @@ Amazon SQS (Simple Queue Service) is a fully managed message queuing service tha
 
 !> AWS will hang indefinitely, leading to a `timeout while waiting` error, when creating or updating an `aws_sqs_queue` with an associated [`aws_sqs_queue_policy`](/docs/providers/aws/r/sqs_queue_policy.html) if `Version = "2012-10-17"` is not explicitly set in the policy.
 
-!> AWS will hang indefinitely and trigger a `timeout while waiting` error when creating or updating an `aws_sqs_queue` if `kms_data_key_reuse_period_seconds` is set to a non-default value, `sqs_managed_sse_enabled` is `false` (explicitly or by default), and `kms_master_key_id` is not set.
-
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a bug where Terraform would hang indefinitely while waiting for SQS queue attributes to propagate. The issue occurred because the resource was incorrectly expecting the `kms_data_key_reuse_period_seconds` attribute to match the configured value, even when encryption was not enabled. Since AWS does not return this attribute unless encryption is enabled via either a KMS master key or SQS-managed SSE, Terraform would continue waiting indefinitely.  

#### Bug Fix
- Updated the attribute propagation logic to account for cases where encryption is not enabled.  
- Now, if neither `kms_master_key_id` nor `sqs_managed_sse_enabled` is set, Terraform will no longer wait for `kms_data_key_reuse_period_seconds` to match.  
- This prevents unnecessary timeouts and ensures the resource creation proceeds as expected.  

#### Relevant Error

```
Error: waiting for SQS Queue (https://sqs.us-east-1.amazonaws.com/012345678901/Test-name.fifo) attributes create: timeout while waiting for state to become 'equal' (last state: 'notequal', timeout: 2m0s)
```

#### Context
SQS does not return the `kms_data_key_reuse_period_seconds` attribute when encryption is not enabled, even if it was included in the request. Previously, `statusQueueAttributeState()` would continue waiting for the attribute to match the configured value, causing the resource creation to hang indefinitely.  

With this fix, Terraform correctly handles the propagation logic, preventing unnecessary timeouts while maintaining expected behavior when encryption is enabled.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41234

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccSQSQueue_ K=sqs P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/sqs/... -v -count 1 -parallel 10 -run='TestAccSQSQueue_'  -timeout 360m -vet=off
2025/03/31 16:04:32 Initializing Terraform AWS Provider...
=== RUN   TestAccSQSQueue_tags
=== PAUSE TestAccSQSQueue_tags
=== RUN   TestAccSQSQueue_tags_null
=== PAUSE TestAccSQSQueue_tags_null
=== RUN   TestAccSQSQueue_tags_EmptyMap
=== PAUSE TestAccSQSQueue_tags_EmptyMap
=== RUN   TestAccSQSQueue_tags_AddOnUpdate
=== PAUSE TestAccSQSQueue_tags_AddOnUpdate
=== RUN   TestAccSQSQueue_tags_EmptyTag_OnCreate
=== PAUSE TestAccSQSQueue_tags_EmptyTag_OnCreate
=== RUN   TestAccSQSQueue_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccSQSQueue_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccSQSQueue_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccSQSQueue_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccSQSQueue_tags_DefaultTags_providerOnly
=== PAUSE TestAccSQSQueue_tags_DefaultTags_providerOnly
=== RUN   TestAccSQSQueue_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSQSQueue_tags_DefaultTags_nonOverlapping
=== RUN   TestAccSQSQueue_tags_DefaultTags_overlapping
=== PAUSE TestAccSQSQueue_tags_DefaultTags_overlapping
=== RUN   TestAccSQSQueue_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSQSQueue_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSQSQueue_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSQSQueue_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSQSQueue_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSQSQueue_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSQSQueue_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSQSQueue_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSQSQueue_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSQSQueue_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSQSQueue_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSQSQueue_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSQSQueue_tags_ComputedTag_OnCreate
=== PAUSE TestAccSQSQueue_tags_ComputedTag_OnCreate
=== RUN   TestAccSQSQueue_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccSQSQueue_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccSQSQueue_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccSQSQueue_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccSQSQueue_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccSQSQueue_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccSQSQueue_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccSQSQueue_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccSQSQueue_basic
=== PAUSE TestAccSQSQueue_basic
=== RUN   TestAccSQSQueue_disappears
=== PAUSE TestAccSQSQueue_disappears
=== RUN   TestAccSQSQueue_Name_generated
=== PAUSE TestAccSQSQueue_Name_generated
=== RUN   TestAccSQSQueue_NameGenerated_fifoQueue
=== PAUSE TestAccSQSQueue_NameGenerated_fifoQueue
=== RUN   TestAccSQSQueue_namePrefix
=== PAUSE TestAccSQSQueue_namePrefix
=== RUN   TestAccSQSQueue_NamePrefix_fifoQueue
=== PAUSE TestAccSQSQueue_NamePrefix_fifoQueue
=== RUN   TestAccSQSQueue_update
=== PAUSE TestAccSQSQueue_update
=== RUN   TestAccSQSQueue_Policy_basic
=== PAUSE TestAccSQSQueue_Policy_basic
=== RUN   TestAccSQSQueue_Policy_ignoreEquivalent
=== PAUSE TestAccSQSQueue_Policy_ignoreEquivalent
=== RUN   TestAccSQSQueue_recentlyDeleted
=== PAUSE TestAccSQSQueue_recentlyDeleted
=== RUN   TestAccSQSQueue_redrivePolicy
=== PAUSE TestAccSQSQueue_redrivePolicy
=== RUN   TestAccSQSQueue_redriveAllowPolicy
=== PAUSE TestAccSQSQueue_redriveAllowPolicy
=== RUN   TestAccSQSQueue_fifoQueue
=== PAUSE TestAccSQSQueue_fifoQueue
=== RUN   TestAccSQSQueue_FIFOQueue_expectNameError
=== PAUSE TestAccSQSQueue_FIFOQueue_expectNameError
=== RUN   TestAccSQSQueue_FIFOQueue_contentBasedDeduplication
=== PAUSE TestAccSQSQueue_FIFOQueue_contentBasedDeduplication
=== RUN   TestAccSQSQueue_FIFOQueue_highThroughputMode
=== PAUSE TestAccSQSQueue_FIFOQueue_highThroughputMode
=== RUN   TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError
=== PAUSE TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError
=== RUN   TestAccSQSQueue_encryption
=== PAUSE TestAccSQSQueue_encryption
=== RUN   TestAccSQSQueue_managedEncryption
=== PAUSE TestAccSQSQueue_managedEncryption
=== RUN   TestAccSQSQueue_zeroVisibilityTimeoutSeconds
=== PAUSE TestAccSQSQueue_zeroVisibilityTimeoutSeconds
=== RUN   TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds
=== PAUSE TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds
=== RUN   TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds
=== PAUSE TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds
=== RUN   TestAccSQSQueue_timeouts
=== PAUSE TestAccSQSQueue_timeouts
=== RUN   TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds
=== PAUSE TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds
=== CONT  TestAccSQSQueue_tags
=== CONT  TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds
=== CONT  TestAccSQSQueue_basic
=== CONT  TestAccSQSQueue_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccSQSQueue_redrivePolicy
=== CONT  TestAccSQSQueue_FIFOQueue_highThroughputMode
=== CONT  TestAccSQSQueue_managedEncryption
=== CONT  TestAccSQSQueue_zeroVisibilityTimeoutSeconds
=== CONT  TestAccSQSQueue_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds
--- PASS: TestAccSQSQueue_noEncryptionKMSDataKeyReusePeriodSeconds (41.98s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccSQSQueue_defaultKMSDataKeyReusePeriodSeconds (44.36s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_overlapping
--- PASS: TestAccSQSQueue_zeroVisibilityTimeoutSeconds (44.88s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_nonOverlapping
--- PASS: TestAccSQSQueue_basic (45.25s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_providerOnly
--- PASS: TestAccSQSQueue_tags_DefaultTags_updateToResourceOnly (53.70s)
=== CONT  TestAccSQSQueue_FIFOQueue_expectNameError
--- PASS: TestAccSQSQueue_FIFOQueue_expectNameError (1.16s)
=== CONT  TestAccSQSQueue_FIFOQueue_contentBasedDeduplication
=== CONT  TestAccSQSQueue_tags_AddOnUpdate
--- PASS: TestAccSQSQueue_tags_EmptyTag_OnUpdate_Replace (54.89s)
--- PASS: TestAccSQSQueue_redrivePolicy (72.33s)
=== CONT  TestAccSQSQueue_NamePrefix_fifoQueue
--- PASS: TestAccSQSQueue_FIFOQueue_highThroughputMode (78.72s)
=== CONT  TestAccSQSQueue_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccSQSQueue_tags (81.25s)
=== CONT  TestAccSQSQueue_tags_EmptyTag_OnCreate
--- PASS: TestAccSQSQueue_tags_DefaultTags_updateToProviderOnly (52.72s)
=== CONT  TestAccSQSQueue_recentlyDeleted
--- PASS: TestAccSQSQueue_FIFOQueue_contentBasedDeduplication (41.75s)
=== CONT  TestAccSQSQueue_tags_EmptyMap
--- PASS: TestAccSQSQueue_tags_AddOnUpdate (52.72s)
=== CONT  TestAccSQSQueue_Policy_ignoreEquivalent
--- PASS: TestAccSQSQueue_tags_DefaultTags_nonOverlapping (68.25s)
=== CONT  TestAccSQSQueue_Policy_basic
--- PASS: TestAccSQSQueue_managedEncryption (113.22s)
=== CONT  TestAccSQSQueue_NameGenerated_fifoQueue
--- PASS: TestAccSQSQueue_tags_DefaultTags_overlapping (68.98s)
=== CONT  TestAccSQSQueue_update
--- PASS: TestAccSQSQueue_NamePrefix_fifoQueue (41.95s)
=== CONT  TestAccSQSQueue_namePrefix
--- PASS: TestAccSQSQueue_tags_DefaultTags_providerOnly (80.63s)
=== CONT  TestAccSQSQueue_encryption
--- PASS: TestAccSQSQueue_tags_EmptyTag_OnCreate (55.13s)
=== CONT  TestAccSQSQueue_fifoQueue
--- PASS: TestAccSQSQueue_tags_EmptyTag_OnUpdate_Add (64.07s)
=== CONT  TestAccSQSQueue_tags_null
--- PASS: TestAccSQSQueue_tags_EmptyMap (46.25s)
=== CONT  TestAccSQSQueue_timeouts
--- PASS: TestAccSQSQueue_Policy_ignoreEquivalent (47.37s)
=== CONT  TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds
--- PASS: TestAccSQSQueue_NameGenerated_fifoQueue (42.58s)
=== CONT  TestAccSQSQueue_redriveAllowPolicy
--- PASS: TestAccSQSQueue_namePrefix (42.07s)
=== CONT  TestAccSQSQueue_Name_generated
--- PASS: TestAccSQSQueue_Policy_basic (46.19s)
=== CONT  TestAccSQSQueue_disappears
--- PASS: TestAccSQSQueue_fifoQueue (41.46s)
=== CONT  TestAccSQSQueue_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccSQSQueue_update (75.88s)
=== CONT  TestAccSQSQueue_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccSQSQueue_tags_null (46.50s)
=== CONT  TestAccSQSQueue_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccSQSQueue_ManagedEncryption_kmsDataKeyReusePeriodSeconds (38.54s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccSQSQueue_Name_generated (41.21s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccSQSQueue_disappears (58.96s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccSQSQueue_recentlyDeleted (131.47s)
=== CONT  TestAccSQSQueue_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccSQSQueue_redriveAllowPolicy (70.66s)
=== CONT  TestAccSQSQueue_tags_ComputedTag_OnCreate
--- PASS: TestAccSQSQueue_timeouts (91.88s)
=== CONT  TestAccSQSQueue_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccSQSQueue_encryption (108.94s)
=== CONT  TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError
--- PASS: TestAccSQSQueue_StandardQueue_expectContentBasedDeduplicationError (1.29s)
--- PASS: TestAccSQSQueue_tags_IgnoreTags_Overlap_DefaultTag (58.35s)
--- PASS: TestAccSQSQueue_tags_DefaultTags_nullOverlappingResourceTag (43.09s)
--- PASS: TestAccSQSQueue_tags_DefaultTags_nullNonOverlappingResourceTag (42.98s)
--- PASS: TestAccSQSQueue_tags_ComputedTag_OnUpdate_Replace (55.22s)
--- PASS: TestAccSQSQueue_tags_IgnoreTags_Overlap_ResourceTag (62.96s)
--- PASS: TestAccSQSQueue_tags_DefaultTags_emptyProviderOnlyTag (42.76s)
--- PASS: TestAccSQSQueue_tags_DefaultTags_emptyResourceTag (42.74s)
--- PASS: TestAccSQSQueue_tags_ComputedTag_OnCreate (45.45s)
--- PASS: TestAccSQSQueue_tags_ComputedTag_OnUpdate_Add (54.37s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sqs	294.558s
```
