### PR TITLE
apigateway_deployment: Deprecate `invoke_url`, `execution_arn`

### DIFF
--- a/.changelog/42244.txt
+++ b/.changelog/42244.txt
@@ -1,0 +1,3 @@
+```release-note:note
+resource/aws_api_gateway_deployment: Computed attributes `invoke_url` and `execution_arn` are deprecated. Use the `invoke_url` and `execution_arn` attributes of the `aws_api_gateway_stage` resource instead.
+```

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -73,12 +73,14 @@ func resourceDeployment() *schema.Resource {
 				Deprecated: "canary_settings is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "execution_arn is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			"invoke_url": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:       schema.TypeString,
+				Computed:   true,
+				Deprecated: "invoke_url is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			"rest_api_id": {
 				Type:     schema.TypeString,

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -154,9 +154,9 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - ID of the deployment
-* `invoke_url` - URL to invoke the API pointing to the stage,
+* `invoke_url` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** URL to invoke the API pointing to the stage,
   e.g., `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/prod`
-* `execution_arn` - Execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
+* `execution_arn` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** Execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
   when allowing API Gateway to invoke a Lambda function,
   e.g., `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `created_date` - Creation date of the deployment


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


This PR deprecates the `invoke_url` and `execution_arn` computed attributes from the `aws_api_gateway_deployment` resource.

#### Background

The `invoke_url` and `execution_arn` attributes were originally included in the `aws_api_gateway_deployment` resource to support the now-deprecated behavior of implicitly creating a stage when a deployment was created. This approach has been phased out in favor of explicitly managing stages using the `aws_api_gateway_stage` resource.

#### Changes

- Marked the `invoke_url` and `execution_arn` attributes on `aws_api_gateway_deployment` as deprecated.
- Updated documentation to direct users to retrieve these attributes from the `aws_api_gateway_stage` resource instead.

#### Impact

These attributes will no longer be populated in the `aws_api_gateway_deployment` resource and should be accessed via `aws_api_gateway_stage`. This change aligns the resource behavior with current best practices and ensures a cleaner separation of concerns between deployments and stages.

#### Migration

Users relying on `aws_api_gateway_deployment.invoke_url` or `.execution_arn` should update their configurations to reference the corresponding attributes in the `aws_api_gateway_stage` resource, e.g.:

```hcl
aws_api_gateway_stage.my_stage.invoke_url
aws_api_gateway_stage.my_stage.execution_arn
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

* #39958
* #39957

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* [AWS API Gateway documentation on stages](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-deploy-api.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
