### PR TITLE
Fix panic in kms_custom_key_store

### DIFF
--- a/.changelog/42241.txt
+++ b/.changelog/42241.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_kms_custom_key_store: Fix `panic: runtime error: invalid memory address or nil pointer dereference` when no `XksProxyConfiguration` is returned
+```

--- a/internal/service/kms/custom_key_store.go
+++ b/internal/service/kms/custom_key_store.go
@@ -184,10 +184,12 @@ func resourceCustomKeyStoreRead(ctx context.Context, d *schema.ResourceData, met
 	d.Set("key_store_password", d.Get("key_store_password"))
 	d.Set("trust_anchor_certificate", output.TrustAnchorCertificate)
 
-	d.Set("xks_proxy_connectivity", output.XksProxyConfiguration.Connectivity)
-	d.Set("xks_proxy_uri_endpoint", output.XksProxyConfiguration.UriEndpoint)
-	d.Set("xks_proxy_uri_path", output.XksProxyConfiguration.UriPath)
-	d.Set("xks_proxy_vpc_endpoint_service_name", output.XksProxyConfiguration.VpcEndpointServiceName)
+	if output.XksProxyConfiguration != nil {
+		d.Set("xks_proxy_connectivity", output.XksProxyConfiguration.Connectivity)
+		d.Set("xks_proxy_uri_endpoint", output.XksProxyConfiguration.UriEndpoint)
+		d.Set("xks_proxy_uri_path", output.XksProxyConfiguration.UriPath)
+		d.Set("xks_proxy_vpc_endpoint_service_name", output.XksProxyConfiguration.VpcEndpointServiceName)
+	}
 
 	return diags
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR fixes a panic in the `kms_custom_key_store` resource when no proxy configuration is returned. I've verified the fix on the following program:

```hcl
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
      version = "5.94.1"
    }
  }
}

provider "aws" {
  region = "eu-west-1"
}

resource "random_password" "keystore_pw" {
  length = 32
}


resource "aws_kms_custom_key_store" "custom_key_store" {
  custom_key_store_name    = "customkeystore"
  cloud_hsm_cluster_id     = "REDACTED"
  key_store_password       = random_password.keystore_pw.result
  trust_anchor_certificate = file("./clusterCA.crt")
}

```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/42240

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
