### PR TITLE
docs: add second example for AMI lookup

### DIFF
--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -14,6 +14,8 @@ Provides an EC2 instance resource. This allows instances to be created, updated,
 
 ### Basic example using AMI lookup
 
+Using a data source
+
 ```terraform
 data "aws_ami" "ubuntu" {
   most_recent = true
@@ -33,6 +35,19 @@ data "aws_ami" "ubuntu" {
 
 resource "aws_instance" "web" {
   ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "HelloWorld"
+  }
+}
+```
+
+Using AWS Systems Manager Parameter Store
+
+```terraform
+resource "aws_instance" "web" {
+  ami           = "resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
   instance_type = "t3.micro"
 
   tags = {


### PR DESCRIPTION
### Description

The [current documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) for the resource `aws_instance`  contains an example using a data source and its filtering mechanism to provide an AMI identifier to the resource `aws_instance.web`. 

```hcl
data "aws_ami" "ubuntu" {
  most_recent = true

  filter {
    name   = "name"
    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
  }

  filter {
    name   = "virtualization-type"
    values = ["hvm"]
  }

  owners = ["099720109477"] # Canonical
}

resource "aws_instance" "web" {
  ami           = data.aws_ami.ubuntu.id
  instance_type = "t3.micro"

  tags = {
    Name = "HelloWorld"
  }
}
```

There exists another approach that utilizes the Systems  Manager Parameter Store and avoids the data source:

```hcl
ami  = "resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
```

This approach could be added to the examples section.

### Relations

Closes #39592 

### References

- [Reference AMIs using Systems Manager parameters](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-systems-manager-parameter-to-find-AMI.html)
- [Reference the latest AMIs using Systems Manager public parameters
](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami-parameter-store.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.
