### PR TITLE
r/aws_securitylake_data_lake: Add sweeper

### DIFF
--- a/internal/service/securitylake/sweep.go
+++ b/internal/service/securitylake/sweep.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package securitylake
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/securitylake"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_securitylake_data_lake", sweepDataLakes)
+}
+
+func sweepDataLakes(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.SecurityLakeClient(ctx)
+	var input securitylake.ListDataLakesInput
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	output, err := conn.ListDataLakes(ctx, &input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, v := range output.DataLakes {
+		sweepResources = append(sweepResources, framework.NewSweepResource(newDataLakeResource, client,
+			framework.NewAttribute(names.AttrID, aws.ToString(v.DataLakeArn))))
+	}
+
+	return sweepResources, nil
+}

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -145,6 +145,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/scheduler"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/schemas"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/securitylake"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalog"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/servicecatalogappregistry"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery"
@@ -319,6 +320,7 @@ func registerSweepers() {
 	scheduler.RegisterSweepers()
 	schemas.RegisterSweepers()
 	secretsmanager.RegisterSweepers()
+	securitylake.RegisterSweepers()
 	servicecatalog.RegisterSweepers()
 	servicecatalogappregistry.RegisterSweepers()
 	servicediscovery.RegisterSweepers()


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a sweeper for `aws_securitylake_data_lake`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/42061.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SWEEPERS=aws_securitylake_data_lake make sweep
# make sweep SWEEPARGS=-sweep-run=aws_example_thing
# set SWEEPARGS=-sweep-allow-failures to continue after first failure
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.23.7 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run='aws_securitylake_data_lake' -timeout 360m -vet=off
2025/03/31 16:32:07 [DEBUG] Running Sweepers for region (us-west-2):
2025/03/31 16:32:07 [DEBUG] Running Sweeper (aws_securitylake_data_lake) in region (us-west-2)
2025/03/31 16:32:07 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:07.012-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-2
2025-03-31T16:32:07.012-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:07.013-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:07.013-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake tf_aws.credentials_source=EnvConfigCredentials
2025-03-31T16:32:07.013-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:07 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:07 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:07.013-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:07.382-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:07 [INFO]  sweeper: listing resources: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:08 [INFO]  sweeper: No resources to sweep: sweeper_region=us-west-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:08 [DEBUG] Completed Sweeper (aws_securitylake_data_lake) in region (us-west-2) in 1.710878875s
2025/03/31 16:32:08 Completed Sweepers for region (us-west-2) in 1.711044667s
2025/03/31 16:32:08 Sweeper Tests for region (us-west-2) ran successfully:
2025/03/31 16:32:08 	- aws_securitylake_data_lake
2025/03/31 16:32:08 [DEBUG] Running Sweepers for region (us-east-1):
2025/03/31 16:32:08 [DEBUG] Running Sweeper (aws_securitylake_data_lake) in region (us-east-1)
2025/03/31 16:32:08 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.722-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.723-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.723-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.723-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_resource_type=aws_securitylake_data_lake tf_aws.credentials_source=EnvConfigCredentials sweeper_region=us-east-1
2025-03-31T16:32:08.723-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-1
2025/03/31 16:32:08 [DEBUG] sweeper: Creating AWS SDK v1 session: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-1
2025/03/31 16:32:08 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.724-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:08.839-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:08 [INFO]  sweeper: listing resources: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:09 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-1 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:09 [DEBUG] Completed Sweeper (aws_securitylake_data_lake) in region (us-east-1) in 627.653ms
2025/03/31 16:32:09 Completed Sweepers for region (us-east-1) in 627.680416ms
2025/03/31 16:32:09 Sweeper Tests for region (us-east-1) ran successfully:
2025/03/31 16:32:09 	- aws_securitylake_data_lake
2025/03/31 16:32:09 [DEBUG] Running Sweepers for region (us-east-2):
2025/03/31 16:32:09 [DEBUG] Running Sweeper (aws_securitylake_data_lake) in region (us-east-2)
2025/03/31 16:32:09 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:09.350-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-2
2025-03-31T16:32:09.350-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-2
2025-03-31T16:32:09.350-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:09.350-0400 [INFO]  sweeper.aws-base: Retrieved credentials: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake tf_aws.credentials_source=EnvConfigCredentials
2025-03-31T16:32:09.350-0400 [DEBUG] sweeper.aws-base: Loading configuration: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-2
2025/03/31 16:32:09 [DEBUG] sweeper: Creating AWS SDK v1 session: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:09 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:09.351-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:09.583-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:09 [INFO]  sweeper: listing resources: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-east-2
2025/03/31 16:32:11 [INFO]  sweeper: No resources to sweep: sweeper_region=us-east-2 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:11 [DEBUG] Completed Sweeper (aws_securitylake_data_lake) in region (us-east-2) in 1.681615541s
2025/03/31 16:32:11 Completed Sweepers for region (us-east-2) in 1.681641917s
2025/03/31 16:32:11 Sweeper Tests for region (us-east-2) ran successfully:
2025/03/31 16:32:11 	- aws_securitylake_data_lake
2025/03/31 16:32:11 [DEBUG] Running Sweepers for region (us-west-1):
2025/03/31 16:32:11 [DEBUG] Running Sweeper (aws_securitylake_data_lake) in region (us-west-1)
2025/03/31 16:32:11 [DEBUG] sweeper: Configuring Terraform AWS Provider: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:11.032-0400 [DEBUG] sweeper.aws-base: Resolving credentials provider: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:11.032-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:11.032-0400 [DEBUG] sweeper.aws-base: Retrieving credentials: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-1
2025-03-31T16:32:11.032-0400 [INFO]  sweeper.aws-base: Retrieved credentials: tf_aws.credentials_source=EnvConfigCredentials sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:11.032-0400 [DEBUG] sweeper.aws-base: Loading configuration: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:11 [DEBUG] sweeper: Creating AWS SDK v1 session: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-1
2025/03/31 16:32:11 [DEBUG] sweeper: Retrieving AWS account details: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025-03-31T16:32:11.033-0400 [DEBUG] sweeper.aws-base: Retrieving caller identity from STS: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-1
2025-03-31T16:32:11.455-0400 [INFO]  sweeper.aws-base: Retrieved caller identity from STS: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-1
2025/03/31 16:32:11 [INFO]  sweeper: listing resources: sweeper_region=us-west-1 tf_resource_type=aws_securitylake_data_lake
2025/03/31 16:32:12 [INFO]  sweeper: No resources to sweep: tf_resource_type=aws_securitylake_data_lake sweeper_region=us-west-1
2025/03/31 16:32:12 [DEBUG] Completed Sweeper (aws_securitylake_data_lake) in region (us-west-1) in 1.584223208s
2025/03/31 16:32:12 Completed Sweepers for region (us-west-1) in 1.584248959s
2025/03/31 16:32:12 Sweeper Tests for region (us-west-1) ran successfully:
2025/03/31 16:32:12 	- aws_securitylake_data_lake
ok  	github.com/hashicorp/terraform-provider-aws/internal/sweep	11.481s
```
