### PR TITLE
Feature: Adding new resource `aws_quicksight_account_settings` to support management of termination protection

### DIFF
--- a/internal/service/quicksight/account_settings.go
+++ b/internal/service/quicksight/account_settings.go
@@ -1,0 +1,679 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package quicksight
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/quicksight/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// awstypes.<Type Name>.
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/quicksight"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+// TIP: ==== FILE STRUCTURE ====
+// All resources should follow this basic outline. Improve this resource's
+// maintainability by sticking to it.
+//
+// 1. Package declaration
+// 2. Imports
+// 3. Main resource struct with schema method
+// 4. Create, read, update, delete methods (in that order)
+// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
+
+// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
+// @FrameworkResource("aws_quicksight_account_settings", name="Account Settings")
+func newResourceAccountSettings(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &resourceAccountSettings{}
+
+	// TIP: ==== CONFIGURABLE TIMEOUTS ====
+	// Users can configure timeout lengths but you need to use the times they
+	// provide. Access the timeout they configure (or the defaults) using,
+	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
+	// the defaults if they don't configure timeouts.
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultUpdateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
+
+	return r, nil
+}
+
+const (
+	ResNameAccountSettings = "Account Settings"
+)
+
+type resourceAccountSettings struct {
+	framework.ResourceWithConfigure
+	framework.WithTimeouts
+}
+
+
+// TIP: ==== SCHEMA ====
+// In the schema, add each of the attributes in snake case (e.g.,
+// delete_automated_backups).
+//
+// Formatting rules:
+// * Alphabetize attributes to make them easier to find.
+// * Do not add a blank line between attributes.
+//
+// Attribute basics:
+// * If a user can provide a value ("configure a value") for an
+//   attribute (e.g., instances = 5), we call the attribute an
+//   "argument."
+// * You change the way users interact with attributes using:
+//     - Required
+//     - Optional
+//     - Computed
+// * There are only four valid combinations:
+//
+// 1. Required only - the user must provide a value
+// Required: true,
+//
+// 2. Optional only - the user can configure or omit a value; do not
+//    use Default or DefaultFunc
+// Optional: true,
+//
+// 3. Computed only - the provider can provide a value but the user
+//    cannot, i.e., read-only
+// Computed: true,
+//
+// 4. Optional AND Computed - the provider or user can provide a value;
+//    use this combination if you are using Default
+// Optional: true,
+// Computed: true,
+//
+// You will typically find arguments in the input struct
+// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
+// they are only in the input struct (e.g., ModifyDBInstanceInput) for
+// the modify operation.
+//
+// For more about schema options, visit
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
+func (r *resourceAccountSettings) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"account_name": schema.StringAttribute{
+				Computed: true,
+			},
+			"default_namespace": schema.StringAttribute{
+				Optional: true,
+				Default:  stringdefault.StaticString("default"),
+			},
+			"edition": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
+			"notification_email": schema.StringAttribute{
+				Optional: true,
+			},
+			"public_sharing_enabled": schema.BoolAttribute{
+				Computed: true,
+			},
+			"termination_protection_enabled": schema.BoolAttribute{
+				Optional: true,
+			},
+			// "name": schema.StringAttribute{
+			// 	Required: true,
+			// 	// TIP: ==== PLAN MODIFIERS ====
+			// 	// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
+			// 	// for adjusting planned changes prior to apply. The planmodifier subpackage
+			// 	// provides built-in modifiers for many common use cases such as 
+			// 	// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK 
+			// 	// resources).
+			// 	//
+			// 	// See more:
+			// 	// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
+			// 	PlanModifiers: []planmodifier.String{
+			// 		stringplanmodifier.RequiresReplace(),
+			// 	},
+			// },
+			// "type": schema.StringAttribute{
+			// 	Required: true,
+			// },
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *resourceAccountSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// TIP: ==== RESOURCE CREATE ====
+	// Generally, the Create function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan
+	// 3. Populate a create input structure
+	// 4. Call the AWS create/put function
+	// 5. Using the output from the create function, set the minimum arguments
+	//    and attributes for the Read function to work, as well as any computed
+	//    only attributes. 
+	// 6. Use a waiter to wait for create to complete
+	// 7. Save the request plan to response state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().QuickSightClient(ctx)
+
+	// TIP: -- 2. Fetch the plan
+	var plan resourceAccountSettingsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Populate a Create input structure
+	awsAccountId := r.Meta().AccountID(ctx)
+	input := quicksight.UpdateAccountSettingsInput{
+		AwsAccountId: &awsAccountId,
+	}
+
+	if !plan.DefaultNamespace.IsNull() {
+		input.DefaultNamespace = plan.DefaultNamespace.ValueStringPointer()
+	}
+
+	if !plan.NotificationEmail.IsNull() {
+		input.NotificationEmail = plan.NotificationEmail.ValueStringPointer()
+	}
+
+	if !plan.TerminationProtectionEnabled.IsNull() {
+		input.TerminationProtectionEnabled = plan.TerminationProtectionEnabled.ValueBool()
+	}
+
+	// TIP: Using a field name prefix allows mapping fields such as `ID` to `AccountSettingsId`
+	// resp.Diagnostics.Append(flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("AccountSettings"))...)
+	// if resp.Diagnostics.HasError() {
+	// 	return
+	// }
+
+
+	// TIP: -- 4. Call the AWS Create function
+	// out, err := conn.UpdateAccountSettings(ctx, &input)
+	// if err != nil {
+	// 	// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
+	// 	// in error messages at this point.
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameAccountSettings, plan.AccountName.String(), err),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+	// if out == nil {
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameAccountSettings, plan.AccountName.String(), nil),
+	// 		errors.New("empty output").Error(),
+	// 	)
+	// 	return
+	// }
+
+	// TIP: -- 5. Using the output from the create function, set attributes
+
+
+	// TIP: -- 6. Use a waiter to wait for create to complete
+	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+	// _, err = waitAccountSettingsCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
+	// if err != nil {
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionWaitingForCreation, ResNameAccountSettings, plan.ID.String(), err),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+	output, err := tfresource.RetryGWhen(ctx, createTimeout,
+		func() (*quicksight.UpdateAccountSettingsOutput, error) {
+			return conn.UpdateAccountSettings(ctx, &input)
+		},
+		func(err error) (bool, error) {
+			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "You don't have access to this item.\n  The provided credentials couldn't be validated.\n  You might not be authorized to carry out the request.\n  Make sure that your account is authorized to use the Amazon QuickSight service, that your policies have the correct permissions, and that you are using the correct credentials.") {
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.InternalFailureException](err, "An internal failure occurred.") {
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "One or more parameters has a value that isn't valid.") {
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found."){
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable."){
+				return true, err
+			}
+			if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled."){
+				return true, err
+			}
+			return false, err
+		},
+	)
+	if err != nil {
+		resp.Diagnostics.AddError("creating Quicksight Account", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, output, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 7. Save the request plan to response state
+	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+}
+
+func (r *resourceAccountSettings) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// TIP: ==== RESOURCE READ ====
+	// Generally, the Read function should do the following things. Make
+	// sure there is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Get the resource from AWS
+	// 4. Remove resource from state if it is not found
+	// 5. Set the arguments and attributes
+	// 6. Set the state
+
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().QuickSightClient(ctx)
+	awsAccountID := r.Meta().AccountID(ctx)
+
+	// TIP: -- 2. Fetch the state
+	var state resourceAccountSettingsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
+	// type function, or, better yet, using a finder.
+	out, err := findAccountSettingsByID(ctx, conn, awsAccountID)
+	// TIP: -- 4. Remove resource from state if it is not found
+	if tfresource.NotFound(err) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.QuickSight, create.ErrActionSetting, ResNameAccountSettings, state.ID.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	// TIP: -- 5. Set the arguments and attributes
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 6. Set the state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *resourceAccountSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// TIP: ==== RESOURCE UPDATE ====
+	// Not all resources have Update functions. There are a few reasons:
+	// a. The AWS API does not support changing a resource
+	// b. All arguments have RequiresReplace() plan modifiers
+	// c. The AWS API uses a create call to modify an existing resource
+	//
+	// In the cases of a. and b., the resource will not have an update method
+	// defined. In the case of c., Update and Create can be refactored to call
+	// the same underlying function.
+	//
+	// The rest of the time, there should be an Update function and it should
+	// do the following things. Make sure there is a good reason if you don't
+	// do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the plan and state
+	// 3. Populate a modify input structure and check for changes
+	// 4. Call the AWS modify/update function
+	// 5. Use a waiter to wait for update to complete
+	// 6. Save the request plan to response state
+	// TIP: -- 1. Get a client connection to the relevant service
+	conn := r.Meta().QuickSightClient(ctx)
+
+
+	// TIP: -- 2. Fetch the plan
+	var plan, state resourceAccountSettingsModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// TIP: -- 3. Get the difference between the plan and state, if any
+	diff, d := flex.Diff(ctx, plan, state)
+	resp.Diagnostics.Append(d...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if diff.HasChanges() {
+		awsAccountID := r.Meta().AccountID(ctx)
+		input := quicksight.UpdateAccountSettingsInput{
+			AwsAccountId: &awsAccountID,
+		}
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !plan.DefaultNamespace.IsNull() {
+			input.DefaultNamespace = plan.DefaultNamespace.ValueStringPointer()
+		}
+
+		if !plan.NotificationEmail.IsNull() {
+			input.NotificationEmail = plan.NotificationEmail.ValueStringPointer()
+		}
+
+		if !plan.TerminationProtectionEnabled.IsNull() {
+			input.TerminationProtectionEnabled = plan.TerminationProtectionEnabled.ValueBool()
+		}
+
+		// TIP: -- 4. Call the AWS modify/update function
+		// out, err := conn.UpdateAccountSettings(ctx, &input)
+		// if err != nil {
+		// 	resp.Diagnostics.AddError(
+		// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameAccountSettings, plan.AccountName.String(), err),
+		// 		err.Error(),
+		// 	)
+		// 	return
+		// }
+		// if out == nil {
+		// 	resp.Diagnostics.AddError(
+		// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameAccountSettings, plan.AccountName.String(), nil),
+		// 		errors.New("empty output").Error(),
+		// 	)
+		// 	return
+		// }
+
+		createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
+		output, err := tfresource.RetryGWhen(ctx, createTimeout,
+			func() (*quicksight.UpdateAccountSettingsOutput, error) {
+				return conn.UpdateAccountSettings(ctx, &input)
+			},
+			func(err error) (bool, error) {
+				if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "You don't have access to this item.\n  The provided credentials couldn't be validated.\n  You might not be authorized to carry out the request.\n  Make sure that your account is authorized to use the Amazon QuickSight service, that your policies have the correct permissions, and that you are using the correct credentials.") {
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.InternalFailureException](err, "An internal failure occurred.") {
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "One or more parameters has a value that isn't valid.") {
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found."){
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable."){
+					return true, err
+				}
+				if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled."){
+					return true, err
+				}
+				return false, err
+			},
+		)
+		if err != nil {
+			resp.Diagnostics.AddError("creating Quicksight Account", err.Error())
+			return
+		}
+
+		// TIP: Using the output from the update function, re-set any computed attributes
+		resp.Diagnostics.Append(flex.Flatten(ctx, output, &plan)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	// TIP: -- 5. Use a waiter to wait for update to complete
+	// updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
+	// _, err := waitAccountSettingsUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
+	// if err != nil {
+	// 	resp.Diagnostics.AddError(
+	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameAccountSettings, plan.ID.String(), err),
+	// 		err.Error(),
+	// 	)
+	// 	return
+	// }
+
+	// TIP: -- 6. Save the request plan to response state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *resourceAccountSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// TIP: ==== RESOURCE DELETE ====
+	// Most resources have Delete functions. There are rare situations
+	// where you might not need a delete:
+	// a. The AWS API does not provide a way to delete the resource
+	// b. The point of your resource is to perform an action (e.g., reboot a
+	//    server) and deleting serves no purpose.
+	//
+	// The Delete function should do the following things. Make sure there
+	// is a good reason if you don't do one of these.
+	//
+	// 1. Get a client connection to the relevant service
+	// 2. Fetch the state
+	// 3. Populate a delete input structure
+	// 4. Call the AWS delete function
+	// 5. Use a waiter to wait for delete to complete
+	// TIP: -- 1. Get a client connection to the relevant service
+
+	// TIP: -- 2. Fetch the state
+	var state resourceAccountSettingsModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// TIP: ==== TERRAFORM IMPORTING ====
+// If Read can get all the information it needs from the Identifier
+// (i.e., path.Root("id")), you can use the PassthroughID importer. Otherwise,
+// you'll need a custom import function.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/resources/import
+func (r *resourceAccountSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("account_name"), req, resp)
+}
+
+
+// TIP: ==== STATUS CONSTANTS ====
+// Create constants for states and statuses if the service does not
+// already have suitable constants. We prefer that you use the constants
+// provided in the service if available (e.g., awstypes.StatusInProgress).
+const (
+	statusChangePending = "Pending"
+	statusDeleting      = "Deleting"
+	statusNormal        = "Normal"
+	statusUpdated       = "Updated"
+)
+
+// TIP: ==== WAITERS ====
+// Some resources of some services have waiters provided by the AWS API.
+// Unless they do not work properly, use them rather than defining new ones
+// here.
+//
+// Sometimes we define the wait, status, and find functions in separate
+// files, wait.go, status.go, and find.go. Follow the pattern set out in the
+// service and define these where it makes the most sense.
+//
+// If these functions are used in the _test.go file, they will need to be
+// exported (i.e., capitalized).
+//
+// You will need to adjust the parameters and names to fit the service.
+// func waitAccountSettingsCreated(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending:                   []string{},
+// 		Target:                    []string{statusNormal},
+// 		Refresh:                   statusAccountSettings(ctx, conn, id),
+// 		Timeout:                   timeout,
+// 		NotFoundChecks:            20,
+// 		ContinuousTargetOccurence: 2,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// TIP: It is easier to determine whether a resource is updated for some
+// resources than others. The best case is a status flag that tells you when
+// the update has been fully realized. Other times, you can check to see if a
+// key resource argument is updated to a new value or not.
+// func waitAccountSettingsUpdated(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending:                   []string{statusChangePending},
+// 		Target:                    []string{statusUpdated},
+// 		Refresh:                   statusAccountSettings(ctx, conn, id),
+// 		Timeout:                   timeout,
+// 		NotFoundChecks:            20,
+// 		ContinuousTargetOccurence: 2,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// TIP: A deleted waiter is almost like a backwards created waiter. There may
+// be additional pending states, however.
+// func waitAccountSettingsDeleted(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
+// 	stateConf := &retry.StateChangeConf{
+// 		Pending:                   []string{statusDeleting, statusNormal},
+// 		Target:                    []string{},
+// 		Refresh:                   statusAccountSettings(ctx, conn, id),
+// 		Timeout:                   timeout,
+// 	}
+
+// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
+// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
+// 		return out, err
+// 	}
+
+// 	return nil, err
+// }
+
+// TIP: ==== STATUS ====
+// The status function can return an actual status when that field is
+// available from the API (e.g., out.Status). Otherwise, you can use custom
+// statuses to communicate the states of the resource.
+//
+// Waiters consume the values returned by status functions. Design status so
+// that it can be reused by a create, update, and delete waiter, if possible.
+func statusAccountSettings(ctx context.Context, conn *quicksight.Client, id string) retry.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		out, err := findAccountSettingsByID(ctx, conn, id)
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return out, aws.ToString(out.AccountName), nil
+	}
+}
+
+// TIP: ==== FINDERS ====
+// The find function is not strictly necessary. You could do the API
+// request from the status function. However, we have found that find often
+// comes in handy in other places besides the status function. As a result, it
+// is good practice to define it separately.
+func findAccountSettingsByID(ctx context.Context, conn *quicksight.Client, id string) (*awstypes.AccountSettings, error) {
+	input := quicksight.DescribeAccountSettingsInput{
+		AwsAccountId: aws.String(id),
+	}
+
+	out, err := conn.DescribeAccountSettings(ctx, &input)
+	if err != nil {
+		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+			return nil, &retry.NotFoundError{
+				LastError:   err,
+				LastRequest: &input,
+			}
+		}
+
+		return nil, err
+	}
+
+	if out == nil || out.AccountSettings == nil {
+		return nil, tfresource.NewEmptyResultError(&input)
+	}
+
+	return out.AccountSettings, nil
+}
+
+// TIP: ==== DATA STRUCTURES ====
+// With Terraform Plugin-Framework configurations are deserialized into
+// Go types, providing type safety without the need for type assertions.
+// These structs should match the schema definition exactly, and the `tfsdk`
+// tag value should match the attribute name. 
+//
+// Nested objects are represented in their own data struct. These will 
+// also have a corresponding attribute type mapping for use inside flex
+// functions.
+//
+// See more:
+// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
+type resourceAccountSettingsModel struct {
+	AccountName types.String `tfsdk:"account_name"`
+	DefaultNamespace types.String `tfsdk:"default_namespace"`
+	Edition types.String `tfsdk:"edition"`
+	ID              types.String                                          `tfsdk:"id"`
+	NotificationEmail types.String `tfsdk:"notification_email"`
+	PublicSharingEnabled types.Bool `tfsdk:"public_sharing_enabled"`
+	TerminationProtectionEnabled types.Bool `tfsdk:"termination_protection_enabled"`
+	Timeouts       timeouts.Value `tfsdk:"timeouts"`
+}

