### PR TITLE
[Enhancement] r/aws_emr_cluster: support custom ami per instance type config

### DIFF
--- a/.changelog/42082.txt
+++ b/.changelog/42082.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_emr_cluster: visible_to_all_users attribute no longer supported
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -766,11 +766,6 @@ func resourceCluster() *schema.Resource {
 					Optional: true,
 					Default:  false,
 				},
-				"visible_to_all_users": {
-					Type:     schema.TypeBool,
-					Optional: true,
-					Default:  true,
-				},
 			}
 		},
 	}
@@ -922,10 +917,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		Name:         aws.String(name),
 		Applications: expandApplications(applications),
 
-		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
-		ServiceRole:       aws.String(d.Get(names.AttrServiceRole).(string)),
-		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
-		Tags:              getTagsIn(ctx),
+		ReleaseLabel: aws.String(d.Get("release_label").(string)),
+		ServiceRole:  aws.String(d.Get(names.AttrServiceRole).(string)),
+		Tags:         getTagsIn(ctx),
 	}
 
 	if v, ok := d.GetOk("additional_info"); ok {
@@ -1122,7 +1116,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("log_encryption_kms_key_id", cluster.LogEncryptionKmsKeyId)
 	d.Set("log_uri", cluster.LogUri)
 	d.Set("master_public_dns", cluster.MasterPublicDnsName)
-	d.Set("visible_to_all_users", cluster.VisibleToAllUsers)
 	d.Set("ebs_root_volume_size", cluster.EbsRootVolumeSize)
 	d.Set("scale_down_behavior", cluster.ScaleDownBehavior)
 	d.Set("termination_protection", cluster.TerminationProtected)
@@ -1211,19 +1204,6 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).EMRClient(ctx)
-
-	if d.HasChange("visible_to_all_users") {
-		input := &emr.SetVisibleToAllUsersInput{
-			JobFlowIds:        []string{d.Id()},
-			VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
-		}
-
-		_, err := conn.SetVisibleToAllUsers(ctx, input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "updating EMR Cluster (%s): setting visibility: %s", d.Id(), err)
-		}
-	}
 
 	if d.HasChange("auto_termination_policy") {
 		_, n := d.GetChange("auto_termination_policy")

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -132,6 +132,12 @@ func resourceCluster() *schema.Resource {
 											},
 										},
 									},
