### PR TITLE
ec2: reject aws_security_group_rule containing an empty list of CIDRs or prefix lists

### DIFF
--- a/internal/service/ec2/vpc_security_group_rule.go
+++ b/internal/service/ec2/vpc_security_group_rule.go
@@ -172,7 +172,11 @@ func resourceSecurityGroupRuleCreate(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading Security Group (%s): %s", securityGroupID, err)
 	}
 
-	ipPermission := expandIPPermission(d, sg)
+	ipPermission, rulesEmpty := expandIPPermission(d, sg)
+	if rulesEmpty {
+		return sdkdiag.AppendErrorf(diags, "this resource must contain at least one rule")
+	}
+
 	ruleType := securityGroupRuleType(d.Get(names.AttrType).(string))
 	id, err := securityGroupRuleCreateID(securityGroupID, string(ruleType), &ipPermission)
 	if err != nil {
@@ -279,7 +283,7 @@ func resourceSecurityGroupRuleRead(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "reading Security Group (%s): %s", securityGroupID, err)
 	}
 
-	ipPermission := expandIPPermission(d, sg)
+	ipPermission, _ := expandIPPermission(d, sg)
 
 	var rules []awstypes.IpPermission
 
@@ -352,7 +356,11 @@ func resourceSecurityGroupRuleUpdate(ctx context.Context, d *schema.ResourceData
 			return sdkdiag.AppendErrorf(diags, "reading Security Group (%s): %s", securityGroupID, err)
 		}
 
-		ipPermission := expandIPPermission(d, sg)
+		ipPermission, rulesEmpty := expandIPPermission(d, sg)
+		if rulesEmpty {
+			return sdkdiag.AppendErrorf(diags, "this resource must contain at least one rule")
+		}
+
 		ruleType := securityGroupRuleType(d.Get(names.AttrType).(string))
 
 		switch ruleType {
@@ -396,7 +404,7 @@ func resourceSecurityGroupRuleDelete(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "reading Security Group (%s): %s", securityGroupID, err)
 	}
 