--- a/internal/service/quicksight/account_settings.go
+++ b/internal/service/quicksight/account_settings.go
@@ -2,36 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package quicksight
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/quicksight/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// awstypes.<Type Name>.
 	"context"
 	"time"
 
@@ -42,7 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -52,26 +27,11 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
-// TIP: ==== FILE STRUCTURE ====
-// All resources should follow this basic outline. Improve this resource's
-// maintainability by sticking to it.
-//
-// 1. Package declaration
-// 2. Imports
-// 3. Main resource struct with schema method
-// 4. Create, read, update, delete methods (in that order)
-// 5. Other functions (flatteners, expanders, waiters, finders, etc.)
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_quicksight_account_settings", name="Account Settings")
 func newResourceAccountSettings(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &resourceAccountSettings{}
 
-	// TIP: ==== CONFIGURABLE TIMEOUTS ====
-	// Users can configure timeout lengths but you need to use the times they
-	// provide. Access the timeout they configure (or the defaults) using,
-	// e.g., r.CreateTimeout(ctx, plan.Timeouts) (see below). The times here are
-	// the defaults if they don't configure timeouts.
 	r.SetDefaultCreateTimeout(5 * time.Minute)
 	r.SetDefaultUpdateTimeout(5 * time.Minute)
 	r.SetDefaultDeleteTimeout(5 * time.Minute)
@@ -88,90 +48,30 @@ type resourceAccountSettings struct {
 	framework.WithTimeouts
 }
 
-
-// TIP: ==== SCHEMA ====
-// In the schema, add each of the attributes in snake case (e.g.,
-// delete_automated_backups).
-//
-// Formatting rules:
-// * Alphabetize attributes to make them easier to find.
-// * Do not add a blank line between attributes.
-//
-// Attribute basics:
-// * If a user can provide a value ("configure a value") for an
-//   attribute (e.g., instances = 5), we call the attribute an
-//   "argument."
-// * You change the way users interact with attributes using:
-//     - Required
-//     - Optional
-//     - Computed
-// * There are only four valid combinations:
-//
-// 1. Required only - the user must provide a value
-// Required: true,
-//
-// 2. Optional only - the user can configure or omit a value; do not
-//    use Default or DefaultFunc
-// Optional: true,
-//
-// 3. Computed only - the provider can provide a value but the user
-//    cannot, i.e., read-only
-// Computed: true,
-//
-// 4. Optional AND Computed - the provider or user can provide a value;
-//    use this combination if you are using Default
-// Optional: true,
-// Computed: true,
-//
-// You will typically find arguments in the input struct
-// (e.g., CreateDBInstanceInput) for the create operation. Sometimes
-// they are only in the input struct (e.g., ModifyDBInstanceInput) for
-// the modify operation.
-//
-// For more about schema options, visit
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/schemas?page=schemas
 func (r *resourceAccountSettings) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
-			"account_name": schema.StringAttribute{
-				Computed: true,
-			},
 			"default_namespace": schema.StringAttribute{
-				Optional: true,
-				Default:  stringdefault.StaticString("default"),
-			},
-			"edition": schema.StringAttribute{
 				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
-			"notification_email": schema.StringAttribute{
+			"reset_on_delete": schema.BoolAttribute{
 				Optional: true,
-			},
-			"public_sharing_enabled": schema.BoolAttribute{
-				Computed: true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
+				DeprecationMessage: `The "reset_on_delete" attribute will be removed in a future version of the provider`,
 			},
 			"termination_protection_enabled": schema.BoolAttribute{
 				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
 			},
-			// "name": schema.StringAttribute{
-			// 	Required: true,
-			// 	// TIP: ==== PLAN MODIFIERS ====
-			// 	// Plan modifiers were introduced with Plugin-Framework to provide a mechanism
-			// 	// for adjusting planned changes prior to apply. The planmodifier subpackage
-			// 	// provides built-in modifiers for many common use cases such as 
-			// 	// requiring replacement on a value change ("ForceNew: true" in Plugin-SDK 
-			// 	// resources).
-			// 	//
-			// 	// See more:
-			// 	// https://developer.hashicorp.com/terraform/plugin/framework/resources/plan-modification
-			// 	PlanModifiers: []planmodifier.String{
-			// 		stringplanmodifier.RequiresReplace(),
-			// 	},
-			// },
-			// "type": schema.StringAttribute{
-			// 	Required: true,
-			// },
 		},
+
 		Blocks: map[string]schema.Block{
 			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
@@ -182,90 +82,38 @@ func (r *resourceAccountSettings) Schema(ctx context.Context, req resource.Schem
 }
 
 func (r *resourceAccountSettings) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	// TIP: ==== RESOURCE CREATE ====
-	// Generally, the Create function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan
-	// 3. Populate a create input structure
-	// 4. Call the AWS create/put function
-	// 5. Using the output from the create function, set the minimum arguments
-	//    and attributes for the Read function to work, as well as any computed
-	//    only attributes. 
-	// 6. Use a waiter to wait for create to complete
-	// 7. Save the request plan to response state
-
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().QuickSightClient(ctx)
-
-	// TIP: -- 2. Fetch the plan
+	awsAccountID := r.Meta().AccountID(ctx)
 	var plan resourceAccountSettingsModel
+
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// TIP: -- 3. Populate a Create input structure
-	awsAccountId := r.Meta().AccountID(ctx)
 	input := quicksight.UpdateAccountSettingsInput{
-		AwsAccountId: &awsAccountId,
-	}
-
-	if !plan.DefaultNamespace.IsNull() {
-		input.DefaultNamespace = plan.DefaultNamespace.ValueStringPointer()
-	}
-
-	if !plan.NotificationEmail.IsNull() {
-		input.NotificationEmail = plan.NotificationEmail.ValueStringPointer()
+		AwsAccountId: &awsAccountID,
+		// API currently does not support overriding default namespace, but requires for API call
+		DefaultNamespace: aws.String("default"),
 	}
 
 	if !plan.TerminationProtectionEnabled.IsNull() {
 		input.TerminationProtectionEnabled = plan.TerminationProtectionEnabled.ValueBool()
 	}
 
-	// TIP: Using a field name prefix allows mapping fields such as `ID` to `AccountSettingsId`
-	// resp.Diagnostics.Append(flex.Expand(ctx, plan, &input, flex.WithFieldNamePrefix("AccountSettings"))...)
-	// if resp.Diagnostics.HasError() {
-	// 	return
-	// }
-
-
-	// TIP: -- 4. Call the AWS Create function
-	// out, err := conn.UpdateAccountSettings(ctx, &input)
-	// if err != nil {
-	// 	// TIP: Since ID has not been set yet, you cannot use plan.ID.String()
-	// 	// in error messages at this point.
-	// 	resp.Diagnostics.AddError(
-	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameAccountSettings, plan.AccountName.String(), err),
-	// 		err.Error(),
-	// 	)
-	// 	return
-	// }
-	// if out == nil {
-	// 	resp.Diagnostics.AddError(
-	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionCreating, ResNameAccountSettings, plan.AccountName.String(), nil),
-	// 		errors.New("empty output").Error(),
-	// 	)
-	// 	return
-	// }
-
-	// TIP: -- 5. Using the output from the create function, set attributes
-
-
-	// TIP: -- 6. Use a waiter to wait for create to complete
 	createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
-	// _, err = waitAccountSettingsCreated(ctx, conn, plan.ID.ValueString(), createTimeout)
-	// if err != nil {
-	// 	resp.Diagnostics.AddError(
-	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionWaitingForCreation, ResNameAccountSettings, plan.ID.String(), err),
-	// 		err.Error(),
-	// 	)
-	// 	return
-	// }
 	output, err := tfresource.RetryGWhen(ctx, createTimeout,
-		func() (*quicksight.UpdateAccountSettingsOutput, error) {
-			return conn.UpdateAccountSettings(ctx, &input)
+		func() (*quicksight.DescribeAccountSettingsOutput, error) {
+			_, err := conn.UpdateAccountSettings(ctx, &input)
+			if err != nil {
+				return nil, err
+			}
+
+			input := quicksight.DescribeAccountSettingsInput{
+				AwsAccountId: aws.String(awsAccountID),
+			}
+
+			return conn.DescribeAccountSettings(ctx, &input)
 		},
 		func(err error) (bool, error) {
 			if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "You don't have access to this item.\n  The provided credentials couldn't be validated.\n  You might not be authorized to carry out the request.\n  Make sure that your account is authorized to use the Amazon QuickSight service, that your policies have the correct permissions, and that you are using the correct credentials.") {
@@ -277,13 +125,13 @@ func (r *resourceAccountSettings) Create(ctx context.Context, req resource.Creat
 			if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "One or more parameters has a value that isn't valid.") {
 				return true, err
 			}
-			if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found."){
+			if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found.") {
 				return true, err
 			}
-			if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable."){
+			if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable.") {
 				return true, err
 			}
-			if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled."){
+			if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled.") {
 				return true, err
 			}
 			return false, err
