### PR TITLE
Fix documentation: clarify that instance_id is the RDS Identifier

### DIFF
--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -264,7 +264,7 @@ To specify data source connection parameters, exactly one of the following sub-o
 ### rds Argument Reference
 
 * `database` - (Required) The database to which to connect.
-* `instance_id` - (Optional) The instance ID to which to connect.
+* `instance_id` - (Optional) The instance Identifier to which to connect.
 
 ### redshift Argument Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This is a small documentation improvement for the `aws_quicksight_data_source` resource.

The `instance_id` field under the `rds` argument was described as "instance ID," which can be confused with an EC2 instance ID. This change clarifies that it actually expects the **RDS instance Identifier**, which is the unique name assigned to the RDS database.

I'm new to contributing and wanted to help clarify this for future users who might run into the same confusion. 😊

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

--->

Closes #41672  

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
-- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source#instance_id-1
-- https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Not applicable — this is a documentation-only change.


