### PR TITLE
[bug fix] aws_vpclattice_listener_rule: avoid panic when empty `match` block is given

### DIFF
--- a/internal/service/vpclattice/listener_rule.go
+++ b/internal/service/vpclattice/listener_rule.go
@@ -238,7 +238,6 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 		Action:             expandRuleAction(d.Get(names.AttrAction).([]any)[0].(map[string]any)),
 		ClientToken:        aws.String(sdkid.UniqueId()),
 		ListenerIdentifier: aws.String(listenerID),
-		Match:              expandRuleMatch(d.Get("match").([]any)[0].(map[string]any)),
 		Name:               aws.String(name),
 		ServiceIdentifier:  aws.String(serviceID),
 		Tags:               getTagsIn(ctx),
@@ -246,6 +245,14 @@ func resourceListenerRuleCreate(ctx context.Context, d *schema.ResourceData, met
 
 	if v, ok := d.GetOk(names.AttrPriority); ok {
 		input.Priority = aws.Int32(int32(v.(int)))
+	}
+
+	if v, ok := d.GetOk("match"); ok {
+		if v, ok := v.([]any); ok && len(v) > 0 && v[0] != nil {
+			input.Match = expandRuleMatch(v[0].(map[string]any))
+		} else {
+			return sdkdiag.AppendErrorf(diags, "Invalid \"match\" value: %v", v)
+		}
 	}
 
 	output, err := conn.CreateRule(ctx, &input)


### PR DESCRIPTION
### Description
* As reported in #42156, Terraform panics when an empty `match` block is provided in the configuration.  
* To prevent the panic, validation has been added for the `match` block.  
* An acceptance test has been added to verify that the appropriate error is raised and that no panic occurs when an empty `match` block is given.

### Relations
Closes #42156 


### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccVPCLatticeListenerRule_ PKG=vpclattice 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/vpclattice/... -v -count 1 -parallel 20 -run='TestAccVPCLatticeListenerRule_'  -timeout 360m -vet=off
2025/04/13 21:58:25 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCLatticeListenerRule_basic
=== PAUSE TestAccVPCLatticeListenerRule_basic
=== RUN   TestAccVPCLatticeListenerRule_fixedResponse
=== PAUSE TestAccVPCLatticeListenerRule_fixedResponse
=== RUN   TestAccVPCLatticeListenerRule_methodMatch
=== PAUSE TestAccVPCLatticeListenerRule_methodMatch
=== RUN   TestAccVPCLatticeListenerRule_emptyMatchError
=== PAUSE TestAccVPCLatticeListenerRule_emptyMatchError
=== RUN   TestAccVPCLatticeListenerRule_tags
=== PAUSE TestAccVPCLatticeListenerRule_tags
=== CONT  TestAccVPCLatticeListenerRule_basic
=== CONT  TestAccVPCLatticeListenerRule_emptyMatchError
=== CONT  TestAccVPCLatticeListenerRule_tags
=== CONT  TestAccVPCLatticeListenerRule_methodMatch
=== CONT  TestAccVPCLatticeListenerRule_fixedResponse
--- PASS: TestAccVPCLatticeListenerRule_emptyMatchError (87.45s)
--- PASS: TestAccVPCLatticeListenerRule_basic (92.28s)
--- PASS: TestAccVPCLatticeListenerRule_methodMatch (99.90s)
--- PASS: TestAccVPCLatticeListenerRule_tags (109.89s)
--- PASS: TestAccVPCLatticeListenerRule_fixedResponse (139.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/vpclattice 144.722s

```
