### PR TITLE
Importing default value

### DIFF
--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -36,7 +36,6 @@ import (
 // @SDKResource("aws_secretsmanager_secret", name="Secret")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/secretsmanager;secretsmanager.DescribeSecretOutput")
-// @Testing(importIgnore="force_overwrite_replica_secret;recovery_window_in_days")
 func resourceSecret() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceSecretCreate,

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -45,6 +45,8 @@ func resourceSecret() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+				// Note: The AWS SDK does not currently support reading the 'recovery_window_in_days' and 'force_overwrite_replica_secret' fields during read operations.
+				// These parameters can be set during write operations, but will not be returned when querying the resource.
 				d.Set("force_overwrite_replica_secret", false)
 				d.Set("recovery_window_in_days", 30)
 				return []*schema.ResourceData{d}, nil

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -195,6 +194,7 @@ func resourceSecretCreate(ctx context.Context, d *schema.ResourceData, meta inte
 			return false, err
 		},
 	)
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Secrets Manager Secret (%s): %s", name, err)
 	}
@@ -204,6 +204,7 @@ func resourceSecretCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	_, err = tfresource.RetryWhenNotFound(ctx, PropagationTimeout, func() (interface{}, error) {
 		return findSecretByID(ctx, conn, d.Id())
 	})
+
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Secrets Manager Secret (%s) create: %s", d.Id(), err)
 	}
@@ -255,6 +256,7 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, meta interf
 	var policy *secretsmanager.GetResourcePolicyOutput
 	err = tfresource.Retry(ctx, PropagationTimeout, func() *retry.RetryError {
 		output, err := findSecretPolicyByID(ctx, conn, d.Id())
+
 		if err != nil {
 			return retry.NonRetryableError(err)
 		}
@@ -324,6 +326,7 @@ func resourceSecretUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 
 		_, err := conn.UpdateSecret(ctx, input)
+
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating Secrets Manager Secret (%s): %s", d.Id(), err)
 		}
@@ -445,6 +448,7 @@ func putSecretPolicy(ctx context.Context, conn *secretsmanager.Client, input *se
 	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.MalformedPolicyDocumentException](ctx, PropagationTimeout, func() (interface{}, error) {
 		return conn.PutResourcePolicy(ctx, input)
 	}, "This resource policy contains an unsupported principal")
+
 	if err != nil {
 		return nil, fmt.Errorf("putting Secrets Manager Secret (%s) policy: %w", aws.ToString(input.SecretId), err)
 	}
@@ -458,6 +462,7 @@ func deleteSecretPolicy(ctx context.Context, conn *secretsmanager.Client, id str
 	}
 
 	_, err := conn.DeleteResourcePolicy(ctx, input)
+
 	if err != nil {
 		return fmt.Errorf("deleting Secrets Manager Secret (%s) policy: %w", id, err)
 	}
@@ -492,6 +497,7 @@ func findSecretByID(ctx context.Context, conn *secretsmanager.Client, id string)
 	}
 
 	output, err := findSecret(ctx, conn, input)
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -358,6 +358,7 @@ func testAccCheckSecretExists(ctx context.Context, n string, v *secretsmanager.D
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SecretsManagerClient(ctx)
 
 		output, err := tfsecretsmanager.FindSecretByID(ctx, conn, rs.Primary.ID)
+		
 		if err != nil {
 			return err
 		}

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -53,10 +53,9 @@ func TestAccSecretsManagerSecret_basic(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -82,10 +81,9 @@ func TestAccSecretsManagerSecret_withNamePrefix(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -142,10 +140,9 @@ func TestAccSecretsManagerSecret_description(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -239,10 +236,9 @@ func TestAccSecretsManagerSecret_kmsKeyID(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"recovery_window_in_days", "force_overwrite_replica_secret"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -362,7 +358,6 @@ func testAccCheckSecretExists(ctx context.Context, n string, v *secretsmanager.D
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SecretsManagerClient(ctx)
 
 		output, err := tfsecretsmanager.FindSecretByID(ctx, conn, rs.Primary.ID)
-
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

PR includes importing into tfstate default values for fields:
* force_overwrite_replica_secret
* recovery_window_in_days

It avoids update-in-place if these fields are not defined in the terraform resource.

### Relations

Relates: #42139

### References

https://docs.aws.amazon.com/sdk-for-go/api/service/secretsmanager/#DescribeSecretOutput

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccSecretsManagerSecret_kmsKeyID PKG=secretsmanager
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.5 test ./internal/service/secretsmanager/... -v -count 1 -parallel 20 -run='TestAccSecretsManagerSecret_kmsKeyID'  -timeout 360m -vet=off
2025/04/14 23:16:52 Initializing Terraform AWS Provider...
=== RUN   TestAccSecretsManagerSecret_kmsKeyID
=== PAUSE TestAccSecretsManagerSecret_kmsKeyID
=== CONT  TestAccSecretsManagerSecret_kmsKeyID
--- PASS: TestAccSecretsManagerSecret_kmsKeyID (36.31s)
PASS
ok      [github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager](http://github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager)     36.452s
```
