### PR TITLE
Fix "Ssh" in variable name to "SSH" to comply with naming caps rule to prevent CI failure (Naming Scan Caps/AWS/EC2)

### DIFF
--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -1260,7 +1260,7 @@ const (
 	securityPolicyNameRestricted_2018_11        securityPolicyName = "TransferSecurityPolicy-Restricted-2018-11"
 	securityPolicyNameRestricted_2020_06        securityPolicyName = "TransferSecurityPolicy-Restricted-2020-06"
 	securityPolicyNameRestricted_2024_06        securityPolicyName = "TransferSecurityPolicy-Restricted-2024-06"
-	securityPolicyNameSshAuditCompliant_2025_02 securityPolicyName = "TransferSecurityPolicy-SshAuditCompliant-2025-02"
+	securityPolicyNameSSHAuditCompliant_2025_02 securityPolicyName = "TransferSecurityPolicy-SshAuditCompliant-2025-02"
 )
 
 func (securityPolicyName) Values() []securityPolicyName {
@@ -1281,6 +1281,6 @@ func (securityPolicyName) Values() []securityPolicyName {
 		securityPolicyNameRestricted_2018_11,
 		securityPolicyNameRestricted_2020_06,
 		securityPolicyNameRestricted_2024_06,
-		securityPolicyNameSshAuditCompliant_2025_02,
+		securityPolicyNameSSHAuditCompliant_2025_02,
 	}
 }


### PR DESCRIPTION
### Description
* Since #42164 was merged, the CI check *Naming Scan Caps/AWS/EC2* continues to fail.  
  * Example log: https://github.com/hashicorp/terraform-provider-aws/actions/runs/14372058248/job/40296841581?pr=42188  
* This is because a variable name containing *SSH* does not comply with the naming caps rule.  
* This PR fixes the variable name to prevent the CI check from failing.
  * It has been confirmed that the renamed variable is not referenced in any other files.

