### PR TITLE
aws_lb_listener_rule: expose use_client_client_secret

### DIFF
--- a/internal/service/elbv2/listener_rule.go
+++ b/internal/service/elbv2/listener_rule.go
@@ -141,8 +141,13 @@ func resourceListenerRule() *schema.Resource {
 									},
 									names.AttrClientSecret: {
 										Type:      schema.TypeString,
-										Required:  true,
 										Sensitive: true,
+										Optional:  true,
+									},
+									"use_existing_client_secret": {
+										Type:     schema.TypeBool,
+										Default:  false,
+										Optional: true,
 									},
 									names.AttrIssuer: {
 										Type:     schema.TypeString,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Allow setting `UseExistingClientSecret` if provided. This should allow managing the `client_secret` outside of terraform so that when the next `elbv2.modify_rule` is called, the secret set outside of tf isn't overriden.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

I couldn't find any tickets referencing this.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

- https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_AuthenticateOidcActionConfig.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Running now, will post when completed.

```console
% make testacc PKG=elb2
```
