### PR TITLE
[Enhancement] `aws_network_insight_path`: add `filter_at_source` and `filter_at_destination` blocks

### DIFF
--- a/internal/service/ec2/vpc_network_insights_path_data_source.go
+++ b/internal/service/ec2/vpc_network_insights_path_data_source.go
@@ -21,6 +21,44 @@ import (
 // @Tags
 // @Testing(tagsTest=false)
 func dataSourceNetworkInsightsPath() *schema.Resource {
+	requestFilterPortRangeSchema := func() map[string]*schema.Schema {
+		return map[string]*schema.Schema{
+			"from_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"to_port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		}
+	}
+	pathRequestFilterSchema := func() map[string]*schema.Schema {
+		return map[string]*schema.Schema{
+			"destination_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"destination_port_range": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: requestFilterPortRangeSchema(),
+				},
+			},
+			"source_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_port_range": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: requestFilterPortRangeSchema(),
+				},
+			},
+		}
+	}
 	return &schema.Resource{
 		ReadWithoutTimeout: dataSourceNetworkInsightsPathRead,
 
@@ -50,6 +88,20 @@ func dataSourceNetworkInsightsPath() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"filter_at_destination": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: pathRequestFilterSchema(),
+				},
+			},
+			"filter_at_source": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: pathRequestFilterSchema(),
+				},
 			},
 			names.AttrProtocol: {
 				Type:     schema.TypeString,
@@ -104,6 +156,18 @@ func dataSourceNetworkInsightsPathRead(ctx context.Context, d *schema.ResourceDa
 	d.Set(names.AttrDestinationARN, nip.DestinationArn)
 	d.Set("destination_ip", nip.DestinationIp)
 	d.Set("destination_port", nip.DestinationPort)
+	if v := nip.FilterAtDestination; v != nil {
+		d.Set("filter_at_destination", []any{flattenPathRequestFilter(v)})
+	} else {
+		d.Set("filter_at_destination", nil)
+	}
+	if v := nip.FilterAtSource; v != nil {
+		d.Set("filter_at_source", []any{flattenPathRequestFilter(v)})
+	} else {
+		d.Set("filter_at_source", nil)
+	}
+	//d.Set("filter_at_destination", []any{flattenPathRequestFilter(nip.FilterAtDestination)})
+	//d.Set("filter_at_source", []any{flattenPathRequestFilter(nip.FilterAtSource)})
 	d.Set("network_insights_path_id", networkInsightsPathID)
 	d.Set(names.AttrProtocol, nip.Protocol)
 	d.Set(names.AttrSource, nip.Source)

--- a/internal/service/ec2/vpc_network_insights_path_data_source_test.go
+++ b/internal/service/ec2/vpc_network_insights_path_data_source_test.go
@@ -32,11 +32,71 @@ func TestAccVPCNetworkInsightsPathDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDestinationARN, resourceName, names.AttrDestinationARN),
 					resource.TestCheckResourceAttrPair(datasourceName, "destination_ip", resourceName, "destination_ip"),
 					resource.TestCheckResourceAttrPair(datasourceName, "destination_port", resourceName, "destination_port"),
+					resource.TestCheckResourceAttr(datasourceName, "filter_at_destination.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "filter_at_source.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "filter_at_source.0.destination_port_range.0.from_port", resourceName, "destination_port"),
+					resource.TestCheckResourceAttrPair(datasourceName, "filter_at_source.0.destination_port_range.0.to_port", resourceName, "destination_port"),
 					resource.TestCheckResourceAttrPair(datasourceName, "network_insights_path_id", resourceName, names.AttrID),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrProtocol, resourceName, names.AttrProtocol),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrSource, resourceName, names.AttrSource),
 					resource.TestCheckResourceAttrPair(datasourceName, "source_arn", resourceName, "source_arn"),
 					resource.TestCheckResourceAttrPair(datasourceName, "source_ip", resourceName, "source_ip"),