+									"custom_ami_id": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ForceNew:     true,
+										ValidateFunc: validCustomAMIID,
+									},
 									"ebs_config": {
 										Type:     schema.TypeSet,
 										Optional: true,
@@ -2114,6 +2120,10 @@ func flattenInstanceTypeSpecifications(apiObjects []awstypes.InstanceTypeSpecifi
 			tfMap["bid_price_as_percentage_of_on_demand_price"] = aws.ToFloat64(apiObject.BidPriceAsPercentageOfOnDemandPrice)
 		}
 
+		if apiObject.CustomAmiId != nil {
+			tfMap["custom_ami_id"] = aws.ToString(apiObject.CustomAmiId)
+		}
+
 		tfMap["ebs_config"] = flattenEBSConfig(apiObject.EbsBlockDevices)
 		tfMap[names.AttrInstanceType] = aws.ToString(apiObject.InstanceType)
 		tfMap["weighted_capacity"] = int(aws.ToInt32(apiObject.WeightedCapacity))
@@ -2211,6 +2221,10 @@ func expandInstanceTypeConfigs(tfList []any) []awstypes.InstanceTypeConfig {
 
 		if v, ok := tfMap["bid_price_as_percentage_of_on_demand_price"].(float64); ok && v != 0 {
 			apiObject.BidPriceAsPercentageOfOnDemandPrice = aws.Float64(v)
+		}
+
+		if v, ok := tfMap["custom_ami_id"].(string); ok && v != "" {
+			apiObject.CustomAmiId = aws.String(v)
 		}
 
 		if v, ok := tfMap["weighted_capacity"].(int); ok {

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -1799,7 +1799,7 @@ func flattenEBSConfig(apiObjects []awstypes.EbsBlockDevice) *schema.Set {
 			tfMap[names.AttrSize] = int(aws.ToInt32(apiObject.VolumeSpecification.SizeInGB))
 		}
 		if apiObject.VolumeSpecification.Throughput != nil {
-			tfMap[names.AttrThroughput] = aws.ToInt32(apiObject.VolumeSpecification.Throughput)
+			tfMap[names.AttrThroughput] = int(aws.ToInt32(apiObject.VolumeSpecification.Throughput))
 		}
 		if apiObject.VolumeSpecification.VolumeType != nil {
 			tfMap[names.AttrType] = aws.ToString(apiObject.VolumeSpecification.VolumeType)

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1496,7 +1496,9 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 				Config: testAccClusterConfig_ebs(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
+					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
 				),
 			},
@@ -3819,13 +3821,14 @@ resource "aws_emr_cluster" "test" {
     instance_count = 1
     instance_type  = "m5.xlarge"
     ebs_config {
-      size                 = 32
+      size                 = 33
       type                 = "gp2"
       volumes_per_instance = %[2]d
     }
     ebs_config {
-      size                 = 125
-      type                 = "sc1"
+      size                 = 50
+      iops                 = 3001
+      type                 = "gp3"
       volumes_per_instance = %[2]d
     }
   }

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -3943,7 +3943,6 @@ func testAccClusterConfig_instanceFleets(rName string) string {
 		testAccClusterConfig_baseVPC(rName, false),
 		testAccClusterConfig_baseIAMServiceRole(rName),
 		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseBootstrapActionBucket(rName),
 		fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -4031,7 +4030,6 @@ func testAccClusterConfig_instanceFleetMultipleSubnets(rName string) string {
 		testAccClusterConfig_baseVPC(rName, false),
 		testAccClusterConfig_baseIAMServiceRole(rName),
 		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseBootstrapActionBucket(rName),
 		fmt.Sprintf(`
 data "aws_partition" "current" {}
 

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -2098,41 +2098,13 @@ resource "aws_s3_bucket" "tester" {
   bucket = %[1]q
 }
 
-resource "aws_s3_bucket_public_access_block" "tester" {
-  bucket = aws_s3_bucket.tester.id
-
-  block_public_acls       = false
-  block_public_policy     = false
-  ignore_public_acls      = false
-  restrict_public_buckets = false
-}
-
-resource "aws_s3_bucket_ownership_controls" "tester" {
-  bucket = aws_s3_bucket.tester.id
-  rule {
-    object_ownership = "BucketOwnerPreferred"
-  }
-}
-
-resource "aws_s3_bucket_acl" "tester" {
-  depends_on = [
-    aws_s3_bucket_public_access_block.tester,
-    aws_s3_bucket_ownership_controls.tester,
-  ]
-
-  bucket = aws_s3_bucket.tester.id
-  acl    = "public-read"
-}
-
 resource "aws_s3_object" "testobject" {
-  bucket  = aws_s3_bucket_acl.tester.bucket
+  bucket  = aws_s3_bucket.tester.bucket
   key     = "testscript.sh"
   content = <<EOF
 #!/bin/bash
 echo $@
 EOF
-
-  acl = "public-read"
 }
 `, rName)
 }

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1287,56 +1287,6 @@ func TestAccEMRCluster_keepJob(t *testing.T) {
 	})
 }
 
-func TestAccEMRCluster_visibleToAllUsers(t *testing.T) {
-	ctx := acctest.Context(t)
-	var cluster awstypes.Cluster
-
-	resourceName := "aws_emr_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "visible_to_all_users", acctest.CtTrue),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"cluster_state", // Ignore RUNNING versus WAITING changes
-					"configurations",
-					"keep_job_flow_alive_when_no_steps",
-				},
-			},
-			{
-				Config: testAccClusterConfig_visibleToAllUsersUpdated(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
-					resource.TestCheckResourceAttr(resourceName, "visible_to_all_users", acctest.CtFalse),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"cluster_state", // Ignore RUNNING versus WAITING changes
-					"configurations",
-					"keep_job_flow_alive_when_no_steps",
-				},
-			},
-		},
-	})
-}
-
 func TestAccEMRCluster_s3Logging(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cluster awstypes.Cluster
@@ -3549,61 +3499,6 @@ resource "aws_emr_cluster" "test" {
   autoscaling_role = aws_iam_role.emr_autoscaling_role.arn
 }
 `, rName, keepJob))
-}
-
-func testAccClusterConfig_visibleToAllUsersUpdated(rName string) string {
-	return acctest.ConfigCompose(
-		testAccClusterConfig_baseVPC(rName, false),
-		testAccClusterConfig_baseIAMServiceRole(rName),
-		testAccClusterConfig_baseIAMInstanceProfile(rName),
-		testAccClusterConfig_baseIAMAutoScalingRole(rName),
-		fmt.Sprintf(`
-data "aws_partition" "current" {}
-
-resource "aws_emr_cluster" "test" {
-  name          = %[1]q
-  release_label = "emr-4.6.0"
-  applications  = ["Spark"]
-
-  ec2_attributes {
-    subnet_id                         = aws_subnet.test.id
-    emr_managed_master_security_group = aws_security_group.test.id
-    emr_managed_slave_security_group  = aws_security_group.test.id
-    instance_profile                  = aws_iam_instance_profile.emr_instance_profile.arn
-  }
-
-  master_instance_group {
-    instance_type = "c4.large"
-  }
-
-  core_instance_group {
-    instance_count = 1
-    instance_type  = "c4.large"
-  }
-
-  tags = {
-    role     = "rolename"
-    dns_zone = "env_zone"
-    env      = "env"
-    name     = "name-env"
-  }
-
-  keep_job_flow_alive_when_no_steps = true
-  visible_to_all_users              = false
-
-  configurations = "test-fixtures/emr_configurations.json"
-
-  depends_on = [
-    aws_route_table_association.test,
-    aws_iam_role_policy_attachment.emr_service,
-    aws_iam_role_policy_attachment.emr_instance_profile,
-    aws_iam_role_policy_attachment.emr_autoscaling_role,
-  ]
-
-  service_role     = aws_iam_role.emr_service.arn
-  autoscaling_role = aws_iam_role.emr_autoscaling_role.arn
-}
-`, rName))
 }
 
 func testAccClusterConfig_s3Logging(rName string) string {

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -1497,9 +1497,19 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "master_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
 					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "core_instance_group.0.ebs_config.0.volumes_per_instance", "2"),
+
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "master_instance_group.0.ebs_config.*", map[string]string{
+						names.AttrSize:         "32",
+						names.AttrType:         "gp2",
+						"volumes_per_instance": "2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "master_instance_group.0.ebs_config.*", map[string]string{
+						names.AttrSize:         "50",
+						names.AttrType:         "gp3",
+						names.AttrThroughput:   "500",
+						"volumes_per_instance": "2",
+					}),
 				),
 			},
 			{
@@ -1510,6 +1520,10 @@ func TestAccEMRCluster_ebs(t *testing.T) {
 					"cluster_state", // Ignore RUNNING versus WAITING changes
 					"configurations",
 					"keep_job_flow_alive_when_no_steps",
+
+					// https://github.com/hashicorp/terraform-plugin-testing/issues/269
+					"master_instance_group.0.ebs_config",
+					"core_instance_group.0.ebs_config",
 				},
 			},
 		},

--- a/internal/service/emr/instance_fleet.go
+++ b/internal/service/emr/instance_fleet.go
@@ -90,6 +90,12 @@ func resourceInstanceFleet() *schema.Resource {
 								},
 							},
 						},
+						"custom_ami_id": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validCustomAMIID,
+						},
 						"ebs_config": {
 							Type:     schema.TypeSet,
 							Optional: true,

--- a/internal/service/emr/instance_fleet_test.go
+++ b/internal/service/emr/instance_fleet_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/emr/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -31,7 +32,7 @@ func TestAccEMRInstanceFleet_basic(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceFleetConfig_basic(rName),
+				Config: testAccInstanceFleetConfig_basicTaskFleet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceFleetExists(ctx, resourceName, &fleet),
 					resource.TestCheckResourceAttr(resourceName, "instance_type_configs.#", "1"),
@@ -62,7 +63,7 @@ func TestAccEMRInstanceFleet_Zero_count(t *testing.T) {
 		CheckDestroy:             acctest.CheckDestroyNoop,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceFleetConfig_basic(rName),
+				Config: testAccInstanceFleetConfig_basicTaskFleet(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceFleetExists(ctx, resourceName, &fleet),
 					resource.TestCheckResourceAttr(resourceName, "instance_type_configs.#", "1"),
@@ -116,6 +117,36 @@ func TestAccEMRInstanceFleet_ebsBasic(t *testing.T) {
 				ImportStateIdFunc:       testAccInstanceFleetResourceImportStateIdFunc(resourceName),
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"instance_type_configs"},
+			},
+		},
+	})
+}
+
+func TestAccEMRInstanceFleet_customami(t *testing.T) {
+	ctx := acctest.Context(t)
+	var fleet awstypes.InstanceFleet
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_emr_instance_fleet.task"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EMRServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceFleetConfig_customami(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceFleetExists(ctx, resourceName, &fleet),
+					resource.TestCheckResourceAttr(resourceName, "instance_type_configs.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "instance_type_configs.0.custom_ami_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccInstanceFleetResourceImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -266,20 +297,20 @@ data "aws_partition" "current" {}
 resource "aws_iam_role" "emr_service" {
   name               = "%[1]s_default_role"
   assume_role_policy = <<EOT
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOT
+  {
+    "Version": "2008-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "elasticmapreduce.${data.aws_partition.current.dns_suffix}"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOT
 }
 
 resource "aws_iam_role_policy_attachment" "emr_service" {
@@ -295,20 +326,20 @@ resource "aws_iam_instance_profile" "emr_instance_profile" {
 resource "aws_iam_role" "emr_instance_profile" {
   name               = "%[1]s_profile_role"
   assume_role_policy = <<EOT
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOT
+  {
+    "Version": "2008-10-17",
+    "Statement": [
+      {
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]
+  }
+  EOT
 }
 
 resource "aws_iam_role_policy_attachment" "emr_instance_profile" {
@@ -319,40 +350,43 @@ resource "aws_iam_role_policy_attachment" "emr_instance_profile" {
 resource "aws_iam_policy" "emr_instance_profile" {
   name   = "%[1]s_profile"
   policy = <<EOT
-{
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Resource": "*",
-        "Action": [
-            "cloudwatch:*",
-            "dynamodb:*",
-            "ec2:Describe*",
-            "elasticmapreduce:Describe*",
-            "elasticmapreduce:ListBootstrapActions",
-            "elasticmapreduce:ListClusters",
-            "elasticmapreduce:ListInstanceGroups",
-            "elasticmapreduce:ListInstances",
-            "elasticmapreduce:ListSteps",
-            "kinesis:CreateStream",
-            "kinesis:DeleteStream",
-            "kinesis:DescribeStream",
-            "kinesis:GetRecords",
-            "kinesis:GetShardIterator",
-            "kinesis:MergeShards",
-            "kinesis:PutRecord",
-            "kinesis:SplitShard",
-            "rds:Describe*",
-            "s3:*",
-            "sdb:*",
-            "sns:*",
-            "sqs:*"
-        ]
-    }]
-}
-EOT
+  {
+      "Version": "2012-10-17",
+      "Statement": [{
+          "Effect": "Allow",
+          "Resource": "*",
+          "Action": [
+              "cloudwatch:*",
+              "dynamodb:*",
+              "ec2:Describe*",
+              "elasticmapreduce:Describe*",
+              "elasticmapreduce:ListBootstrapActions",
+              "elasticmapreduce:ListClusters",
+              "elasticmapreduce:ListInstanceGroups",
+              "elasticmapreduce:ListInstances",
+              "elasticmapreduce:ListSteps",
+              "kinesis:CreateStream",
+              "kinesis:DeleteStream",
+              "kinesis:DescribeStream",
+              "kinesis:GetRecords",
+              "kinesis:GetShardIterator",
+              "kinesis:MergeShards",
+              "kinesis:PutRecord",
+              "kinesis:SplitShard",
+              "rds:Describe*",
+              "s3:*",
+              "sdb:*",
+              "sns:*",
+              "sqs:*"
+          ]
+      }]
+  }
+  EOT
+}`, rName))
 }
 
