### PR TITLE
Resolve the Launch Configuration deprecated error in ASG

### DIFF
--- a/examples/asg/main.tf
+++ b/examples/asg/main.tf
@@ -42,7 +42,10 @@ resource "aws_autoscaling_group" "web-asg" {
   min_size             = var.asg_min
   desired_capacity     = var.asg_desired
   force_delete         = true
-  launch_configuration = aws_launch_configuration.web-lc.name
+  launch_template {
+    id      = aws_launch_template.web-lt.id
+    version = aws_launch_template.web-lt.latest_version
+  }
   load_balancers       = [aws_elb.web-elb.name]
 
   #vpc_zone_identifier = ["${split(",", var.availability_zones)}"]
@@ -53,14 +56,14 @@ resource "aws_autoscaling_group" "web-asg" {
   }
 }
 
-resource "aws_launch_configuration" "web-lc" {
-  name          = "terraform-example-lc"
+resource "aws_launch_template" "web-lt" {
+  name          = "terraform-example-lt"
   image_id      = var.aws_amis[var.aws_region]
   instance_type = var.instance_type
 
   # Security group
-  security_groups = [aws_security_group.default.id]
-  user_data       = file("userdata.sh")
+  vpc_security_group_ids = [aws_security_group.default.id]
+  user_data       = base64encode(file("userdata.sh"))
   key_name        = var.key_name
 }
 

--- a/examples/asg/outputs.tf
+++ b/examples/asg/outputs.tf
@@ -6,7 +6,7 @@ output "security_group" {
 }
 
 output "launch_configuration" {
-  value = aws_launch_configuration.web-lc.id
+  value = aws_launch_template.web-lt.id
 }
 
 output "asg_name" {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This pull request resolves the Launch Configuration deprecated error in ASG

Error: creating Auto Scaling Launch Configuration (terraform-example-lc): operation error Auto Scaling: CreateLaunchConfiguration, https response error StatusCode: 400, RequestID: 3b44fccd-****-****-****-d612a1d843aa, api error UnsupportedOperation: The Launch Configuration creation operation is not available in your account. Use launch templates to create configuration templates for your Auto Scaling groups.
│ 
│   with aws_launch_configuration.web-lc,
│   on main.tf line 56, in resource "aws_launch_configuration" "web-lc":
│   56: resource "aws_launch_configuration" "web-lc" {


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->



