### PR TITLE
r/aws_elasticache_serverless_cache: allow in-place `redis` to `valkey` engine updates

### DIFF
--- a/.changelog/42208.txt
+++ b/.changelog/42208.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_serverless_cache: Fix to allow in-place updates when `engine` is changed from `redis` to `valkey` 
+```

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -5,11 +5,9 @@ package elasticache_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -285,7 +283,7 @@ func TestAccElastiCacheServerlessCache_fullValkey(t *testing.T) {
 	})
 }
 
-func TestAccElastiCacheServerlessCache_update(t *testing.T) {
+func TestAccElastiCacheServerlessCache_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -306,7 +304,7 @@ func TestAccElastiCacheServerlessCache_update(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServerlessCacheConfig_update(rName, descriptionOld),
+				Config: testAccServerlessCacheConfig_description(rName, descriptionOld),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
@@ -328,7 +326,7 @@ func TestAccElastiCacheServerlessCache_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServerlessCacheConfig_update(rName, descriptionNew),
+				Config: testAccServerlessCacheConfig_description(rName, descriptionNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
@@ -343,12 +341,17 @@ func TestAccElastiCacheServerlessCache_update(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_ids.#"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
 }
 
-func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
+func TestAccElastiCacheServerlessCache_cacheUsageLimits(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
 		t.Skip("skipping long-running test in short mode")
@@ -358,7 +361,7 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 	descriptionOld := "Memcached Serverless Cluster"
 	descriptionNew := "Memcached Serverless Cluster updated"
 	resourceName := "aws_elasticache_serverless_cache.test"
-	var v1, v2, v3, v4 awstypes.ServerlessCache
+	var v awstypes.ServerlessCache
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -369,9 +372,9 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServerlessCacheConfig_updatesc(rName, descriptionOld, 1, 1000),
+				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionOld, 1, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v1),
+					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -384,6 +387,11 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_ids.#"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -391,10 +399,9 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServerlessCacheConfig_updatesc(rName, descriptionOld, 2, 1000),
+				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionOld, 2, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v2),
-					testAccCheckServerlessCacheNotRecreated(&v1, &v2),
+					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -407,12 +414,16 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_ids.#"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
-				Config: testAccServerlessCacheConfig_updatesc(rName, descriptionNew, 2, 1000),
+				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionNew, 2, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v3),
-					testAccCheckServerlessCacheNotRecreated(&v2, &v3),
+					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -425,12 +436,16 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_ids.#"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 			{
-				Config: testAccServerlessCacheConfig_updatesc(rName, descriptionNew, 2, 1010),
+				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionNew, 2, 1010),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v4),
-					testAccCheckServerlessCacheNotRecreated(&v3, &v4),
+					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -443,6 +458,11 @@ func TestAccElastiCacheServerlessCache_updatesc(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrStatus),
 					resource.TestCheckResourceAttrSet(resourceName, "subnet_ids.#"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -530,6 +550,11 @@ func TestAccElastiCacheServerlessCache_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceServerlessCache, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})
@@ -629,7 +654,6 @@ func testAccCheckServerlessCacheDestroy(ctx context.Context) resource.TestCheckF
 			}
 
 			_, err := tfelasticache.FindServerlessCacheByID(ctx, conn, rs.Primary.ID)
-
 			if tfresource.NotFound(err) {
 				continue
 			}
@@ -638,16 +662,6 @@ func testAccCheckServerlessCacheDestroy(ctx context.Context) resource.TestCheckF
 			}
 
 			return fmt.Errorf("ElastiCache Serverless Cache (%s) still exists", rs.Primary.ID)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckServerlessCacheNotRecreated(i, j *awstypes.ServerlessCache) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if !aws.ToTime(i.CreateTime).Equal(aws.ToTime(j.CreateTime)) {
-			return errors.New("ElastiCache Serverless Cache was recreated")
 		}
 
 		return nil
@@ -876,7 +890,7 @@ resource "aws_security_group" "test" {
 `, rName))
 }
 
-func testAccServerlessCacheConfig_update(rName, desc string) string {
+func testAccServerlessCacheConfig_description(rName, desc string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_serverless_cache" "test" {
   engine      = "memcached"
@@ -886,7 +900,7 @@ resource "aws_elasticache_serverless_cache" "test" {
 `, rName, desc)
 }
 
-func testAccServerlessCacheConfig_updatesc(rName string, desc string, d1 int64, d2 int64) string {
+func testAccServerlessCacheConfig_cacheUsageLimits(rName, desc string, d1, d2 int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_serverless_cache" "test" {
   engine      = "memcached"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously changing the `engine` from `redis` to `valkey` would have forced a replacement of the resource. Migrations from `redis` to `valkey` are now supported in-place as intended in the original implementation of `valkey` support.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #39745
Closes #42204 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://discuss.hashicorp.com/t/in-place-update-for-aws-elasticache-serverless-cache-from-redis-to-valkey/73319
- https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_ModifyServerlessCache.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheServerlessCache_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheServerlessCache_'  -timeout 360m -vet=off
2025/04/11 16:04:25 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheServerlessCache_full (399.87s)
--- PASS: TestAccElastiCacheServerlessCache_basicValkey (556.51s)
--- PASS: TestAccElastiCacheServerlessCache_basicRedis (567.35s)
--- PASS: TestAccElastiCacheServerlessCache_disappears (584.55s)
--- PASS: TestAccElastiCacheServerlessCache_description (584.98s)
--- PASS: TestAccElastiCacheServerlessCache_fullValkey (586.27s)
--- PASS: TestAccElastiCacheServerlessCache_tags (632.07s)
--- PASS: TestAccElastiCacheServerlessCache_fullRedis (638.54s)
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (797.42s)
--- PASS: TestAccElastiCacheServerlessCache_cacheUsageLimits (874.83s)
--- PASS: TestAccElastiCacheServerlessCache_engine (1456.48s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1463.285s
```