@@ -294,42 +142,28 @@ func (r *resourceAccountSettings) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	resp.Diagnostics.Append(flex.Flatten(ctx, output, &plan)...)
+	resp.Diagnostics.Append(flex.Flatten(ctx, output.AccountSettings, &plan)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// TIP: -- 7. Save the request plan to response state
+	plan.ID = types.StringValue(awsAccountID)
+	plan.DefaultNamespace = types.StringValue("default")
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
 func (r *resourceAccountSettings) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	// TIP: ==== RESOURCE READ ====
-	// Generally, the Read function should do the following things. Make
-	// sure there is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Get the resource from AWS
-	// 4. Remove resource from state if it is not found
-	// 5. Set the arguments and attributes
-	// 6. Set the state
-
-	// TIP: -- 1. Get a client connection to the relevant service
 	conn := r.Meta().QuickSightClient(ctx)
 	awsAccountID := r.Meta().AccountID(ctx)
-
-	// TIP: -- 2. Fetch the state
 	var state resourceAccountSettingsModel
+
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// TIP: -- 3. Get the resource from AWS using an API Get, List, or Describe-
-	// type function, or, better yet, using a finder.
 	out, err := findAccountSettingsByID(ctx, conn, awsAccountID)
-	// TIP: -- 4. Remove resource from state if it is not found
 	if tfresource.NotFound(err) {
 		resp.State.RemoveResource(ctx)
 		return
@@ -342,50 +176,25 @@ func (r *resourceAccountSettings) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	// TIP: -- 5. Set the arguments and attributes
 	resp.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// TIP: -- 6. Set the state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *resourceAccountSettings) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// TIP: ==== RESOURCE UPDATE ====
-	// Not all resources have Update functions. There are a few reasons:
-	// a. The AWS API does not support changing a resource
-	// b. All arguments have RequiresReplace() plan modifiers
-	// c. The AWS API uses a create call to modify an existing resource
-	//
-	// In the cases of a. and b., the resource will not have an update method
-	// defined. In the case of c., Update and Create can be refactored to call
-	// the same underlying function.
-	//
-	// The rest of the time, there should be an Update function and it should
-	// do the following things. Make sure there is a good reason if you don't
-	// do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the plan and state
-	// 3. Populate a modify input structure and check for changes
-	// 4. Call the AWS modify/update function
-	// 5. Use a waiter to wait for update to complete
-	// 6. Save the request plan to response state
-	// TIP: -- 1. Get a client connection to the relevant service
+
 	conn := r.Meta().QuickSightClient(ctx)
-
-
-	// TIP: -- 2. Fetch the plan
 	var plan, state resourceAccountSettingsModel
+
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// TIP: -- 3. Get the difference between the plan and state, if any
 	diff, d := flex.Diff(ctx, plan, state)
 	resp.Diagnostics.Append(d...)
 	if resp.Diagnostics.HasError() {
@@ -396,44 +205,30 @@ func (r *resourceAccountSettings) Update(ctx context.Context, req resource.Updat
 		awsAccountID := r.Meta().AccountID(ctx)
 		input := quicksight.UpdateAccountSettingsInput{
 			AwsAccountId: &awsAccountID,
+			// API currently does not support overriding default namespace, but requires for API call
+			DefaultNamespace: aws.String("default"),
 		}
 		if resp.Diagnostics.HasError() {
 			return
-		}
-
-		if !plan.DefaultNamespace.IsNull() {
-			input.DefaultNamespace = plan.DefaultNamespace.ValueStringPointer()
-		}
-
-		if !plan.NotificationEmail.IsNull() {
-			input.NotificationEmail = plan.NotificationEmail.ValueStringPointer()
 		}
 
 		if !plan.TerminationProtectionEnabled.IsNull() {
 			input.TerminationProtectionEnabled = plan.TerminationProtectionEnabled.ValueBool()
 		}
 
-		// TIP: -- 4. Call the AWS modify/update function
-		// out, err := conn.UpdateAccountSettings(ctx, &input)
-		// if err != nil {
-		// 	resp.Diagnostics.AddError(
-		// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameAccountSettings, plan.AccountName.String(), err),
-		// 		err.Error(),
-		// 	)
-		// 	return
-		// }
-		// if out == nil {
-		// 	resp.Diagnostics.AddError(
-		// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionUpdating, ResNameAccountSettings, plan.AccountName.String(), nil),
-		// 		errors.New("empty output").Error(),
-		// 	)
-		// 	return
-		// }
-
 		createTimeout := r.CreateTimeout(ctx, plan.Timeouts)
 		output, err := tfresource.RetryGWhen(ctx, createTimeout,
-			func() (*quicksight.UpdateAccountSettingsOutput, error) {
-				return conn.UpdateAccountSettings(ctx, &input)
+			func() (*quicksight.DescribeAccountSettingsOutput, error) {
+				_, err := conn.UpdateAccountSettings(ctx, &input)
+				if err != nil {
+					return nil, err
+				}
+
+				input := quicksight.DescribeAccountSettingsInput{
+					AwsAccountId: aws.String(awsAccountID),
+				}
+
+				return conn.DescribeAccountSettings(ctx, &input)
 			},
 			func(err error) (bool, error) {
 				if errs.IsAErrorMessageContains[*awstypes.AccessDeniedException](err, "You don't have access to this item.\n  The provided credentials couldn't be validated.\n  You might not be authorized to carry out the request.\n  Make sure that your account is authorized to use the Amazon QuickSight service, that your policies have the correct permissions, and that you are using the correct credentials.") {
@@ -445,13 +240,13 @@ func (r *resourceAccountSettings) Update(ctx context.Context, req resource.Updat
 				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "One or more parameters has a value that isn't valid.") {
 					return true, err
 				}
-				if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found."){
+				if errs.IsAErrorMessageContains[*awstypes.ResourceNotFoundException](err, "One or more resources can't be found.") {
 					return true, err
 				}
-				if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable."){
+				if errs.IsAErrorMessageContains[*awstypes.ResourceUnavailableException](err, "This resource is currently unavailable.") {
 					return true, err
 				}
-				if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled."){
+				if errs.IsAErrorMessageContains[*awstypes.ThrottlingException](err, "Access is throttled.") {
 					return true, err
 				}
 				return false, err
@@ -462,175 +257,69 @@ func (r *resourceAccountSettings) Update(ctx context.Context, req resource.Updat
 			return
 		}
 
-		// TIP: Using the output from the update function, re-set any computed attributes
-		resp.Diagnostics.Append(flex.Flatten(ctx, output, &plan)...)
+		resp.Diagnostics.Append(flex.Flatten(ctx, output.AccountSettings, &plan)...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 	}
 
-	// TIP: -- 5. Use a waiter to wait for update to complete
-	// updateTimeout := r.UpdateTimeout(ctx, plan.Timeouts)
-	// _, err := waitAccountSettingsUpdated(ctx, conn, plan.ID.ValueString(), updateTimeout)
-	// if err != nil {
-	// 	resp.Diagnostics.AddError(
-	// 		create.ProblemStandardMessage(names.QuickSight, create.ErrActionWaitingForUpdate, ResNameAccountSettings, plan.ID.String(), err),
-	// 		err.Error(),
-	// 	)
-	// 	return
-	// }
-
-	// TIP: -- 6. Save the request plan to response state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *resourceAccountSettings) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// TIP: ==== RESOURCE DELETE ====
-	// Most resources have Delete functions. There are rare situations
-	// where you might not need a delete:
-	// a. The AWS API does not provide a way to delete the resource
-	// b. The point of your resource is to perform an action (e.g., reboot a
-	//    server) and deleting serves no purpose.
-	//
-	// The Delete function should do the following things. Make sure there
-	// is a good reason if you don't do one of these.
-	//
-	// 1. Get a client connection to the relevant service
-	// 2. Fetch the state
-	// 3. Populate a delete input structure
-	// 4. Call the AWS delete function
-	// 5. Use a waiter to wait for delete to complete
-	// TIP: -- 1. Get a client connection to the relevant service
-
-	// TIP: -- 2. Fetch the state
 	var state resourceAccountSettingsModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-}
 
-// TIP: ==== TERRAFORM IMPORTING ====
-// If Read can get all the information it needs from the Identifier
-// (i.e., path.Root("id")), you can use the PassthroughID importer. Otherwise,
-// you'll need a custom import function.
-//
-// See more:
-// https://developer.hashicorp.com/terraform/plugin/framework/resources/import
-func (r *resourceAccountSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	resource.ImportStatePassthroughID(ctx, path.Root("account_name"), req, resp)
-}
-
-
-// TIP: ==== STATUS CONSTANTS ====
-// Create constants for states and statuses if the service does not
-// already have suitable constants. We prefer that you use the constants
-// provided in the service if available (e.g., awstypes.StatusInProgress).
-const (
-	statusChangePending = "Pending"
-	statusDeleting      = "Deleting"
-	statusNormal        = "Normal"
-	statusUpdated       = "Updated"
-)
-
-// TIP: ==== WAITERS ====
-// Some resources of some services have waiters provided by the AWS API.
-// Unless they do not work properly, use them rather than defining new ones
-// here.
-//
-// Sometimes we define the wait, status, and find functions in separate
-// files, wait.go, status.go, and find.go. Follow the pattern set out in the
-// service and define these where it makes the most sense.
-//
-// If these functions are used in the _test.go file, they will need to be
-// exported (i.e., capitalized).
-//
-// You will need to adjust the parameters and names to fit the service.
-// func waitAccountSettingsCreated(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending:                   []string{},
-// 		Target:                    []string{statusNormal},
-// 		Refresh:                   statusAccountSettings(ctx, conn, id),
-// 		Timeout:                   timeout,
-// 		NotFoundChecks:            20,
-// 		ContinuousTargetOccurence: 2,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// TIP: It is easier to determine whether a resource is updated for some
-// resources than others. The best case is a status flag that tells you when
-// the update has been fully realized. Other times, you can check to see if a
-// key resource argument is updated to a new value or not.
-// func waitAccountSettingsUpdated(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending:                   []string{statusChangePending},
-// 		Target:                    []string{statusUpdated},
-// 		Refresh:                   statusAccountSettings(ctx, conn, id),
-// 		Timeout:                   timeout,
-// 		NotFoundChecks:            20,
-// 		ContinuousTargetOccurence: 2,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// TIP: A deleted waiter is almost like a backwards created waiter. There may
-// be additional pending states, however.
-// func waitAccountSettingsDeleted(ctx context.Context, conn *quicksight.Client, id string, timeout time.Duration) (*awstypes.AccountSettings, error) {
-// 	stateConf := &retry.StateChangeConf{
-// 		Pending:                   []string{statusDeleting, statusNormal},
-// 		Target:                    []string{},
-// 		Refresh:                   statusAccountSettings(ctx, conn, id),
-// 		Timeout:                   timeout,
-// 	}
-
-// 	outputRaw, err := stateConf.WaitForStateContext(ctx)
-// 	if out, ok := outputRaw.(*quicksight.AccountSettings); ok {
-// 		return out, err
-// 	}
-
-// 	return nil, err
-// }
-
-// TIP: ==== STATUS ====
-// The status function can return an actual status when that field is
-// available from the API (e.g., out.Status). Otherwise, you can use custom
-// statuses to communicate the states of the resource.
-//
-// Waiters consume the values returned by status functions. Design status so
-// that it can be reused by a create, update, and delete waiter, if possible.
-func statusAccountSettings(ctx context.Context, conn *quicksight.Client, id string) retry.StateRefreshFunc {
-	return func() (interface{}, string, error) {
-		out, err := findAccountSettingsByID(ctx, conn, id)
-		if tfresource.NotFound(err) {
-			return nil, "", nil
+	if state.ResetOnDelete.ValueBool() {
+		conn := r.Meta().QuickSightClient(ctx)
+		awsAccountID := r.Meta().AccountID(ctx)
+		input := quicksight.UpdateAccountSettingsInput{
+			AwsAccountId:                 &awsAccountID,
+			TerminationProtectionEnabled: true,
+			DefaultNamespace:             aws.String("default"),
 		}
 
+		_, err := conn.UpdateAccountSettings(ctx, &input)
 		if err != nil {
-			return nil, "", err
+			resp.Diagnostics.AddError("resetting Quicksight Account Settings", err.Error())
+			return
 		}
-
-		return out, aws.ToString(out.AccountName), nil
+	} else {
+		resp.Diagnostics.AddWarning(
+			"Resource Destruction",
+			"This resource has only been removed from Terraform state. "+
+				"Manually use the AWS Console to fully destroy this resource. "+
+				"Setting the attribute \"reset_on_delete\" will also fully destroy resources of this type.",
+		)
 	}
 }
 
-// TIP: ==== FINDERS ====
-// The find function is not strictly necessary. You could do the API
-// request from the status function. However, we have found that find often
-// comes in handy in other places besides the status function. As a result, it
-// is good practice to define it separately.
+func (r *resourceAccountSettings) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if req.Plan.Raw.IsNull() {
+		var resetOnDelete types.Bool
+		resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("reset_on_delete"), &resetOnDelete)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		if !resetOnDelete.ValueBool() {
+			resp.Diagnostics.AddWarning(
+				"Resource Destruction",
+				"Applying this resource destruction will only remove the resource from Terraform state and will not reset account settings. "+
+					"Either manually use the AWS Console to fully destroy this resource or "+
+					"update the resource with \"reset_on_delete\" set to true.",
+			)
+		}
+	}
+}
+
+func (r *resourceAccountSettings) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), req, resp)
+}
+
 func findAccountSettingsByID(ctx context.Context, conn *quicksight.Client, id string) (*awstypes.AccountSettings, error) {
 	input := quicksight.DescribeAccountSettingsInput{
 		AwsAccountId: aws.String(id),
@@ -655,25 +344,10 @@ func findAccountSettingsByID(ctx context.Context, conn *quicksight.Client, id st
 	return out.AccountSettings, nil
 }
 
-// TIP: ==== DATA STRUCTURES ====
-// With Terraform Plugin-Framework configurations are deserialized into
-// Go types, providing type safety without the need for type assertions.
-// These structs should match the schema definition exactly, and the `tfsdk`
-// tag value should match the attribute name. 
-//
-// Nested objects are represented in their own data struct. These will 
-// also have a corresponding attribute type mapping for use inside flex
-// functions.
-//
-// See more:
-// https://developer.hashicorp.com/terraform/plugin/framework/handling-data/accessing-values
 type resourceAccountSettingsModel struct {
-	AccountName types.String `tfsdk:"account_name"`
-	DefaultNamespace types.String `tfsdk:"default_namespace"`
-	Edition types.String `tfsdk:"edition"`
-	ID              types.String                                          `tfsdk:"id"`
-	NotificationEmail types.String `tfsdk:"notification_email"`
-	PublicSharingEnabled types.Bool `tfsdk:"public_sharing_enabled"`
-	TerminationProtectionEnabled types.Bool `tfsdk:"termination_protection_enabled"`
-	Timeouts       timeouts.Value `tfsdk:"timeouts"`
+	DefaultNamespace             types.String   `tfsdk:"default_namespace"`
+	ID                           types.String   `tfsdk:"id"`
+	ResetOnDelete                types.Bool     `tfsdk:"reset_on_delete"`
+	TerminationProtectionEnabled types.Bool     `tfsdk:"termination_protection_enabled"`
+	Timeouts                     timeouts.Value `tfsdk:"timeouts"`
 }

--- a/internal/service/quicksight/account_settings_test.go
+++ b/internal/service/quicksight/account_settings_test.go
@@ -2,225 +2,88 @@
 // SPDX-License-Identifier: MPL-2.0
 
 package quicksight_test
-// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
-//
-// TIP: ==== INTRODUCTION ====
-// Thank you for trying the skaff tool!
-//
-// You have opted to include these helpful comments. They all include "TIP:"
-// to help you find and remove them when you're done with them.
-//
-// While some aspects of this file are customized to your input, the
-// scaffold tool does *not* look at the AWS API and ensure it has correct
-// function, structure, and variable names. It makes guesses based on
-// commonalities. You will need to make significant adjustments.
-//
-// In other words, as generated, this is a rough outline of the work you will
-// need to do. If something doesn't make sense for your situation, get rid of
-// it.
 
 import (
-	// TIP: ==== IMPORTS ====
-	// This is a common set of imports but not customized to your code since
-	// your code hasn't been written yet. Make sure you, your IDE, or
-	// goimports -w <file> fixes these imports.
-	//
-	// The provider linter wants your imports to be in two groups: first,
-	// standard library (i.e., "fmt" or "strings"), second, everything else.
-	//
-	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
-	// using the services/quicksight/types package. If so, you'll
-	// need to import types and reference the nested types, e.g., as
-	// types.<Type Name>.
 	"context"
 	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/quicksight"
 	"github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 
-	// TIP: You will often need to import the package that this test file lives
-	// in. Since it is in the "test" context, it must import the package to use
-	// any normal context constants, variables, or functions.
 	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
 )
 
-// TIP: File Structure. The basic outline for all test files should be as
-// follows. Improve this resource's maintainability by following this
-// outline.
-//
-// 1. Package declaration (add "_test" since this is a test file)
-// 2. Imports
-// 3. Unit tests
-// 4. Basic test
-// 5. Disappears test
-// 6. All the other tests
-// 7. Helper functions (exists, destroy, check, etc.)
-// 8. Functions that return Terraform configurations
-
-// TIP: ==== UNIT TESTS ====
-// This is an example of a unit test. Its name is not prefixed with
-// "TestAcc" like an acceptance test.
-//
-// Unlike acceptance tests, unit tests do not access AWS and are focused on a
-// function (or method). Because of this, they are quick and cheap to run.
-//
-// In designing a resource's implementation, isolate complex bits from AWS bits
-// so that they can be tested through a unit test. We encourage more unit tests
-// in the provider.
-//
-// Cut and dry functions using well-used patterns, like typical flatteners and
-// expanders, don't need unit testing. However, if they are complex or
-// intricate, they should be unit tested.
-func TestAccountSettingsExampleUnitTest(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		TestName string
-		Input    string
-		Expected string
-		Error    bool
-	}{
-		{
-			TestName: "empty",
-			Input:    "",
-			Expected: "",
-			Error:    true,
-		},
-		{
-			TestName: "descriptive name",
-			Input:    "some input",
-			Expected: "some output",
-			Error:    false,
-		},
-		{
-			TestName: "another descriptive name",
-			Input:    "more input",
-			Expected: "more output",
-			Error:    false,
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.TestName, func(t *testing.T) {
-			t.Parallel()
-			got, err := tfquicksight.FunctionFromResource(testCase.Input)
-
-			if err != nil && !testCase.Error {
-				t.Errorf("got error (%s), expected no error", err)
-			}
-
-			if err == nil && testCase.Error {
-				t.Errorf("got (%s) and no error, expected error", got)
-			}
-
-			if got != testCase.Expected {
-				t.Errorf("got %s, expected %s", got, testCase.Expected)
-			}
-		})
-	}
-}
-
-// TIP: ==== ACCEPTANCE TESTS ====
-// This is an example of a basic acceptance test. This should test as much of
-// standard functionality of the resource as possible, and test importing, if
-// applicable. We prefix its name with "TestAcc", the service, and the
-// resource name.
-//
-// Acceptance test access AWS and cost money to run.
 func TestAccQuickSightAccountSettings_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	// TIP: This is a long-running test guard for tests that run longer than
-	// 300s (5 min) generally.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var accountsettings quicksight.DescribeAccountSettingsResponse
+	var accountsettings awstypes.AccountSettings
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_quicksight_account_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.QuickSightEndpointID)
-			testAccPreCheck(ctx, t)
-		},
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountSettingsDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccountSettingsConfig_basic(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: testAccAccountSettings_basic(rName),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAccountSettingsExists(ctx, resourceName, &accountsettings),
-					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
-					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
-					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
-						"console_access": "false",
-						"groups.#":       "0",
-						"username":       "Test",
-						"password":       "TestTest1234",
-					}),
-					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
-					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "quicksight", regexache.MustCompile(`accountsettings:.+$`)),
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+				ResourceName: resourceName,
+				ImportState:  false,
+				RefreshState: true,
 			},
 		},
 	})
 }
 
