### PR TITLE
ds/servicediscovery_service: Remove tags_all

### DIFF
--- a/.changelog/42136.txt
+++ b/.changelog/42136.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-data-source/aws_service_discovery_service: Attribute `tags_all` has been removed
+data-source/aws_service_discovery_service: Remove `tags_all` attribute
 ```

--- a/.changelog/42136.txt
+++ b/.changelog/42136.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+data-source/aws_service_discovery_service: Attribute `tags_all` has been removed
+```

--- a/internal/service/servicediscovery/service_data_source.go
+++ b/internal/service/servicediscovery/service_data_source.go
@@ -102,13 +102,6 @@ func dataSourceService() *schema.Resource {
 				Required: true,
 			},
 			names.AttrTags: tftags.TagsSchema(),
-			names.AttrTagsAll: {
-				Type:       schema.TypeMap,
-				Optional:   true,
-				Computed:   true,
-				Elem:       &schema.Schema{Type: schema.TypeString},
-				Deprecated: "tags_all is deprecated. This argument will be removed in a future major version.",
-			},
 		},
 	}
 }

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -22,7 +22,7 @@ Upgrade topics:
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
-- [data-source/aws_service_discovery_service](#)
+- [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_instance](#resourceaws_instance)

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -22,6 +22,7 @@ Upgrade topics:
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
+- [data-source/aws_service_discovery_service](#)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_instance](#resourceaws_instance)
@@ -130,6 +131,10 @@ This is not recommended.
 ## data-source/aws_globalaccelerator_accelerator
 
 `id` is now computed only.
+
+## data-source/aws_service_discovery_service
+
+`tags_all` has been removed.
 
 ## resource/aws_batch_compute_environment
 

--- a/website/docs/r/service_discovery_service.html.markdown
+++ b/website/docs/r/service_discovery_service.html.markdown
@@ -120,7 +120,6 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - The ID of the service.
 * `arn` - The ARN of the service.
-* `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

`tags_all` are not included in data sources. Here they were included erroneously.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31163 
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccServiceDiscoveryServiceDataSource_ K=servicediscovery
make: go1.24.2 not found
make: installing go1.24.2...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
Downloaded   0.0% (   16384 / 76241216 bytes) ...
Downloaded  79.4% (60538432 / 76241216 bytes) ...
Downloaded 100.0% (76241216 / 76241216 bytes)
Unpacking /Users/dirk/sdk/go1.24.2/go1.24.2.darwin-arm64.tar.gz ...
Success. You may now run 'go1.24.2'
make: go1.24.2 ready
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/servicediscovery/... -v -count 1 -parallel 20 -run='TestAccServiceDiscoveryServiceDataSource_'  -timeout 360m -vet=off
2025/04/04 15:15:39 Initializing Terraform AWS Provider...
=== RUN   TestAccServiceDiscoveryServiceDataSource_basic
=== PAUSE TestAccServiceDiscoveryServiceDataSource_basic
=== RUN   TestAccServiceDiscoveryServiceDataSource_private
=== PAUSE TestAccServiceDiscoveryServiceDataSource_private
=== RUN   TestAccServiceDiscoveryServiceDataSource_public
=== PAUSE TestAccServiceDiscoveryServiceDataSource_public
=== CONT  TestAccServiceDiscoveryServiceDataSource_basic
=== CONT  TestAccServiceDiscoveryServiceDataSource_public
=== CONT  TestAccServiceDiscoveryServiceDataSource_private
--- PASS: TestAccServiceDiscoveryServiceDataSource_public (101.60s)
--- PASS: TestAccServiceDiscoveryServiceDataSource_basic (101.62s)
--- PASS: TestAccServiceDiscoveryServiceDataSource_private (105.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/servicediscovery	111.390s
```
