### PR TITLE
resource/aws_cloudfront_key_value_store: Set `id` attribute to remote object's `Id`

### DIFF
--- a/.changelog/42230.txt
+++ b/.changelog/42230.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_cloudfront_key_value_store: Attribute `id` is now set to remote object's `Id` instead of `name`
+```

--- a/internal/service/cloudfront/key_value_store.go
+++ b/internal/service/cloudfront/key_value_store.go
@@ -241,7 +241,7 @@ func (r *keyValueStoreResource) Delete(ctx context.Context, request resource.Del
 	}
 }
 
-func (w *keyValueStoreResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+func (r *keyValueStoreResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrName), request, response)
 }
 

--- a/internal/service/cloudfront/key_value_store_test.go
+++ b/internal/service/cloudfront/key_value_store_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -39,12 +38,10 @@ func TestAccCloudFrontKeyValueStore_basic(t *testing.T) {
 				Config: testAccKeyValueStoreConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckKeyValueStoreExists(ctx, resourceName, &keyvaluestore),
-					func(s *terraform.State) error {
-						return acctest.CheckResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "cloudfront", "key-value-store/"+aws.ToString(keyvaluestore.Id))(s)
-					},
+					acctest.CheckResourceAttrGlobalARNFormat(ctx, resourceName, names.AttrARN, "cloudfront", "key-value-store/{id}"),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrComment),
 					resource.TestCheckResourceAttrSet(resourceName, "etag"),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttrSet(resourceName, "last_modified_time"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
@@ -52,6 +49,7 @@ func TestAccCloudFrontKeyValueStore_basic(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportStateVerify: true,
 			},
 		},
@@ -109,6 +107,7 @@ func TestAccCloudFrontKeyValueStore_comment(t *testing.T) {
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportStateVerify: true,
 			},
 			{
@@ -117,6 +116,12 @@ func TestAccCloudFrontKeyValueStore_comment(t *testing.T) {
 					testAccCheckKeyValueStoreExists(ctx, resourceName, &keyvaluestore),
 					resource.TestCheckResourceAttr(resourceName, names.AttrComment, comment2),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -131,7 +136,7 @@ func testAccCheckKeyValueStoreDestroy(ctx context.Context) resource.TestCheckFun
 				continue
 			}
 
-			_, err := tfcloudfront.FindKeyValueStoreByName(ctx, conn, rs.Primary.ID)
+			_, err := tfcloudfront.FindKeyValueStoreByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -141,7 +146,7 @@ func testAccCheckKeyValueStoreDestroy(ctx context.Context) resource.TestCheckFun
 				return err
 			}
 
-			return fmt.Errorf("CloudFront Key Value Store %s still exists", rs.Primary.ID)
+			return fmt.Errorf("CloudFront Key Value Store %q still exists", rs.Primary.Attributes[names.AttrName])
 		}
 
 		return nil
@@ -157,7 +162,7 @@ func testAccCheckKeyValueStoreExists(ctx context.Context, n string, v *awstypes.
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontClient(ctx)
 
-		output, err := tfcloudfront.FindKeyValueStoreByName(ctx, conn, rs.Primary.ID)
+		output, err := tfcloudfront.FindKeyValueStoreByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 
 		if err != nil {
 			return err

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -27,6 +27,7 @@ Upgrade topics:
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
+- [resource/aws_cloudfront_key_value_store](#resourceaws_cloudfront_key_value_store)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
 - [resource/aws_instance](#resourceaws_instance)
@@ -158,6 +159,11 @@ Remove `elastic_inference_accelerator` from your configuration—it no longer ex
 
 * `compute_environment_name` has been renamed to `name`.
 * `compute_environment_name_prefix` has been renamed to `name_prefix`.
+
+## resource/aws_cloudfront_key_value_store
+
+The `id` attribute is now set the to ID value returned by the AWS API.
+For the name, use the `name` attribute.
 
 ## resource/aws_cloudfront_response_headers_policy
 

--- a/website/docs/r/cloudfront_key_value_store.html.markdown
+++ b/website/docs/r/cloudfront_key_value_store.html.markdown
@@ -36,8 +36,8 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) identifying your CloudFront KeyValueStore.
-* `id` - A unique identifier for the KeyValueStore. Same as `name`.
 * `etag` - ETag hash of the KeyValueStore.
+* `id` - A unique identifier for the KeyValueStore.
 
 ## Timeouts
 


### PR DESCRIPTION
### Description

The `id` attribute was set to `name`, though the AWS API returned an `Id` parameter. Update `id` to `Id`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40839

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cloudfront TESTS=TestAccCloudFrontKeyValueStore_

--- PASS: TestAccCloudFrontKeyValueStore_disappears (28.86s)
--- PASS: TestAccCloudFrontKeyValueStore_basic (31.18s)
--- PASS: TestAccCloudFrontKeyValueStore_comment (42.87s)
```