-func TestAccQuickSightAccountSettings_disappears(t *testing.T) {
+func TestAccQuickSightAccountSettings_resetOnDelete_false(t *testing.T) {
 	ctx := acctest.Context(t)
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var accountsettings quicksight.DescribeAccountSettingsResponse
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_quicksight_account_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckPartitionHasService(t, names.QuickSightEndpointID)
-			testAccPreCheck(ctx, t)
-		},
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckAccountSettingsDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAccountSettingsConfig_basic(rName, testAccAccountSettingsVersionNewer),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAccountSettingsExists(ctx, resourceName, &accountsettings),
-					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
-					// but expects a new resource factory function as the third argument. To expose this
-					// private function to the testing package, you may need to add a line like the following
-					// to exports_test.go:
-					//
-					//   var ResourceAccountSettings = newResourceAccountSettings
-					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceAccountSettings, resourceName),
-				),
-				ExpectNonEmptyPlan: true,
+				Config: testAccAccountConfig_resetOnDelete(rName, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("termination_protection_enabled"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("reset_on_delete"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"reset_on_delete",
+				},
 			},
 		},
 	})
@@ -235,34 +98,39 @@ func testAccCheckAccountSettingsDestroy(ctx context.Context) resource.TestCheckF
 				continue
 			}
 
