### PR TITLE
resource/aws_s3_bucket_lifecycle_configuration: Fixes error when removing rules from top of list

### DIFF
--- a/.changelog/42228.txt
+++ b/.changelog/42228.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: Fix errors when removing `rule` from top of list
+```

--- a/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
@@ -42,8 +42,6 @@ func (m legacyValueModifier) PlanModifyBool(ctx context.Context, req planmodifie
 		return
 	}
 
-	if req.StateValue.IsNull() {
-		resp.PlanValue = types.BoolValue(false)
-		return
-	}
+	resp.PlanValue = types.BoolValue(false)
+	return
 }

--- a/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
@@ -43,5 +43,4 @@ func (m legacyValueModifier) PlanModifyBool(ctx context.Context, req planmodifie
 	}
 
 	resp.PlanValue = types.BoolValue(false)
-	return
 }

--- a/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/boolplanmodifier/legacy_value.go
@@ -27,13 +27,13 @@ func (m legacyValueModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m legacyValueModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	// Use value from Config if set
-	if !req.ConfigValue.IsNull() {
+	// Exit if another planmodifier has set the value
+	if !req.PlanValue.IsUnknown() {
 		return
 	}
 
-	// Exit if another planmodifier has set the value
-	if !req.PlanValue.IsUnknown() {
+	// Use value from Config if set
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 

--- a/internal/framework/planmodifiers/boolplanmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/boolplanmodifier/legacy_value_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package boolplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/boolplanmodifier"
+)
+
+func TestLegacyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  planmodifier.BoolRequest
+		expected *planmodifier.BoolResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the zero value
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolNull(),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(false),
+			},
+		},
+		"known-plan": {
+			// if another plan modifier has set the planned value, use that
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(false),
+				PlanValue:   types.BoolValue(true),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(true),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// if no value is set in the config on update, use the zero value.
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(true),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(false),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.BoolRequest{
+				StateValue:  types.BoolValue(true),
+				PlanValue:   types.BoolUnknown(),
+				ConfigValue: types.BoolUnknown(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolUnknown(),
+			},
+		},
+		"under-list": {
+			request: planmodifier.BoolRequest{
+				ConfigValue: types.BoolNull(),
+				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:   types.BoolUnknown(),
+				StateValue:  types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(false),
+			},
+		},
+		"under-set": {
+			request: planmodifier.BoolRequest{
+				ConfigValue: types.BoolNull(),
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.BoolType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.BoolType,
+								},
+								map[string]attr.Value{
+									"nested_test": types.BoolUnknown(),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue:  types.BoolUnknown(),
+				StateValue: types.BoolNull(),
+			},
+			expected: &planmodifier.BoolResponse{
+				PlanValue: types.BoolValue(false),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &planmodifier.BoolResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			boolplanmodifier.LegacyValue().PlanModifyBool(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/planmodifiers/boolplanmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/boolplanmodifier/legacy_value_test.go
@@ -20,7 +20,7 @@ func TestLegacyValue(t *testing.T) {
 
 	testCases := map[string]struct {
 		request  planmodifier.BoolRequest
-		expected *planmodifier.BoolResponse
+		expected planmodifier.BoolResponse
 	}{
 		"null-state": {
 			// when we first create the resource, use the zero value
@@ -29,7 +29,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.BoolUnknown(),
 				ConfigValue: types.BoolNull(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolValue(false),
 			},
 		},
@@ -40,7 +40,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.BoolValue(true),
 				ConfigValue: types.BoolNull(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolValue(true),
 			},
 		},
@@ -51,7 +51,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.BoolUnknown(),
 				ConfigValue: types.BoolNull(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolValue(false),
 			},
 		},
@@ -67,7 +67,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.BoolUnknown(),
 				ConfigValue: types.BoolUnknown(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolUnknown(),
 			},
 		},
@@ -78,7 +78,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.BoolUnknown(),
 				StateValue:  types.BoolNull(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolValue(false),
 			},
 		},
@@ -107,7 +107,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:  types.BoolUnknown(),
 				StateValue: types.BoolNull(),
 			},
-			expected: &planmodifier.BoolResponse{
+			expected: planmodifier.BoolResponse{
 				PlanValue: types.BoolValue(false),
 			},
 		},
@@ -117,11 +117,11 @@ func TestLegacyValue(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			resp := &planmodifier.BoolResponse{
+			resp := planmodifier.BoolResponse{
 				PlanValue: testCase.request.PlanValue,
 			}
 
-			boolplanmodifier.LegacyValue().PlanModifyBool(context.Background(), testCase.request, resp)
+			boolplanmodifier.LegacyValue().PlanModifyBool(context.Background(), testCase.request, &resp)
 
 			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/framework/planmodifiers/int32planmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/int32planmodifier/legacy_value.go
@@ -27,13 +27,13 @@ func (m legacyValueModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m legacyValueModifier) PlanModifyInt32(ctx context.Context, req planmodifier.Int32Request, resp *planmodifier.Int32Response) {
-	// Use value from Config if set
-	if !req.ConfigValue.IsNull() {
+	// Exit if another planmodifier has set the value
+	if !req.PlanValue.IsUnknown() {
 		return
 	}
 
-	// Exit if another planmodifier has set the value
-	if !req.PlanValue.IsUnknown() {
+	// Use value from Config if set
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 

--- a/internal/framework/planmodifiers/int32planmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/int32planmodifier/legacy_value.go
@@ -42,8 +42,5 @@ func (m legacyValueModifier) PlanModifyInt32(ctx context.Context, req planmodifi
 		return
 	}
 
-	if req.StateValue.IsNull() {
-		resp.PlanValue = types.Int32Value(0)
-		return
-	}
+	resp.PlanValue = types.Int32Value(0)
 }

--- a/internal/framework/planmodifiers/int32planmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/int32planmodifier/legacy_value_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int32planmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/int32planmodifier"
+)
+
+func TestLegacyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  planmodifier.Int32Request
+		expected *planmodifier.Int32Response
+	}{
+		"null-state": {
+			// when we first create the resource, use the zero value
+			request: planmodifier.Int32Request{
+				StateValue:  types.Int32Null(),
+				PlanValue:   types.Int32Unknown(),
+				ConfigValue: types.Int32Null(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Value(0),
+			},
+		},
+		"known-plan": {
+			// if another plan modifier has set the planned value, use that
+			request: planmodifier.Int32Request{
+				StateValue:  types.Int32Value(2),
+				PlanValue:   types.Int32Value(1),
+				ConfigValue: types.Int32Null(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Value(1),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// if no value is set in the config on update, use the zero value.
+			request: planmodifier.Int32Request{
+				StateValue:  types.Int32Value(1),
+				PlanValue:   types.Int32Unknown(),
+				ConfigValue: types.Int32Null(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Value(0),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.Int32Request{
+				StateValue:  types.Int32Value(1),
+				PlanValue:   types.Int32Unknown(),
+				ConfigValue: types.Int32Unknown(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Unknown(),
+			},
+		},
+		"under-list": {
+			request: planmodifier.Int32Request{
+				ConfigValue: types.Int32Null(),
+				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:   types.Int32Unknown(),
+				StateValue:  types.Int32Null(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Value(0),
+			},
+		},
+		"under-set": {
+			request: planmodifier.Int32Request{
+				ConfigValue: types.Int32Null(),
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.Int32Type,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.Int32Type,
+								},
+								map[string]attr.Value{
+									"nested_test": types.Int32Unknown(),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue:  types.Int32Unknown(),
+				StateValue: types.Int32Null(),
+			},
+			expected: &planmodifier.Int32Response{
+				PlanValue: types.Int32Value(0),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &planmodifier.Int32Response{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			int32planmodifier.LegacyValue().PlanModifyInt32(context.Background(), testCase.request, resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/planmodifiers/int32planmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/int32planmodifier/legacy_value_test.go
@@ -20,7 +20,7 @@ func TestLegacyValue(t *testing.T) {
 
 	testCases := map[string]struct {
 		request  planmodifier.Int32Request
-		expected *planmodifier.Int32Response
+		expected planmodifier.Int32Response
 	}{
 		"null-state": {
 			// when we first create the resource, use the zero value
@@ -29,7 +29,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.Int32Unknown(),
 				ConfigValue: types.Int32Null(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Value(0),
 			},
 		},
@@ -40,7 +40,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.Int32Value(1),
 				ConfigValue: types.Int32Null(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Value(1),
 			},
 		},
@@ -51,7 +51,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.Int32Unknown(),
 				ConfigValue: types.Int32Null(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Value(0),
 			},
 		},
@@ -67,7 +67,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.Int32Unknown(),
 				ConfigValue: types.Int32Unknown(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Unknown(),
 			},
 		},
@@ -78,7 +78,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:   types.Int32Unknown(),
 				StateValue:  types.Int32Null(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Value(0),
 			},
 		},
@@ -107,7 +107,7 @@ func TestLegacyValue(t *testing.T) {
 				PlanValue:  types.Int32Unknown(),
 				StateValue: types.Int32Null(),
 			},
-			expected: &planmodifier.Int32Response{
+			expected: planmodifier.Int32Response{
 				PlanValue: types.Int32Value(0),
 			},
 		},
@@ -117,11 +117,11 @@ func TestLegacyValue(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			resp := &planmodifier.Int32Response{
+			resp := planmodifier.Int32Response{
 				PlanValue: testCase.request.PlanValue,
 			}
 
-			int32planmodifier.LegacyValue().PlanModifyInt32(context.Background(), testCase.request, resp)
+			int32planmodifier.LegacyValue().PlanModifyInt32(context.Background(), testCase.request, &resp)
 
 			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
 				t.Errorf("unexpected difference: %s", diff)

--- a/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
@@ -42,8 +42,6 @@ func (m legacyValueModifier) PlanModifyInt64(ctx context.Context, req planmodifi
 		return
 	}
 
-	if req.StateValue.IsNull() {
-		resp.PlanValue = types.Int64Value(0)
-		return
-	}
+	resp.PlanValue = types.Int64Value(0)
+	return
 }

--- a/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
@@ -27,13 +27,13 @@ func (m legacyValueModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m legacyValueModifier) PlanModifyInt64(ctx context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	// Use value from Config if set
-	if !req.ConfigValue.IsNull() {
+	// Exit if another planmodifier has set the value
+	if !req.PlanValue.IsUnknown() {
 		return
 	}
 
-	// Exit if another planmodifier has set the value
-	if !req.PlanValue.IsUnknown() {
+	// Use value from Config if set
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 

--- a/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/int64planmodifier/legacy_value.go
@@ -43,5 +43,4 @@ func (m legacyValueModifier) PlanModifyInt64(ctx context.Context, req planmodifi
 	}
 
 	resp.PlanValue = types.Int64Value(0)
-	return
 }

--- a/internal/framework/planmodifiers/int64planmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/int64planmodifier/legacy_value_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package int64planmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/int64planmodifier"
+)
+
+func TestLegacyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  planmodifier.Int64Request
+		expected planmodifier.Int64Response
+	}{
+		"null-state": {
+			// when we first create the resource, use the zero value
+			request: planmodifier.Int64Request{
+				StateValue:  types.Int64Null(),
+				PlanValue:   types.Int64Unknown(),
+				ConfigValue: types.Int64Null(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Value(0),
+			},
+		},
+		"known-plan": {
+			// if another plan modifier has set the planned value, use that
+			request: planmodifier.Int64Request{
+				StateValue:  types.Int64Value(2),
+				PlanValue:   types.Int64Value(1),
+				ConfigValue: types.Int64Null(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Value(1),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// if no value is set in the config on update, use the zero value.
+			request: planmodifier.Int64Request{
+				StateValue:  types.Int64Value(1),
+				PlanValue:   types.Int64Unknown(),
+				ConfigValue: types.Int64Null(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Value(0),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.Int64Request{
+				StateValue:  types.Int64Value(1),
+				PlanValue:   types.Int64Unknown(),
+				ConfigValue: types.Int64Unknown(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Unknown(),
+			},
+		},
+		"under-list": {
+			request: planmodifier.Int64Request{
+				ConfigValue: types.Int64Null(),
+				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:   types.Int64Unknown(),
+				StateValue:  types.Int64Null(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Value(0),
+			},
+		},
+		"under-set": {
+			request: planmodifier.Int64Request{
+				ConfigValue: types.Int64Null(),
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.Int64Type,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.Int64Type,
+								},
+								map[string]attr.Value{
+									"nested_test": types.Int64Unknown(),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue:  types.Int64Unknown(),
+				StateValue: types.Int64Null(),
+			},
+			expected: planmodifier.Int64Response{
+				PlanValue: types.Int64Value(0),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := planmodifier.Int64Response{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			int64planmodifier.LegacyValue().PlanModifyInt64(context.Background(), testCase.request, &resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
@@ -42,8 +42,6 @@ func (m legacyValueModifier) PlanModifyString(ctx context.Context, req planmodif
 		return
 	}
 
-	if req.StateValue.IsNull() {
-		resp.PlanValue = types.StringValue("")
-		return
-	}
+	resp.PlanValue = types.StringValue("")
+	return
 }

--- a/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
@@ -43,5 +43,4 @@ func (m legacyValueModifier) PlanModifyString(ctx context.Context, req planmodif
 	}
 
 	resp.PlanValue = types.StringValue("")
-	return
 }

--- a/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
+++ b/internal/framework/planmodifiers/stringplanmodifier/legacy_value.go
@@ -27,13 +27,13 @@ func (m legacyValueModifier) MarkdownDescription(ctx context.Context) string {
 }
 
 func (m legacyValueModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Use value from Config if set
-	if !req.ConfigValue.IsNull() {
+	// Exit if another planmodifier has set the value
+	if !req.PlanValue.IsUnknown() {
 		return
 	}
 
-	// Exit if another planmodifier has set the value
-	if !req.PlanValue.IsUnknown() {
+	// Use value from Config if set
+	if !req.ConfigValue.IsNull() {
 		return
 	}
 

--- a/internal/framework/planmodifiers/stringplanmodifier/legacy_value_test.go
+++ b/internal/framework/planmodifiers/stringplanmodifier/legacy_value_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stringplanmodifier_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/planmodifiers/stringplanmodifier"
+)
+
+func TestLegacyValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		request  planmodifier.StringRequest
+		expected planmodifier.StringResponse
+	}{
+		"null-state": {
+			// when we first create the resource, use the zero value
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringNull(),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringValue(""),
+			},
+		},
+		"known-plan": {
+			// if another plan modifier has set the planned value, use that
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("state"),
+				PlanValue:   types.StringValue("plan"),
+				ConfigValue: types.StringNull(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringValue("plan"),
+			},
+		},
+		"non-null-state-unknown-plan": {
+			// if no value is set in the config on update, use the zero value.
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("state"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringNull(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringValue(""),
+			},
+		},
+		"unknown-config": {
+			// this is the situation in which a user is
+			// interpolating into a field. We want that to still
+			// show up as unknown, otherwise they'll get apply-time
+			// errors for changing the value even though we knew it
+			// was legitimately possible for it to change and the
+			// provider can't prevent this from happening
+			request: planmodifier.StringRequest{
+				StateValue:  types.StringValue("state"),
+				PlanValue:   types.StringUnknown(),
+				ConfigValue: types.StringUnknown(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringUnknown(),
+			},
+		},
+		"under-list": {
+			request: planmodifier.StringRequest{
+				ConfigValue: types.StringNull(),
+				Path:        path.Root("test").AtListIndex(0).AtName("nested_test"),
+				PlanValue:   types.StringUnknown(),
+				StateValue:  types.StringNull(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringValue(""),
+			},
+		},
+		"under-set": {
+			request: planmodifier.StringRequest{
+				ConfigValue: types.StringNull(),
+				Path: path.Root("test").AtSetValue(
+					types.SetValueMust(
+						types.ObjectType{
+							AttrTypes: map[string]attr.Type{
+								"nested_test": types.StringType,
+							},
+						},
+						[]attr.Value{
+							types.ObjectValueMust(
+								map[string]attr.Type{
+									"nested_test": types.StringType,
+								},
+								map[string]attr.Value{
+									"nested_test": types.StringUnknown(),
+								},
+							),
+						},
+					),
+				).AtName("nested_test"),
+				PlanValue:  types.StringUnknown(),
+				StateValue: types.StringNull(),
+			},
+			expected: planmodifier.StringResponse{
+				PlanValue: types.StringValue(""),
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := planmodifier.StringResponse{
+				PlanValue: testCase.request.PlanValue,
+			}
+
+			stringplanmodifier.LegacyValue().PlanModifyString(context.Background(), testCase.request, &resp)
+
+			if diff := cmp.Diff(testCase.expected, resp); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -3611,8 +3611,8 @@ func TestAccS3BucketLifecycleConfiguration_removeRule(t *testing.T) {
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
 							"expiration":                        checkExpiration_Days(1),
-							names.AttrFilter:                    checkFilter_Prefix("asdf1"),
-							names.AttrID:                        knownvalue.StringExact("del asdf1"),
+							names.AttrFilter:                    checkFilter_Prefix("prefix/"),
+							names.AttrID:                        knownvalue.StringExact("to delete"),
 							"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
 							"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
 							names.AttrPrefix:                    knownvalue.StringExact(""),
@@ -4811,11 +4811,11 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   bucket = aws_s3_bucket.test.bucket
 
   rule {
-    id     = "del asdf1"
+    id     = "to delete"
     status = "Enabled"
 
-    filter { # the issue happens even without prefix, keeping it to show how disastrous the result is
-      prefix = "asdf1"
+    filter {
+      prefix = "prefix/"
     }
     expiration {
       days = 1

--- a/internal/service/s3/bucket_lifecycle_configuration_test.go
+++ b/internal/service/s3/bucket_lifecycle_configuration_test.go
@@ -3587,6 +3587,110 @@ func TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_re
 	})
 }
 
+func TestAccS3BucketLifecycleConfiguration_removeRule(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_lifecycle_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketLifecycleConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_removeRule_Setup(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrBucket), "aws_s3_bucket.test", tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrExpectedBucketOwner), knownvalue.StringExact("")),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRule), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
+							"expiration":                        checkExpiration_Days(1),
+							names.AttrFilter:                    checkFilter_Prefix("asdf1"),
+							names.AttrID:                        knownvalue.StringExact("del asdf1"),
+							"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+							"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+							names.AttrPrefix:                    knownvalue.StringExact(""),
+							names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+							"transition":                        checkTransitions(),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
+							"expiration":                        checkExpiration_DeleteMarker(true),
+							names.AttrFilter:                    checkFilter_None(),
+							names.AttrID:                        knownvalue.StringExact("expire delete markers"),
+							"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+							"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+							names.AttrPrefix:                    knownvalue.StringExact(""),
+							names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+							"transition":                        checkTransitions(),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("transition_default_minimum_object_size"), knownvalue.StringExact("all_storage_classes_128K")),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBucketLifecycleConfigurationConfig_removeRule(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckBucketLifecycleConfigurationExists(ctx, resourceName),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrBucket), "aws_s3_bucket.test", tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrExpectedBucketOwner), knownvalue.StringExact("")),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrBucket), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRule), knownvalue.ListExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
+							"expiration":                        checkExpiration_DeleteMarker(true),
+							names.AttrFilter:                    checkFilter_None(),
+							names.AttrID:                        knownvalue.StringExact("expire delete markers"),
+							"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+							"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+							names.AttrPrefix:                    knownvalue.StringExact(""),
+							names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+							"transition":                        checkTransitions(),
+						}),
+					})),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("transition_default_minimum_object_size"), knownvalue.StringExact("all_storage_classes_128K")),
+				},
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRule), knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"abort_incomplete_multipart_upload": checkAbortIncompleteMultipartUpload_None(),
+								"expiration":                        checkExpiration_DeleteMarker(true),
+								names.AttrFilter:                    checkFilter_None(),
+								names.AttrID:                        knownvalue.StringExact("expire delete markers"),
+								"noncurrent_version_expiration":     checkNoncurrentVersionExpiration_None(),
+								"noncurrent_version_transition":     checkNoncurrentVersionTransitions(),
+								names.AttrPrefix:                    knownvalue.StringExact(""),
+								names.AttrStatus:                    knownvalue.StringExact(tfs3.LifecycleRuleStatusEnabled),
+								"transition":                        checkTransitions(),
+							}),
+						})),
+					},
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBucketLifecycleConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -4699,4 +4803,58 @@ resource "aws_s3_bucket_lifecycle_configuration" "test" {
   transition_default_minimum_object_size = %[2]q
 }
 `, rName, transitionDefaultMinimumObjectSize)
