### PR TITLE
s3tables: Correctly identify arguments as objects rather than blocks

### DIFF
--- a/website/docs/r/s3tables_table.html.markdown
+++ b/website/docs/r/s3tables_table.html.markdown
@@ -49,30 +49,30 @@ The following arguments are required:
 
 The following argument is optional:
 
-* `maintenance_configuration` - (Optional) A single table bucket maintenance configuration block.
+* `maintenance_configuration` - (Optional) A single table bucket maintenance configuration object.
   [See `maintenance_configuration` below](#maintenance_configuration).
 
 ### `maintenance_configuration`
 
-The `maintenance_configuration` configuration block supports the following arguments:
+The `maintenance_configuration` object supports the following arguments:
 
-* `iceberg_compaction` - (Required) A single Iceberg compaction settings block.
+* `iceberg_compaction` - (Required) A single Iceberg compaction settings object.
   [See `iceberg_compaction` below](#iceberg_compaction).
-* `iceberg_snapshot_management` - (Required) A single Iceberg snapshot management settings block.
+* `iceberg_snapshot_management` - (Required) A single Iceberg snapshot management settings object.
   [See `iceberg_snapshot_management` below](#iceberg_snapshot_management).
 
 ### `iceberg_compaction`
 
-The `iceberg_compaction` configuration block supports the following arguments:
+The `iceberg_compaction` object supports the following arguments:
 
-* `settings` - (Required) Settings for compaction.
+* `settings` - (Required) Settings object for compaction.
   [See `iceberg_compaction.settings` below](#iceberg_compactionsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 
 ### `iceberg_compaction.settings`
 
-The `iceberg_compaction.settings` configuration block supports the following argument:
+The `iceberg_compaction.settings` object supports the following argument:
 
 * `target_file_size_mb` - (Required) Data objects smaller than this size may be combined with others to improve query performance.
   Must be between `64` and `512`.
@@ -81,14 +81,14 @@ The `iceberg_compaction.settings` configuration block supports the following arg
 
 The `iceberg_snapshot_management` configuration block supports the following arguments:
 
-* `settings` - (Required) Settings for snapshot management.
+* `settings` - (Required) Settings object for snapshot management.
   [See `iceberg_snapshot_management.settings` below](#iceberg_snapshot_managementsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 
 ### `iceberg_snapshot_management.settings`
 
-The `iceberg_snapshot_management.settings` configuration block supports the following argument:
+The `iceberg_snapshot_management.settings` object supports the following argument:
 
 * `max_snapshot_age_hours` - (Required) Snapshots older than this will be marked for deletiion.
   Must be at least `1`.

--- a/website/docs/r/s3tables_table_bucket.html.markdown
+++ b/website/docs/r/s3tables_table_bucket.html.markdown
@@ -31,28 +31,28 @@ The following argument is required:
 
 The following argument is optional:
 
-* `maintenance_configuration` - (Optional) A single table bucket maintenance configuration block.
+* `maintenance_configuration` - (Optional) A single table bucket maintenance configuration object.
   [See `maintenance_configuration` below](#maintenance_configuration).
 
 ### `maintenance_configuration`
 
-The `maintenance_configuration` configuration block supports the following argument:
+The `maintenance_configuration` object supports the following argument:
 
-* `iceberg_unreferenced_file_removal` - (Required) A single Iceberg unreferenced file removal settings block.
+* `iceberg_unreferenced_file_removal` - (Required) A single Iceberg unreferenced file removal settings object.
   [See `iceberg_unreferenced_file_removal` below](#iceberg_unreferenced_file_removal).
 
 ### `iceberg_unreferenced_file_removal`
 
-The `iceberg_unreferenced_file_removal` configuration block supports the following arguments:
+The `iceberg_unreferenced_file_removal` object supports the following arguments:
 
-* `settings` - (Required) Settings for unreferenced file removal.
+* `settings` - (Required) Settings object for unreferenced file removal.
   [See `iceberg_unreferenced_file_removal.settings` below](#iceberg_unreferenced_file_removalsettings).
 * `status` - (Required) Whether the configuration is enabled.
   Valid values are `enabled` and `disabled`.
 
 ### `iceberg_unreferenced_file_removal.settings`
 
-The `iceberg_unreferenced_file_removal.settings` configuration block supports the following arguments:
+The `iceberg_unreferenced_file_removal.settings` object supports the following arguments:
 
 * `non_current_days` - (Required) Data objects marked for deletion are deleted after this many days.
   Must be at least `1`.


### PR DESCRIPTION
### Description

This PR updates the description of several arguments of the `aws_s3tables_table` and `aws_s3tables_table_bucket` resources to indicate that they are [object attributes](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/attributes/object) rather than [blocks](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/blocks).

Since they were previously described as blocks, operators intuited that they were compatible with `dynamic` blocks, which isn't the case. Updating the description will hopefully make it more clear that these arguments are incompatible with `dynamic` and that other approaches should be used. 


### Relations

Closes #40569
