### PR TITLE
redshift_cluster: Remove optional for computed-only attributes

### DIFF
--- a/.changelog/42119.txt
+++ b/.changelog/42119.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_redshift_cluster: Attributes `cluster_public_key`, `cluster_revision_number`, and `endpoint` are now read only and should not be set
+```

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -135,12 +135,10 @@ func resourceCluster() *schema.Resource {
 			},
 			"cluster_public_key": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"cluster_revision_number": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"cluster_subnet_group_name": {
@@ -190,7 +188,6 @@ func resourceCluster() *schema.Resource {
 			},
 			names.AttrEndpoint: {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"enhanced_vpc_routing": {

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -157,6 +157,7 @@ The `base_policy_region` argument has been removed. Use `base_policy_regions` in
 * The `publicly_accessible` attribute now defaults to `false`.
 * Remove `snapshot_copy` from your configuration—it no longer exists. Use the `aws_redshift_snapshot_copy` resource instead.
 * Remove `logging` from your configuration—it no longer exists. Use the `aws_redshift_logging` resource instead.
+* Attributes `cluster_public_key`, `cluster_revision_number`, and `endpoint` are now read only and should not be set.
 
 ## resource/aws_redshift_service_account
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The documentation for this resource is already up to date for this change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41044 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