-
-			// TIP: ==== FINDERS ====
-			// The find function should be exported. Since it won't be used outside of the package, it can be exported
-			// in the `exports_test.go` file.
-			_, err := tfquicksight.FindAccountSettingsByID(ctx, conn, rs.Primary.ID)
+			settings, err := tfquicksight.FindAccountSettingsByID(ctx, conn, rs.Primary.ID)
 			if tfresource.NotFound(err) {
 				return nil
 			}
-			if err != nil {
-			        return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, err)
+
+			fmt.Println("testAccCheckAccountSettingsReset: ")
+			fmt.Println(settings)
+
+			if settings.AccountName == nil {
+				// Settings have not been reset
+				return nil
 			}
 
-			return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, errors.New("not destroyed"))
+			if err != nil {
+				return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, errors.New("Quicksight account settings were reset"))
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckAccountSettingsExists(ctx context.Context, name string, accountsettings *quicksight.DescribeAccountSettingsResponse) resource.TestCheckFunc {
+func testAccCheckAccountSettingsExists(ctx context.Context, n string, v *types.AccountSettings) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, name, errors.New("not found"))
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, n, errors.New("not found"))
 		}
 
 		if rs.Primary.ID == "" {
-			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, name, errors.New("not set"))
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, n, errors.New("not set"))
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightClient(ctx)
@@ -272,57 +140,44 @@ func testAccCheckAccountSettingsExists(ctx context.Context, name string, account
 			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, rs.Primary.ID, err)
 		}
 
