### PR TITLE
fix: use error type to detect document deletion

### DIFF
--- a/internal/service/ssm/document.go
+++ b/internal/service/ssm/document.go
@@ -527,7 +527,7 @@ func resourceDocumentDelete(ctx context.Context, d *schema.ResourceData, meta an
 		Name: aws.String(d.Get(names.AttrName).(string)),
 	})
 
-	if errs.IsAErrorMessageContains[*awstypes.InvalidDocument](err, "does not exist") {
+	if errs.IsA[*awstypes.InvalidDocument](err) {
 		return diags
 	}
 
@@ -549,7 +549,7 @@ func findDocumentByName(ctx context.Context, conn *ssm.Client, name string) (*aw
 
 	output, err := conn.DescribeDocument(ctx, input)
 
-	if errs.IsAErrorMessageContains[*awstypes.InvalidDocument](err, "does not exist") {
+	if errs.IsA[*awstypes.InvalidDocument](err) {
 		return nil, &retry.NotFoundError{
 			LastError:   err,
 			LastRequest: input,


### PR DESCRIPTION
As described in #42125 the error message associated with document deletion has changed and consequently terraform fails to detect InvalidDocument errors correctly. This PR proposes using the error type as suggested by AWS in that issue. 

Closes #42125 

### References

https://github.com/hashicorp/terraform-provider-aws/issues/42125#issuecomment-2785421999 

### Output from Acceptance Testing

```console
% % make testacc TESTS=TestAccSSMDocument PKG=ssm
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ssm/... -v -count 1 -parallel 20 -run='TestAccSSMDocument'  -timeout 360m -vet=off
go: downloading gopkg.in/dnaeon/go-vcr.v3 v3.2.1
2025/04/08 18:08:35 Initializing Terraform AWS Provider...
=== RUN   TestAccSSMDocumentDataSource_basic
=== PAUSE TestAccSSMDocumentDataSource_basic
=== RUN   TestAccSSMDocumentDataSource_basicAutomation
=== PAUSE TestAccSSMDocumentDataSource_basicAutomation
=== RUN   TestAccSSMDocumentDataSource_managed
=== PAUSE TestAccSSMDocumentDataSource_managed
=== RUN   TestAccSSMDocument_tags
=== PAUSE TestAccSSMDocument_tags
=== RUN   TestAccSSMDocument_tags_null
=== PAUSE TestAccSSMDocument_tags_null
=== RUN   TestAccSSMDocument_tags_EmptyMap
=== PAUSE TestAccSSMDocument_tags_EmptyMap
=== RUN   TestAccSSMDocument_tags_AddOnUpdate
=== PAUSE TestAccSSMDocument_tags_AddOnUpdate
=== RUN   TestAccSSMDocument_tags_EmptyTag_OnCreate
=== PAUSE TestAccSSMDocument_tags_EmptyTag_OnCreate
=== RUN   TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccSSMDocument_tags_DefaultTags_providerOnly
=== PAUSE TestAccSSMDocument_tags_DefaultTags_providerOnly
=== RUN   TestAccSSMDocument_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccSSMDocument_tags_DefaultTags_nonOverlapping
=== RUN   TestAccSSMDocument_tags_DefaultTags_overlapping
=== PAUSE TestAccSSMDocument_tags_DefaultTags_overlapping
=== RUN   TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccSSMDocument_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccSSMDocument_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccSSMDocument_tags_ComputedTag_OnCreate
=== PAUSE TestAccSSMDocument_tags_ComputedTag_OnCreate
=== RUN   TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccSSMDocument_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccSSMDocument_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccSSMDocument_basic
=== PAUSE TestAccSSMDocument_basic
=== RUN   TestAccSSMDocument_name
=== PAUSE TestAccSSMDocument_name
=== RUN   TestAccSSMDocument_Target_type
=== PAUSE TestAccSSMDocument_Target_type
=== RUN   TestAccSSMDocument_versionName
=== PAUSE TestAccSSMDocument_versionName
=== RUN   TestAccSSMDocument_update
=== PAUSE TestAccSSMDocument_update
=== RUN   TestAccSSMDocument_Permission_public
=== PAUSE TestAccSSMDocument_Permission_public
=== RUN   TestAccSSMDocument_Permission_private
=== PAUSE TestAccSSMDocument_Permission_private
=== RUN   TestAccSSMDocument_Permission_batching
=== PAUSE TestAccSSMDocument_Permission_batching
=== RUN   TestAccSSMDocument_Permission_change
=== PAUSE TestAccSSMDocument_Permission_change
=== RUN   TestAccSSMDocument_params
=== PAUSE TestAccSSMDocument_params
=== RUN   TestAccSSMDocument_automation
=== PAUSE TestAccSSMDocument_automation
=== RUN   TestAccSSMDocument_package
=== PAUSE TestAccSSMDocument_package
=== RUN   TestAccSSMDocument_SchemaVersion_1
=== PAUSE TestAccSSMDocument_SchemaVersion_1
=== RUN   TestAccSSMDocument_session
=== PAUSE TestAccSSMDocument_session
=== RUN   TestAccSSMDocument_DocumentFormat_yaml
=== PAUSE TestAccSSMDocument_DocumentFormat_yaml
=== RUN   TestAccSSMDocument_disappears
=== PAUSE TestAccSSMDocument_disappears
=== CONT  TestAccSSMDocumentDataSource_basic
=== CONT  TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccSSMDocument_Permission_private
=== CONT  TestAccSSMDocument_Permission_public
=== CONT  TestAccSSMDocument_tags_DefaultTags_providerOnly
=== CONT  TestAccSSMDocument_name
=== CONT  TestAccSSMDocument_package
=== CONT  TestAccSSMDocument_DocumentFormat_yaml
=== CONT  TestAccSSMDocument_session
=== CONT  TestAccSSMDocument_SchemaVersion_1
=== CONT  TestAccSSMDocument_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccSSMDocument_tags_ComputedTag_OnCreate
=== CONT  TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag
=== CONT  TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag
=== CONT  TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly
=== CONT  TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccSSMDocument_tags_EmptyMap
=== CONT  TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccSSMDocument_disappears
--- PASS: TestAccSSMDocument_disappears (32.27s)
=== CONT  TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccSSMDocument_session (40.33s)
=== CONT  TestAccSSMDocument_tags_EmptyTag_OnCreate
--- PASS: TestAccSSMDocument_Permission_public (40.54s)
=== CONT  TestAccSSMDocument_tags_AddOnUpdate
--- PASS: TestAccSSMDocument_Permission_private (42.42s)
=== CONT  TestAccSSMDocument_params
--- PASS: TestAccSSMDocumentDataSource_basic (56.22s)
=== CONT  TestAccSSMDocument_automation
--- PASS: TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag (57.37s)
=== CONT  TestAccSSMDocument_Permission_change
--- PASS: TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag (58.32s)
=== CONT  TestAccSSMDocument_Permission_batching
--- PASS: TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag (62.78s)
=== CONT  TestAccSSMDocument_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccSSMDocument_DocumentFormat_yaml (68.36s)
=== CONT  TestAccSSMDocument_basic
--- PASS: TestAccSSMDocument_SchemaVersion_1 (68.57s)
=== CONT  TestAccSSMDocument_tags
--- PASS: TestAccSSMDocument_name (69.08s)
=== CONT  TestAccSSMDocument_tags_null
--- PASS: TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace (69.68s)
=== CONT  TestAccSSMDocument_versionName
--- PASS: TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly (70.88s)
=== CONT  TestAccSSMDocument_update
--- PASS: TestAccSSMDocument_tags_EmptyMap (71.28s)
=== CONT  TestAccSSMDocumentDataSource_managed
--- PASS: TestAccSSMDocument_tags_DefaultTags_emptyResourceTag (71.55s)
=== CONT  TestAccSSMDocumentDataSource_basicAutomation
--- PASS: TestAccSSMDocument_tags_ComputedTag_OnCreate (73.21s)
=== CONT  TestAccSSMDocument_Target_type
--- PASS: TestAccSSMDocument_params (38.34s)
=== CONT  TestAccSSMDocument_tags_DefaultTags_overlapping
--- PASS: TestAccSSMDocumentDataSource_managed (27.89s)
=== CONT  TestAccSSMDocument_tags_DefaultTags_nonOverlapping
--- PASS: TestAccSSMDocument_Permission_batching (41.13s)
=== CONT  TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add (104.90s)
=== CONT  TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly (107.19s)
--- PASS: TestAccSSMDocument_basic (43.09s)
--- PASS: TestAccSSMDocument_tags_AddOnUpdate (71.88s)
--- PASS: TestAccSSMDocument_tags_EmptyTag_OnCreate (76.66s)
--- PASS: TestAccSSMDocument_automation (63.41s)
--- PASS: TestAccSSMDocument_tags_null (50.89s)
--- PASS: TestAccSSMDocument_package (124.46s)
--- PASS: TestAccSSMDocument_update (60.39s)
--- PASS: TestAccSSMDocument_versionName (62.46s)
--- PASS: TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add (100.45s)
--- PASS: TestAccSSMDocument_Target_type (62.59s)
--- PASS: TestAccSSMDocument_Permission_change (82.37s)
--- PASS: TestAccSSMDocumentDataSource_basicAutomation (70.15s)
--- PASS: TestAccSSMDocument_tags_DefaultTags_providerOnly (145.10s)
--- PASS: TestAccSSMDocument_tags_IgnoreTags_Overlap_ResourceTag (84.66s)
--- PASS: TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace (50.64s)
--- PASS: TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag (57.84s)
--- PASS: TestAccSSMDocument_tags_DefaultTags_overlapping (82.66s)
--- PASS: TestAccSSMDocument_tags_DefaultTags_nonOverlapping (72.39s)
--- PASS: TestAccSSMDocument_tags (103.59s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	179.229s
```
