### PR TITLE
fix(docs): fix sqs_queue_policy docs example by removing resources from policy

### DIFF
--- a/website/docs/r/sqs_queue_policy.html.markdown
+++ b/website/docs/r/sqs_queue_policy.html.markdown
@@ -31,8 +31,7 @@ data "aws_iam_policy_document" "test" {
       identifiers = ["*"]
     }
 
-    actions   = ["sqs:SendMessage"]
-    resources = [aws_sqs_queue.q.arn]
+    actions = ["sqs:SendMessage"]
 
     condition {
       test     = "ArnEquals"
@@ -72,8 +71,7 @@ resource "aws_sqs_queue_policy" "example" {
       Principal = {
         Service = "s3.amazonaws.com"
       }
-      Action   = "SQS:SendMessage"
-      Resource = aws_sqs_queue.example.arn
+      Action = "SQS:SendMessage"
       Condition = {
         ArnLike = {
           "aws:SourceArn" = aws_s3_bucket.example.arn


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The current [sqs_queue_policy example in the provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) is invalid. When providing a `resources` key in the sqs_policy resource, terraform fails with the following error:

```
│ Error: setting SQS Queue (https://sqs.us-west-2.amazonaws.com/<account id>/<queue arn>) attribute (Policy): operation error SQS: SetQueueAttributes, https response error StatusCode: 400, RequestID: <request id>, InvalidAttributeValue: Invalid value for the parameter Policy.
│ 
```

The resource policy was successfully applied after removing the `resources` from the policy