### PR TITLE
[Enhancement] add `network_card_index` to `aws_network_interface` and `aws_network_interface_attachment`

### DIFF
--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -69,6 +69,11 @@ func resourceNetworkInterface() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
+						"network_card_index": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  0,
+						},
 					},
 				},
 			},
@@ -490,8 +495,14 @@ func resourceNetworkInterfaceCreate(ctx context.Context, d *schema.ResourceData,
 
 	if v, ok := d.GetOk("attachment"); ok && v.(*schema.Set).Len() > 0 {
 		attachment := v.(*schema.Set).List()[0].(map[string]any)
+		var networkCardIndex int
+		if attachment["network_card_index"] != nil {
+			networkCardIndex = attachment["network_card_index"].(int)
+		} else {
+			networkCardIndex = 0
+		}
 
-		_, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkInterfaceAttachedTimeout)
+		_, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkCardIndex, networkInterfaceAttachedTimeout)
 
 		if err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
@@ -600,8 +611,14 @@ func resourceNetworkInterfaceUpdate(ctx context.Context, d *schema.ResourceData,
 
 		if na != nil && na.(*schema.Set).Len() > 0 {
 			attachment := na.(*schema.Set).List()[0].(map[string]any)
+			var networkCardIndex int
+			if attachment["network_card_index"] != nil {
+				networkCardIndex = attachment["network_card_index"].(int)
+			} else {
+				networkCardIndex = 0
+			}
 
-			if _, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkInterfaceAttachedTimeout); err != nil {
+			if _, err := attachNetworkInterface(ctx, conn, d.Id(), attachment["instance"].(string), attachment["device_index"].(int), networkCardIndex, networkInterfaceAttachedTimeout); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)
 			}
 		}
@@ -1083,10 +1100,11 @@ func resourceNetworkInterfaceDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func attachNetworkInterface(ctx context.Context, conn *ec2.Client, networkInterfaceID, instanceID string, deviceIndex int, timeout time.Duration) (string, error) {
+func attachNetworkInterface(ctx context.Context, conn *ec2.Client, networkInterfaceID, instanceID string, deviceIndex int, networkCardIndex int, timeout time.Duration) (string, error) {
 	input := &ec2.AttachNetworkInterfaceInput{
 		DeviceIndex:        aws.Int32(int32(deviceIndex)),
 		InstanceId:         aws.String(instanceID),
+		NetworkCardIndex:   aws.Int32(int32(networkCardIndex)),
 		NetworkInterfaceId: aws.String(networkInterfaceID),
 	}
 
@@ -1211,6 +1229,10 @@ func flattenNetworkInterfaceAttachment(apiObject *types.NetworkInterfaceAttachme
 
 	if v := apiObject.InstanceId; v != nil {
 		tfMap["instance"] = aws.ToString(v)
+	}
+
+	if v := apiObject.NetworkCardIndex; v != nil {
+		tfMap["network_card_index"] = aws.ToInt32(v)
 	}
 
 	return tfMap

--- a/internal/service/ec2/vpc_network_interface_attachment.go
+++ b/internal/service/ec2/vpc_network_interface_attachment.go
@@ -40,6 +40,12 @@ func resourceNetworkInterfaceAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"network_card_index": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+				ForceNew: true,
+			},
 			names.AttrNetworkInterfaceID: {
 				Type:     schema.TypeString,
 				Required: true,
@@ -61,6 +67,7 @@ func resourceNetworkInterfaceAttachmentCreate(ctx context.Context, d *schema.Res
 		d.Get(names.AttrNetworkInterfaceID).(string),
 		d.Get(names.AttrInstanceID).(string),
 		d.Get("device_index").(int),
+		d.Get("network_card_index").(int),
 		networkInterfaceAttachedTimeout,
 	)
 
@@ -95,6 +102,7 @@ func resourceNetworkInterfaceAttachmentRead(ctx context.Context, d *schema.Resou
 	d.Set("attachment_id", network_interface.Attachment.AttachmentId)
 	d.Set("device_index", network_interface.Attachment.DeviceIndex)
 	d.Set(names.AttrInstanceID, network_interface.Attachment.InstanceId)
+	d.Set("network_card_index", network_interface.Attachment.NetworkCardIndex)
 	d.Set(names.AttrStatus, network_interface.Attachment.Status)
 
 	return diags

--- a/internal/service/ec2/vpc_network_interface_attachment_test.go
+++ b/internal/service/ec2/vpc_network_interface_attachment_test.go
@@ -5,6 +5,7 @@ package ec2_test
 
 import (
 	"fmt"
+	"github.com/YakDriver/regexache"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -33,6 +34,7 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "attachment_id"),
 					resource.TestCheckResourceAttr(resourceName, "device_index", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrInstanceID),
+					resource.TestCheckResourceAttr(resourceName, "network_card_index", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrNetworkInterfaceID),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 				),
@@ -41,6 +43,28 @@ func TestAccVPCNetworkInterfaceAttachment_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#network-cards.
+// Only specialized (and expensive) instance types support multiple network cards (and hence network_card_index > 0).
+// This test verifies that the resource is not created when a non-zero network_card_index is specified on an instance that does not support multiple network cards.
+// This ensures that network_card_index is passed when calling the AttachNetworkInterface API.
+func TestAccVPCNetworkInterfaceAttachment_networkCardIndex(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckENIDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccVPCNetworkInterfaceAttachmentConfig_networkCardIndex(rName),
+				ExpectError: regexache.MustCompile("NetworkCard index 1 exceeds the limit for"),
 			},
 		},
 	})
@@ -104,6 +128,71 @@ resource "aws_instance" "test" {
 
 resource "aws_network_interface_attachment" "test" {
   device_index         = 1
+  instance_id          = aws_instance.test.id
+  network_interface_id = aws_network_interface.test.id
+}
+`, rName))
+}
+
+func testAccVPCNetworkInterfaceAttachmentConfig_networkCardIndex(rName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		acctest.AvailableEC2InstanceTypeForRegion("t3.micro", "t2.micro"),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = aws_vpc.test.id
+  cidr_block        = "172.16.10.0/24"
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+  name   = %[1]q
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/16"]
+  }
+}
+
+resource "aws_network_interface" "test" {
+  subnet_id       = aws_subnet.test.id
+  private_ips     = ["172.16.10.100"]
+  security_groups = [aws_security_group.test.id]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = data.aws_ec2_instance_type_offering.available.instance_type
+  subnet_id     = aws_subnet.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_network_interface_attachment" "test" {
+  device_index         = 1
+  network_card_index   = 1
   instance_id          = aws_instance.test.id
   network_interface_id = aws_network_interface.test.id
 }


### PR DESCRIPTION
### Description
* The argument `network_card_index` has been added to `aws_network_interface` and `aws_network_interface_attachment`.
* The default value of  `network_card_index` is 0.

#### Acceptance Test
* Only specialized (and expensive) instance types support multiple network cards. Considering that, the newly introduced acc tests just verify that the resource is not created when a non-zero network_card_index is specified on an instance that does not support multiple network cards.
This ensures that network_card_index is passed when calling APIs.

### Relations
Closes #36527

### References


### Output from Acceptance Testing
```console
```