+}
+
+func testAccBucketLifecycleConfigurationConfig_removeRule_Setup(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id     = "del asdf1"
+    status = "Enabled"
+
+    filter { # the issue happens even without prefix, keeping it to show how disastrous the result is
+      prefix = "asdf1"
+    }
+    expiration {
+      days = 1
+    }
+  }
+
+  rule {
+    id     = "expire delete markers"
+    status = "Enabled"
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+`, rName)
+}
+
+func testAccBucketLifecycleConfigurationConfig_removeRule(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket_lifecycle_configuration" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  rule {
+    id     = "expire delete markers"
+    status = "Enabled"
+
+    expiration {
+      expired_object_delete_marker = true
+    }
+  }
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+`, rName)
 }


### PR DESCRIPTION
### Description

Prevents error when removing rules from top of list

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41835

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TPKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_

--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (76.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_removeRule (109.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter (111.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (117.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (118.49s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (118.52s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (119.04s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (121.73s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (122.58s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (50.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (131.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (132.15s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (132.95s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (147.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (162.52s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_noChange (61.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_withChange (60.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_rule_NoFilterOrPrefix (3659.77s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (3666.62s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (3671.52s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_rule_NoFilterOrPrefix (3683.02s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (3684.50s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (3729.76s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (147.17s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (3833.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (3842.22s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (3842.84s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (3842.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (3844.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (3852.00s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (3848.54s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (3855.07s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (3864.73s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (3826.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (3846.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate (3904.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (65.66s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (77.72s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (139.04s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (143.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (130.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (70.59s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd (129.87s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (180.74s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (147.61s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (126.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (137.40s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (138.35s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (129.67s)
--- PASS: TestAccS3BucketLifecycleConfiguration_rule_NoFilterOrPrefix (59.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (58.24s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (62.96s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (122.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (3089.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (3099.92s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (3110.61s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (3108.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (3099.82s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (6683.31s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (6772.87s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (3137.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (3139.28s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (3142.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (3131.99s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (3158.55s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (3040.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (3042.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (2966.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (2948.09s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (2912.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (2950.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (3545.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (3176.90s)
```
