### PR TITLE
TechDebt: Resource aws_evidently deprecation

### DIFF
--- a/.changelog/42227.txt
+++ b/.changelog/42227.txt
@@ -1,0 +1,12 @@
+```release-note:note
+resource/aws_evidently_feature: This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+```
+```release-note:note
+resource/aws_evidently_launch: This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+```
+```release-note:note
+resource/aws_evidently_project: This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+```
+```release-note:note
+resource/aws_evidently_segment: This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+```

--- a/internal/service/evidently/feature.go
+++ b/internal/service/evidently/feature.go
@@ -38,6 +38,8 @@ func ResourceFeature() *schema.Resource {
 		UpdateWithoutTimeout: resourceFeatureUpdate,
 		DeleteWithoutTimeout: resourceFeatureDelete,
 
+		DeprecationMessage: "This resource is deprecated. Use AWS AppConfig feature flags instead.",
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/service/evidently/launch.go
+++ b/internal/service/evidently/launch.go
@@ -37,6 +37,8 @@ func ResourceLaunch() *schema.Resource {
 		UpdateWithoutTimeout: resourceLaunchUpdate,
 		DeleteWithoutTimeout: resourceLaunchDelete,
 
+		DeprecationMessage: "This resource is deprecated. Use AWS AppConfig feature flags instead.",
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/service/evidently/project.go
+++ b/internal/service/evidently/project.go
@@ -32,6 +32,8 @@ func ResourceProject() *schema.Resource {
 		UpdateWithoutTimeout: resourceProjectUpdate,
 		DeleteWithoutTimeout: resourceProjectDelete,
 
+		DeprecationMessage: "This resource is deprecated. Use AWS AppConfig feature flags instead.",
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/internal/service/evidently/segment.go
+++ b/internal/service/evidently/segment.go
@@ -34,6 +34,8 @@ func ResourceSegment() *schema.Resource {
 		UpdateWithoutTimeout: resourceSegmentUpdate,
 		DeleteWithoutTimeout: resourceSegmentDelete,
 
+		DeprecationMessage: "This resource is deprecated. Use AWS AppConfig feature flags instead.",
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -19,6 +19,7 @@ Upgrade topics:
 - [Dropping Support For Amazon SimpleDB](#dropping-support-for-amazon-simpledb)
 - [Dropping Support For Amazon Worklink](#dropping-support-for-amazon-worklink)
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
+- [AWS CloudWatch Evidently Deprecation](#aws-cloudwatch-evidently-deprecation)
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
@@ -134,6 +135,18 @@ As the AWS OpsWorks Stacks service has reached [End Of Life](https://docs.aws.am
 * `aws_opsworks_stack`
 * `aws_opsworks_static_web_layer`
 * `aws_opsworks_user_profile`
+
+## AWS CloudWatch Evidently Deprecation
+
+Effective October 17, 2025, AWS will [no longer support Cloudwatch Evidently](https://aws.amazon.com/blogs/mt/support-for-amazon-cloudwatch-evidently-ending-soon/).
+The following resources have been deprecated and will be removed in a future major version.
+
+* `aws_evidently_feature`
+* `aws_evidently_launch`
+* `aws_evidently_project`
+* `aws_evidently_segment`
+
+Use [AWS AppConfig Feature Flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
 
 ## data-source/aws_ami
 

--- a/website/docs/r/evidently_feature.html.markdown
+++ b/website/docs/r/evidently_feature.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a CloudWatch Evidently Feature resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+
 ## Example Usage
 
 ### Basic

--- a/website/docs/r/evidently_launch.html.markdown
+++ b/website/docs/r/evidently_launch.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a CloudWatch Evidently Launch resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+
 ## Example Usage
 
 ### Basic

--- a/website/docs/r/evidently_project.html.markdown
+++ b/website/docs/r/evidently_project.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a CloudWatch Evidently Project resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+
 ## Example Usage
 
 ### Basic

--- a/website/docs/r/evidently_segment.html.markdown
+++ b/website/docs/r/evidently_segment.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a CloudWatch Evidently Segment resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS AppConfig feature flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+
 ## Example Usage
 
 ### Basic


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In accordance with the AWS announcement that support for CloudWatch Evidently will be discontinued effective 10/17/2025, the corresponding Terraform resource are being deprecated.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39915
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://aws.amazon.com/blogs/mt/support-for-amazon-cloudwatch-evidently-ending-soon/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/a
