### PR TITLE
r/sagemaker_domain - allow removing custom file config

### DIFF
--- a/.changelog/42144.txt
+++ b/.changelog/42144.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+resource/aws_sagemaker_domain: Allow removing `custom_file_system_config`
+```
+
+```release-note:bug
+resource/aws_sagemaker_user_profile: Allow removing `custom_file_system_config`
+```

--- a/.changelog/42144.txt
+++ b/.changelog/42144.txt
@@ -1,7 +1,7 @@
 ```release-note:bug
-resource/aws_sagemaker_domain: Allow removing `custom_file_system_config`
+resource/aws_sagemaker_domain: Allow `default_user_settings.custom_file_system_config` and `default_space_settings.custom_file_system_config` to be removed on Update
 ```
 
 ```release-note:bug
-resource/aws_sagemaker_user_profile: Allow removing `custom_file_system_config`
+resource/aws_sagemaker_user_profile: Allow `user_settings.custom_file_system_config` to be removed on Update
 ```

--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -3122,7 +3122,7 @@ func expanDefaultSpaceSettings(l []any) *awstypes.DefaultSpaceSettings {
 		if len(v) > 0 {
 			config.CustomFileSystemConfigs = expandCustomFileSystemConfigs(v)
 		} else {
-			config.CustomFileSystemConfigs = nil
+			config.CustomFileSystemConfigs = []awstypes.CustomFileSystemConfig{}
 		}
 	}
 

--- a/internal/service/sagemaker/domain.go
+++ b/internal/service/sagemaker/domain.go
@@ -1853,8 +1853,12 @@ func expandUserSettings(l []any) *awstypes.UserSettings {
 		config.CodeEditorAppSettings = expandDomainCodeEditorAppSettings(v)
 	}
 
-	if v, ok := m["custom_file_system_config"].([]any); ok && len(v) > 0 {
-		config.CustomFileSystemConfigs = expandCustomFileSystemConfigs(v)
+	if v, ok := m["custom_file_system_config"].([]any); ok {
+		if len(v) > 0 {
+			config.CustomFileSystemConfigs = expandCustomFileSystemConfigs(v)
+		} else {
+			config.CustomFileSystemConfigs = []awstypes.CustomFileSystemConfig{}
+		}
 	}
 
 	if v, ok := m["custom_posix_user_config"].([]any); ok && len(v) > 0 {
@@ -3114,8 +3118,12 @@ func expanDefaultSpaceSettings(l []any) *awstypes.DefaultSpaceSettings {
 		config.SpaceStorageSettings = expandDefaultSpaceStorageSettings(v)
 	}
 
-	if v, ok := m["custom_file_system_config"].([]any); ok && len(v) > 0 {
-		config.CustomFileSystemConfigs = expandCustomFileSystemConfigs(v)
+	if v, ok := m["custom_file_system_config"].([]any); ok {
+		if len(v) > 0 {
+			config.CustomFileSystemConfigs = expandCustomFileSystemConfigs(v)
+		} else {
+			config.CustomFileSystemConfigs = nil
+		}
 	}
 
 	if v, ok := m["custom_posix_user_config"].([]any); ok && len(v) > 0 {

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -1451,6 +1451,15 @@ func testAccDomain_efs(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"retention_policy"},
 			},
+			{
+				Config: testAccDomainConfig_efsRemoved(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDomainExists(ctx, resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomainName, rName),
+					resource.TestCheckResourceAttrPair(resourceName, "default_user_settings.0.execution_role", "aws_iam_role.test", names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "default_user_settings.0.custom_file_system_config.#", "0"),
+				),
+			},
 		},
 	})
 }
@@ -3044,6 +3053,36 @@ resource "aws_sagemaker_domain" "test" {
         file_system_path = "/"
       }
     }
+  }
+
+  retention_policy {
+    home_efs_file_system = "Delete"
+  }
+}
+`, rName))
+}
+
+func testAccDomainConfig_efsRemoved(rName string) string {
+	return acctest.ConfigCompose(testAccDomainConfig_base(rName), fmt.Sprintf(`
+resource "aws_efs_file_system" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_efs_mount_target" "test" {
+  file_system_id = aws_efs_file_system.test.id
+  subnet_id      = aws_subnet.test[0].id
+}
+
+resource "aws_sagemaker_domain" "test" {
+  domain_name = %[1]q
+  auth_mode   = "IAM"
+  vpc_id      = aws_vpc.test.id
+  subnet_ids  = aws_subnet.test[*].id
+
+  default_user_settings {
+    execution_role = aws_iam_role.test.arn
   }
 
   retention_policy {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35503

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccSageMaker_serial/Domain/efs  PKG=sagemaker

--- PASS: TestAccSageMaker_serial (341.54s)
    --- PASS: TestAccSageMaker_serial/Domain (341.54s)
        --- PASS: TestAccSageMaker_serial/Domain/efs (341.54s)
```
