### PR TITLE
d/aws_ami: upgrade unsafe filter warning to suppressible error

### DIFF
--- a/.changelog/42114.txt
+++ b/.changelog/42114.txt
@@ -1,0 +1,6 @@
+```release-note:breaking-change
+data-source/aws_ami: The severity of the diagnostic returned when `most_recent` is `true` and owner and image ID filter criteria has been increased to an error. Existing configurations which were previously receiving a warning diagnostic will now fail to apply. To prevent this error, set the `owner` argument or include a `filter` block with an `image-id` or `owner-id` name/value pair. To continue using unsafe filter values with `most_recent` set to `true`, set the new `allow_unsafe_filter` argument to `true`. This is not recommended.
+```
+```release-note:enhancement
+data-source/aws_ami: Add `allow_unsafe_filter` argument
+```

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -36,6 +36,10 @@ func dataSourceAMI() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"allow_unsafe_filter": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"architecture": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -253,7 +257,7 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta any) di
 		describeImagesInput.Owners = flex.ExpandStringValueList(v.([]any))
 	}
 
-	diags = checkMostRecentAndMissingFilters(diags, &describeImagesInput, d.Get(names.AttrMostRecent).(bool))
+	diags = checkMostRecentAndMissingFilters(diags, &describeImagesInput, d.Get(names.AttrMostRecent).(bool), d.Get("allow_unsafe_filter").(bool))
 
 	images, err := findImages(ctx, conn, &describeImagesInput)
 
