### PR TITLE
r/aws_globalaccelerator/accelerator_data_source: Make ID only computed

### DIFF
--- a/.changelog/42097.txt
+++ b/.changelog/42097.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_globalaccelerator_accelerator: The `id` attribute is now computed only
+```

--- a/internal/service/globalaccelerator/accelerator_data_source.go
+++ b/internal/service/globalaccelerator/accelerator_data_source.go
@@ -58,7 +58,6 @@ func (d *acceleratorDataSource) Schema(ctx context.Context, request datasource.S
 				Computed: true,
 			},
 			names.AttrID: schema.StringAttribute{
-				Optional: true,
 				Computed: true,
 			},
 			names.AttrIPAddressType: schema.StringAttribute{

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -135,3 +135,16 @@ The `aws_redshift_service_account` resource has been removed. AWS [recommends](h
 ## resource/aws_spot_instance_request
 
 * Remove `block_duration_minutes` from configuration as it no longer exists.
+
+## resource/aws_batch_compute_environment
+
+* `compute_environment_name` has been renamed to `name`.
+* `compute_environment_name_prefix` has been renamed to `name_prefix`.
+
+## resource/aws_batch_comptete_environment_data_source
+
+* `compute_environment_name` has been renamed to `name`.
+
+## datasource/aws_globalaccelerator_accelerator
+
+* `id` is now computed only.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39236

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
> make testacc TESTARGS='-run=TestAccGlobalAcceleratorAcceleratorDataSource_' PKG=globalaccelerator
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.1 test ./internal/service/globalaccelerator/... -v -count 1 -parallel 20  -run=TestAccGlobalAcceleratorAcceleratorDataSource_ -timeout 360m -vet=off
2025/04/02 12:32:34 Initializing Terraform AWS Provider...
=== RUN   TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== PAUSE TestAccGlobalAcceleratorAcceleratorDataSource_basic
=== CONT  TestAccGlobalAcceleratorAcceleratorDataSource_basic
--- PASS: TestAccGlobalAcceleratorAcceleratorDataSource_basic (93.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/globalaccelerator  100.296s

...
```
