### PR TITLE
sagemaker: Remove `accelerator_types` from notebook instance

### DIFF
--- a/.changelog/42099.txt
+++ b/.changelog/42099.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_sagemaker_notebook_instance: `accelerator_types` has been removed and must be reomved from configurations. Use `instance_type` instead.
+```

--- a/.changelog/42099.txt
+++ b/.changelog/42099.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-resource/aws_sagemaker_notebook_instance: `accelerator_types` has been removed and must be reomved from configurations. Use `instance_type` instead.
+resource/aws_sagemaker_notebook_instance: Remove `accelerator_types` from your configuration—it no longer exists. Instead, use `instance_type` to use [Inferentia](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-supported-cloud.html).
 ```

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -43,7 +43,6 @@ func TestAccSageMakerNotebookInstance_basic(t *testing.T) {
 				Config: testAccNotebookInstanceConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckNotebookInstanceExists(ctx, resourceName, &notebook),
-					resource.TestCheckResourceAttr(resourceName, "accelerator_types.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "additional_code_repositories.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_code_repository", ""),
 					resource.TestCheckResourceAttr(resourceName, "direct_internet_access", "Enabled"),

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -24,6 +24,7 @@ Upgrade topics:
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
+- [resource/aws_sagemaker_notebook_instance](#resourceaws_sagemaker_notebook_instance)
 - [resource/aws_spot_instance_request](#resourceaws_spot_instance_request)
 
 <!-- /TOC -->
@@ -125,13 +126,17 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 ## resource/aws_redshift_cluster
 
 * The `publicly_accessible` attribute now defaults to `false`.
-* Remove `snapshot_copy` from configuration as it no longer exists. Use the `aws_redshift_snapshot_copy` resource instead.
-* Remove `logging` from configuration as it no longer exists. Use the `aws_redshift_logging` resource instead.
+* Remove `snapshot_copy` from your configuration—it no longer exists. Use the `aws_redshift_snapshot_copy` resource instead.
+* Remove `logging` from your configuration—it no longer exists. Use the `aws_redshift_logging` resource instead.
 
 ## resource/aws_redshift_service_account
 
 The `aws_redshift_service_account` resource has been removed. AWS [recommends](https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html#db-auditing-bucket-permissions) that a [service principal name](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services) should be used instead of an AWS account ID in any relevant IAM policy.
 
+## resource/aws_sagemaker_notebook_instance
+
+* Remove `accelerator_types` from your configuration—it no longer exists. Use `instance_type` instead to use [Inferentia](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-supported-cloud.html).
+
 ## resource/aws_spot_instance_request
 
-* Remove `block_duration_minutes` from configuration as it no longer exists.
+* Remove `block_duration_minutes` from your configuration—it no longer exists.

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -135,7 +135,7 @@ The `aws_redshift_service_account` resource has been removed. AWS [recommends](h
 
 ## resource/aws_sagemaker_notebook_instance
 
-* Remove `accelerator_types` from your configuration—it no longer exists. Use `instance_type` instead to use [Inferentia](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-supported-cloud.html).
+* Remove `accelerator_types` from your configuration—it no longer exists. Instead, use `instance_type` to use [Inferentia](https://docs.aws.amazon.com/sagemaker/latest/dg/neo-supported-cloud.html).
 
 ## resource/aws_spot_instance_request
 

--- a/website/docs/r/sagemaker_notebook_instance.html.markdown
+++ b/website/docs/r/sagemaker_notebook_instance.html.markdown
@@ -60,7 +60,6 @@ This resource supports the following arguments:
 * `volume_size` - (Optional) The size, in GB, of the ML storage volume to attach to the notebook instance. The default value is 5 GB.
 * `subnet_id` - (Optional) The VPC subnet ID.
 * `security_groups` - (Optional) The associated security groups.
-* `accelerator_types` - (Optional, Deprecated) A list of Elastic Inference (EI) instance types to associate with this notebook instance. See [Elastic Inference Accelerator](https://docs.aws.amazon.com/sagemaker/latest/dg/ei.html) for more details. Valid values: `ml.eia1.medium`, `ml.eia1.large`, `ml.eia1.xlarge`, `ml.eia2.medium`, `ml.eia2.large`, `ml.eia2.xlarge`.
 * `additional_code_repositories` - (Optional) An array of up to three Git repositories to associate with the notebook instance.
  These can be either the names of Git repositories stored as resources in your account, or the URL of Git repositories in [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) or in any other Git repository. These repositories are cloned at the same level as the default repository of your notebook instance.
 * `default_code_repository` - (Optional) The Git repository associated with the notebook instance as its default code repository. This can be either the name of a Git repository stored as a resource in your account, or the URL of a Git repository in [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/welcome.html) or in any other Git repository.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #38844
Relates #41673
Relates #41101

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccSageMakerNotebookInstance_basic K=sagemaker
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.1 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerNotebookInstance_basic'  -timeout 360m -vet=off
2025/04/02 16:52:24 Initializing Terraform AWS Provider...
=== RUN   TestAccSageMakerNotebookInstance_basic
=== PAUSE TestAccSageMakerNotebookInstance_basic
=== CONT  TestAccSageMakerNotebookInstance_basic
--- PASS: TestAccSageMakerNotebookInstance_basic (361.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	366.991s
```