@@ -435,7 +439,7 @@ func flattenAMIStateReason(m *awstypes.StateReason) map[string]any {
 
 // checkMostRecentAndMissingFilters appends a diagnostic if the provided configuration
 // uses the most recent image and is not filtered by owner or image ID
-func checkMostRecentAndMissingFilters(diags diag.Diagnostics, input *ec2.DescribeImagesInput, mostRecent bool) diag.Diagnostics {
+func checkMostRecentAndMissingFilters(diags diag.Diagnostics, input *ec2.DescribeImagesInput, mostRecent, allowUnsafe bool) diag.Diagnostics {
 	filtered := false
 	for _, f := range input.Filters {
 		name := aws.ToString(f.Name)
@@ -445,14 +449,19 @@ func checkMostRecentAndMissingFilters(diags diag.Diagnostics, input *ec2.Describ
 	}
 
 	if mostRecent && len(input.Owners) == 0 && !filtered {
-		return append(diags, diag.Diagnostic{
-			Severity: diag.Warning,
+		d := diag.Diagnostic{
+			Severity: diag.Error,
 			Summary:  "Most Recent Image Not Filtered",
 			Detail: `"most_recent" is set to "true" and results are not filtered by owner or image ID. ` +
 				"With this configuration, a third party may introduce a new image which " +
-				"will be returned by this data source. Consider filtering by owner or image ID " +
-				"to avoid this possibility.",
-		})
+				"will be returned by this data source. Filter by owner or image ID to " +
+				"avoid this possibility.",
+		}
+		if allowUnsafe {
+			d.Severity = diag.Warning
+		}
+
+		return append(diags, d)
 	}
 
 	return diags

--- a/internal/service/ec2/ec2_ami_data_source_test.go
+++ b/internal/service/ec2/ec2_ami_data_source_test.go
@@ -22,10 +22,11 @@ func TestCheckMostRecentAndMissingFilters(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		input      *ec2.DescribeImagesInput
-		mostRecent bool
-		wantDiag   bool
+		name        string
+		input       *ec2.DescribeImagesInput
+		mostRecent  bool
+		allowUnsafe bool
+		wantDiag    bool
 	}{
 		{
 			name:       "most_recent false",
@@ -76,13 +77,27 @@ func TestCheckMostRecentAndMissingFilters(t *testing.T) {
 			mostRecent: true,
 			wantDiag:   true,
 		},
+		{
+			name: "missing filters, allow unsafe",
+			input: &ec2.DescribeImagesInput{
+				Filters: []awstypes.Filter{
+					{
+						Name:   aws.String("name"), // nosemgrep:ci.literal-Name-string-test-constant,ci.literal-name-string-constant
+						Values: []string{"some-ami-name-*"},
+					},
+				},
+			},
+			mostRecent:  true,
+			allowUnsafe: true,
+			wantDiag:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var diags diag.Diagnostics
-			got := tfec2.CheckMostRecentAndMissingFilters(diags, tt.input, tt.mostRecent)
+			got := tfec2.CheckMostRecentAndMissingFilters(diags, tt.input, tt.mostRecent, tt.allowUnsafe)
 			if (len(got) > 0) != tt.wantDiag {
 				t.Errorf("CheckMostRecentAndMissingFilters() diag = %v, wantErr %v", got, tt.wantDiag)
 				return
@@ -305,6 +320,22 @@ func TestAccEC2AMIDataSource_productCode(t *testing.T) {
 	})
 }
 
+func TestAccEC2AMIDataSource_unsafeFilter(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAMIDataSourceConfig_unsafeFilter,
+				ExpectError: regexache.MustCompile("Most Recent Image Not Filtered"),
+			},
+		},
+	})
+}
+
 // testAccAMIDataSourceConfig_latestUbuntuBionicHVMInstanceStore returns the configuration for a data source that
 // describes the latest Ubuntu 18.04 AMI using HVM virtualization and an instance store root device.
 // The data source is named 'ubuntu-bionic-ami-hvm-instance-store'.
@@ -429,6 +460,23 @@ data "aws_ami" "test" {
   filter {
     name   = "name"
     values = ["AwsMarketPublished_IBM App Connect v13.0.1.0 and IBM MQ v9.4.0.5 with RapidDeploy 5.1.15 by-422d2ddd-3288-4067-be37-4e2a69450606"]
+  }
+}
+`
+
+// Most recent AMI with no filter on owner or image ID
+const testAccAMIDataSourceConfig_unsafeFilter = `
+data "aws_ami" "test" {
+  most_recent = true
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-2023.*"]
   }
 }
 `

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -53,6 +53,11 @@ recent AMI.
 several valid keys, for a full reference, check out
 [describe-images in the AWS CLI reference][1].
 
+* `allow_unsafe_filter` - (Optional) If true, allow unsafe filter values. With unsafe
+filters and `most_recent` set to `true`, a third party may introduce a new image which
+will be returned by this data source. Consider filtering by owner or image ID rather
+than setting this argument.
+
 * `name_regex` - (Optional) Regex string to apply to the AMI list returned
 by AWS. This allows more advanced filtering not supported from the AWS API. This
 filtering is done locally on what AWS returns, and could have a performance

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -19,6 +19,7 @@ Upgrade topics:
 - [Dropping Support For Amazon SimpleDB](#dropping-support-for-amazon-simpledb)
 - [Dropping Support For Amazon Worklink](#dropping-support-for-amazon-worklink)
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
+- [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
@@ -112,6 +113,14 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 * `aws_opsworks_stack`
 * `aws_opsworks_static_web_layer`
 * `aws_opsworks_user_profile`
+
+## data-source/aws_ami
+
+Configurations with `most_recent` set to `true` and no owner or image ID filters will now trigger an error diagnostic.
+Previously, these configurations would result in only a [warning diagnostic](https://github.com/hashicorp/terraform-provider-aws/pull/40211).
+To prevent this error, set the `owner` argument or include a `filter` block with an `image-id` or `owner-id` name/value pair.
+To continue using unsafe filter values with `most_recent` set to `true`, set the new `allow_unsafe_filter` argument to `true`.
+This is not recommended.
 
 ## data-source/aws_batch_compute_environment
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
`v5.77.0` of the AWS provider introduced a warning diagnostic on the `aws_ami` data source to notify practitioners of certain cases when filtering criteria are missing. In `v6.0.0` of the AWS provider, the diagnostic severity is increased to an error. To allow users to opt-in to the unsafe behavior, the error can be suppressed by setting a new, optional argument `allow_unsafe_filter`. The same diagnostic message will still be displayed, but at a warning severity level.

Screenshots of the varying diagnostic severities are included below for reference.

Default:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/2df15574-39a7-4d8c-aaf8-185315e12274" />


With `allow_unsafe_filter` set to `true`:

<img width="760" alt="image" src="https://github.com/user-attachments/assets/2a9612f4-3f18-44fd-a3ce-d0c493a961e4" />


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40198
Relates #40211
Relates https://github.com/hashicorp/terraform-provider-aws/issues/40197
Relates https://github.com/hashicorp/terraform-provider-aws/issues/14158
Relates https://github.com/hashicorp/terraform-provider-aws/pull/25566
Relates https://github.com/hashicorp/terraform-provider-aws/issues/25521

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15869

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccEC2AMIDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.1 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2AMIDataSource_'  -timeout 360m -vet=off
2025/04/03 14:25:26 Initializing Terraform AWS Provider...

--- PASS: TestAccEC2AMIDataSource_unsafeFilter (3.92s)
--- PASS: TestAccEC2AMIDataSource_instanceStore (13.76s)
--- PASS: TestAccEC2AMIDataSource_localNameFilter (14.00s)
--- PASS: TestAccEC2AMIDataSource_productCode (14.11s)
--- PASS: TestAccEC2AMIDataSource_linuxInstance (14.53s)
--- PASS: TestAccEC2AMIDataSource_windowsInstance (15.03s)
--- PASS: TestAccEC2AMIDataSource_gp3BlockDevice (114.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        121.703s
```