### PR TITLE
docs: fixed missing required name-argument in example

### DIFF
--- a/website/docs/r/backup_restore_testing_plan.html.markdown
+++ b/website/docs/r/backup_restore_testing_plan.html.markdown
@@ -15,6 +15,8 @@ Terraform resource for managing an AWS Backup Restore Testing Plan.
 
 ```terraform
 resource "aws_backup_restore_testing_plan" "example" {
+  name = "example_restore_testing_plan"
+  
   recovery_point_selection {
     algorithm            = "LATEST_WITHIN_WINDOW"
     include_vaults       = ["*"]

--- a/website/docs/r/backup_restore_testing_plan.html.markdown
+++ b/website/docs/r/backup_restore_testing_plan.html.markdown
@@ -16,7 +16,7 @@ Terraform resource for managing an AWS Backup Restore Testing Plan.
 ```terraform
 resource "aws_backup_restore_testing_plan" "example" {
   name = "example_restore_testing_plan"
-  
+
   recovery_point_selection {
     algorithm            = "LATEST_WITHIN_WINDOW"
     include_vaults       = ["*"]


### PR DESCRIPTION
### Description
FIxes an error in doc for aws_backup_restore_testing_plan where a required argument (`name`) was missing from the example code for the resource


### Relations
Closes #0000

### References
Link to [doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_restore_testing_plan)


### Output from Acceptance Testing

