### PR TITLE
r/aws_connect_queue: Fix API limitation when assigning more than 50 Quick Connects to a queue

### DIFF
--- a/.changelog/42108.txt
+++ b/.changelog/42108.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_connect_queue: Fix API limitation when assigning more than 50 Quick Connects to a queue
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The `AssociateQueueQuickConnects` and `DisassociateQueueQuickConnects` APIs accept a maximum of 50 items (_quick connects IDs_) per request. Currently, when passing more than 50 items to the `quick_connect_ids` argument of `aws_connect_queue` resource, it fails with the following error:

```
Error: associating Connect Queue (XXX:XXX) Quick Connects: operation error Connect: AssociateQueueQuickConnects, https response error StatusCode: 400, RequestID:XXX, InvalidParameterException: QuickConnectIds must include at most 50 items
```

This pull request addresses this issue by splitting API requests against both endpoints into chunks of 50 items.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/33447

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/connect/latest/APIReference/API_AssociateQueueQuickConnects.html
https://docs.aws.amazon.com/connect/latest/APIReference/API_DisassociateQueueQuickConnects.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS='TestAccConnect_serial/Queue/quickConnectIds' PKG=connect 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/connect/... -v -count 1 -parallel 20 -run='TestAccConnect_serial/Queue/quickConnectIds'  -timeout 360m -vet=off
2025/04/03 14:30:01 Initializing Terraform AWS Provider...
=== RUN   TestAccConnect_serial
=== PAUSE TestAccConnect_serial
=== CONT  TestAccConnect_serial
=== RUN   TestAccConnect_serial/Queue
=== RUN   TestAccConnect_serial/Queue/quickConnectIds
--- PASS: TestAccConnect_serial (341.18s)
    --- PASS: TestAccConnect_serial/Queue (341.18s)
        --- PASS: TestAccConnect_serial/Queue/quickConnectIds (341.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/connect	346.476s
```