+					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCNetworkInsightsPathDataSource_filterAtSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_network_insights_path.test"
+	datasourceName := "data.aws_ec2_network_insights_path.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInsightsPathDataSourceConfig_filterAtDestination(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, "filter_at_source", resourceName, "filter_at_source"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_insights_path_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrProtocol, resourceName, names.AttrProtocol),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrSource, resourceName, names.AttrSource),
+					resource.TestCheckResourceAttrPair(datasourceName, "source_arn", resourceName, "source_arn"),
+					resource.TestCheckResourceAttrPair(datasourceName, "source_ip", resourceName, "source_ip"),
+					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVPCNetworkInsightsPathDataSource_filterAtDestination(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_network_insights_path.test"
+	datasourceName := "data.aws_ec2_network_insights_path.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInsightsPathDataSourceConfig_filterAtSource(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDestination, resourceName, names.AttrDestination),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDestinationARN, resourceName, names.AttrDestinationARN),
+					resource.TestCheckResourceAttrPair(datasourceName, "filter_at_destination", resourceName, "filter_at_destination"),
+					resource.TestCheckResourceAttrPair(datasourceName, "network_insights_path_id", resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrProtocol, resourceName, names.AttrProtocol),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrSource, resourceName, names.AttrSource),
 					resource.TestCheckResourceAttrPair(datasourceName, acctest.CtTagsPercent, resourceName, acctest.CtTagsPercent),
 				),
 			},
@@ -61,6 +121,85 @@ resource "aws_ec2_network_insights_path" "test" {
   destination      = aws_network_interface.test[1].id
   destination_port = 443
   protocol         = "tcp"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_network_insights_path" "test" {
+  network_insights_path_id = aws_ec2_network_insights_path.test.id
+}
+`, rName))
+}
+
+func testAccVPCNetworkInsightsPathDataSourceConfig_filterAtSource(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  count = 2
+
+  subnet_id = aws_subnet.test[0].id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source                = aws_network_interface.test[0].id
+  filter_at_source {
+    destination_address = aws_network_interface.test[1].private_ip
+    destination_port_range {
+      from_port = 80
+      to_port   = 80
+    }
+    source_address      = aws_network_interface.test[0].private_ip
+    source_port_range {
+      from_port = 0
+      to_port   = 65535
+    }
+  }
+  protocol              = "tcp"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+data "aws_ec2_network_insights_path" "test" {
+  network_insights_path_id = aws_ec2_network_insights_path.test.id
+}
+`, rName))
+}
+
+func testAccVPCNetworkInsightsPathDataSourceConfig_filterAtDestination(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  count = 2
+
+  subnet_id = aws_subnet.test[0].id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source                = aws_network_interface.test[0].id
+  destination           = aws_network_interface.test[1].id
+  filter_at_destination {
+    destination_address = aws_network_interface.test[1].private_ip
+    destination_port_range {
+      from_port = 80
+      to_port   = 80
+    }
+    source_address      = aws_network_interface.test[0].private_ip
+    source_port_range {
+      from_port = 0
+      to_port   = 65535
+    }
+  }
+  protocol              = "tcp"
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/vpc_network_insights_path_test.go
+++ b/internal/service/ec2/vpc_network_insights_path_test.go
@@ -255,6 +255,70 @@ func TestAccVPCNetworkInsightsPath_destinationPort(t *testing.T) {
 	})
 }
 
