### PR TITLE
resource/aws_codeconnections_host: Deprecates `id` in favour of `arn`

### DIFF
--- a/.changelog/42232.txt
+++ b/.changelog/42232.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codeconnections_host: Deprecates `id` in favor of `arn`
+```

--- a/.changelog/42232.txt
+++ b/.changelog/42232.txt
@@ -1,3 +1,3 @@
-```release-note:enhancement
+```release-note:note
 resource/aws_codeconnections_host: Deprecates `id` in favor of `arn`
 ```

--- a/internal/service/codeconnections/host.go
+++ b/internal/service/codeconnections/host.go
@@ -57,7 +57,7 @@ func (r *hostResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
-			names.AttrID:  framework.IDAttribute(),
+			names.AttrID:  framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
 			names.AttrName: schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{

--- a/internal/service/codeconnections/host_test.go
+++ b/internal/service/codeconnections/host_test.go
@@ -38,8 +38,8 @@ func TestAccCodeConnectionsHost_basic(t *testing.T) {
 				Config: testAccHostConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHostExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrID, "codeconnections", regexache.MustCompile("host/.+")),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+")),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+$")),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", string(types.ProviderTypeGithubEnterpriseServer)),
@@ -98,8 +98,8 @@ func TestAccCodeConnectionsHost_vpc(t *testing.T) {
 				Config: testAccHostConfig_vpcNoCertificate(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHostExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrID, "codeconnections", regexache.MustCompile("host/.+")),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+")),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+$")),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", string(types.ProviderTypeGithubEnterpriseServer)),
@@ -119,8 +119,8 @@ func TestAccCodeConnectionsHost_vpc(t *testing.T) {
 				Config: testAccHostConfig_vpc(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckHostExists(ctx, resourceName, &v),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrID, "codeconnections", regexache.MustCompile("host/.+")),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+")),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codeconnections", regexache.MustCompile("host/.+$")),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "provider_endpoint", "https://example.com"),
 					resource.TestCheckResourceAttr(resourceName, "provider_type", string(types.ProviderTypeGithubEnterpriseServer)),

--- a/website/docs/r/codeconnections_host.html.markdown
+++ b/website/docs/r/codeconnections_host.html.markdown
@@ -44,8 +44,8 @@ A `vpc_configuration` block supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The CodeConnections Host ARN.
 * `arn` - The CodeConnections Host ARN.
+* `id` - (**Deprecated**) The CodeConnections Host ARN.
 * `status` - The CodeConnections Host status. Possible values are `PENDING`, `AVAILABLE`, `VPC_CONFIG_DELETING`, `VPC_CONFIG_INITIALIZING`, and `VPC_CONFIG_FAILED_INITIALIZATION`.
 
 ## Import


### PR DESCRIPTION
### Description

Deprecates `id` in favour of `arn` in resource `aws_codeconnections_host`


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=codeconnections TESTS=TestAccCodeConnectionsHost_

--- PASS: TestAccCodeConnectionsHost_disappears (12.32s)
--- PASS: TestAccCodeConnectionsHost_basic (14.51s)
--- PASS: TestAccCodeConnectionsHost_tags (28.58s)
--- PASS: TestAccCodeConnectionsHost_vpc (582.97s)
```
