### PR TITLE
Add state attribute to aws_dx_connection resource

### DIFF
--- a/.changelog/42150.txt
+++ b/.changelog/42150.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_dx_connection: Add `state` attribute
+```

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -83,6 +83,10 @@ func resourceConnection() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				names.AttrOwnerAccountID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -205,6 +209,10 @@ func resourceConnection() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
+				},
 				names.AttrOwnerAccountID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -299,6 +307,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set(names.AttrLocation, connection.Location)
 	d.Set("macsec_capable", connection.MacSecCapable)
 	d.Set(names.AttrName, connection.ConnectionName)
+	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set("port_encryption_status", connection.PortEncryptionStatus)

--- a/internal/service/directconnect/connection.go
+++ b/internal/service/directconnect/connection.go
@@ -83,10 +83,6 @@ func resourceConnection() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
-				names.AttrState: {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
 				names.AttrOwnerAccountID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -209,10 +205,6 @@ func resourceConnection() *schema.Resource {
 					Required: true,
 					ForceNew: true,
 				},
-				names.AttrState: {
-					Type:     schema.TypeString,
-					Computed: true,
-				},
 				names.AttrOwnerAccountID: {
 					Type:     schema.TypeString,
 					Computed: true,
@@ -235,6 +227,10 @@ func resourceConnection() *schema.Resource {
 					Type:     schema.TypeBool,
 					Default:  false,
 					Optional: true,
+				},
+				names.AttrState: {
+					Type:     schema.TypeString,
+					Computed: true,
 				},
 				names.AttrTags:    tftags.TagsSchema(),
 				names.AttrTagsAll: tftags.TagsSchemaComputed(),
@@ -307,7 +303,6 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set(names.AttrLocation, connection.Location)
 	d.Set("macsec_capable", connection.MacSecCapable)
 	d.Set(names.AttrName, connection.ConnectionName)
-	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set(names.AttrOwnerAccountID, connection.OwnerAccount)
 	d.Set("partner_name", connection.PartnerName)
 	d.Set("port_encryption_status", connection.PortEncryptionStatus)
@@ -315,6 +310,7 @@ func resourceConnectionRead(ctx context.Context, d *schema.ResourceData, meta an
 	if !d.IsNewResource() && !d.Get("request_macsec").(bool) {
 		d.Set("request_macsec", aws.Bool(false))
 	}
+	d.Set(names.AttrState, connection.ConnectionState)
 	d.Set("vlan_id", connection.Vlan)
 
 	return diags

--- a/internal/service/directconnect/connection_test.go
+++ b/internal/service/directconnect/connection_test.go
@@ -40,6 +40,7 @@ func TestAccDirectConnectConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrLocation),
 					acctest.CheckResourceAttrAccountID(ctx, resourceName, names.AttrOwnerAccountID),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrState),
 					resource.TestCheckResourceAttr(resourceName, "partner_name", ""),
 					resource.TestCheckResourceAttr(resourceName, names.AttrProviderName, ""),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),

--- a/website/docs/r/dx_connection.html.markdown
+++ b/website/docs/r/dx_connection.html.markdown
@@ -77,6 +77,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `owner_account_id` - The ID of the AWS account that owns the connection.
 * `partner_name` - The name of the AWS Direct Connect service provider associated with the connection.
 * `port_encryption_status` - The MAC Security (MACsec) port link status of the connection.
+* `state` - State of the connection. See [CreateConnection](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_CreateConnection.html#API_CreateConnection_ResponseSyntax) for list of possible state values.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `vlan_id` - The VLAN ID.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---

--->
Add `state` attribute to `aws_dx_connection` resource, updated acceptance test and docs to include `state`

### Relations
<!---

--->

Closes #42149

### References
<!---
[AWS Direct Connect API connectionState attribute](https://docs.aws.amazon.com/directconnect/latest/APIReference/API_Connection.html)
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
make testacc TESTS=TestAccDirectConnectConnection_basic PKG=directconnect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectConnection_basic'  -timeout 360m -vet=off
2025/04/06 23:37:54 Initializing Terraform AWS Provider...
=== RUN   TestAccDirectConnectConnection_basic
=== PAUSE TestAccDirectConnectConnection_basic
=== CONT  TestAccDirectConnectConnection_basic
--- PASS: TestAccDirectConnectConnection_basic (14.49s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      14.637s
```
