### PR TITLE
r/aws_osis_pipeline: Add sweeper

### DIFF
--- a/internal/service/osis/pipeline.go
+++ b/internal/service/osis/pipeline.go
@@ -236,11 +236,13 @@ func (r *pipelineResource) Create(ctx context.Context, request resource.CreateRe
 		return
 	}
 
-	data.setID()
+	// Set values for unknowns.
+	data.ID = fwflex.StringValueToFramework(ctx, name)
 
 	pipeline, err := waitPipelineCreated(ctx, conn, name, r.CreateTimeout(ctx, data.Timeouts))
 
 	if err != nil {
+		response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrID), name)...)
 		response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("pipeline_name"), name)...)
 		response.Diagnostics.AddError(fmt.Sprintf("waiting for OpenSearch Ingestion Pipeline (%s) create", name), err.Error())
 
@@ -248,7 +250,7 @@ func (r *pipelineResource) Create(ctx context.Context, request resource.CreateRe
 	}
 
 	// Set values for unknowns.
-	data.IngestEndpointUrls.SetValue = fwflex.FlattenFrameworkStringValueSet(ctx, pipeline.IngestEndpointUrls)
+	data.IngestEndpointURLs.SetValue = fwflex.FlattenFrameworkStringValueSet(ctx, pipeline.IngestEndpointUrls)
 	data.PipelineARN = fwflex.StringToFramework(ctx, pipeline.PipelineArn)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
@@ -261,14 +263,9 @@ func (r *pipelineResource) Read(ctx context.Context, request resource.ReadReques
 		return
 	}
 
-	if err := data.InitFromID(); err != nil {
-		response.Diagnostics.AddError("parsing resource ID", err.Error())
-
-		return
-	}
-
 	conn := r.Meta().OpenSearchIngestionClient(ctx)
 
+	data.PipelineName = data.ID
 	name := data.PipelineName.ValueString()
 	pipeline, err := findPipelineByName(ctx, conn, name)
 
