### PR TITLE
r/aws_sns_topic_subscription: ignore `AuthorizationError` for `ListSubscriptionByTopic` operations

### DIFF
--- a/.changelog/42117.txt
+++ b/.changelog/42117.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_service_thing: Ignore `AuthorizationError` exceptions for `ListSubscriptionByTopic` operations. This fixes a regression introduced in [`v5.94.0`](https://github.com/hashicorp/terraform-provider-aws/pull/42093).
+```

--- a/.changelog/42117.txt
+++ b/.changelog/42117.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_service_thing: Ignore `AuthorizationError` exceptions for `ListSubscriptionByTopic` operations. This fixes a regression introduced in [`v5.94.0`](https://github.com/hashicorp/terraform-provider-aws/pull/42093).
+resource/aws_sns_topic_subscription: Ignore `AuthorizationError` exceptions for `ListSubscriptionByTopic` operations. This fixes a regression introduced in [`v5.94.0`](https://github.com/hashicorp/terraform-provider-aws/pull/42093).
 ```


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`v5.94.0` introduced an additional call to the `ListSubscriptionByTopic` API during the read operation to properly detect topic and subscription deletions which are only eventually consistent from the `GetSubscriptionAttributes` API. An unintended side effect of this addition was that existing principals which lack the appropriate IAM permissions to call `ListSubscriptionsByTopic` will observe apply time failures similar to:

```
AuthorizationError: User: arn:aws:sts::111111111111:assumed-role/abc123/terraform-run-V6rpqcU7sztpyrnS is not authorized to perform: SNS:ListSubscriptionsByTopic on resource: arn:aws:sns:us-west-2:222222222222:TopicName because no resource-based policy allows the SNS:ListSubscriptionsByTopic action
```

This change addresses the regression by skipping `AuthorizationError` exceptions rather than surfacing them as hard errors. The impact of ignoring these errors should be minimal, as the additional API call was only intended to catch eventual consistency edge cases that `GetSubscriptionAttributes` will still (eventually) catch.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42115
Relates #42093 



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=sns TESTS=TestAccSNSTopicSubscription_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/sns/... -v -count 1 -parallel 20 -run='TestAccSNSTopicSubscription_'  -timeout 360m -vet=off
2025/04/03 15:52:40 Initializing Terraform AWS Provider...

--- PASS: TestAccSNSTopicSubscription_filterPolicyScope_policyNotSet (3.73s)
--- PASS: TestAccSNSTopicSubscription_email (17.09s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingEndpoint (41.72s)
--- PASS: TestAccSNSTopicSubscription_disappears (50.27s)
--- PASS: TestAccSNSTopicSubscription_disappears_TopicExternal (50.46s)
--- PASS: TestAccSNSTopicSubscription_disappears_Topic (50.53s)
--- PASS: TestAccSNSTopicSubscription_basic (52.11s)
--- PASS: TestAccSNSTopicSubscription_rawMessageDelivery (70.27s)
--- PASS: TestAccSNSTopicSubscription_deliveryPolicy (70.86s)
--- PASS: TestAccSNSTopicSubscription_filterPolicy (71.45s)
--- PASS: TestAccSNSTopicSubscription_autoConfirmingSecuredEndpoint (85.36s)
--- PASS: TestAccSNSTopicSubscription_firehose (95.70s)
--- PASS: TestAccSNSTopicSubscription_redrivePolicy (104.99s)
--- PASS: TestAccSNSTopicSubscription_filterPolicyScope (148.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sns        155.739s
```
