### PR TITLE
r/aws_api_gateway_account: remove `reset_on_delete` argument

### DIFF
--- a/.changelog/42226.txt
+++ b/.changelog/42226.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_api_gateway_account: The `reset_on_delete` argument has been removed
+```

--- a/internal/service/apigateway/account.go
+++ b/internal/service/apigateway/account.go
@@ -13,8 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -60,14 +58,7 @@ func (r *resourceAccount) Schema(ctx context.Context, request resource.SchemaReq
 				ElementType: types.StringType,
 				Computed:    true,
 			},
-			names.AttrID: framework.IDAttributeDeprecatedNoReplacement(),
-			"reset_on_delete": schema.BoolAttribute{
-				Optional: true,
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
-				DeprecationMessage: `The "reset_on_delete" attribute will be removed in a future version of the provider`,
-			},
+			names.AttrID:        framework.IDAttributeDeprecatedNoReplacement(),
 			"throttle_settings": framework.DataSourceComputedListOfObjectAttribute[throttleSettingsModel](ctx),
 		},
 	}
@@ -227,28 +218,19 @@ func (r *resourceAccount) Delete(ctx context.Context, request resource.DeleteReq
 		return
 	}
 
-	if data.ResetOnDelete.ValueBool() {
-		conn := r.Meta().APIGatewayClient(ctx)
+	conn := r.Meta().APIGatewayClient(ctx)
 
-		input := apigateway.UpdateAccountInput{}
+	input := apigateway.UpdateAccountInput{}
 
-		input.PatchOperations = []awstypes.PatchOperation{{
-			Op:    awstypes.OpReplace,
-			Path:  aws.String("/cloudwatchRoleArn"),
-			Value: nil,
-		}}
+	input.PatchOperations = []awstypes.PatchOperation{{
+		Op:    awstypes.OpReplace,
+		Path:  aws.String("/cloudwatchRoleArn"),
+		Value: nil,
+	}}
 
-		_, err := conn.UpdateAccount(ctx, &input)
-		if err != nil {
-			response.Diagnostics.AddError("resetting API Gateway Account", err.Error())
-		}
-	} else {
-		response.Diagnostics.AddWarning(
-			"Resource Destruction",
-			"This resource has only been removed from Terraform state. "+
-				"Manually use the AWS Console to fully destroy this resource. "+
-				"Setting the attribute \"reset_on_delete\" will also fully destroy resources of this type.",
-		)
+	_, err := conn.UpdateAccount(ctx, &input)
+	if err != nil {
+		response.Diagnostics.AddError("resetting API Gateway Account", err.Error())
 	}
 }
 
@@ -261,33 +243,12 @@ type resourceAccountModel struct {
 	CloudwatchRoleARN types.String                                           `tfsdk:"cloudwatch_role_arn" autoflex:",legacy"`
 	Features          types.Set                                              `tfsdk:"features"`
 	ID                types.String                                           `tfsdk:"id"`
-	ResetOnDelete     types.Bool                                             `tfsdk:"reset_on_delete"`
 	ThrottleSettings  fwtypes.ListNestedObjectValueOf[throttleSettingsModel] `tfsdk:"throttle_settings"`
 }
 
 type throttleSettingsModel struct {
 	BurstLimit types.Int32   `tfsdk:"burst_limit"`
 	RateLimit  types.Float64 `tfsdk:"rate_limit"`
-}
-
-func (r *resourceAccount) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
-	// If the entire plan is null, the resource is planned for destruction.
-	if request.Plan.Raw.IsNull() {
-		var resetOnDelete types.Bool
-		response.Diagnostics.Append(request.State.GetAttribute(ctx, path.Root("reset_on_delete"), &resetOnDelete)...)
-		if response.Diagnostics.HasError() {
-			return
-		}
-
-		if !resetOnDelete.ValueBool() {
-			response.Diagnostics.AddWarning(
-				"Resource Destruction",
-				"Applying this resource destruction will only remove the resource from Terraform state and will not reset account settings. "+
-					"Either manually use the AWS Console to fully destroy this resource or "+
-					"update the resource with \"reset_on_delete\" set to true.",
-			)
-		}
-	}
 }
 
 func findAccount(ctx context.Context, conn *apigateway.Client) (*apigateway.GetAccountOutput, error) {

--- a/internal/service/apigateway/account_test.go
+++ b/internal/service/apigateway/account_test.go
@@ -9,9 +9,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/apigateway"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -32,7 +29,6 @@ func testAccAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -45,7 +41,6 @@ func testAccAccount_basic(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("cloudwatch_role_arn"), knownvalue.StringExact("")),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("features"), knownvalue.NotNull()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringExact("api-gateway-account")),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("reset_on_delete"), knownvalue.Null()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("throttle_settings"), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"burst_limit": knownvalue.Int32Exact(5000),
@@ -71,7 +66,6 @@ func testAccAccount_cloudwatchRoleARN_value(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -129,7 +123,6 @@ func testAccAccount_cloudwatchRoleARN_empty(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -150,80 +143,6 @@ func testAccAccount_cloudwatchRoleARN_empty(t *testing.T) {
 	})
 }
 
-func testAccAccount_resetOnDelete_false(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_api_gateway_account.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountNotDestroyed(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAccountConfig_resetOnDelete(rName, false),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.CompareValuePairs(
-						resourceName, tfjsonpath.New("cloudwatch_role_arn"),
-						"aws_iam_role.test[0]", tfjsonpath.New(names.AttrARN),
-						compare.ValuesSame(),
-					),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("reset_on_delete"), knownvalue.Bool(false)),
-				},
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"reset_on_delete",
-				},
-			},
-		},
-	})
-}
-
-func testAccAccount_resetOnDelete_true(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_api_gateway_account.test"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAccountConfig_resetOnDelete(rName, true),
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.CompareValuePairs(
-						resourceName, tfjsonpath.New("cloudwatch_role_arn"),
-						"aws_iam_role.test[0]", tfjsonpath.New(names.AttrARN),
-						compare.ValuesSame(),
-					),
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("reset_on_delete"), knownvalue.Bool(true)),
-				},
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"reset_on_delete",
-				},
-			},
-		},
-	})
-}
-
 func testAccAccount_frameworkMigration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_account.test"
@@ -231,7 +150,6 @@ func testAccAccount_frameworkMigration_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAccountDestroy(ctx),
@@ -265,10 +183,9 @@ func testAccAccount_frameworkMigration_cloudwatchRoleARN(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			t.Cleanup(accountCleanup(ctx, t))
 		},
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		CheckDestroy: testAccCheckAccountNotDestroyed(ctx),
+		CheckDestroy: testAccCheckAccountDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -295,6 +212,52 @@ func testAccAccount_frameworkMigration_cloudwatchRoleARN(t *testing.T) {
 	})
 }
 
+// Verifies the upgrade to V6.0.0 in which the reset_on_delete attribute is
+// removed does not result in unexpected behavior.
+func testAccAccount_upgradeV6(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_account.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		CheckDestroy: testAccCheckAccountDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.94.1",
+					},
+				},
+				Config: testAccAccountConfig_resetOnDelete(rName, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("cloudwatch_role_arn"),
+						"aws_iam_role.test[0]", tfjsonpath.New(names.AttrARN),
+						compare.ValuesSame(),
+					),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("reset_on_delete"), knownvalue.Bool(false)),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccAccountConfig_role0(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(
+						resourceName, tfjsonpath.New("cloudwatch_role_arn"),
+						"aws_iam_role.test[0]", tfjsonpath.New(names.AttrARN),
+						compare.ValuesSame(),
+					),
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckAccountDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
@@ -310,46 +273,6 @@ func testAccCheckAccountDestroy(ctx context.Context) resource.TestCheckFunc {
 		}
 
 		return errors.New("API Gateway Account still exists")
-	}
-}
-
-func testAccCheckAccountNotDestroyed(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
-
-		account, err := tfapigateway.FindAccount(ctx, conn)
-		if err != nil {
-			return err
-		}
-
-		if account.CloudwatchRoleArn != nil {
-			// Settings have not been reset
-			return nil
-		}
-
-		return errors.New("API Gateway Account was reset")
-	}
-}
-
-func accountCleanup(ctx context.Context, t *testing.T) func() {
-	return func() {
-		t.Helper()
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).APIGatewayClient(ctx)
-
-		input := apigateway.UpdateAccountInput{
-			PatchOperations: []awstypes.PatchOperation{
-				{
-					Op:    awstypes.OpReplace,
-					Path:  aws.String("/cloudwatchRoleArn"),
-					Value: nil,
-				},
-			},
-		}
-
-		if _, err := conn.UpdateAccount(ctx, &input); err != nil {
-			t.Errorf("API Gateway Account cleanup: %s", err)
-		}
 	}
 }
 

--- a/internal/service/apigateway/apigateway_test.go
+++ b/internal/service/apigateway/apigateway_test.go
@@ -30,8 +30,7 @@ func TestAccAPIGateway_serial(t *testing.T) {
 			"CloudwatchRoleARN_Empty":              testAccAccount_cloudwatchRoleARN_empty,
 			"FrameworkMigration_Basic":             testAccAccount_frameworkMigration_basic,
 			"FrameworkMigration_CloudwatchRoleARN": testAccAccount_frameworkMigration_cloudwatchRoleARN,
-			"ResetOnDelete_false":                  testAccAccount_resetOnDelete_false,
-			"ResetOnDelete_true":                   testAccAccount_resetOnDelete_true,
+			"UpgradeV6":                            testAccAccount_upgradeV6,
 		},
 		// Some aws_api_gateway_method_settings tests require the account-level CloudWatch Logs role ARN to be set.
 		// Serialize all this resource's acceptance tests.

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -26,6 +26,7 @@ Upgrade topics:
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
+- [resource/aws_api_gateway_account](#resourceaws_api_gateway_account)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
@@ -153,6 +154,12 @@ Remove `inference_accelerator_overrides` from your configuration—it no longer 
 ## data-source/aws_launch_template
 
 Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## resource/aws_api_gateway_account
+
+`reset_on_delete` has been removed.
+The destroy operation will now always reset the API Gateway account settings.
+Use a [removed](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) block to retain the previous behavior which left the account settings unchanged upon destruction.
 
 ## resource/aws_batch_compute_environment
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The default behavior of this resource is now to always reset account settings upon destruction. Practitioners may use a [`removed`](https://developer.hashicorp.com/terraform/language/resources/syntax#removing-resources) block if the previous behavior of leaving settings unmodified upon destruction is desired.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40043
Relates #40004
Relates #41101


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```console
% make testacc PKG=apigateway TESTS=TestAccAPIGateway_serial/Account/
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGateway_serial/Account/'  -timeout 360m -vet=off
2025/04/14 15:41:21 Initializing Terraform AWS Provider...

--- PASS: TestAccAPIGateway_serial (520.30s)
    --- PASS: TestAccAPIGateway_serial/Account (520.30s)
        --- PASS: TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Empty (30.94s)
        --- PASS: TestAccAPIGateway_serial/Account/FrameworkMigration_Basic (38.65s)
        --- PASS: TestAccAPIGateway_serial/Account/FrameworkMigration_CloudwatchRoleARN (151.16s)
        --- PASS: TestAccAPIGateway_serial/Account/UpgradeV6 (56.97s)
        --- PASS: TestAccAPIGateway_serial/Account/basic (59.85s)
        --- PASS: TestAccAPIGateway_serial/Account/CloudwatchRoleARN_Value (182.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/apigateway 526.905s
```
