### PR TITLE
[TechDebt]: add `ExpectResourceAction` plan check to `_disappears` test examples, skaff

### DIFF
--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -761,6 +761,11 @@ func TestAccExampleThing_disappears(t *testing.T) {
           acctest.CheckResourceDisappears(ctx, acctest.Provider, ResourceExampleThing(), resourceName),
         ),
         ExpectNonEmptyPlan: true,
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+          PostApplyPostRefresh: []plancheck.PlanCheck{
+            plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+          },
+        },
       },
     },
   })
@@ -805,6 +810,12 @@ func TestAccExampleChildThing_disappears_ParentThing(t *testing.T) {
           acctest.CheckResourceDisappears(ctx, acctest.Provider, ResourceExampleParentThing(), parentResourceName),
         ),
         ExpectNonEmptyPlan: true,
+        ConfigPlanChecks: resource.ConfigPlanChecks{
+          PostApplyPostRefresh: []plancheck.PlanCheck{
+            plancheck.ExpectResourceAction(parentResourceName, plancheck.ResourceActionCreate),
+            plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+          },
+        },
       },
     },
   })

--- a/skaff/resource/resourcetest.gtpl
+++ b/skaff/resource/resourcetest.gtpl
@@ -48,6 +48,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/{{ .SDKPackage }}/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -242,6 +243,11 @@ func TestAcc{{ .Service }}{{ .Resource }}_disappears(t *testing.T) {
 					{{- end }}
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Updates `skaff` and the `_disappears` test examples in the contributor guide to include a post-apply, post-refresh `ExpectResourceAction` plan check. This change does not modify existing `_disappears` tests, though an attempt may be made at doing so in the future.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42206

