### PR TITLE
The former AMI ubuntu14.04 is too old & The nginx welcome page can not be accessed

### DIFF
--- a/examples/eip/variables.tf
+++ b/examples/eip/variables.tf
@@ -6,7 +6,7 @@ variable "aws_region" {
   default     = "us-east-1"
 }
 
-# ubuntu-trusty-14.04 (x64)
+# ubuntu-jammy-22.04 (amd64)
 variable "aws_amis" {
   default = {
     "us-east-1" = "ami-005fc0f236362e99f"

--- a/examples/eip/variables.tf
+++ b/examples/eip/variables.tf
@@ -9,8 +9,8 @@ variable "aws_region" {
 # ubuntu-trusty-14.04 (x64)
 variable "aws_amis" {
   default = {
-    "us-east-1" = "ami-5f709f34"
-    "us-west-2" = "ami-7f675e4f"
+    "us-east-1" = "ami-005fc0f236362e99f"
+    "us-west-2" = "ami-0075013580f6322a1"
   }
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The former AMI ubuntu14.04 is too old and  is out of DeprecationTime. The nginx welcome page can not be accessed 
Replace with ubuntu-22.04 AMI and works well

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