@@ -485,7 +482,7 @@ type pipelineResourceModel struct {
 	BufferOptions             fwtypes.ListNestedObjectValueOf[bufferOptionsModel]           `tfsdk:"buffer_options"`
 	EncryptionAtRestOptions   fwtypes.ListNestedObjectValueOf[encryptionAtRestOptionsModel] `tfsdk:"encryption_at_rest_options"`
 	ID                        types.String                                                  `tfsdk:"id"`
-	IngestEndpointUrls        fwtypes.SetValueOf[types.String]                              `tfsdk:"ingest_endpoint_urls"`
+	IngestEndpointURLs        fwtypes.SetOfString                                           `tfsdk:"ingest_endpoint_urls"`
 	LogPublishingOptions      fwtypes.ListNestedObjectValueOf[logPublishingOptionsModel]    `tfsdk:"log_publishing_options"`
 	MaxUnits                  types.Int64                                                   `tfsdk:"max_units"`
 	MinUnits                  types.Int64                                                   `tfsdk:"min_units"`
@@ -496,16 +493,6 @@ type pipelineResourceModel struct {
 	TagsAll                   tftags.Map                                                    `tfsdk:"tags_all"`
 	Timeouts                  timeouts.Value                                                `tfsdk:"timeouts"`
 	VPCOptions                fwtypes.ListNestedObjectValueOf[vpcOptionsModel]              `tfsdk:"vpc_options"`
-}
-
-func (data *pipelineResourceModel) InitFromID() error {
-	data.PipelineName = data.ID
-
-	return nil
-}
-
-func (data *pipelineResourceModel) setID() {
-	data.ID = data.PipelineName
 }
 
 type bufferOptionsModel struct {

--- a/internal/service/osis/sweep.go
+++ b/internal/service/osis/sweep.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package osis
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/osis"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func RegisterSweepers() {
+	awsv2.Register("aws_osis_pipeline", sweepPipelines)
+}
+
+func sweepPipelines(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.OpenSearchIngestionClient(ctx)
+	var input osis.ListPipelinesInput
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	pages := osis.NewListPipelinesPaginator(conn, &input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.Pipelines {
+			name := aws.ToString(v.PipelineName)
+
+			sweepResources = append(sweepResources, framework.NewSweepResource(newPipelineResource, client,
+				framework.NewAttribute(names.AttrID, name), framework.NewAttribute("pipeline_name", name)))
+		}
+	}
+
+	return sweepResources, nil
+}

--- a/internal/sweep/register_gen_test.go
+++ b/internal/sweep/register_gen_test.go
@@ -120,6 +120,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/service/opensearch"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/organizations"
+	"github.com/hashicorp/terraform-provider-aws/internal/service/osis"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/pinpoint"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/pinpointsmsvoicev2"
 	"github.com/hashicorp/terraform-provider-aws/internal/service/pipes"
@@ -295,6 +296,7 @@ func registerSweepers() {
 	opensearch.RegisterSweepers()
 	opensearchserverless.RegisterSweepers()
 	organizations.RegisterSweepers()
+	osis.RegisterSweepers()
 	pinpoint.RegisterSweepers()
 	pinpointsmsvoicev2.RegisterSweepers()
 	pipes.RegisterSweepers()


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Adds a sweeper for `aws_osis_pipeline`.
Attempting to reproduce (unsuccessfully) the error in https://github.com/hashicorp/terraform-provider-aws/issues/41769.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccOpenSearchIngestionPipeline_' PKG=osis ACCTEST_PARALLELISM=2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/osis/... -v -count 1 -parallel 2  -run=TestAccOpenSearchIngestionPipeline_ -timeout 360m -vet=off
2025/04/02 16:47:28 Initializing Terraform AWS Provider...
=== RUN   TestAccOpenSearchIngestionPipeline_basic
=== PAUSE TestAccOpenSearchIngestionPipeline_basic
=== RUN   TestAccOpenSearchIngestionPipeline_disappears
=== PAUSE TestAccOpenSearchIngestionPipeline_disappears
=== RUN   TestAccOpenSearchIngestionPipeline_buffer
=== PAUSE TestAccOpenSearchIngestionPipeline_buffer
=== RUN   TestAccOpenSearchIngestionPipeline_encryption
=== PAUSE TestAccOpenSearchIngestionPipeline_encryption
=== RUN   TestAccOpenSearchIngestionPipeline_logPublishing
=== PAUSE TestAccOpenSearchIngestionPipeline_logPublishing
=== RUN   TestAccOpenSearchIngestionPipeline_vpc
=== PAUSE TestAccOpenSearchIngestionPipeline_vpc
=== RUN   TestAccOpenSearchIngestionPipeline_tags
=== PAUSE TestAccOpenSearchIngestionPipeline_tags
=== RUN   TestAccOpenSearchIngestionPipeline_upgradeV5_90_0
=== PAUSE TestAccOpenSearchIngestionPipeline_upgradeV5_90_0
=== CONT  TestAccOpenSearchIngestionPipeline_basic
=== CONT  TestAccOpenSearchIngestionPipeline_logPublishing
--- PASS: TestAccOpenSearchIngestionPipeline_basic (524.61s)
=== CONT  TestAccOpenSearchIngestionPipeline_buffer
--- PASS: TestAccOpenSearchIngestionPipeline_logPublishing (524.77s)
=== CONT  TestAccOpenSearchIngestionPipeline_encryption
--- PASS: TestAccOpenSearchIngestionPipeline_encryption (517.36s)
=== CONT  TestAccOpenSearchIngestionPipeline_disappears
--- PASS: TestAccOpenSearchIngestionPipeline_buffer (647.62s)
=== CONT  TestAccOpenSearchIngestionPipeline_tags
--- PASS: TestAccOpenSearchIngestionPipeline_disappears (499.74s)
=== CONT  TestAccOpenSearchIngestionPipeline_upgradeV5_90_0
--- PASS: TestAccOpenSearchIngestionPipeline_tags (506.87s)
=== CONT  TestAccOpenSearchIngestionPipeline_vpc
--- PASS: TestAccOpenSearchIngestionPipeline_upgradeV5_90_0 (531.76s)
--- PASS: TestAccOpenSearchIngestionPipeline_vpc (566.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/osis	2251.243s
```
