### PR TITLE
doc: Fix parameter name from table_wild_card to wildcard in aws_lakeformation_opt_in resource

### DIFF
--- a/website/docs/r/lakeformation_opt_in.html.markdown
+++ b/website/docs/r/lakeformation_opt_in.html.markdown
@@ -88,7 +88,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `database_name` - The name of the database for the table. Unique to a Data Catalog. A database is a set of associated table definitions organized into a logical group. You can Grant and Revoke database privileges to a principal.
 * `name` - Name of the table.
 * `catalog_id` - Identifier for the Data Catalog. By default, it is the account ID of the caller.
-* `table_wild_card` - Wildcard object representing every table under a database. At least one of TableResource$Name or TableResource$TableWildcard is required.
+* `wildcard` - Boolean value that indicates whether to use a wildcard representing every table under the specified database. When set to true, this represents all tables within the specified database. At least one of TableResource$Name or TableResource$Wildcard is required.
 
 ### Table With Columns
 
@@ -105,20 +105,3 @@ This resource exports the following attributes in addition to the arguments abov
 * `create` - (Default `60m`)
 * `update` - (Default `180m`)
 * `delete` - (Default `90m`)
-
-## Import
-
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Lake Formation Opt In using the `example_id_arg`. For example:
-
-```terraform
-import {
-  to = aws_lakeformation_opt_in.example
-  id = "opt_in-id-12345678"
-}
-```
-
-Using `terraform import`, import Lake Formation Opt In using the `example_id_arg`. For example:
-
-```console
-% terraform import aws_lakeformation_opt_in.example opt_in-id-12345678
-```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
This PR corrects the documentation for the `aws_lakeformation_opt_in` resource by fixing the parameter name for table wildcard functionality. The documentation incorrectly referred to the parameter as `table_wild_card`, but the actual parameter name in the Terraform AWS provider is `wildcard`. This change ensures the documentation accurately reflects the provider's implementation.


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Opt-in creation error with current doc:
```
│ Error: Unsupported block type
│ 
│   on src/lakeformation_restrictions/opt_in_commands.tf line 64, in resource "aws_lakeformation_opt_in" "app_database_lakeformation_opt_in":
│   64:       table_wildcard {}
│ 
│ Blocks of type "table_wildcard" are not expected here.
```

Terraform import error:
```
│ Error: Resource Import Not Implemented
│ 
│ This resource does not support import. Please contact the provider developer for additional information.
```

### Output from Acceptance Testing
No acceptance tests needed for documentation-only changes
This is a documentation-only change that doesn't affect the provider's functionality
