### PR TITLE
internal/framework/flex: skip planned unknown values in `Diff`

### DIFF
--- a/internal/framework/flex/diff.go
+++ b/internal/framework/flex/diff.go
@@ -76,6 +76,10 @@ func Diff(ctx context.Context, plan, state any, options ...ChangeOption) (*Resul
 			continue
 		}
 
+		if planFieldValue.IsUnknown() {
+			continue
+		}
+
 		if !planFieldValue.Equal(stateFieldValue) {
 			hasChanges = true
 		} else {

--- a/internal/framework/flex/diff_test.go
+++ b/internal/framework/flex/diff_test.go
@@ -28,7 +28,7 @@ type testResourceData3 struct {
 	Age    types.Int64
 }
 
-func TestCalculate(t *testing.T) {
+func TestDiff(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
@@ -44,6 +44,16 @@ func TestCalculate(t *testing.T) {
 			expectedIgnoredFieldNames: []string{
 				"Name",
 				"Number",
+				"Age",
+			},
+			expectedChange: false,
+			expectErr:      false,
+		},
+		"unknown plan": {
+			plan:  testResourceData1{Name: types.StringValue("test"), Number: types.Int64Unknown(), Age: types.Int64Value(100)},
+			state: testResourceData1{Name: types.StringValue("test"), Number: types.Int64Value(1), Age: types.Int64Value(100)},
+			expectedIgnoredFieldNames: []string{
+				"Name",
 				"Age",
 			},
 			expectedChange: false,
@@ -136,19 +146,19 @@ func TestCalculate(t *testing.T) {
 	}
 }
 
-func TestWithException(t *testing.T) {
+func TestDiffWithChangeOption(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
 		plan                      any
 		state                     any
-		withException             []fwflex.ChangeOption
+		opts                      []fwflex.ChangeOption
 		expectedIgnoredFieldNames []string
 	}{
 		"ignore changed field": {
-			plan:          testResourceData1{Name: types.StringValue("test2"), Number: types.Int64Value(1), Age: types.Int64Value(100)},
-			state:         testResourceData1{Name: types.StringValue("test"), Number: types.Int64Value(1), Age: types.Int64Value(100)},
-			withException: []fwflex.ChangeOption{fwflex.WithIgnoredField("Name")},
+			plan:  testResourceData1{Name: types.StringValue("test2"), Number: types.Int64Value(1), Age: types.Int64Value(100)},
+			state: testResourceData1{Name: types.StringValue("test"), Number: types.Int64Value(1), Age: types.Int64Value(100)},
+			opts:  []fwflex.ChangeOption{fwflex.WithIgnoredField("Name")},
 			expectedIgnoredFieldNames: []string{
 				"Name",
 				"Number",
@@ -161,7 +171,7 @@ func TestWithException(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			results, _ := fwflex.Diff(context.Background(), test.plan, test.state, test.withException...)
+			results, _ := fwflex.Diff(context.Background(), test.plan, test.state, test.opts...)
 
 			if diff := cmp.Diff(results.IgnoredFieldNames(), test.expectedIgnoredFieldNames); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -331,7 +331,7 @@ func (r *serverlessCacheResource) Update(ctx context.Context, request resource.U
 
 	conn := r.Meta().ElastiCacheClient(ctx)
 
-	diff, d := fwflex.Diff(ctx, new, old, fwflex.WithIgnoredField("FullEngineVersion"))
+	diff, d := fwflex.Diff(ctx, new, old)
 	response.Diagnostics.Append(d...)
 	if response.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously a computed or optional/computed attribute in state without a `UseStateForUnknown` plan modifier would cause `flex.Diff` to indicate the plan has changes due to the previously known value now being known after apply. In this scenario we now skip this field as it can't be ensured whether or not the value has changed.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42208 (behavior was uncovered while implementing this fix)



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheServerlessCache_tags
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheServerlessCache_tags'  -timeout 360m -vet=off
2025/04/14 11:13:08 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheServerlessCache_tags (381.21s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        388.060s
```
