### PR TITLE
ec2, ecs: EOL Amazon Elastic Inference

### DIFF
--- a/.changelog/42137.txt
+++ b/.changelog/42137.txt
@@ -1,0 +1,19 @@
+```release-note:breaking-change
+resource/aws_ecs_task_definition: Remove `inference_accelerator` attribute. Amazon Elastic Inference reached end of life on April, 2024.
+```
+
+```release-note:breaking-change
+data-source/aws_ecs_task_definition: Remove `inference_accelerator` attribute. Amazon Elastic Inference reached end of life on April, 2024.
+```
+
+```release-note:breaking-change
+data-source/aws_ecs_task_execution: Remove `inference_accelerator_overrides` attribute. Amazon Elastic Inference reached end of life on April, 2024.
+```
+
+```release-note:breaking-change
+data-source/aws_launch_template: Remove `elastic_inference_accelerator` attribute. Amazon Elastic Inference reached end of life on April, 2024.
+```
+
+```release-note:breaking-change
+resource/aws_launch_template: Remove `elastic_inference_accelerator` attribute. Amazon Elastic Inference reached end of life on April, 2024.
+```

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -232,20 +232,6 @@ func resourceLaunchTemplate() *schema.Resource {
 					},
 				},
 			},
-			"elastic_inference_accelerator": {
-				Deprecated: "elastic_inference_accelerator is deprecated. AWS no longer supports the Elastic Inference service.",
-				Type:       schema.TypeList,
-				Optional:   true,
-				MaxItems:   1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"enclave_options": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -1139,7 +1125,6 @@ func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 		"disable_api_termination",
 		"ebs_optimized",
 		"elastic_gpu_specifications",
-		"elastic_inference_accelerator",
 		"enclave_options",
 		"hibernation_options",
 		"iam_instance_profile",
@@ -1331,10 +1316,6 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 
 	if v, ok := d.GetOk("elastic_gpu_specifications"); ok && len(v.([]any)) > 0 {
 		apiObject.ElasticGpuSpecifications = expandElasticGpuSpecifications(v.([]any))
-	}
-
-	if v, ok := d.GetOk("elastic_inference_accelerator"); ok && len(v.([]any)) > 0 {
-		apiObject.ElasticInferenceAccelerators = expandLaunchTemplateElasticInferenceAccelerators(v.([]any))
 	}
 
 	if v, ok := d.GetOk("enclave_options"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
@@ -1581,36 +1562,6 @@ func expandElasticGpuSpecifications(tfList []any) []awstypes.ElasticGpuSpecifica
 		}
 
 		apiObjects = append(apiObjects, expandElasticGpuSpecification(tfMap))
-	}
-
-	return apiObjects
-}
-
-func expandLaunchTemplateElasticInferenceAccelerator(tfMap map[string]any) awstypes.LaunchTemplateElasticInferenceAccelerator {
-	apiObject := awstypes.LaunchTemplateElasticInferenceAccelerator{}
-
-	if v, ok := tfMap[names.AttrType].(string); ok && v != "" {
-		apiObject.Type = aws.String(v)
-	}
-
-	return apiObject
-}
-
-func expandLaunchTemplateElasticInferenceAccelerators(tfList []any) []awstypes.LaunchTemplateElasticInferenceAccelerator {
-	if len(tfList) == 0 {
-		return nil
-	}
-
-	var apiObjects []awstypes.LaunchTemplateElasticInferenceAccelerator
-
-	for _, tfMapRaw := range tfList {
-		tfMap, ok := tfMapRaw.(map[string]any)
-
-		if !ok {
-			continue
-		}
-
-		apiObjects = append(apiObjects, expandLaunchTemplateElasticInferenceAccelerator(tfMap))
 	}
 
 	return apiObjects
@@ -2310,9 +2261,6 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 	if err := d.Set("elastic_gpu_specifications", flattenElasticGpuSpecificationResponses(apiObject.ElasticGpuSpecifications)); err != nil {
 		return fmt.Errorf("setting elastic_gpu_specifications: %w", err)
 	}
-	if err := d.Set("elastic_inference_accelerator", flattenLaunchTemplateElasticInferenceAcceleratorResponses(apiObject.ElasticInferenceAccelerators)); err != nil {
-		return fmt.Errorf("setting elastic_inference_accelerator: %w", err)
-	}
 	if apiObject.EnclaveOptions != nil {
 		tfMap := map[string]any{
 			names.AttrEnabled: aws.ToBool(apiObject.EnclaveOptions.Enabled),
@@ -2568,30 +2516,6 @@ func flattenElasticGpuSpecificationResponses(apiObjects []awstypes.ElasticGpuSpe
 
 	for _, apiObject := range apiObjects {
 		tfList = append(tfList, flattenElasticGpuSpecificationResponse(apiObject))
-	}
-
-	return tfList
-}
-
-func flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) map[string]any {
-	tfMap := map[string]any{}
-
-	if v := apiObject.Type; v != nil {
-		tfMap[names.AttrType] = aws.ToString(v)
-	}
-
-	return tfMap
-}
-
-func flattenLaunchTemplateElasticInferenceAcceleratorResponses(apiObjects []awstypes.LaunchTemplateElasticInferenceAcceleratorResponse) []any {
-	if len(apiObjects) == 0 {
-		return nil
-	}
-
-	var tfList []any
-
-	for _, apiObject := range apiObjects {
-		tfList = append(tfList, flattenLaunchTemplateElasticInferenceAcceleratorResponse(apiObject))
 	}
 
 	return tfList

--- a/internal/service/ec2/ec2_launch_template_data_source.go
+++ b/internal/service/ec2/ec2_launch_template_data_source.go
@@ -190,19 +190,6 @@ func dataSourceLaunchTemplate() *schema.Resource {
 					},
 				},
 			},
-			"elastic_inference_accelerator": {
-				Deprecated: "elastic_inference_accelerator is deprecated. AWS no longer supports the Elastic Inference service.",
-				Type:       schema.TypeList,
-				Computed:   true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
 			"enclave_options": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/internal/service/ec2/ec2_launch_template_data_source_test.go
+++ b/internal/service/ec2/ec2_launch_template_data_source_test.go
@@ -41,7 +41,6 @@ func TestAccEC2LaunchTemplateDataSource_name(t *testing.T) {
 					resource.TestCheckResourceAttrPair(resourceName, "disable_api_stop", dataSourceName, "disable_api_stop"),
 					resource.TestCheckResourceAttrPair(resourceName, "disable_api_termination", dataSourceName, "disable_api_termination"),
 					resource.TestCheckResourceAttrPair(resourceName, "ebs_optimized", dataSourceName, "ebs_optimized"),
-					resource.TestCheckResourceAttrPair(resourceName, "elastic_inference_accelerator.#", dataSourceName, "elastic_inference_accelerator.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "enclave_options.#", dataSourceName, "enclave_options.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "hibernation_options.#", dataSourceName, "hibernation_options.#"),
 					resource.TestCheckResourceAttrPair(resourceName, "iam_instance_profile.#", dataSourceName, "iam_instance_profile.#"),
@@ -163,10 +162,6 @@ resource "aws_launch_template" "test" {
       volume_size = 15
       volume_type = "gp3"
     }
-  }
-
-  elastic_inference_accelerator {
-    type = "eia1.medium"
   }
 
   iam_instance_profile {

--- a/internal/service/ec2/ec2_launch_template_test.go
+++ b/internal/service/ec2/ec2_launch_template_test.go
@@ -47,7 +47,6 @@ func TestAccEC2LaunchTemplate_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "disable_api_stop", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "disable_api_termination", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", ""),
-					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "enclave_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "hibernation_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "iam_instance_profile.#", "0"),
@@ -327,43 +326,6 @@ func TestAccEC2LaunchTemplate_ebsOptimized(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLaunchTemplateExists(ctx, resourceName, &template),
 					resource.TestCheckResourceAttr(resourceName, "ebs_optimized", ""),
-				),
-			},
-		},
-	})
-}
-
-func TestAccEC2LaunchTemplate_elasticInferenceAccelerator(t *testing.T) {
-	ctx := acctest.Context(t)
-	var template1 awstypes.LaunchTemplate
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_launch_template.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckLaunchTemplateDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, "eia1.medium"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchTemplateExists(ctx, resourceName, &template1),
-					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.0.type", "eia1.medium"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, "eia1.large"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLaunchTemplateExists(ctx, resourceName, &template1),
-					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "elastic_inference_accelerator.0.type", "eia1.large"),
 				),
 			},
 		},