-		*accountsettings = *resp
+		*v = *resp
 
 		return nil
 	}
 }
 
-func testAccPreCheck(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightClient(ctx)
-
-	input := &quicksight.ListAccountSettingssInput{}
-
-	_, err := conn.ListAccountSettingss(ctx, input)
-
-	if acctest.PreCheckSkipError(err) {
-		t.Skipf("skipping acceptance testing: %s", err)
-	}
-	if err != nil {
-		t.Fatalf("unexpected PreCheck error: %s", err)
-	}
-}
-
-func testAccCheckAccountSettingsNotRecreated(before, after *quicksight.DescribeAccountSettingsResponse) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if before, after := aws.ToString(before.AccountSettingsId), aws.ToString(after.AccountSettingsId); before != after {
-			return create.Error(names.QuickSight, create.ErrActionCheckingNotRecreated, tfquicksight.ResNameAccountSettings, aws.ToString(before.AccountSettingsId), errors.New("recreated"))
-		}
-
-		return nil
-	}
-}
-
-func testAccAccountSettingsConfig_basic(rName, version string) string {
+func testAccAccountSettings_base(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_security_group" "test" {
-  name = %[1]q
+resource "aws_quicksight_account_subscription" "test" {
+  account_name          = %[1]q
+  authentication_method = "IAM_AND_QUICKSIGHT"
+  edition               = "ENTERPRISE"
+  notification_email    = %[2]q
 }
+
+`, rName, acctest.DefaultEmailAddress)
+}
+
+func testAccAccountSettings_basic(rName string) string {
+	return acctest.ConfigCompose(
+		testAccAccountSettings_base(rName), `
 resource "aws_quicksight_account_settings" "test" {
-  account_settings_name             = %[1]q
-  engine_type             = "ActiveQuickSight"
-  engine_version          = %[2]q
-  host_instance_type      = "quicksight.t2.micro"
-  security_groups         = [aws_security_group.test.id]
-  authentication_strategy = "simple"
-  storage_type            = "efs"
-  logs {
-    general = true
-  }
-  user {
-    username = "Test"
-    password = "TestTest1234"
-  }
+  termination_protection_enabled = false
+
+  depends_on = [aws_quicksight_account_subscription.test]
 }
-`, rName, version)
+`)
+}
+
+func testAccAccountConfig_resetOnDelete(rName string, reset bool) string {
+	return acctest.ConfigCompose(
+		testAccAccountSettings_base(rName),
+		fmt.Sprintf(`
+resource "aws_quicksight_account_settings" "test" {
+  termination_protection_enabled = false
+  reset_on_delete                = %[1]t
+
+  depends_on = [aws_quicksight_account_subscription.test]
+}
+`, reset))
 }

