### PR TITLE
docs: add missing policy to basic usage example

### DIFF
--- a/website/docs/r/sns_topic_subscription.html.markdown
+++ b/website/docs/r/sns_topic_subscription.html.markdown
@@ -22,17 +22,7 @@ Provides a resource for subscribing to SNS topics. Requires that an SNS topic ex
 
 ## Example Usage
 
-You can directly supply a topic and ARN by hand in the `topic_arn` property along with the queue ARN:
-
-```terraform
-resource "aws_sns_topic_subscription" "user_updates_sqs_target" {
-  topic_arn = "arn:aws:sns:us-west-2:432981146916:user-updates-topic"
-  protocol  = "sqs"
-  endpoint  = "arn:aws:sqs:us-west-2:432981146916:terraform-queue-too"
-}
-```
-
-Alternatively you can use the ARN properties of a managed SNS topic and SQS queue:
+### Basic usage
 
 ```terraform
 resource "aws_sns_topic" "user_updates" {
@@ -40,7 +30,8 @@ resource "aws_sns_topic" "user_updates" {
 }
 
 resource "aws_sqs_queue" "user_updates_queue" {
-  name = "user-updates-queue"
+  name   = "user-updates-queue"
+  policy = data.aws_iam_policy_document.sqs_queue_policy.json
 }
 
 resource "aws_sns_topic_subscription" "user_updates_sqs_target" {
@@ -48,7 +39,40 @@ resource "aws_sns_topic_subscription" "user_updates_sqs_target" {
   protocol  = "sqs"
   endpoint  = aws_sqs_queue.user_updates_queue.arn
 }
+
+data "aws_iam_policy_document" "sqs_queue_policy" {
+  policy_id = "arn:aws:sqs:us-west-2:123456789012:user_updates_queue/SQSDefaultPolicy"
+
+  statement {
+    sid    = "user_updates_sqs_target"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["sns.amazonaws.com"]
+    }
+
+    actions = [
+      "SQS:SendMessage",
+    ]
+
+    resources = [
+      "arn:aws:sqs:us-west-2:123456789012:user-updates-queue",
+    ]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+
+      values = [
+        aws_sns_topic.user_updates.arn,
+      ]
+    }
+  }
+}
 ```
+
+### Example Cross-account Subscription
 
 You can subscribe SNS topics to SQS queues in different Amazon accounts and regions:
 
@@ -72,7 +96,7 @@ variable "sqs" {
   }
 }
 
-data "aws_iam_policy_document" "sns-topic-policy" {
+data "aws_iam_policy_document" "sns_topic_policy" {
   policy_id = "__default_policy_ID"
 
   statement {
@@ -140,7 +164,7 @@ data "aws_iam_policy_document" "sns-topic-policy" {
   }
 }
 
-data "aws_iam_policy_document" "sqs-queue-policy" {
+data "aws_iam_policy_document" "sqs_queue_policy" {
   policy_id = "arn:aws:sqs:${var.sqs["region"]}:${var.sqs["account-id"]}:${var.sqs["name"]}/SQSDefaultPolicy"
 
   statement {
@@ -204,28 +228,28 @@ provider "aws" {
   }
 }
 
-resource "aws_sns_topic" "sns-topic" {
+resource "aws_sns_topic" "sns_topic" {
   provider     = aws.sns
   name         = var.sns["name"]
   display_name = var.sns["display_name"]
-  policy       = data.aws_iam_policy_document.sns-topic-policy.json
+  policy       = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
-resource "aws_sqs_queue" "sqs-queue" {
+resource "aws_sqs_queue" "sqs_queue" {
   provider = aws.sqs
   name     = var.sqs["name"]
-  policy   = data.aws_iam_policy_document.sqs-queue-policy.json
+  policy   = data.aws_iam_policy_document.sqs_queue_policy.json
 }
 
-resource "aws_sns_topic_subscription" "sns-topic" {
+resource "aws_sns_topic_subscription" "sns_topic" {
   provider  = aws.sns2sqs
-  topic_arn = aws_sns_topic.sns-topic.arn
+  topic_arn = aws_sns_topic.sns_topic.arn
   protocol  = "sqs"
-  endpoint  = aws_sqs_queue.sqs-queue.arn
+  endpoint  = aws_sqs_queue.sqs_queue.arn
 }
 ```
 
-## Example with Delivery Policy
+### Example with Delivery Policy
 
 This example demonstrates how to define a `delivery_policy` for an HTTPS subscription. Unlike the `aws_sns_topic` resource, the `delivery_policy` for `aws_sns_topic_subscription` should not be wrapped in an `"http"` object.
 


### PR DESCRIPTION
### Description

The documentation for the resource [aws_sns_topic_subscription](`aws_sns_topic_subscription`) contains examples for forwarding SNS messages to an SQS queue.  The examples are missing the required policies to actually make the forwarding work. This issue was pointed out in #40863.

This pull request 

- adds the missing policy to one of the SNS-SQS examples
- removes one of the two examples for SNS-SQS.  The removed example uses hard coded strings and content-wise I see it covered by the example we fix.
- introduces subsections (`###`)  to separate the examples for basic usage and cross-account subscription. In addition, the section level for _Example with Delivery Policy_ was adjusted from 2 to 3  to match the document structure
- Resource names in the cross account subscription were slightly adjusted to match the resource naming convention

### Relations

Closes #40863 

### References

### Output from Acceptance Testing

Not applicable, only documentation is updated.