@@ -3591,18 +3553,6 @@ resource "aws_launch_template" "test" {
   name          = %[2]q
 }
 `, ebsOptimized, rName)
-}
-
-func testAccLaunchTemplateConfig_elasticInferenceAccelerator(rName, elasticInferenceAcceleratorType string) string {
-	return fmt.Sprintf(`
-resource "aws_launch_template" "test" {
-  name = %[1]q
-
-  elastic_inference_accelerator {
-    type = %[2]q
-  }
-}
-`, rName, elasticInferenceAcceleratorType)
 }
 
 func testAccLaunchTemplateConfig_data(rName string) string {

--- a/internal/service/ecs/task_definition_data_source.go
+++ b/internal/service/ecs/task_definition_data_source.go
@@ -61,22 +61,6 @@ func dataSourceTaskDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"inference_accelerator": {
-				Type:     schema.TypeList,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrDeviceName: {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-						"device_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-					},
-				},
-			},
 			"ipc_mode": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -335,9 +319,6 @@ func dataSourceTaskDefinitionRead(ctx context.Context, d *schema.ResourceData, m
 	}
 	d.Set(names.AttrExecutionRoleARN, taskDefinition.ExecutionRoleArn)
 	d.Set(names.AttrFamily, taskDefinition.Family)
-	if err := d.Set("inference_accelerator", flattenInferenceAccelerators(taskDefinition.InferenceAccelerators)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting inference_accelerator: %s", err)
-	}
 	d.Set("ipc_mode", taskDefinition.IpcMode)
 	d.Set("memory", taskDefinition.Memory)
 	d.Set("network_mode", taskDefinition.NetworkMode)

--- a/internal/service/ecs/task_definition_data_source_test.go
+++ b/internal/service/ecs/task_definition_data_source_test.go
@@ -57,9 +57,6 @@ func TestAccECSTaskDefinitionDataSource_ec2(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, "aws_ecs_task_definition.test", names.AttrARN),
 					resource.TestCheckResourceAttrSet(dataSourceName, "container_definitions"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrFamily, rName),
-					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.#", "1"),
-					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.0.device_name", "device_1"),
-					resource.TestCheckResourceAttr(dataSourceName, "inference_accelerator.0.device_type", "eia1.medium"),
 					resource.TestCheckResourceAttr(dataSourceName, "ipc_mode", "host"),
 					resource.TestCheckResourceAttr(dataSourceName, "network_mode", "awsvpc"),
 					resource.TestCheckResourceAttr(dataSourceName, "pid_mode", "host"),
@@ -262,11 +259,6 @@ resource "aws_ecs_task_definition" "test" {
   }
 ]
 TASK_DEFINITION
-
-  inference_accelerator {
-    device_name = "device_1"
-    device_type = "eia1.medium"
-  }
 
   placement_constraints {
     expression = "attribute:ecs.availability-zone in [${data.aws_availability_zones.available.names[0]}, ${data.aws_availability_zones.available.names[1]}]"

--- a/internal/service/ecs/task_definition_data_source_test.go
+++ b/internal/service/ecs/task_definition_data_source_test.go
@@ -249,13 +249,7 @@ resource "aws_ecs_task_definition" "test" {
     "command": ["sleep", "360"],
     "memory": 2048,
     "essential": true,
-    "portMappings": [{"protocol": "tcp", "containerPort": 8000}],
-     "resourceRequirements": [
-      {
-        "type": "InferenceAccelerator",
-        "value": "device_1"
-      }
-    ]
+    "portMappings": [{"protocol": "tcp", "containerPort": 8000}]
   }
 ]
 TASK_DEFINITION

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -1176,36 +1176,6 @@ func TestAccECSTaskDefinition_proxy(t *testing.T) {
 	})
 }
 
-func TestAccECSTaskDefinition_inferenceAccelerator(t *testing.T) {
-	ctx := acctest.Context(t)
-	var def awstypes.TaskDefinition
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_ecs_task_definition.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckTaskDefinitionDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccTaskDefinitionConfig_inferenceAccelerator(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckTaskDefinitionExists(ctx, resourceName, &def),
-					resource.TestCheckResourceAttr(resourceName, "inference_accelerator.#", "1"),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateIdFunc:       acctest.AttrImportStateIdFunc(resourceName, names.AttrARN),
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{names.AttrSkipDestroy, "track_latest"},
-			},
-		},
-	})
-}
-
 func TestAccECSTaskDefinition_invalidContainerDefinition(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -3199,48 +3169,6 @@ DEFINITION
   }
 }
 `, rName, tag1Key, tag1Value, tag2Key, tag2Value)