--- a/internal/service/quicksight/account_settings_test.go
+++ b/internal/service/quicksight/account_settings_test.go
@@ -1,0 +1,328 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package quicksight_test
+// **PLEASE DELETE THIS AND ALL TIP COMMENTS BEFORE SUBMITTING A PR FOR REVIEW!**
+//
+// TIP: ==== INTRODUCTION ====
+// Thank you for trying the skaff tool!
+//
+// You have opted to include these helpful comments. They all include "TIP:"
+// to help you find and remove them when you're done with them.
+//
+// While some aspects of this file are customized to your input, the
+// scaffold tool does *not* look at the AWS API and ensure it has correct
+// function, structure, and variable names. It makes guesses based on
+// commonalities. You will need to make significant adjustments.
+//
+// In other words, as generated, this is a rough outline of the work you will
+// need to do. If something doesn't make sense for your situation, get rid of
+// it.
+
+import (
+	// TIP: ==== IMPORTS ====
+	// This is a common set of imports but not customized to your code since
+	// your code hasn't been written yet. Make sure you, your IDE, or
+	// goimports -w <file> fixes these imports.
+	//
+	// The provider linter wants your imports to be in two groups: first,
+	// standard library (i.e., "fmt" or "strings"), second, everything else.
+	//
+	// Also, AWS Go SDK v2 may handle nested structures differently than v1,
+	// using the services/quicksight/types package. If so, you'll
+	// need to import types and reference the nested types, e.g., as
+	// types.<Type Name>.
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/YakDriver/regexache"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/quicksight"
+	"github.com/aws/aws-sdk-go-v2/service/quicksight/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/names"
+
+	// TIP: You will often need to import the package that this test file lives
+	// in. Since it is in the "test" context, it must import the package to use
+	// any normal context constants, variables, or functions.
+	tfquicksight "github.com/hashicorp/terraform-provider-aws/internal/service/quicksight"
+)
+
+// TIP: File Structure. The basic outline for all test files should be as
+// follows. Improve this resource's maintainability by following this
+// outline.
+//
+// 1. Package declaration (add "_test" since this is a test file)
+// 2. Imports
+// 3. Unit tests
+// 4. Basic test
+// 5. Disappears test
+// 6. All the other tests
+// 7. Helper functions (exists, destroy, check, etc.)
+// 8. Functions that return Terraform configurations
+
+// TIP: ==== UNIT TESTS ====
+// This is an example of a unit test. Its name is not prefixed with
+// "TestAcc" like an acceptance test.
+//
+// Unlike acceptance tests, unit tests do not access AWS and are focused on a
+// function (or method). Because of this, they are quick and cheap to run.
+//
+// In designing a resource's implementation, isolate complex bits from AWS bits
+// so that they can be tested through a unit test. We encourage more unit tests
+// in the provider.
+//
+// Cut and dry functions using well-used patterns, like typical flatteners and
+// expanders, don't need unit testing. However, if they are complex or
+// intricate, they should be unit tested.
+func TestAccountSettingsExampleUnitTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		TestName string
+		Input    string
+		Expected string
+		Error    bool
+	}{
+		{
+			TestName: "empty",
+			Input:    "",
+			Expected: "",
+			Error:    true,
+		},
+		{
+			TestName: "descriptive name",
+			Input:    "some input",
+			Expected: "some output",
+			Error:    false,
+		},
+		{
+			TestName: "another descriptive name",
+			Input:    "more input",
+			Expected: "more output",
+			Error:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			t.Parallel()
+			got, err := tfquicksight.FunctionFromResource(testCase.Input)
+
+			if err != nil && !testCase.Error {
+				t.Errorf("got error (%s), expected no error", err)
+			}
+
+			if err == nil && testCase.Error {
+				t.Errorf("got (%s) and no error, expected error", got)
+			}
+
+			if got != testCase.Expected {
+				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+// TIP: ==== ACCEPTANCE TESTS ====
+// This is an example of a basic acceptance test. This should test as much of
+// standard functionality of the resource as possible, and test importing, if
+// applicable. We prefix its name with "TestAcc", the service, and the
+// resource name.
+//
+// Acceptance test access AWS and cost money to run.
+func TestAccQuickSightAccountSettings_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	// TIP: This is a long-running test guard for tests that run longer than
+	// 300s (5 min) generally.
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accountsettings quicksight.DescribeAccountSettingsResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_quicksight_account_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.QuickSightEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSettingsConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountSettingsExists(ctx, resourceName, &accountsettings),
+					resource.TestCheckResourceAttr(resourceName, "auto_minor_version_upgrade", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "maintenance_window_start_time.0.day_of_week"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "user.*", map[string]string{
+						"console_access": "false",
+						"groups.#":       "0",
+						"username":       "Test",
+						"password":       "TestTest1234",
+					}),
+					// TIP: If the ARN can be partially or completely determined by the parameters passed, e.g. it contains the
+					// value of `rName`, either include the values in the regex or check for an exact match using `acctest.CheckResourceAttrRegionalARN`
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "quicksight", regexache.MustCompile(`accountsettings:.+$`)),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"apply_immediately", "user"},
+			},
+		},
+	})
+}
+
+func TestAccQuickSightAccountSettings_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var accountsettings quicksight.DescribeAccountSettingsResponse
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_quicksight_account_settings.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.QuickSightEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAccountSettingsDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccountSettingsConfig_basic(rName, testAccAccountSettingsVersionNewer),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAccountSettingsExists(ctx, resourceName, &accountsettings),
+					// TIP: The Plugin-Framework disappears helper is similar to the Plugin-SDK version,
+					// but expects a new resource factory function as the third argument. To expose this
+					// private function to the testing package, you may need to add a line like the following
+					// to exports_test.go:
+					//
+					//   var ResourceAccountSettings = newResourceAccountSettings
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfquicksight.ResourceAccountSettings, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAccountSettingsDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_quicksight_account_settings" {
+				continue
+			}
+
+
+			// TIP: ==== FINDERS ====
+			// The find function should be exported. Since it won't be used outside of the package, it can be exported
+			// in the `exports_test.go` file.
+			_, err := tfquicksight.FindAccountSettingsByID(ctx, conn, rs.Primary.ID)
+			if tfresource.NotFound(err) {
+				return nil
+			}
+			if err != nil {
+			        return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, err)
+			}
+
+			return create.Error(names.QuickSight, create.ErrActionCheckingDestroyed, tfquicksight.ResNameAccountSettings, rs.Primary.ID, errors.New("not destroyed"))
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAccountSettingsExists(ctx context.Context, name string, accountsettings *quicksight.DescribeAccountSettingsResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, name, errors.New("not found"))
+		}
+
+		if rs.Primary.ID == "" {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, name, errors.New("not set"))
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightClient(ctx)
+
+		resp, err := tfquicksight.FindAccountSettingsByID(ctx, conn, rs.Primary.ID)
+		if err != nil {
+			return create.Error(names.QuickSight, create.ErrActionCheckingExistence, tfquicksight.ResNameAccountSettings, rs.Primary.ID, err)
+		}
+
+		*accountsettings = *resp
+
+		return nil
+	}
+}
+
+func testAccPreCheck(ctx context.Context, t *testing.T) {
+	conn := acctest.Provider.Meta().(*conns.AWSClient).QuickSightClient(ctx)
+
+	input := &quicksight.ListAccountSettingssInput{}
+
+	_, err := conn.ListAccountSettingss(ctx, input)
+
+	if acctest.PreCheckSkipError(err) {
+		t.Skipf("skipping acceptance testing: %s", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected PreCheck error: %s", err)
+	}
+}
+
+func testAccCheckAccountSettingsNotRecreated(before, after *quicksight.DescribeAccountSettingsResponse) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if before, after := aws.ToString(before.AccountSettingsId), aws.ToString(after.AccountSettingsId); before != after {
+			return create.Error(names.QuickSight, create.ErrActionCheckingNotRecreated, tfquicksight.ResNameAccountSettings, aws.ToString(before.AccountSettingsId), errors.New("recreated"))
+		}
+
+		return nil
+	}
+}
+
+func testAccAccountSettingsConfig_basic(rName, version string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "test" {
+  name = %[1]q
+}
+resource "aws_quicksight_account_settings" "test" {
+  account_settings_name             = %[1]q
+  engine_type             = "ActiveQuickSight"
+  engine_version          = %[2]q
+  host_instance_type      = "quicksight.t2.micro"
+  security_groups         = [aws_security_group.test.id]
+  authentication_strategy = "simple"
+  storage_type            = "efs"
+  logs {
+    general = true
+  }
+  user {
+    username = "Test"
+    password = "TestTest1234"
+  }
+}
+`, rName, version)
+}

--- a/internal/service/quicksight/exports_test.go
+++ b/internal/service/quicksight/exports_test.go
@@ -5,6 +5,7 @@ package quicksight
 
 // Exports for use in tests only.
 var (
+	ResourceAccountSettings     = newResourceAccountSettings
 	ResourceAccountSubscription = resourceAccountSubscription
 	ResourceAnalysis            = resourceAnalysis
 	ResourceDashboard           = resourceDashboard
@@ -29,6 +30,7 @@ var (
 	DefaultGroupNamespace                 = defaultGroupNamespace
 	DefaultIAMPolicyAssignmentNamespace   = defaultIAMPolicyAssignmentNamespace
 	DefaultUserNamespace                  = defaultUserNamespace
+	FindAccountSettingsByID               = findAccountSettingsByID
 	FindAccountSubscriptionByID           = findAccountSubscriptionByID
 	FindAnalysisByTwoPartKey              = findAnalysisByTwoPartKey
 	FindDashboardByThreePartKey           = findDashboardByThreePartKey

--- a/internal/service/quicksight/service_package_gen.go
+++ b/internal/service/quicksight/service_package_gen.go
@@ -21,6 +21,11 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.Serv
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {
 	return []*types.ServicePackageFrameworkResource{
 		{
+			Factory:  newResourceAccountSettings,
+			TypeName: "aws_quicksight_account_settings",
+			Name:     "Account Settings",
+		},
+		{
 			Factory:  newFolderMembershipResource,
 			TypeName: "aws_quicksight_folder_membership",
 			Name:     "Folder Membership",

--- a/website/docs/r/quicksight_account_settings.html.markdown
+++ b/website/docs/r/quicksight_account_settings.html.markdown
@@ -46,7 +46,7 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import QuickSight Account Settings using the AWS account ID `api-gateway-account`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import QuickSight Account Settings using the AWS account ID. For example:
 
 ```terraform
 import {
@@ -55,7 +55,7 @@ import {
 }
 ```
 
-Using `terraform import`, import QuickSight Account Settings using the AWS account ID `api-gateway-account`. For example:
+Using `terraform import`, import QuickSight Account Settings using the AWS account ID. For example:
 
 ```console
 % terraform import aws_quicksight_account_settings.example "012345678901"

--- a/website/docs/r/quicksight_account_settings.html.markdown
+++ b/website/docs/r/quicksight_account_settings.html.markdown
@@ -1,0 +1,62 @@
+---
+subcategory: "QuickSight"
+layout: "aws"
+page_title: "AWS: aws_quicksight_account_settings"
+description: |-
+  Terraform resource for managing an AWS QuickSight Account Settings.
+---
+
+# Resource: aws_quicksight_account_settings
+
+Terraform resource for managing an AWS QuickSight Account Settings.
+
+~> Due to the collision of the `notification_email` attribute of the [`aws_quicksight_account_subscription`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_account_subscription) resource and the [`UpdateAccountSettings`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateAccountSettings.html) API does not support updating the default namespace, this resource does not support their management.
+
+## Example Usage
+
+```terraform
+resource "aws_quicksight_account_subscription" "subscription" {
+  account_name          = "quicksight-terraform"
+  authentication_method = "IAM_AND_QUICKSIGHT"
+  edition               = "ENTERPRISE"
+  notification_email    = "notification@email.com"
+}
+
+resource "aws_quicksight_account_settings" "example" {
+  termination_protection_enabled = false
+
+  depends_on = [aws_quicksight_account_subscription.subscription]
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `termination_protection_enabled` - (Optional) A boolean value that determines whether or not an Amazon QuickSight account can be deleted. If `true`, it does not allow the account to be deleted and results in an error message if a user tries to make a DeleteAccountSubscription request. If `false`, it will allow the account to be deleted.
+* `reset_on_delete` - (Optional) If `true`, destroying the resource will reset the TerminationProtectionEnabled account settings to default of `true`, otherwise account settings are not modified.
+  Defaults to `false`.
+  Will be removed in a future major version of the provider.
+
+## Attribute Reference
+
+This resource exports the following attributes in addition to the arguments above:
+
+* `default_namespace` - The default namespace for this Amazon Web Services account. Currently, the default is default.
+
+## Import
+
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import QuickSight Account Settings using the AWS account ID `api-gateway-account`. For example:
+
+```terraform
+import {
+  to = aws_quicksight_account_settings.example
+  id = "012345678901"
+}
+```
+
+Using `terraform import`, import QuickSight Account Settings using the AWS account ID `api-gateway-account`. For example:
+
+```console
+% terraform import aws_quicksight_account_settings.example "012345678901"
+```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
* This pull request adds a new resource, `aws_quicksight_account_settings` that introduces support for managing the termination protection for an AWS Quicksight Account.

The proposed resource schema is as follows,

```terraform
resource "aws_quicksight_account_settings" "example" {
  termination_protection_enabled = false
}
```

As the API does support a native way of resetting this setting upon resource destroy, an optional attribute, `reset_on_delete` is proposed that when set to `true` will set the termination protection back to the default, `true`.

> [!NOTE]
> Although the [`UpdateAccountSettings`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateAccountSettings.html) API supports setting the notification email, due to the collision of the `notification_email` attribute of the [`aws_quicksight_account_subscription`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_account_subscription) resource, this attribute was chosen not be exposed.
>
> As the [`UpdateAccountSettings`](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateAccountSettings.html) API does not support updating the default namespace, this resource does not support their management.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41578

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* https://docs.aws.amazon.com/quicksight/latest/APIReference/API_UpdateAccountSettings.html
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_account_subscription


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccQuickSightAccountSettings_basic PKG=quicksight
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAccountSettings_basic'  -timeout 360m -vet=off
2025/04/09 19:36:46 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightAccountSettings_basic
--- PASS: TestAccQuickSightAccountSettings_basic (155.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 155.959s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.130s [no tests to run]
...

```console
% make testacc TESTS=TEST=TestAccQuickSightAccountSettings_resetOnDelete_false PKG=quicksight
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.7 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightAccountSettings_resetOnDelete_false'  -timeout 360m -vet=off
2025/04/09 19:36:46 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightAccountSettings_resetOnDelete_false
--- PASS: TestAccQuickSightAccountSettings_resetOnDelete_false (182.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 182.872s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.133s [no tests to run]
...
```