+func TestAccVPCNetworkInsightsPath_filterAtSource(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_network_insights_path.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkInsightsPathDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInsightsPathConfig_filterAtSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInsightsPathExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "filter_at_source.0.destination_address", "aws_network_interface.test.1", "private_ip"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_source.0.destination_port_range.0.from_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_source.0.destination_port_range.0.to_port", "80"),
+					resource.TestCheckResourceAttrPair(resourceName, "filter_at_source.0.source_address", "aws_network_interface.test.0", "private_ip"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_source.0.source_port_range.0.from_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_source.0.source_port_range.0.to_port", "65535"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCNetworkInsightsPath_filterAtDestination(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_ec2_network_insights_path.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckNetworkInsightsPathDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCNetworkInsightsPathConfig_filterAtDestination(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkInsightsPathExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "filter_at_destination.0.destination_address", "aws_network_interface.test.1", "private_ip"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_destination.0.destination_port_range.0.from_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_destination.0.destination_port_range.0.to_port", "80"),
+					resource.TestCheckResourceAttrPair(resourceName, "filter_at_destination.0.source_address", "aws_network_interface.test.0", "private_ip"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_destination.0.source_port_range.0.from_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "filter_at_destination.0.source_port_range.0.to_port", "65535"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkInsightsPathExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -470,4 +534,75 @@ resource "aws_ec2_network_insights_path" "test" {
   }
 }
 `, rName, destinationPort))
+}
+
+func testAccVPCNetworkInsightsPathConfig_filterAtSource(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  count = 2
+
+  subnet_id = aws_subnet.test[0].id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source                = aws_network_interface.test[0].id
+  filter_at_source {
+    destination_address = aws_network_interface.test[1].private_ip
+    destination_port_range {
+      from_port = 80
+      to_port   = 80
+    }
+    source_address      = aws_network_interface.test[0].private_ip
+    source_port_range {
+      from_port = 0
+      to_port   = 65535
+    }
+  }
+  protocol              = "tcp"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
+}
+
+func testAccVPCNetworkInsightsPathConfig_filterAtDestination(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+resource "aws_network_interface" "test" {
+  count = 2
+
+  subnet_id = aws_subnet.test[0].id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_network_insights_path" "test" {
+  source                = aws_network_interface.test[0].id
+  destination           = aws_network_interface.test[1].id
+  filter_at_destination {
+    destination_address = aws_network_interface.test[1].private_ip
+    destination_port_range {
+      from_port = 80
+      to_port   = 80
+    }
+    source_address      = aws_network_interface.test[0].private_ip
+    source_port_range {
+      from_port = 0
+      to_port   = 65535
+    }
+  }
+  protocol              = "tcp"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName))
 }

--- a/website/docs/d/ec2_network_insights_path.html.markdown
+++ b/website/docs/d/ec2_network_insights_path.html.markdown
@@ -43,6 +43,8 @@ This data source exports the following attributes in addition to the arguments a
 * `destination_arn` - ARN of the destination.
 * `destination_ip` - IP address of the AWS resource that is the destination of the path.
 * `destination_port` - Destination port.
+* `filter_at_destination` - Filters of the network paths at the destination.
+* `filter_at_source` - Filters of the network paths at the source.
 * `protocol` - Protocol.
 * `source` - AWS resource that is the source of the path.
 * `source_arn` - ARN of the source.

--- a/website/docs/r/ec2_network_insights_path.html.markdown
+++ b/website/docs/r/ec2_network_insights_path.html.markdown
@@ -25,7 +25,7 @@ resource "aws_ec2_network_insights_path" "test" {
 The following arguments are required:
 
 * `source` - (Required) ID or ARN of the resource which is the source of the path. Can be an Instance, Internet Gateway, Network Interface, Transit Gateway, VPC Endpoint, VPC Peering Connection or VPN Gateway. If the resource is in another account, you must specify an ARN.
-* `destination` - (Optional) ID or ARN of the resource which is the destination of the path. Can be an Instance, Internet Gateway, Network Interface, Transit Gateway, VPC Endpoint, VPC Peering Connection or VPN Gateway. If the resource is in another account, you must specify an ARN.
+* `destination` - (Optional) ID or ARN of the resource which is the destination of the path. Can be an Instance, Internet Gateway, Network Interface, Transit Gateway, VPC Endpoint, VPC Peering Connection or VPN Gateway. If the resource is in another account, you must specify an ARN. Either the `destination` argument or the `destination_address` argument in the `filter_at_source` block must be specified.
 * `protocol` - (Required) Protocol to use for analysis. Valid options are `tcp` or `udp`.
 
 The following arguments are optional:
@@ -33,7 +33,21 @@ The following arguments are optional:
 * `source_ip` - (Optional) IP address of the source resource.
 * `destination_ip` - (Optional) IP address of the destination resource.
 * `destination_port` - (Optional) Destination port to analyze access to.
+* `filter_at_destination` - (Optional) Scopes the analysis to network paths that match specific filters at the destination. If you specify this parameter, you can't specify `destination_ip`. See below for details. Note that Terraform performs drift detection on this argument only when the value is provided.
+* `filter_at_source` - (Optional) Scopes the analysis to network paths that match specific filters at the source. If you specify this parameter, you can't specify `source_ip` or `destination_port`. See below for details. Note that Terraform performs drift detection on this argument only when the value is provided.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+`filter_at_destination` and `filter_at_source` configuration block support the following arguments:
+
+* `destination_address` - (Optional) The destination IPv4 address.
+* `destination_port_range` - (Optional) The destination port range. See below for details.
+* `source_address` - (Optional) IP address of the source resource.
+* `source_port_range` - (Optional) The source port range. See below for details.
+
+`destination_port_range` and `source_port_range` configuration block support the following arguments:
+
+* `from_port` - (Optional) The first port in the range.
+* `to_port` - (Optional) The last port in the range.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description


### Relations

Closes #38132

### References


### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccVPCNetworkInsightsPath_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInsightsPath_'  -timeout 360m -vet=off
2025/04/13 10:32:28 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNetworkInsightsPath_basic
=== PAUSE TestAccVPCNetworkInsightsPath_basic
=== RUN   TestAccVPCNetworkInsightsPath_disappears
=== PAUSE TestAccVPCNetworkInsightsPath_disappears
=== RUN   TestAccVPCNetworkInsightsPath_tags
=== PAUSE TestAccVPCNetworkInsightsPath_tags
=== RUN   TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== PAUSE TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== RUN   TestAccVPCNetworkInsightsPath_sourceIP
=== PAUSE TestAccVPCNetworkInsightsPath_sourceIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationIP
=== PAUSE TestAccVPCNetworkInsightsPath_destinationIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationPort
=== PAUSE TestAccVPCNetworkInsightsPath_destinationPort
=== RUN   TestAccVPCNetworkInsightsPath_filterAtSource
=== PAUSE TestAccVPCNetworkInsightsPath_filterAtSource
=== RUN   TestAccVPCNetworkInsightsPath_filterAtDestination
=== PAUSE TestAccVPCNetworkInsightsPath_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPath_basic
=== CONT  TestAccVPCNetworkInsightsPath_destinationIP
=== CONT  TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== CONT  TestAccVPCNetworkInsightsPath_sourceIP
=== CONT  TestAccVPCNetworkInsightsPath_filterAtSource
=== CONT  TestAccVPCNetworkInsightsPath_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPath_tags
=== CONT  TestAccVPCNetworkInsightsPath_destinationPort
=== CONT  TestAccVPCNetworkInsightsPath_disappears
--- PASS: TestAccVPCNetworkInsightsPath_disappears (39.33s)
--- PASS: TestAccVPCNetworkInsightsPath_filterAtDestination (42.49s)
--- PASS: TestAccVPCNetworkInsightsPath_basic (42.49s)
--- PASS: TestAccVPCNetworkInsightsPath_sourceAndDestinationARN (42.80s)
--- PASS: TestAccVPCNetworkInsightsPath_filterAtSource (42.91s)
--- PASS: TestAccVPCNetworkInsightsPath_sourceIP (58.05s)
--- PASS: TestAccVPCNetworkInsightsPath_destinationIP (58.11s)
--- PASS: TestAccVPCNetworkInsightsPath_destinationPort (62.94s)
--- PASS: TestAccVPCNetworkInsightsPath_tags (73.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        79.110s

```

```console
$ make testacc TESTS=TestAccVPCNetworkInsightsPathDataSource_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInsightsPathDataSource_'  -timeout 360m -vet=off
2025/04/13 10:34:21 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNetworkInsightsPathDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_basic
=== RUN   TestAccVPCNetworkInsightsPathDataSource_filterAtSource
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_filterAtSource
=== RUN   TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPathDataSource_basic
=== CONT  TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPathDataSource_filterAtSource
--- PASS: TestAccVPCNetworkInsightsPathDataSource_filterAtDestination (29.19s)
--- PASS: TestAccVPCNetworkInsightsPathDataSource_filterAtSource (29.22s)
--- PASS: TestAccVPCNetworkInsightsPathDataSource_basic (29.23s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        34.195s
```