-}
-
-func testAccTaskDefinitionConfig_inferenceAccelerator(rName string) string {
-	return fmt.Sprintf(`
-resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
-
-  container_definitions = <<TASK_DEFINITION
-[
-	{
-		"cpu": 10,
-		"command": ["sleep", "10"],
-		"entryPoint": ["/"],
-		"environment": [
-			{"name": "VARNAME", "value": "VARVAL"}
-		],
-		"essential": true,
-		"image": "jenkins",
-		"memory": 128,
-		"name": "jenkins",
-		"portMappings": [
-			{
-				"containerPort": 80,
-				"hostPort": 8080
-			}
-		],
-        "resourceRequirements":[
-            {
-                "type":"InferenceAccelerator",
-                "value":"device_1"
-            }
-        ]
-	}
-]
-TASK_DEFINITION
-
-  inference_accelerator {
-    device_name = "device_1"
-    device_type = "eia1.medium"
-  }
-}
-`, rName)
 }
 
 func testAccTaskDefinitionConfig_fsxVolume(domain, rName string) string {

--- a/internal/service/ecs/task_execution_data_source.go
+++ b/internal/service/ecs/task_execution_data_source.go
@@ -180,23 +180,6 @@ func dataSourceTaskExecution() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"inference_accelerator_overrides": {
-							Deprecated: "inference_accelerator_overrides is deprecated. AWS no longer supports the Elastic Inference service.",
-							Type:       schema.TypeSet,
-							Optional:   true,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									names.AttrDeviceName: {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-									"device_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-									},
-								},
-							},
-						},
 						"memory": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -382,29 +365,8 @@ func expandTaskOverride(tfList []any) *awstypes.TaskOverride {
 	if v, ok := tfMap["task_role_arn"]; ok {
 		apiObject.TaskRoleArn = aws.String(v.(string))
 	}
-	if v, ok := tfMap["inference_accelerator_overrides"]; ok {
-		apiObject.InferenceAcceleratorOverrides = expandInferenceAcceleratorOverrides(v.(*schema.Set))
-	}
 	if v, ok := tfMap["container_overrides"]; ok {
 		apiObject.ContainerOverrides = expandContainerOverride(v.([]any))
-	}
-
-	return apiObject
-}
-
-func expandInferenceAcceleratorOverrides(tfSet *schema.Set) []awstypes.InferenceAcceleratorOverride {
-	if tfSet.Len() == 0 {
-		return nil
-	}
-	apiObject := make([]awstypes.InferenceAcceleratorOverride, 0)
-
-	for _, item := range tfSet.List() {
-		tfMap := item.(map[string]any)
-		iao := awstypes.InferenceAcceleratorOverride{
-			DeviceName: aws.String(tfMap[names.AttrDeviceName].(string)),
-			DeviceType: aws.String(tfMap["device_type"].(string)),
-		}
-		apiObject = append(apiObject, iao)
 	}
 
 	return apiObject

--- a/website/docs/d/ecs_task_definition.html.markdown
+++ b/website/docs/d/ecs_task_definition.html.markdown
@@ -73,7 +73,6 @@ This data source exports the following attributes in addition to the arguments a
 * `execution_role_arn` - ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
 * `family` - A unique name for your task definition.
 The following arguments are optional:
-* `inference_accelerator` - Configuration block(s) with Inference Accelerators settings. [Detailed below.](#inference_accelerator)
 * `ipc_mode` - IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
 * `memory` - Amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `network_mode` - Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
@@ -90,11 +89,6 @@ The following arguments are optional:
 ### ephemeral_storage
 
 * `size_in_gib` - The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is `21` GiB and the maximum supported value is `200` GiB.
-
-### inference_accelerator
-
-* `device_name` - Elastic Inference accelerator device name. The deviceName must also be referenced in a container definition as a ResourceRequirement.
-* `device_type` - Elastic Inference accelerator type to use.
 
 ### placement_constraints
 

--- a/website/docs/d/ecs_task_execution.html.markdown
+++ b/website/docs/d/ecs_task_execution.html.markdown
@@ -76,7 +76,6 @@ For more information, see the [Task Networking](https://docs.aws.amazon.com/Amaz
 * `container_overrides` - (Optional) One or more container overrides that are sent to a task. See below.
 * `cpu` - (Optional) The CPU override for the task.
 * `execution_role_arn` - (Optional) Amazon Resource Name (ARN) of the task execution role override for the task.
-* `inference_accelerator_overrides` - (Optional) **DEPRECATED** Elastic Inference accelerator override for the task. See below.
 * `memory` - (Optional) The memory override for the task.
 * `task_role_arn` - (Optional) Amazon Resource Name (ARN) of the role that containers in this task can assume.
 
@@ -97,13 +96,8 @@ For more information, see the [Task Networking](https://docs.aws.amazon.com/Amaz
 
 ### resource_requirements
 
-* `type` - (Required) The type of resource to assign to a container. Valid values are `GPU` or `InferenceAccelerator`.
-* `value` - (Required) The value for the specified resource type. If the `GPU` type is used, the value is the number of physical GPUs the Amazon ECS container agent reserves for the container. The number of GPUs that's reserved for all containers in a task can't exceed the number of available GPUs on the container instance that the task is launched on. If the `InferenceAccelerator` type is used, the value matches the `deviceName` for an InferenceAccelerator specified in a task definition.
-
-### inference_accelerator_overrides
-
-* `device_name` - (Optional) The Elastic Inference accelerator device name to override for the task. This parameter must match a deviceName specified in the task definition.
-* `device_type` - (Optional) The Elastic Inference accelerator type to use.
+* `type` - (Required) The type of resource to assign to a container. Valid values are `GPU`.
+* `value` - (Required) The value for the specified resource type. If the `GPU` type is used, the value is the number of physical GPUs the Amazon ECS container agent reserves for the container. The number of GPUs that's reserved for all containers in a task can't exceed the number of available GPUs on the container instance that the task is launched on.
 
 ### placement_constraints
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -21,11 +21,16 @@ Upgrade topics:
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
+- [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
+- [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
+- [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
+- [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
 - [resource/aws_instance](#resourceaws_instance)
 - [resource/aws_kinesis_analytics_application](#resourceaws_kinesis_analytics_application)
+- [resource/aws_launch_template](#resourceaws_launch_template)
 - [resource/aws_networkmanager_core_network](#resourceaws_networkmanager_core_network)
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
@@ -136,9 +141,29 @@ This is not recommended.
 * `compute_environment_name` has been renamed to `name`.
 * `compute_environment_name_prefix` has been renamed to `name_prefix`.
 
+## data-source/aws_ecs_task_definition
+
+Remove `inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## data-source/aws_ecs_task_execution
+
+Remove `inference_accelerator_overrides` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## data-source/aws_launch_template
+
+Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
 ## resource/aws_cloudfront_response_headers_policy
 
 The `etag` argument is now computed only.
+
+## resource/aws_ecs_task_definition
+
+Remove `inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## resource/aws_launch_template
+
+Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
 
 ## resource/aws_instance
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -156,7 +156,7 @@ resource "aws_secretsmanager_secret_version" "test" {
 }
 ```
 
-### Example Using `container_definitions` and `inference_accelerator`
+### Example Using `container_definitions`
 
 ```terraform
 resource "aws_ecs_task_definition" "test" {
@@ -179,21 +179,10 @@ resource "aws_ecs_task_definition" "test" {
         "containerPort": 80,
         "hostPort": 8080
       }
-    ],
-        "resourceRequirements":[
-            {
-                "type":"InferenceAccelerator",
-                "value":"device_1"
-            }
-        ]
+    ]
   }
 ]
 TASK_DEFINITION
-
-  inference_accelerator {
-    device_name = "device_1"
-    device_type = "eia1.medium"
-  }
 }
 ```
 
@@ -241,7 +230,6 @@ The following arguments are optional:
 
     **Note:** Fault injection only works with tasks using the `awsvpc` or `host` network modes. Fault injection isn't available on Windows.
 * `execution_role_arn` - (Optional) ARN of the task execution role that the Amazon ECS container agent and the Docker daemon can assume.
-* `inference_accelerator` - (Optional) Configuration block(s) with Inference Accelerators settings. [Detailed below.](#inference_accelerator)
 * `ipc_mode` - (Optional) IPC resource namespace to be used for the containers in the task The valid values are `host`, `task`, and `none`.
 * `memory` - (Optional) Amount (in MiB) of memory used by the task. If the `requires_compatibilities` is `FARGATE` this field is required.
 * `network_mode` - (Optional) Docker networking mode to use for the containers in the task. Valid values are `none`, `bridge`, `awsvpc`, and `host`.
@@ -324,11 +312,6 @@ For more information, see [Specifying an FSX Windows File Server volume in your 
 ### ephemeral_storage
 
 * `size_in_gib` - (Required) The total amount, in GiB, of ephemeral storage to set for the task. The minimum supported value is `21` GiB and the maximum supported value is `200` GiB.
-
-### inference_accelerator
-
-* `device_name` - (Required) Elastic Inference accelerator device name. The deviceName must also be referenced in a container definition as a ResourceRequirement.
-* `device_type` - (Required) Elastic Inference accelerator type to use.
 
 ## Attribute Reference
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -46,10 +46,6 @@ resource "aws_launch_template" "foo" {
     type = "test"
   }
 
-  elastic_inference_accelerator {
-    type = "eia1.medium"
-  }
-
   iam_instance_profile {
     name = "test"
   }
@@ -125,7 +121,6 @@ This resource supports the following arguments:
 * `ebs_optimized` - (Optional) If `true`, the launched EC2 instance will be EBS-optimized.
 * `elastic_gpu_specifications` - (Optional) **DEPRECATED** The elastic GPU to attach to the instance. See [Elastic GPU](#elastic-gpu)
   below for more details.
-* `elastic_inference_accelerator` - (Optional) **DEPRECATED** Configuration block containing an Elastic Inference Accelerator to attach to the instance. See [Elastic Inference Accelerator](#elastic-inference-accelerator) below for more details.
 * `enclave_options` - (Optional) Enable Nitro Enclaves on launched instances. See [Enclave Options](#enclave-options) below for more details.
 * `hibernation_options` - (Optional) The hibernation options for the instance. See [Hibernation Options](#hibernation-options) below for more details.
 * `iam_instance_profile` - (Optional) The IAM Instance Profile to launch the instance with. See [Instance Profile](#instance-profile)
@@ -233,14 +228,6 @@ Attach an elastic GPU the instance.
 The `elastic_gpu_specifications` block supports the following:
 
 * `type` - The [Elastic GPU Type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-graphics.html#elastic-graphics-basics)
-
-### Elastic Inference Accelerator
-
-**DEPRECATED** Attach an Elastic Inference Accelerator to the instance. Additional information about Elastic Inference in EC2 can be found in the [EC2 User Guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-inference.html).
-
-The `elastic_inference_accelerator` configuration block supports the following:
-
-* `type` - (Required) Accelerator type.
 
 ### Enclave Options
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Amazon Elastic Inference reached end of life on April, 2024. This removes places in EC2 and ECS where it was used.

This equates to the following changes:

- [x] From `aws_ecs_task_definition ` resource, remove `inference_accelerator`
- [x] From `aws_ecs_task_definition ` data source, remove `inference_accelerator`
- [x] From `aws_ecs_task_execution` data source, remove `inference_accelerator_overrides`
- [x] From `aws_launch_template` data source, remove `elastic_inference_accelerator`
- [x] From `aws_launch_template` resource, remove `elastic_inference_accelerator`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40992 
Relates #41101

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccEC2LaunchTemplate_|TestAccEC2LaunchTemplateDataSource_|TestAccECSTaskDefinition_|TestAccECSTaskDefinitionDataSource_|TestAccECSTaskExecutionDataSource_' K=ec2 P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/ec2/... -v -count 1 -parallel 10 -run='TestAccEC2LaunchTemplate_|TestAccEC2LaunchTemplateDataSource_|TestAccECSTaskDefinition_|TestAccECSTaskDefinitionDataSource_|TestAccECSTaskExecutionDataSource_'  -timeout 360m -vet=off
2025/04/04 15:42:19 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2LaunchTemplateDataSource_name
=== PAUSE TestAccEC2LaunchTemplateDataSource_name
=== RUN   TestAccEC2LaunchTemplateDataSource_id
=== PAUSE TestAccEC2LaunchTemplateDataSource_id
=== RUN   TestAccEC2LaunchTemplateDataSource_filter
=== PAUSE TestAccEC2LaunchTemplateDataSource_filter
=== RUN   TestAccEC2LaunchTemplateDataSource_matchTags
=== PAUSE TestAccEC2LaunchTemplateDataSource_matchTags
=== RUN   TestAccEC2LaunchTemplate_basic
=== PAUSE TestAccEC2LaunchTemplate_basic
=== RUN   TestAccEC2LaunchTemplate_Name_generated
=== PAUSE TestAccEC2LaunchTemplate_Name_generated
=== RUN   TestAccEC2LaunchTemplate_Name_prefix
=== PAUSE TestAccEC2LaunchTemplate_Name_prefix
=== RUN   TestAccEC2LaunchTemplate_disappears
=== PAUSE TestAccEC2LaunchTemplate_disappears
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== PAUSE TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
=== RUN   TestAccEC2LaunchTemplate_ebsOptimized
=== PAUSE TestAccEC2LaunchTemplate_ebsOptimized
=== RUN   TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
=== RUN   TestAccEC2LaunchTemplate_data
=== PAUSE TestAccEC2LaunchTemplate_data
=== RUN   TestAccEC2LaunchTemplate_description
=== PAUSE TestAccEC2LaunchTemplate_description
=== RUN   TestAccEC2LaunchTemplate_update
=== PAUSE TestAccEC2LaunchTemplate_update
=== RUN   TestAccEC2LaunchTemplate_tags
=== PAUSE TestAccEC2LaunchTemplate_tags
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_preference
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_preference
=== RUN   TestAccEC2LaunchTemplate_CapacityReservation_target
=== PAUSE TestAccEC2LaunchTemplate_CapacityReservation_target
=== RUN   TestAccEC2LaunchTemplate_cpuOptions
=== PAUSE TestAccEC2LaunchTemplate_cpuOptions
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t2
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t2
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t3
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t3
=== RUN   TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== PAUSE TestAccEC2LaunchTemplate_CreditSpecification_t4g
=== RUN   TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== PAUSE TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
=== RUN   TestAccEC2LaunchTemplate_networkInterface
=== PAUSE TestAccEC2LaunchTemplate_networkInterface
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceType
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceType
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceCardIndex
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
=== RUN   TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification
=== PAUSE TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification
=== RUN   TestAccEC2LaunchTemplate_associatePublicIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associatePublicIPAddress
=== RUN   TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== PAUSE TestAccEC2LaunchTemplate_associateCarrierIPAddress
=== RUN   TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== PAUSE TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== RUN   TestAccEC2LaunchTemplate_Placement_partitionNum
=== PAUSE TestAccEC2LaunchTemplate_Placement_partitionNum
=== RUN   TestAccEC2LaunchTemplate_privateDNSNameOptions
=== PAUSE TestAccEC2LaunchTemplate_privateDNSNameOptions
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
=== RUN   TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
=== PAUSE TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
=== RUN   TestAccEC2LaunchTemplate_instanceMarketOptions
=== PAUSE TestAccEC2LaunchTemplate_instanceMarketOptions
=== RUN   TestAccEC2LaunchTemplate_primaryIPv6
=== PAUSE TestAccEC2LaunchTemplate_primaryIPv6
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorage
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
=== RUN   TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== PAUSE TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
=== RUN   TestAccEC2LaunchTemplate_licenseSpecification
=== PAUSE TestAccEC2LaunchTemplate_licenseSpecification
=== RUN   TestAccEC2LaunchTemplate_metadataOptions
=== PAUSE TestAccEC2LaunchTemplate_metadataOptions
=== RUN   TestAccEC2LaunchTemplate_enclaveOptions
=== PAUSE TestAccEC2LaunchTemplate_enclaveOptions
=== RUN   TestAccEC2LaunchTemplate_hibernation
=== PAUSE TestAccEC2LaunchTemplate_hibernation
=== RUN   TestAccEC2LaunchTemplate_defaultVersion
=== PAUSE TestAccEC2LaunchTemplate_defaultVersion
=== RUN   TestAccEC2LaunchTemplate_updateDefaultVersion
=== PAUSE TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplateDataSource_name
=== CONT  TestAccEC2LaunchTemplate_Placement_partitionNum
=== CONT  TestAccEC2LaunchTemplate_cpuOptions
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
=== CONT  TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN
=== CONT  TestAccEC2LaunchTemplate_updateDefaultVersion
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
=== CONT  TestAccEC2LaunchTemplate_defaultVersion
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccEC2LaunchTemplateDataSource_name (25.45s)
=== CONT  TestAccEC2LaunchTemplate_associateCarrierIPAddress
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (27.56s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
--- PASS: TestAccEC2LaunchTemplate_cpuOptions (40.57s)
=== CONT  TestAccEC2LaunchTemplate_associatePublicIPAddress
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (43.19s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (52.88s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (53.62s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (56.53s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (68.76s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification (21.74s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (75.56s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (75.96s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (20.58s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes (48.07s)
--- PASS: TestAccEC2LaunchTemplate_associateCarrierIPAddress (67.39s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (20.92s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (21.26s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (72.13s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (47.19s)
=== CONT  TestAccEC2LaunchTemplate_primaryIPv6
--- PASS: TestAccEC2LaunchTemplate_associatePublicIPAddress (64.32s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceAddresses
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (21.92s)
=== CONT  TestAccEC2LaunchTemplate_instanceMarketOptions
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (20.59s)
=== CONT  TestAccEC2LaunchTemplate_networkInterface
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (20.37s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (47.14s)
=== CONT  TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (46.73s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (27.26s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t4g
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (69.38s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (18.72s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t3
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (45.68s)
=== CONT  TestAccEC2LaunchTemplate_privateDNSNameOptions
--- PASS: TestAccEC2LaunchTemplate_networkInterface (27.72s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t2
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (20.29s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (19.70s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (19.62s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_enaSrd (39.50s)
=== CONT  TestAccEC2LaunchTemplate_hibernation
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (20.00s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (69.43s)
=== CONT  TestAccEC2LaunchTemplate_enclaveOptions
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (19.55s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccEC2LaunchTemplate_primaryIPv6 (62.56s)
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (19.39s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (19.70s)
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
--- PASS: TestAccEC2LaunchTemplate_instanceMarketOptions (54.10s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorage
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (23.20s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice (23.27s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (21.37s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (22.61s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
--- PASS: TestAccEC2LaunchTemplate_hibernation (47.40s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (47.19s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (59.23s)
=== CONT  TestAccEC2LaunchTemplate_Name_generated
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (64.78s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_target
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps (64.60s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (64.31s)
=== CONT  TestAccEC2LaunchTemplate_CapacityReservation_preference
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (44.24s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (64.55s)
=== CONT  TestAccEC2LaunchTemplate_tags
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (64.80s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination
--- PASS: TestAccEC2LaunchTemplate_Name_generated (19.10s)
=== CONT  TestAccEC2LaunchTemplate_ebsOptimized
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (19.04s)
=== CONT  TestAccEC2LaunchTemplate_update
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (44.06s)
=== CONT  TestAccEC2LaunchTemplateDataSource_matchTags
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_target (21.67s)
=== CONT  TestAccEC2LaunchTemplate_basic
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (42.85s)
=== CONT  TestAccEC2LaunchTemplate_Name_prefix
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (44.38s)
=== CONT  TestAccEC2LaunchTemplateDataSource_filter
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (34.22s)
=== CONT  TestAccEC2LaunchTemplate_description
--- PASS: TestAccEC2LaunchTemplateDataSource_matchTags (17.69s)
=== CONT  TestAccEC2LaunchTemplateDataSource_id
--- PASS: TestAccEC2LaunchTemplate_basic (20.36s)
=== CONT  TestAccEC2LaunchTemplate_disappears
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (19.27s)
=== CONT  TestAccEC2LaunchTemplate_data
--- PASS: TestAccEC2LaunchTemplateDataSource_filter (17.77s)
--- PASS: TestAccEC2LaunchTemplate_tags (47.69s)
--- PASS: TestAccEC2LaunchTemplateDataSource_id (17.47s)
--- PASS: TestAccEC2LaunchTemplate_disappears (16.76s)
--- PASS: TestAccEC2LaunchTemplate_data (19.95s)
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (60.52s)
--- PASS: TestAccEC2LaunchTemplate_description (33.13s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (54.86s)
--- PASS: TestAccEC2LaunchTemplate_update (61.52s)
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (75.41s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	323.182s
% make t T='TestAccEC2LaunchTemplate_|TestAccEC2LaunchTemplateDataSource_|TestAccECSTaskDefinition_|TestAccECSTaskDefinitionDataSource_|TestAccECSTaskExecutionDataSource_' K=ecs P=10
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/ecs/... -v -count 1 -parallel 10 -run='TestAccEC2LaunchTemplate_|TestAccEC2LaunchTemplateDataSource_|TestAccECSTaskDefinition_|TestAccECSTaskDefinitionDataSource_|TestAccECSTaskExecutionDataSource_'  -timeout 360m -vet=off
2025/04/04 15:42:06 Initializing Terraform AWS Provider...
=== RUN   TestAccECSTaskDefinitionDataSource_basic
=== PAUSE TestAccECSTaskDefinitionDataSource_basic
=== RUN   TestAccECSTaskDefinitionDataSource_ec2
=== PAUSE TestAccECSTaskDefinitionDataSource_ec2
=== RUN   TestAccECSTaskDefinitionDataSource_fargate
=== PAUSE TestAccECSTaskDefinitionDataSource_fargate
=== RUN   TestAccECSTaskDefinitionDataSource_proxyConfiguration
=== PAUSE TestAccECSTaskDefinitionDataSource_proxyConfiguration
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== RUN   TestAccECSTaskDefinition_disappears
=== PAUSE TestAccECSTaskDefinition_disappears
=== RUN   TestAccECSTaskDefinition_scratchVolume
=== PAUSE TestAccECSTaskDefinition_scratchVolume
=== RUN   TestAccECSTaskDefinition_configuredAtLaunch
=== PAUSE TestAccECSTaskDefinition_configuredAtLaunch
=== RUN   TestAccECSTaskDefinition_DockerVolume_basic
=== PAUSE TestAccECSTaskDefinition_DockerVolume_basic
=== RUN   TestAccECSTaskDefinition_DockerVolume_minimal
=== PAUSE TestAccECSTaskDefinition_DockerVolume_minimal
=== RUN   TestAccECSTaskDefinition_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatform
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatform
=== RUN   TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== PAUSE TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== RUN   TestAccECSTaskDefinition_EFSVolume_minimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_minimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_basic
=== PAUSE TestAccECSTaskDefinition_EFSVolume_basic
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryption
=== RUN   TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== PAUSE TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
=== RUN   TestAccECSTaskDefinition_EFSVolume_accessPoint
=== PAUSE TestAccECSTaskDefinition_EFSVolume_accessPoint
=== RUN   TestAccECSTaskDefinition_fsxWinFileSystem
=== PAUSE TestAccECSTaskDefinition_fsxWinFileSystem
=== RUN   TestAccECSTaskDefinition_DockerVolume_taskScoped
=== PAUSE TestAccECSTaskDefinition_DockerVolume_taskScoped
=== RUN   TestAccECSTaskDefinition_service
=== PAUSE TestAccECSTaskDefinition_service
=== RUN   TestAccECSTaskDefinition_taskRoleARN
=== PAUSE TestAccECSTaskDefinition_taskRoleARN
=== RUN   TestAccECSTaskDefinition_networkMode
=== PAUSE TestAccECSTaskDefinition_networkMode
=== RUN   TestAccECSTaskDefinition_ipcMode
=== PAUSE TestAccECSTaskDefinition_ipcMode
=== RUN   TestAccECSTaskDefinition_pidMode
=== PAUSE TestAccECSTaskDefinition_pidMode
=== RUN   TestAccECSTaskDefinition_constraint
=== PAUSE TestAccECSTaskDefinition_constraint
=== RUN   TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== PAUSE TestAccECSTaskDefinition_changeVolumesForcesNewResource
=== RUN   TestAccECSTaskDefinition_arrays
=== PAUSE TestAccECSTaskDefinition_arrays
=== RUN   TestAccECSTaskDefinition_Fargate_basic
=== PAUSE TestAccECSTaskDefinition_Fargate_basic
=== RUN   TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== PAUSE TestAccECSTaskDefinition_Fargate_ephemeralStorage
=== RUN   TestAccECSTaskDefinition_enableFaultInjection
=== PAUSE TestAccECSTaskDefinition_enableFaultInjection
=== RUN   TestAccECSTaskDefinition_executionRole
=== PAUSE TestAccECSTaskDefinition_executionRole
=== RUN   TestAccECSTaskDefinition_tags
=== PAUSE TestAccECSTaskDefinition_tags
=== RUN   TestAccECSTaskDefinition_proxy
=== PAUSE TestAccECSTaskDefinition_proxy
=== RUN   TestAccECSTaskDefinition_invalidContainerDefinition
=== PAUSE TestAccECSTaskDefinition_invalidContainerDefinition
=== RUN   TestAccECSTaskDefinition_trackLatest
=== PAUSE TestAccECSTaskDefinition_trackLatest
=== RUN   TestAccECSTaskDefinition_unknownContainerDefinitions
=== PAUSE TestAccECSTaskDefinition_unknownContainerDefinitions
=== RUN   TestAccECSTaskDefinition_v5590ContainerDefinitionsRegression
=== PAUSE TestAccECSTaskDefinition_v5590ContainerDefinitionsRegression
=== RUN   TestAccECSTaskDefinition_containerDefinitionEmptyPortMappings
=== PAUSE TestAccECSTaskDefinition_containerDefinitionEmptyPortMappings
=== RUN   TestAccECSTaskDefinition_containerDefinitionDockerLabels
=== PAUSE TestAccECSTaskDefinition_containerDefinitionDockerLabels
=== RUN   TestAccECSTaskDefinition_containerDefinitionNullPortMapping
=== PAUSE TestAccECSTaskDefinition_containerDefinitionNullPortMapping
=== RUN   TestAccECSTaskDefinition_containerDefinitionVersionConsistency
=== PAUSE TestAccECSTaskDefinition_containerDefinitionVersionConsistency
=== RUN   TestAccECSTaskDefinition_containerDefinitionVersionConsistency_enabledToNull
=== PAUSE TestAccECSTaskDefinition_containerDefinitionVersionConsistency_enabledToNull
=== RUN   TestAccECSTaskDefinition_containerDefinitionVersionConsistency_nullToEnabled
=== PAUSE TestAccECSTaskDefinition_containerDefinitionVersionConsistency_nullToEnabled
=== RUN   TestAccECSTaskDefinition_DockerVolume_detectChangeInDriverOpts
=== PAUSE TestAccECSTaskDefinition_DockerVolume_detectChangeInDriverOpts
=== RUN   TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
=== PAUSE TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
=== RUN   TestAccECSTaskExecutionDataSource_basic
=== PAUSE TestAccECSTaskExecutionDataSource_basic
=== RUN   TestAccECSTaskExecutionDataSource_overrides
=== PAUSE TestAccECSTaskExecutionDataSource_overrides
=== RUN   TestAccECSTaskExecutionDataSource_tags
=== PAUSE TestAccECSTaskExecutionDataSource_tags
=== CONT  TestAccECSTaskDefinitionDataSource_basic
=== CONT  TestAccECSTaskDefinition_pidMode
=== CONT  TestAccECSTaskDefinition_ipcMode
=== CONT  TestAccECSTaskDefinition_configuredAtLaunch
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch
=== CONT  TestAccECSTaskDefinition_Fargate_runtimePlatform
=== CONT  TestAccECSTaskDefinition_runtimePlatform
=== CONT  TestAccECSTaskDefinition_DockerVolume_minimal
=== CONT  TestAccECSTaskDefinition_DockerVolume_basic
=== CONT  TestAccECSTaskDefinition_EFSVolume_minimal
--- PASS: TestAccECSTaskDefinitionDataSource_basic (15.84s)
=== CONT  TestAccECSTaskDefinition_fsxWinFileSystem
--- PASS: TestAccECSTaskDefinition_runtimePlatform (18.87s)
=== CONT  TestAccECSTaskDefinition_networkMode
--- PASS: TestAccECSTaskDefinition_configuredAtLaunch (19.00s)
=== CONT  TestAccECSTaskDefinition_taskRoleARN
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatformWithoutArch (19.38s)
=== CONT  TestAccECSTaskDefinition_service
--- PASS: TestAccECSTaskDefinition_Fargate_runtimePlatform (19.39s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_taskScoped
--- PASS: TestAccECSTaskDefinition_DockerVolume_basic (19.50s)
=== CONT  TestAccECSTaskDefinition_basic
=== CONT  TestAccECSTaskDefinition_scratchVolume
--- PASS: TestAccECSTaskDefinition_DockerVolume_minimal (19.54s)
--- PASS: TestAccECSTaskDefinition_ipcMode (19.63s)
=== CONT  TestAccECSTaskDefinition_disappears
--- PASS: TestAccECSTaskDefinition_pidMode (19.68s)
=== CONT  TestAccECSTaskDefinition_v5590ContainerDefinitionsRegression
--- PASS: TestAccECSTaskDefinition_EFSVolume_minimal (25.96s)
=== CONT  TestAccECSTaskExecutionDataSource_tags
--- PASS: TestAccECSTaskDefinition_DockerVolume_taskScoped (13.43s)
=== CONT  TestAccECSTaskExecutionDataSource_overrides
--- PASS: TestAccECSTaskDefinition_scratchVolume (16.86s)
=== CONT  TestAccECSTaskExecutionDataSource_basic
--- PASS: TestAccECSTaskDefinition_networkMode (17.80s)
=== CONT  TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch
--- PASS: TestAccECSTaskDefinition_taskRoleARN (17.91s)
=== CONT  TestAccECSTaskDefinition_DockerVolume_detectChangeInDriverOpts
--- PASS: TestAccECSTaskDefinition_disappears (23.68s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionVersionConsistency_nullToEnabled
--- PASS: TestAccECSTaskDefinition_basic (25.99s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionVersionConsistency_enabledToNull
--- PASS: TestAccECSTaskDefinition_Volume_detectChangeInConfigureAtLaunch (15.36s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionVersionConsistency
--- PASS: TestAccECSTaskDefinition_DockerVolume_detectChangeInDriverOpts (22.96s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionNullPortMapping
--- PASS: TestAccECSTaskDefinition_containerDefinitionVersionConsistency_nullToEnabled (21.67s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionDockerLabels
--- PASS: TestAccECSTaskDefinition_containerDefinitionVersionConsistency_enabledToNull (21.28s)
=== CONT  TestAccECSTaskDefinition_containerDefinitionEmptyPortMappings
--- PASS: TestAccECSTaskDefinition_containerDefinitionNullPortMapping (11.47s)
=== CONT  TestAccECSTaskDefinition_executionRole
--- PASS: TestAccECSTaskDefinition_v5590ContainerDefinitionsRegression (54.05s)
=== CONT  TestAccECSTaskDefinition_unknownContainerDefinitions
--- PASS: TestAccECSTaskDefinition_containerDefinitionDockerLabels (11.11s)
=== CONT  TestAccECSTaskDefinition_trackLatest
--- PASS: TestAccECSTaskDefinition_containerDefinitionVersionConsistency (30.63s)
=== CONT  TestAccECSTaskDefinition_invalidContainerDefinition
--- PASS: TestAccECSTaskDefinition_invalidContainerDefinition (0.73s)
=== CONT  TestAccECSTaskDefinition_proxy
--- PASS: TestAccECSTaskDefinition_service (64.37s)
=== CONT  TestAccECSTaskDefinition_tags
--- PASS: TestAccECSTaskDefinition_executionRole (15.77s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryption
--- PASS: TestAccECSTaskDefinition_unknownContainerDefinitions (14.31s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_accessPoint
--- PASS: TestAccECSTaskDefinition_trackLatest (14.26s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled
--- PASS: TestAccECSTaskDefinition_proxy (25.96s)
=== CONT  TestAccECSTaskDefinition_Fargate_basic
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryption (23.35s)
=== CONT  TestAccECSTaskDefinition_enableFaultInjection
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionDisabled (23.34s)
=== CONT  TestAccECSTaskDefinition_Fargate_ephemeralStorage
--- PASS: TestAccECSTaskDefinition_EFSVolume_accessPoint (28.19s)
=== CONT  TestAccECSTaskDefinitionDataSource_ec2
--- PASS: TestAccECSTaskDefinitionDataSource_ec2 (12.05s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal
--- PASS: TestAccECSTaskDefinition_enableFaultInjection (13.81s)
=== CONT  TestAccECSTaskDefinition_EFSVolume_basic
--- PASS: TestAccECSTaskDefinition_tags (43.31s)
=== CONT  TestAccECSTaskDefinitionDataSource_proxyConfiguration
--- PASS: TestAccECSTaskDefinition_Fargate_ephemeralStorage (14.37s)
=== CONT  TestAccECSTaskDefinition_changeVolumesForcesNewResource
--- PASS: TestAccECSTaskDefinition_Fargate_basic (18.80s)
=== CONT  TestAccECSTaskDefinition_arrays
--- PASS: TestAccECSTaskDefinitionDataSource_proxyConfiguration (11.63s)
=== CONT  TestAccECSTaskDefinition_constraint
--- PASS: TestAccECSTaskDefinition_containerDefinitionEmptyPortMappings (74.83s)
=== CONT  TestAccECSTaskDefinitionDataSource_fargate
--- PASS: TestAccECSTaskDefinition_arrays (14.18s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_transitEncryptionMinimal (23.07s)
--- PASS: TestAccECSTaskDefinition_EFSVolume_basic (22.58s)
--- PASS: TestAccECSTaskDefinition_changeVolumesForcesNewResource (22.93s)
--- PASS: TestAccECSTaskDefinitionDataSource_fargate (11.27s)
--- PASS: TestAccECSTaskDefinition_constraint (15.41s)
--- PASS: TestAccECSTaskExecutionDataSource_tags (281.65s)
--- PASS: TestAccECSTaskExecutionDataSource_basic (278.77s)
--- PASS: TestAccECSTaskExecutionDataSource_overrides (289.88s)
--- PASS: TestAccECSTaskDefinition_fsxWinFileSystem (3941.64s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	3963.233s
```
