### PR TITLE
Update docs to make addresses optional to match the code

### DIFF
--- a/website/docs/r/wafv2_ip_set.html.markdown
+++ b/website/docs/r/wafv2_ip_set.html.markdown
@@ -36,7 +36,7 @@ This resource supports the following arguments:
 * `description` - (Optional) A friendly description of the IP set.
 * `scope` - (Required, Forces new resource) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the Region US East (N. Virginia).
 * `ip_address_version` - (Required, Forces new resource) Specify IPV4 or IPV6. Valid values are `IPV4` or `IPV6`.
-* `addresses` - (Required) Contains an array of strings that specifies zero or more IP addresses or blocks of IP addresses. All addresses must be specified using Classless Inter-Domain Routing (CIDR) notation. WAF supports all IPv4 and IPv6 CIDR ranges except for `/0`.
+* `addresses` - (Optional) Contains an array of strings that specifies zero or more IP addresses or blocks of IP addresses. All addresses must be specified using Classless Inter-Domain Routing (CIDR) notation. WAF supports all IPv4 and IPv6 CIDR ranges except for `/0`.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION
The [code](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/wafv2/ip_set.go#L63) suggests that actually addresses is optional. In practice this also seems to the case