-	ipPermission := expandIPPermission(d, sg)
+	ipPermission, _ := expandIPPermission(d, sg)
 	ruleType := securityGroupRuleType(d.Get(names.AttrType).(string))
 
 	switch ruleType {
@@ -764,7 +772,7 @@ func securityGroupRuleCreateID(securityGroupID, ruleType string, ip *awstypes.Ip
 	return fmt.Sprintf("sgrule-%d", create.StringHashcode(buf.String())), nil
 }
 
-func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awstypes.IpPermission { // nosemgrep:ci.caps5-in-func-name
+func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) (awstypes.IpPermission, bool) { // nosemgrep:ci.caps5-in-func-name
 	apiObject := awstypes.IpPermission{
 		IpProtocol: aws.String(protocolForValue(d.Get(names.AttrProtocol).(string))),
 	}
@@ -775,7 +783,10 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 		apiObject.ToPort = aws.Int32(int32(d.Get("to_port").(int)))
 	}
 
+	rulesEmpty := true
+
 	if v, ok := d.GetOk("cidr_blocks"); ok && len(v.([]any)) > 0 {
+		rulesEmpty = false
 		for _, v := range v.([]any) {
 			apiObject.IpRanges = append(apiObject.IpRanges, awstypes.IpRange{
 				CidrIp: aws.String(v.(string)),
@@ -784,6 +795,7 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 	}
 
 	if v, ok := d.GetOk("ipv6_cidr_blocks"); ok && len(v.([]any)) > 0 {
+		rulesEmpty = false
 		for _, v := range v.([]any) {
 			apiObject.Ipv6Ranges = append(apiObject.Ipv6Ranges, awstypes.Ipv6Range{
 				CidrIpv6: aws.String(v.(string)),
@@ -792,6 +804,7 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 	}
 
 	if v, ok := d.GetOk("prefix_list_ids"); ok && len(v.([]any)) > 0 {
+		rulesEmpty = false
 		for _, v := range v.([]any) {
 			apiObject.PrefixListIds = append(apiObject.PrefixListIds, awstypes.PrefixListId{
 				PrefixListId: aws.String(v.(string)),
@@ -802,6 +815,7 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 	var self string
 
 	if _, ok := d.GetOk("self"); ok {
+		rulesEmpty = false
 		self = aws.ToString(sg.GroupId)
 		apiObject.UserIdGroupPairs = append(apiObject.UserIdGroupPairs, awstypes.UserIdGroupPair{
 			GroupId: aws.String(self),
@@ -810,6 +824,7 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 
 	if v, ok := d.GetOk("source_security_group_id"); ok {
 		if v := v.(string); v != self {
+			rulesEmpty = false
 			// [OwnerID/]SecurityGroupID.
 			if parts := strings.Split(v, "/"); len(parts) == 1 {
 				apiObject.UserIdGroupPairs = append(apiObject.UserIdGroupPairs, awstypes.UserIdGroupPair{
@@ -843,7 +858,7 @@ func expandIPPermission(d *schema.ResourceData, sg *awstypes.SecurityGroup) awst
 		}
 	}
 
-	return apiObject
+	return apiObject, rulesEmpty
 }
 
 func flattenIpPermission(d *schema.ResourceData, apiObject *awstypes.IpPermission) { // nosemgrep:ci.caps5-in-func-name

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -465,6 +465,10 @@ func TestAccVPCSecurityGroupRule_expectInvalidCIDR(t *testing.T) {
 				Config:      testAccVPCSecurityGroupRuleConfig_invalidIPv6CIDR(rName),
 				ExpectError: regexache.MustCompile("invalid CIDR address: ::/244"),
 			},
+			{
+				Config:      testAccVPCSecurityGroupRuleConfig_emptyIngress(rName),
+				ExpectError: regexache.MustCompile("this resource must contain at least one rule"),
+			},
 		},
 	})
 }
@@ -2425,6 +2429,27 @@ resource "aws_security_group_rule" "test" {
   to_port           = 0
   protocol          = "-1"
   cidr_blocks       = ["1.2.3.4/33"]
+  security_group_id = aws_security_group.test.id
+}
+`, rName)
+}
+
+func testAccVPCSecurityGroupRuleConfig_emptyIngress(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group_rule" "test" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = []
   security_group_id = aws_security_group.test.id
 }
 `, rName)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

When creating or updating an `aws_security_group_rule`, if the `cidr_blocks`, `ipv6_cidr_blocks`, or `prefix_lists` attributes are specified as an empty list, raise an error indicating that at least one rule is needed.

This prevents a bug where Terraform will wait indefinitely for a nonexistent rule to be created, then time out.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42018

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% AWS_PROFILE=default make testacc TESTS=TestAccVPCSecurityGroupRule_expectInvalidCIDR PKG=ec2
make: go1.23.8 not found
make: installing go1.23.8...
make: if you get an error, see https://go.dev/doc/manage-install to locally install various Go versions
go: downloading golang.org/dl v0.0.0-20250401154141-6c7fc191c4d8
Downloaded   0.0% (    3120 / 71659445 bytes) ...
Downloaded  13.7% ( 9846720 / 71659445 bytes) ...
Downloaded  39.0% (27918128 / 71659445 bytes) ...
Downloaded  66.5% (47677088 / 71659445 bytes) ...
Downloaded  93.8% (67223040 / 71659445 bytes) ...
Downloaded 100.0% (71659445 / 71659445 bytes)
Unpacking /Users/sodle/sdk/go1.23.8/go1.23.8.darwin-arm64.tar.gz ...
Success. You may now run 'go1.23.8'
make: go1.23.8 ready
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCSecurityGroupRule_expectInvalidCIDR'  -timeout 360m -vet=off
2025/04/04 23:20:01 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== PAUSE TestAccVPCSecurityGroupRule_expectInvalidCIDR
=== CONT  TestAccVPCSecurityGroupRule_expectInvalidCIDR
--- PASS: TestAccVPCSecurityGroupRule_expectInvalidCIDR (9.01s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        14.606s
```