+func testAccInstanceFleetConfig_baseCluster(rName string) string {
+	return acctest.ConfigCompose(testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
 resource "aws_emr_cluster" "test" {
   name          = "%[1]s"
   release_label = "emr-5.30.1"
@@ -402,8 +436,8 @@ resource "aws_emr_cluster" "test" {
 `, rName))
 }
 
-func testAccInstanceFleetConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
+func testAccInstanceFleetConfig_basicTaskFleet(rName string) string {
+	return acctest.ConfigCompose(testAccInstanceFleetConfig_baseCluster(rName), fmt.Sprintf(`
 resource "aws_emr_instance_fleet" "task" {
   cluster_id = aws_emr_cluster.test.id
 
@@ -426,7 +460,7 @@ resource "aws_emr_instance_fleet" "task" {
 }
 
 func testAccInstanceFleetConfig_zeroCount(rName string) string {
-	return acctest.ConfigCompose(testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccInstanceFleetConfig_baseCluster(rName), fmt.Sprintf(`
 resource "aws_emr_instance_fleet" "task" {
   cluster_id = aws_emr_cluster.test.id
 
@@ -449,7 +483,7 @@ resource "aws_emr_instance_fleet" "task" {
 }
 
 func testAccInstanceFleetConfig_ebsBasic(rName string) string {
-	return acctest.ConfigCompose(testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccInstanceFleetConfig_baseCluster(rName), fmt.Sprintf(`
 resource "aws_emr_instance_fleet" "task" {
   cluster_id = aws_emr_cluster.test.id
 
@@ -480,8 +514,81 @@ resource "aws_emr_instance_fleet" "task" {
 `, rName))
 }
 
+func testAccInstanceFleetConfig_customami(rName string) string {
+	return acctest.ConfigCompose(
+		configLatestAmazonLinux2FullHVMEBSAMI(ec2types.ArchitectureValuesX8664),
+		testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
+resource "aws_emr_cluster" "test" {
+  name          = "%[1]s"
+  release_label = "emr-5.30.1"
+  applications  = ["Hadoop", "Hive"]
+  log_uri       = "s3n://terraform/testlog/"
+
+  master_instance_fleet {
+    instance_type_configs {
+      custom_ami_id = data.aws_ami.amzn2-ami-hvm-ebs-x86_64.id
+      instance_type = "m3.xlarge"
+    }
+
+    target_on_demand_capacity = 1
+  }
+
+  core_instance_fleet {
+    instance_type_configs {
+      bid_price_as_percentage_of_on_demand_price = 100
+      custom_ami_id                              = data.aws_ami.amzn2-ami-hvm-ebs-x86_64.id
+
+      ebs_config {
+        size                 = 100
+        type                 = "gp2"
+        volumes_per_instance = 1
+      }
+
+      instance_type     = "m4.xlarge"
+      weighted_capacity = 1
+    }
+    name                      = "core fleet"
+    target_on_demand_capacity = 1
+  }
+
+  service_role = aws_iam_role.emr_service.arn
+  depends_on = [
+    aws_route_table_association.test,
+    aws_iam_role_policy_attachment.emr_service,
+    aws_iam_role_policy_attachment.emr_instance_profile,
+  ]
+
+  ec2_attributes {
+    subnet_id                         = aws_subnet.test.id
+    emr_managed_master_security_group = aws_security_group.test.id
+    emr_managed_slave_security_group  = aws_security_group.test.id
+    instance_profile                  = aws_iam_instance_profile.emr_instance_profile.arn
+  }
+}
+
+resource "aws_emr_instance_fleet" "task" {
+  cluster_id = aws_emr_cluster.test.id
+
+  instance_type_configs {
+    custom_ami_id     = data.aws_ami.amzn2-ami-hvm-ebs-x86_64.id
+    instance_type     = "m3.xlarge"
+    weighted_capacity = 1
+  }
+
+  launch_specifications {
+    on_demand_specification {
+      allocation_strategy = "lowest-price"
+    }
+  }
+
+  name                      = "emr_instance_fleet_%[1]s"
+  target_on_demand_capacity = 1
+}
+`, rName))
+}
+
 func testAccInstanceFleetConfig_full(rName string) string {
-	return acctest.ConfigCompose(testAccInstanceFleetConfig_base(rName), fmt.Sprintf(`
+	return acctest.ConfigCompose(testAccInstanceFleetConfig_baseCluster(rName), fmt.Sprintf(`
 resource "aws_emr_instance_fleet" "task" {
   cluster_id = aws_emr_cluster.test.id
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -664,7 +664,6 @@ EOF
 * `tags` - (Optional) list of tags to apply to the EMR Cluster. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `termination_protection` - (Optional) Switch on/off termination protection (default is `false`, except when using multiple master nodes). Before attempting to destroy the resource when termination protection is enabled, this configuration must be applied with its value set to `false`.
 * `unhealthy_node_replacement` - (Optional) Whether whether Amazon EMR should gracefully replace core nodes that have degraded within the cluster. Default value is `false`.
-* `visible_to_all_users` - (Optional) Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default value is `true`.
 
 ### bootstrap_action
 
@@ -832,7 +831,6 @@ This resource exports the following attributes in addition to the arguments abov
 * `release_label` - Release label for the Amazon EMR release.
 * `service_role` - IAM role that will be assumed by the Amazon EMR service to access AWS resources on your behalf.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
-* `visible_to_all_users` - Indicates whether the job flow is visible to all IAM users of the AWS account associated with the job flow.
 
 ## Import
 

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -156,7 +156,9 @@ resource "aws_emr_cluster" "example" {
       bid_price_as_percentage_of_on_demand_price = 80
       ebs_config {
         size                 = 100
-        type                 = "gp2"
+        type                 = "gp3"
+        throughput           = 500
+        iops                 = 3000
         volumes_per_instance = 1
       }
       instance_type     = "m3.xlarge"
@@ -213,7 +215,9 @@ resource "aws_emr_instance_fleet" "task" {
     ebs_config {
       size                 = 100
       type                 = "gp2"
-      volumes_per_instance = 1
+      volumes_per_instance = 2
+      throughput           = 500
+      iops                 = 3000
     }
     instance_type     = "m4.2xlarge"
     weighted_capacity = 2

--- a/website/docs/r/emr_instance_fleet.html.markdown
+++ b/website/docs/r/emr_instance_fleet.html.markdown
@@ -88,6 +88,7 @@ Attributes for the EBS volumes attached to each EC2 instance in the `master_inst
 * `size` - (Required) The volume size, in gibibytes (GiB).
 * `type` - (Required) The volume type. Valid options are `gp2`, `io1`, `standard` and `st1`. See [EBS Volume Types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html).
 * `iops` - (Optional) The number of I/O operations per second (IOPS) that the volume supports
+* `throughput` - (Optional) The throughput, in mebibyte per second (MiB/s).
 * `volumes_per_instance` - (Optional) The number of EBS volumes with this configuration to attach to each EC2 instance in the instance group (default is 1)
 
 ## launch_specifications Configuration Block


### PR DESCRIPTION
### Description
Enables setting custom ami per instance-type-config. This allows running mixed-architecture EMR clusters (e.g. some parts of the fleet on ARM, some x86). 

### Relations
Closes #39036

### Output from Acceptance Testing

> [!NOTE]  
> This branch is based on #42082, which fixes a number of unit test failures in the provider today.

```console
% make testacc PKG=emr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/emr/... -v -count 1 -parallel 35   -timeout 360m -vet=off
2025/04/03 09:27:57 Initializing Terraform AWS Provider...
=== RUN   TestValidCustomAMIID
=== PAUSE TestValidCustomAMIID
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial
=== PAUSE TestAccEMRBlockPublicAccessConfiguration_serial
=== RUN   TestAccEMRCluster_basic
2025/04/03 09:27:57 [WARN] Invalid log level: "JSON". Defaulting to level: TRACE. Valid levels are: [TRACE DEBUG INFO WARN ERROR]
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_autoTerminationPolicy
=== PAUSE TestAccEMRCluster_autoTerminationPolicy
=== RUN   TestAccEMRCluster_additionalInfo
=== PAUSE TestAccEMRCluster_additionalInfo
=== RUN   TestAccEMRCluster_disappears
=== PAUSE TestAccEMRCluster_disappears
=== RUN   TestAccEMRCluster_sJSON
=== PAUSE TestAccEMRCluster_sJSON
=== RUN   TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== RUN   TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_CoreInstanceGroup_name
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_name
=== RUN   TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== PAUSE TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== RUN   TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== PAUSE TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== RUN   TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_MasterInstanceGroup_name
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_name
=== RUN   TestAccEMRCluster_security
=== PAUSE TestAccEMRCluster_security
=== RUN   TestAccEMRCluster_Step_basic
=== PAUSE TestAccEMRCluster_Step_basic
=== RUN   TestAccEMRCluster_Step_mode
=== PAUSE TestAccEMRCluster_Step_mode
=== RUN   TestAccEMRCluster_Step_multiple
=== PAUSE TestAccEMRCluster_Step_multiple
=== RUN   TestAccEMRCluster_Step_multiple_listStates
=== PAUSE TestAccEMRCluster_Step_multiple_listStates
=== RUN   TestAccEMRCluster_Bootstrap_ordering
=== PAUSE TestAccEMRCluster_Bootstrap_ordering
=== RUN   TestAccEMRCluster_PlacementGroupConfigs
=== PAUSE TestAccEMRCluster_PlacementGroupConfigs
=== RUN   TestAccEMRCluster_terminationProtected
=== PAUSE TestAccEMRCluster_terminationProtected
=== RUN   TestAccEMRCluster_keepJob
=== PAUSE TestAccEMRCluster_keepJob
=== RUN   TestAccEMRCluster_s3Logging
=== PAUSE TestAccEMRCluster_s3Logging
=== RUN   TestAccEMRCluster_s3LogEncryption
=== PAUSE TestAccEMRCluster_s3LogEncryption
=== RUN   TestAccEMRCluster_tags
=== PAUSE TestAccEMRCluster_tags
=== RUN   TestAccEMRCluster_RootVolume_size
=== PAUSE TestAccEMRCluster_RootVolume_size
=== RUN   TestAccEMRCluster_StepConcurrency_level
=== PAUSE TestAccEMRCluster_StepConcurrency_level
=== RUN   TestAccEMRCluster_ebs
=== PAUSE TestAccEMRCluster_ebs
=== RUN   TestAccEMRCluster_CustomAMI_id
=== PAUSE TestAccEMRCluster_CustomAMI_id
=== RUN   TestAccEMRCluster_InstanceFleet_basic
=== PAUSE TestAccEMRCluster_InstanceFleet_basic
=== RUN   TestAccEMRCluster_InstanceFleetMaster_only
=== PAUSE TestAccEMRCluster_InstanceFleetMaster_only
=== RUN   TestAccEMRCluster_unhealthyNodeReplacement
=== PAUSE TestAccEMRCluster_unhealthyNodeReplacement
=== RUN   TestAccEMRInstanceFleet_basic
=== PAUSE TestAccEMRInstanceFleet_basic
=== RUN   TestAccEMRInstanceFleet_Zero_count
=== PAUSE TestAccEMRInstanceFleet_Zero_count
=== RUN   TestAccEMRInstanceFleet_ebsBasic
=== PAUSE TestAccEMRInstanceFleet_ebsBasic
=== RUN   TestAccEMRInstanceFleet_customAmi
=== PAUSE TestAccEMRInstanceFleet_customAmi
=== RUN   TestAccEMRInstanceFleet_full
=== PAUSE TestAccEMRInstanceFleet_full
=== RUN   TestAccEMRInstanceGroup_basic
=== PAUSE TestAccEMRInstanceGroup_basic
=== RUN   TestAccEMRInstanceGroup_disappears
=== PAUSE TestAccEMRInstanceGroup_disappears
=== RUN   TestAccEMRInstanceGroup_Disappears_emrCluster
=== PAUSE TestAccEMRInstanceGroup_Disappears_emrCluster
=== RUN   TestAccEMRInstanceGroup_bidPrice
=== PAUSE TestAccEMRInstanceGroup_bidPrice
=== RUN   TestAccEMRInstanceGroup_sJSON
=== PAUSE TestAccEMRInstanceGroup_sJSON
=== RUN   TestAccEMRInstanceGroup_autoScalingPolicy
=== PAUSE TestAccEMRInstanceGroup_autoScalingPolicy
=== RUN   TestAccEMRInstanceGroup_instanceCountDecrease
=== PAUSE TestAccEMRInstanceGroup_instanceCountDecrease
=== RUN   TestAccEMRInstanceGroup_instanceCountCreateZero
=== PAUSE TestAccEMRInstanceGroup_instanceCountCreateZero
=== RUN   TestAccEMRInstanceGroup_EBS_ebsOptimized
=== PAUSE TestAccEMRInstanceGroup_EBS_ebsOptimized
=== RUN   TestAccEMRManagedScalingPolicy_basic
=== PAUSE TestAccEMRManagedScalingPolicy_basic
=== RUN   TestAccEMRManagedScalingPolicy_disappears
=== PAUSE TestAccEMRManagedScalingPolicy_disappears
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
=== RUN   TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== PAUSE TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== RUN   TestAccEMRReleaseLabels_basic
=== PAUSE TestAccEMRReleaseLabels_basic
=== RUN   TestAccEMRReleaseLabels_prefix
=== PAUSE TestAccEMRReleaseLabels_prefix
=== RUN   TestAccEMRReleaseLabels_application
=== PAUSE TestAccEMRReleaseLabels_application
=== RUN   TestAccEMRReleaseLabels_full
=== PAUSE TestAccEMRReleaseLabels_full
=== RUN   TestAccEMRReleaseLabels_empty
=== PAUSE TestAccEMRReleaseLabels_empty
=== RUN   TestAccEMRSecurityConfiguration_basic
=== PAUSE TestAccEMRSecurityConfiguration_basic
=== RUN   TestAccEMRSecurityConfiguration_disappears
=== PAUSE TestAccEMRSecurityConfiguration_disappears
=== RUN   TestAccEMRSecurityConfiguration_nameGenerated
=== PAUSE TestAccEMRSecurityConfiguration_nameGenerated
=== RUN   TestAccEMRSecurityConfiguration_namePrefix
=== PAUSE TestAccEMRSecurityConfiguration_namePrefix
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
--- PASS: TestEndpointConfiguration (0.44s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.02s)
    --- PASS: TestEndpointConfiguration/no_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.03s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.02s)
=== RUN   TestAccEMRStudioSessionMapping_basic
=== PAUSE TestAccEMRStudioSessionMapping_basic
=== RUN   TestAccEMRStudioSessionMapping_disappears
=== PAUSE TestAccEMRStudioSessionMapping_disappears
=== RUN   TestAccEMRStudio_sso
=== PAUSE TestAccEMRStudio_sso
=== RUN   TestAccEMRStudio_iam
=== PAUSE TestAccEMRStudio_iam
=== RUN   TestAccEMRStudio_disappears
=== PAUSE TestAccEMRStudio_disappears
=== RUN   TestAccEMRStudio_workspaceStorageEncryption
=== PAUSE TestAccEMRStudio_workspaceStorageEncryption
=== RUN   TestAccEMRStudio_tags
=== PAUSE TestAccEMRStudio_tags
=== RUN   TestAccEMRSupportedInstanceTypesDataSource_basic
=== PAUSE TestAccEMRSupportedInstanceTypesDataSource_basic
=== CONT  TestValidCustomAMIID
=== CONT  TestAccEMRInstanceFleet_basic
=== CONT  TestAccEMRCluster_Step_basic
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly
=== CONT  TestAccEMRCluster_additionalInfo
=== CONT  TestAccEMRInstanceGroup_sJSON
=== CONT  TestAccEMRStudio_disappears
=== CONT  TestAccEMRSupportedInstanceTypesDataSource_basic
=== CONT  TestAccEMRSecurityConfiguration_namePrefix
=== CONT  TestAccEMRInstanceFleet_customAmi
=== CONT  TestAccEMRStudio_iam
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceType
=== CONT  TestAccEMRCluster_MasterInstanceGroup_name
=== CONT  TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== CONT  TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== CONT  TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== CONT  TestAccEMRCluster_CoreInstanceGroup_name
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceType
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== CONT  TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== CONT  TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== CONT  TestAccEMRCluster_sJSON
=== CONT  TestAccEMRCluster_disappears
=== CONT  TestAccEMRCluster_security
=== CONT  TestAccEMRCluster_autoTerminationPolicy
=== CONT  TestAccEMRCluster_basic
=== CONT  TestAccEMRBlockPublicAccessConfiguration_serial
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/enabledMultiRange
=== CONT  TestAccEMRInstanceGroup_basic
=== CONT  TestAccEMRInstanceGroup_bidPrice
=== CONT  TestAccEMRInstanceGroup_Disappears_emrCluster
=== CONT  TestAccEMRInstanceGroup_disappears
=== CONT  TestAccEMRStudio_sso
=== CONT  TestAccEMRStudioSessionMapping_disappears
=== CONT  TestAccEMRStudioSessionMapping_basic
=== CONT  TestAccEMRCluster_s3LogEncryption
--- PASS: TestValidCustomAMIID (0.00s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== NAME  TestAccEMRStudioSessionMapping_disappears
    studio_session_mapping_test.go:180: AWS_IDENTITY_STORE_USER_ID env var must be set for AWS Identity Store User acceptance test. This is required until ListUsers API returns results without filtering by name.
=== NAME  TestAccEMRStudioSessionMapping_basic
    studio_session_mapping_test.go:180: AWS_IDENTITY_STORE_USER_ID env var must be set for AWS Identity Store User acceptance test. This is required until ListUsers API returns results without filtering by name.
--- SKIP: TestAccEMRStudioSessionMapping_disappears (0.51s)
--- SKIP: TestAccEMRStudioSessionMapping_basic (0.51s)
=== CONT  TestAccEMRCluster_unhealthyNodeReplacement
=== CONT  TestAccEMRCluster_InstanceFleetMaster_only
--- PASS: TestAccEMRSupportedInstanceTypesDataSource_basic (47.44s)
=== CONT  TestAccEMRCluster_InstanceFleet_basic
--- PASS: TestAccEMRSecurityConfiguration_namePrefix (52.96s)
=== CONT  TestAccEMRCluster_CustomAMI_id
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/basic
--- PASS: TestAccEMRStudio_disappears (86.73s)
=== CONT  TestAccEMRCluster_ebs
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/disappears
--- PASS: TestAccEMRStudio_iam (98.30s)
=== CONT  TestAccEMRCluster_StepConcurrency_level
=== RUN   TestAccEMRBlockPublicAccessConfiguration_serial/default
--- PASS: TestAccEMRStudio_sso (118.46s)
=== CONT  TestAccEMRCluster_RootVolume_size
--- PASS: TestAccEMRBlockPublicAccessConfiguration_serial (126.65s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/enabledMultiRange (53.64s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/basic (36.64s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/disappears (17.00s)
    --- PASS: TestAccEMRBlockPublicAccessConfiguration_serial/default (19.38s)
=== CONT  TestAccEMRCluster_tags
--- PASS: TestAccEMRCluster_additionalInfo (345.68s)
=== CONT  TestAccEMRCluster_PlacementGroupConfigs
--- PASS: TestAccEMRCluster_security (373.83s)
=== CONT  TestAccEMRCluster_s3Logging
--- PASS: TestAccEMRCluster_disappears (376.10s)
=== CONT  TestAccEMRCluster_keepJob
--- PASS: TestAccEMRCluster_Kerberos_clusterDedicatedKdc (377.64s)
=== CONT  TestAccEMRCluster_terminationProtected
--- PASS: TestAccEMRCluster_sJSON (421.09s)
=== CONT  TestAccEMRInstanceGroup_EBS_ebsOptimized
--- PASS: TestAccEMRCluster_Step_basic (425.49s)
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits
--- PASS: TestAccEMRCluster_basic (470.33s)
=== CONT  TestAccEMRManagedScalingPolicy_disappears
--- PASS: TestAccEMRCluster_ebs (390.14s)
=== CONT  TestAccEMRManagedScalingPolicy_basic
--- PASS: TestAccEMRCluster_StepConcurrency_level (423.50s)
=== CONT  TestAccEMRCluster_Step_multiple_listStates
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnitsSpotOnly (546.61s)
=== CONT  TestAccEMRCluster_Bootstrap_ordering
--- PASS: TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy (567.31s)
=== CONT  TestAccEMRStudio_tags
--- PASS: TestAccEMRInstanceFleet_customAmi (638.86s)
=== CONT  TestAccEMRInstanceFleet_ebsBasic
--- PASS: TestAccEMRCluster_unhealthyNodeReplacement (644.29s)
=== CONT  TestAccEMRInstanceFleet_full
--- PASS: TestAccEMRInstanceGroup_Disappears_emrCluster (682.56s)
=== CONT  TestAccEMRInstanceFleet_Zero_count
--- PASS: TestAccEMRStudio_tags (121.56s)
=== CONT  TestAccEMRInstanceGroup_instanceCountDecrease
--- PASS: TestAccEMRInstanceGroup_disappears (692.09s)
=== CONT  TestAccEMRInstanceGroup_instanceCountCreateZero
--- PASS: TestAccEMRInstanceGroup_basic (707.60s)
=== CONT  TestAccEMRInstanceGroup_autoScalingPolicy
--- PASS: TestAccEMRCluster_CoreInstanceGroup_name (717.34s)
=== CONT  TestAccEMRCluster_Step_multiple
--- PASS: TestAccEMRCluster_CustomAMI_id (671.09s)
=== CONT  TestAccEMRStudio_workspaceStorageEncryption
--- PASS: TestAccEMRCluster_keepJob (350.49s)
=== CONT  TestAccEMRCluster_Step_mode
--- PASS: TestAccEMRCluster_autoTerminationPolicy (735.32s)
=== CONT  TestAccEMRReleaseLabels_full
--- PASS: TestAccEMRCluster_tags (611.48s)
=== CONT  TestAccEMRSecurityConfiguration_nameGenerated
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceType (743.52s)
=== CONT  TestAccEMRSecurityConfiguration_disappears
--- PASS: TestAccEMRReleaseLabels_full (13.99s)
=== CONT  TestAccEMRSecurityConfiguration_basic
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceType (755.39s)
=== CONT  TestAccEMRReleaseLabels_empty
--- PASS: TestAccEMRSecurityConfiguration_nameGenerated (22.83s)
=== CONT  TestAccEMRReleaseLabels_prefix
--- PASS: TestAccEMRSecurityConfiguration_disappears (21.21s)
=== CONT  TestAccEMRReleaseLabels_application
--- PASS: TestAccEMRCluster_terminationProtected (391.29s)
=== CONT  TestAccEMRReleaseLabels_basic
--- PASS: TestAccEMRCluster_InstanceFleetMaster_only (770.31s)
=== CONT  TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits
--- PASS: TestAccEMRReleaseLabels_empty (18.25s)
--- PASS: TestAccEMRCluster_RootVolume_size (655.25s)
--- PASS: TestAccEMRSecurityConfiguration_basic (25.54s)
--- PASS: TestAccEMRReleaseLabels_prefix (17.54s)
--- PASS: TestAccEMRReleaseLabels_application (16.88s)
--- PASS: TestAccEMRInstanceFleet_basic (783.78s)
--- PASS: TestAccEMRReleaseLabels_basic (15.96s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_name (787.73s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_bidPrice (789.14s)
--- PASS: TestAccEMRStudio_workspaceStorageEncryption (67.44s)
--- PASS: TestAccEMRInstanceGroup_sJSON (833.68s)
--- PASS: TestAccEMRCluster_s3LogEncryption (850.58s)
--- PASS: TestAccEMRCluster_s3Logging (521.01s)
--- PASS: TestAccEMRCluster_Step_multiple_listStates (423.37s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_bidPrice (955.67s)
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumCoreCapacityUnits (552.23s)
--- PASS: TestAccEMRManagedScalingPolicy_disappears (557.02s)
--- PASS: TestAccEMRManagedScalingPolicy_basic (551.35s)
--- PASS: TestAccEMRCluster_PlacementGroupConfigs (686.36s)
--- PASS: TestAccEMRInstanceGroup_instanceCountCreateZero (416.00s)
--- PASS: TestAccEMRCluster_Step_multiple (418.32s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceCount (1204.97s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceCount (1265.94s)
--- PASS: TestAccEMRInstanceFleet_ebsBasic (645.52s)
--- PASS: TestAccEMRInstanceFleet_full (662.92s)
--- PASS: TestAccEMRManagedScalingPolicy_ComputeLimits_maximumOnDemandCapacityUnits (543.63s)
--- PASS: TestAccEMRInstanceGroup_bidPrice (1361.27s)
--- PASS: TestAccEMRInstanceGroup_EBS_ebsOptimized (951.10s)
--- PASS: TestAccEMRInstanceGroup_autoScalingPolicy (670.18s)
--- PASS: TestAccEMRCluster_Step_mode (665.56s)
--- PASS: TestAccEMRInstanceFleet_Zero_count (809.27s)
--- PASS: TestAccEMRCluster_Bootstrap_ordering (1010.73s)
--- PASS: TestAccEMRCluster_InstanceFleet_basic (1551.63s)
--- PASS: TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups (1832.24s)
--- PASS: TestAccEMRInstanceGroup_instanceCountDecrease (1289.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emr        1984.192s
```
