### PR TITLE
apigateway_deployment: Remove stage from deployment

### DIFF
--- a/.changelog/42249.txt
+++ b/.changelog/42249.txt
@@ -1,3 +1,3 @@
 ```release-note:breaking-change
-resource/aws_api_gateway_deployment: Remove `canary_settings`, `execution_arn`, `invoke_url`, `stage_description`, `stage_name` arguments. Instead, use the `aws_api_gateway_stage` resource to manage stages.
+resource/aws_api_gateway_deployment: Remove `canary_settings`, `execution_arn`, `invoke_url`, `stage_description`, and `stage_name` arguments. Instead, use the `aws_api_gateway_stage` resource to manage stages.
 ```

--- a/.changelog/42249.txt
+++ b/.changelog/42249.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_api_gateway_deployment: Remove `canary_settings`, `execution_arn`, `invoke_url`, `stage_description`, `stage_name` arguments. Instead, use the `aws_api_gateway_stage` resource to manage stages.
+```

--- a/internal/service/apigateway/deployment.go
+++ b/internal/service/apigateway/deployment.go
@@ -11,10 +11,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,55 +45,10 @@ func resourceDeployment() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"canary_settings": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"percent_traffic": {
-							Type:     schema.TypeFloat,
-							Optional: true,
-							Default:  0.0,
-						},
-						"stage_variable_overrides": {
-							Type:     schema.TypeMap,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Optional: true,
-						},
-						"use_stage_cache": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
-					},
-				},
-				Deprecated: "canary_settings is deprecated. Use the aws_api_gateway_stage resource instead.",
-			},
-			"execution_arn": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"invoke_url": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"rest_api_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-			},
-			"stage_description": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "stage_description is deprecated. Use the aws_api_gateway_stage resource instead.",
-			},
-			"stage_name": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "stage_name is deprecated. Use the aws_api_gateway_stage resource instead.",
 			},
 			names.AttrTriggers: {
 				Type:     schema.TypeMap,
@@ -118,30 +71,9 @@ func resourceDeploymentCreate(ctx context.Context, d *schema.ResourceData, meta 
 	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
 
 	input := apigateway.CreateDeploymentInput{
-		Description:      aws.String(d.Get(names.AttrDescription).(string)),
-		RestApiId:        aws.String(d.Get("rest_api_id").(string)),
-		StageDescription: aws.String(d.Get("stage_description").(string)),
-		StageName:        aws.String(d.Get("stage_name").(string)),
-		Variables:        flex.ExpandStringValueMap(d.Get("variables").(map[string]any)),
-	}
-
-	_, hasStageName := d.GetOk("stage_name")
-
-	if _, ok := d.GetOk("stage_description"); !hasStageName && ok {
-		diags = append(diags, noEffectWithoutWarningDiag(
-			cty.GetAttrPath("stage_description"),
-			cty.GetAttrPath("stage_name"),
-		))
-	}
-
-	if v, ok := d.GetOk("canary_settings"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
-		input.CanarySettings = expandDeploymentCanarySettings(v.([]any)[0].(map[string]any))
-		if !hasStageName {
-			diags = append(diags, noEffectWithoutWarningDiag(
-				cty.GetAttrPath("canary_settings"),
-				cty.GetAttrPath("stage_name"),
-			))
-		}
+		Description: aws.String(d.Get(names.AttrDescription).(string)),
+		RestApiId:   aws.String(d.Get("rest_api_id").(string)),
+		Variables:   flex.ExpandStringValueMap(d.Get("variables").(map[string]any)),
 	}
 
 	deployment, err := conn.CreateDeployment(ctx, &input)
@@ -172,18 +104,8 @@ func resourceDeploymentRead(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendErrorf(diags, "reading API Gateway Deployment (%s): %s", d.Id(), err)
 	}
 
-	stageName := d.Get("stage_name").(string)
 	d.Set(names.AttrCreatedDate, deployment.CreatedDate.Format(time.RFC3339))
 	d.Set(names.AttrDescription, deployment.Description)
-	executionARN := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Service:   "execute-api",
-		Region:    meta.(*conns.AWSClient).Region(ctx),
-		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
-		Resource:  fmt.Sprintf("%s/%s", restAPIID, stageName),
-	}.String()
-	d.Set("execution_arn", executionARN)
-	d.Set("invoke_url", meta.(*conns.AWSClient).APIGatewayInvokeURL(ctx, restAPIID, stageName))
 
 	return diags
 }
@@ -222,36 +144,7 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).APIGatewayClient(ctx)
 
-	// If the stage has been updated to point at a different deployment, then
-	// the stage should not be removed when this deployment is deleted.
-	shouldDeleteStage := false
-	// API Gateway allows an empty state name (e.g. ""), but the AWS Go SDK
-	// now has validation for the parameter, so we must check first.
-	// InvalidParameter: 1 validation error(s) found.
-	//  - minimum field size of 1, GetStageInput.StageName.
 	restAPIID := d.Get("rest_api_id").(string)
-	stageName := d.Get("stage_name").(string)
-	if stageName != "" {
-		stage, err := findStageByTwoPartKey(ctx, conn, restAPIID, stageName)
-
-		if err == nil {
-			shouldDeleteStage = aws.ToString(stage.DeploymentId) == d.Id()
-		} else if !tfresource.NotFound(err) {
-			return sdkdiag.AppendErrorf(diags, "reading API Gateway Stage (%s): %s", stageName, err)
-		}
-	}
-
-	if shouldDeleteStage {
-		input := apigateway.DeleteStageInput{
-			StageName: aws.String(stageName),
-			RestApiId: aws.String(restAPIID),
-		}
-		_, err := conn.DeleteStage(ctx, &input)
-
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "deleting API Gateway Stage (%s): %s", stageName, err)
-		}
-	}
 
 	log.Printf("[DEBUG] Deleting API Gateway Deployment: %s", d.Id())
 	input := apigateway.DeleteDeploymentInput{
@@ -261,15 +154,6 @@ func resourceDeploymentDelete(ctx context.Context, d *schema.ResourceData, meta 
 	_, err := conn.DeleteDeployment(ctx, &input)
 
 	if errs.IsAErrorMessageContains[*types.BadRequestException](err, "Active stages with canary settings pointing to this deployment must be moved or deleted") {
-		stageInput := apigateway.DeleteStageInput{
-			StageName: aws.String(stageName),
-			RestApiId: aws.String(restAPIID),
-		}
-		_, err = conn.DeleteStage(ctx, &stageInput)
-		if err != nil {
-			return sdkdiag.AppendErrorf(diags, "deleting API Gateway Stage (%s): %s", stageName, err)
-		}
-
 		deploymentInput := apigateway.DeleteDeploymentInput{
 			DeploymentId: aws.String(d.Id()),
 			RestApiId:    aws.String(restAPIID),
@@ -327,37 +211,4 @@ func findDeploymentByTwoPartKey(ctx context.Context, conn *apigateway.Client, re
 	}
 
 	return output, nil
-}
-
-func expandDeploymentCanarySettings(tfMap map[string]any) *types.DeploymentCanarySettings {
-	if tfMap == nil {
-		return nil
-	}
-
-	apiObject := &types.DeploymentCanarySettings{}
-
-	if v, ok := tfMap["percent_traffic"].(float64); ok {
-		apiObject.PercentTraffic = v
-	}
-
-	if v, ok := tfMap["stage_variable_overrides"].(map[string]any); ok && len(v) > 0 {
-		apiObject.StageVariableOverrides = flex.ExpandStringValueMap(v)
-	}
-
-	if v, ok := tfMap["use_stage_cache"].(bool); ok {
-		apiObject.UseStageCache = v
-	}
-
-	return apiObject
-}
-
-func noEffectWithoutWarningDiag(path, otherPath cty.Path) diag.Diagnostic {
-	return errs.NewAttributeWarningDiagnostic(
-		path,
-		"Invalid Attribute Combination",
-		fmt.Sprintf("Attribute %q has no effect when %q is not set.",
-			errs.PathString(path),
-			errs.PathString(otherPath),
-		),
-	)
 }

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -126,7 +126,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment1),
 					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
 				// Due to how the Terraform state is handled for resources during creation,
 				// any SHA1 of whole resources will change after first apply, then stabilize.
@@ -139,7 +139,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 					testAccCheckDeploymentRecreated(&deployment1, &deployment2),
 					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
 			},
 			{
@@ -149,7 +149,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 					testAccCheckDeploymentNotRecreated(&deployment2, &deployment3),
 					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
 			},
 			{
@@ -159,7 +159,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 					testAccCheckDeploymentRecreated(&deployment3, &deployment4),
 					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
-					resource.TestCheckResourceAttr(stageResource, "description", "description2"),
+					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description2"),
 				),
 			},
 		},
@@ -215,7 +215,7 @@ func TestAccAPIGatewayDeployment_stageDescription(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
 					testAccCheckStageExists(ctx, stageResource, &stage),
-					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, names.AttrDescription, "description1"),
 				),
 			},
 		},

--- a/internal/service/apigateway/deployment_test.go
+++ b/internal/service/apigateway/deployment_test.go
@@ -40,11 +40,7 @@ func TestAccAPIGatewayDeployment_basic(t *testing.T) {
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreatedDate),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "execution_arn", "execute-api", regexache.MustCompile(".+/")),
-					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexache.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/", acctest.Region()))),
 					resource.TestCheckResourceAttrPair(resourceName, "rest_api_id", restApiResourceName, names.AttrID),
-					resource.TestCheckNoResourceAttr(resourceName, "stage_description"),
-					resource.TestCheckNoResourceAttr(resourceName, "stage_name"),
 					resource.TestCheckNoResourceAttr(resourceName, "variables.%"),
 				),
 			},
@@ -116,6 +112,7 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 	var stage apigateway.GetStageOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
+	stageResource := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
@@ -127,9 +124,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 				Config: testAccDeploymentConfig_triggers(rName, "description1", "https://example.com"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment1),
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
 				),
 				// Due to how the Terraform state is handled for resources during creation,
 				// any SHA1 of whole resources will change after first apply, then stabilize.
@@ -140,9 +137,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment2),
 					testAccCheckDeploymentRecreated(&deployment1, &deployment2),
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
 				),
 			},
 			{
@@ -150,9 +147,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment3),
 					testAccCheckDeploymentNotRecreated(&deployment2, &deployment3),
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
-					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
+					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
 				),
 			},
 			{
@@ -160,9 +157,9 @@ func TestAccAPIGatewayDeployment_triggers(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment4),
 					testAccCheckDeploymentRecreated(&deployment3, &deployment4),
-					testAccCheckStageExists(ctx, resourceName, &stage),
+					testAccCheckStageExists(ctx, stageResource, &stage),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description2"),
-					resource.TestCheckResourceAttr(resourceName, "stage_description", "description2"),
+					resource.TestCheckResourceAttr(stageResource, "description", "description2"),
 				),
 			},
 		},
@@ -205,6 +202,7 @@ func TestAccAPIGatewayDeployment_stageDescription(t *testing.T) {
 	var stage apigateway.GetStageOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
+	stageResource := "aws_api_gateway_stage.test"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
@@ -216,8 +214,8 @@ func TestAccAPIGatewayDeployment_stageDescription(t *testing.T) {
 				Config: testAccDeploymentConfig_stageDescription(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					testAccCheckStageExists(ctx, resourceName, &stage),
-					resource.TestCheckResourceAttr(resourceName, "stage_description", "description1"),
+					testAccCheckStageExists(ctx, stageResource, &stage),
+					resource.TestCheckResourceAttr(stageResource, "description", "description1"),
 				),
 			},
 		},
@@ -230,6 +228,7 @@ func TestAccAPIGatewayDeployment_stageName(t *testing.T) {
 	var stage apigateway.GetStageOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_api_gateway_deployment.test"
+	stageResource := "aws_api_gateway_stage.test"
 	stageName := sdkacctest.RandomWithPrefix("tf-acc-test-deployment")
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -242,41 +241,10 @@ func TestAccAPIGatewayDeployment_stageName(t *testing.T) {
 				Config: testAccDeploymentConfig_stageName(rName, stageName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					testAccCheckStageExists(ctx, resourceName, &stage),
-					resource.TestCheckResourceAttr(resourceName, "stage_name", stageName),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "execution_arn", "execute-api", regexache.MustCompile(fmt.Sprintf(".+/%s", stageName))),
-					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexache.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", acctest.Region(), stageName))),
-				),
-			},
-			{
-				Config: testAccDeploymentConfig_required(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckNoResourceAttr(resourceName, "stage_name"),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "execution_arn", "execute-api", regexache.MustCompile(".+/")),
-					resource.TestMatchResourceAttr(resourceName, "invoke_url", regexache.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/", acctest.Region()))),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAPIGatewayDeployment_StageName_emptyString(t *testing.T) {
-	ctx := acctest.Context(t)
-	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_api_gateway_deployment.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeploymentConfig_stageName(rName, ""),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					resource.TestCheckResourceAttr(resourceName, "stage_name", ""),
+					testAccCheckStageExists(ctx, stageResource, &stage),
+					resource.TestCheckResourceAttr(stageResource, "stage_name", stageName),
+					acctest.MatchResourceAttrRegionalARN(ctx, stageResource, "execution_arn", "execute-api", regexache.MustCompile(fmt.Sprintf(".+/%s", stageName))),
+					resource.TestMatchResourceAttr(stageResource, "invoke_url", regexache.MustCompile(fmt.Sprintf("https://.+\\.execute-api\\.%s.amazonaws\\.com/%s", acctest.Region(), stageName))),
 				),
 			},
 		},
@@ -326,46 +294,6 @@ func TestAccAPIGatewayDeployment_conflictingConnectionType(t *testing.T) {
 					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
 				),
 				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
-func TestAccAPIGatewayDeployment_deploymentCanarySettings(t *testing.T) {
-	ctx := acctest.Context(t)
-	var deployment apigateway.GetDeploymentOutput
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	url := "https://example.com"
-	resourceName := "aws_api_gateway_deployment.test"
-	resourceNameDeploymentMain := "aws_api_gateway_deployment.test_main"
-	resourceNameStage := "aws_api_gateway_stage.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeploymentDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccDeploymentConfig_canarySettings(rName, url),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeploymentExists(ctx, resourceName, &deployment),
-					resource.TestCheckResourceAttrPair(resourceNameStage, "deployment_id", resourceNameDeploymentMain, names.AttrID),
-					resource.TestCheckResourceAttr(resourceName, "variables.one", "1"),
-					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.percent_traffic", "33.33"),
-					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.stage_variable_overrides.one", "3"),
-					resource.TestCheckResourceAttr(resourceName, "canary_settings.0.use_stage_cache", acctest.CtTrue),
-				),
-			},
-			{
-				RefreshState: true,
-				Check: resource.ComposeTestCheckFunc(
-					// check that canary settings on the deployment match what is on the stage
-					resource.TestCheckResourceAttrPair(resourceNameStage, "deployment_id", resourceNameDeploymentMain, names.AttrID),
-					resource.TestCheckResourceAttrPair(resourceName, "canary_settings.0.percent_traffic", resourceNameStage, "canary_settings.0.percent_traffic"),
-					resource.TestCheckResourceAttrPair(resourceName, "canary_settings.0.stage_variable_overrides.one", resourceNameStage, "canary_settings.0.stage_variable_overrides.one"),
-					resource.TestCheckResourceAttrPair(resourceName, "canary_settings.0.use_stage_cache", resourceNameStage, "canary_settings.0.use_stage_cache"),
-				),
 			},
 		},
 	})
@@ -496,11 +424,20 @@ resource "aws_api_gateway_integration_response" "test" {
 
 func testAccDeploymentConfig_triggers(rName, description, url string) string {
 	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, url), fmt.Sprintf(`
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = %[1]q
+  description   = %[2]q
+  deployment_id = aws_api_gateway_deployment.test.id
+
+  lifecycle {
+    ignore_changes = [variables, canary_settings]
+  }
+}
+
 resource "aws_api_gateway_deployment" "test" {
-  description       = %[1]q
-  rest_api_id       = aws_api_gateway_rest_api.test.id
-  stage_description = %[1]q
-  stage_name        = "tf-acc-test"
+  description = %[2]q
+  rest_api_id = aws_api_gateway_rest_api.test.id
 
   triggers = {
     redeployment = sha1(jsonencode(aws_api_gateway_integration.test))
@@ -510,7 +447,7 @@ resource "aws_api_gateway_deployment" "test" {
     create_before_destroy = true
   }
 }
-`, description))
+`, rName, description))
 }
 
 func testAccDeploymentConfig_description(rName, description string) string {
@@ -525,7 +462,8 @@ resource "aws_api_gateway_deployment" "test" {
 }
 
 func testAccDeploymentConfig_required(rName string) string {
-	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, "http://example.com"), `
+	return acctest.ConfigCompose(
+		testAccDeploymentConfig_base(rName, "http://example.com"), `
 resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
@@ -536,23 +474,41 @@ resource "aws_api_gateway_deployment" "test" {
 
 func testAccDeploymentConfig_stageDescription(rName, stageDescription string) string {
 	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, "http://example.com"), fmt.Sprintf(`
-resource "aws_api_gateway_deployment" "test" {
-  depends_on = [aws_api_gateway_integration.test]
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = %[1]q
+  description   = %[2]q
+  deployment_id = aws_api_gateway_deployment.test.id
 
-  rest_api_id       = aws_api_gateway_rest_api.test.id
-  stage_description = %[1]q
-  stage_name        = "tf-acc-test"
-}
-`, stageDescription))
+  lifecycle {
+    ignore_changes = [variables, canary_settings]
+  }
 }
 
-func testAccDeploymentConfig_stageName(rName, stageName string) string {
-	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, "http://example.com"), fmt.Sprintf(`
 resource "aws_api_gateway_deployment" "test" {
   depends_on = [aws_api_gateway_integration.test]
 
   rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = %[1]q
+}
+`, rName, stageDescription))
+}
+
+func testAccDeploymentConfig_stageName(rName, stageName string) string {
+	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, "http://example.com"), fmt.Sprintf(`
+resource "aws_api_gateway_stage" "test" {
+  rest_api_id   = aws_api_gateway_rest_api.test.id
+  stage_name    = %[1]q
+  deployment_id = aws_api_gateway_deployment.test.id
+
+  lifecycle {
+    ignore_changes = [variables, canary_settings]
+  }
+}
+
+resource "aws_api_gateway_deployment" "test" {
+  depends_on = [aws_api_gateway_integration.test]
+
+  rest_api_id = aws_api_gateway_rest_api.test.id
 }
 `, stageName))
 }
@@ -621,43 +577,4 @@ resource "aws_lambda_function" "test" {
   runtime       = "nodejs20.x"
 }
 `, rName))
-}
-
-func testAccDeploymentConfig_canarySettings(rName, url string) string {
-	return acctest.ConfigCompose(testAccDeploymentConfig_base(rName, url), `
-resource "aws_api_gateway_stage" "test" {
-  rest_api_id   = aws_api_gateway_rest_api.test.id
-  stage_name    = "prod"
-  deployment_id = aws_api_gateway_deployment.test_main.id
-
-  lifecycle {
-    ignore_changes = [variables, canary_settings]
-  }
-}
-
-resource "aws_api_gateway_deployment" "test_main" {
-  depends_on = [aws_api_gateway_integration.test]
-
-  description = "test-api-gateway"
-  rest_api_id = aws_api_gateway_rest_api.test.id
-}
-
-resource "aws_api_gateway_deployment" "test" {
-  depends_on = [aws_api_gateway_integration.test]
-
-  rest_api_id = aws_api_gateway_rest_api.test.id
-  stage_name  = aws_api_gateway_stage.test.stage_name
-  canary_settings {
-    percent_traffic = "33.33"
-    stage_variable_overrides = {
-      one = "3"
-    }
-    use_stage_cache = "true"
-  }
-  variables = {
-    one = "1"
-    two = "2"
-  }
-}
-`)
 }

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -26,6 +26,7 @@ Upgrade topics:
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
+- [resource/aws_api_gateway_deployment](#resourceaws_api_gateway_deployment)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
@@ -153,6 +154,47 @@ Remove `inference_accelerator_overrides` from your configuration—it no longer 
 ## data-source/aws_launch_template
 
 Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## resource/aws_api_gateway_deployment
+
+The following arguments have been **removed** from the `aws_api_gateway_deployment` resource:
+
+- `stage_name`
+- `stage_description`
+- `canary_settings`
+
+Additionally, the computed attributes `invoke_url` and `execution_arn` have been removed from `aws_api_gateway_deployment`. These are now only available via the `aws_api_gateway_stage` resource.
+
+### Migration Example
+
+**Before (v5 and earlier, using implicit stage):**
+```hcl
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = "prod"
+}
+```
+
+**After (v6+, using explicit stage):**
+```hcl
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+}
+
+resource "aws_api_gateway_stage" "prod" {
+  stage_name    = "prod"
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  deployment_id = aws_api_gateway_deployment.example.id
+}
+```
+
+### Importing an Implicit Stage into Terraform
+
+If your previous configuration relied on an implicitly created stage, you can import it into a managed `aws_api_gateway_stage` resource like so:
+
+```sh
+terraform import aws_api_gateway_stage.prod <rest_api_id>/<stage_name>
+```
 
 ## resource/aws_batch_compute_environment
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -176,7 +176,8 @@ Additionally, the computed attributes `invoke_url` and `execution_arn` have been
 ### Migration Example
 
 **Before (v5 and earlier, using implicit stage):**
-```hcl
+
+```terraform
 resource "aws_api_gateway_deployment" "example" {
   rest_api_id = aws_api_gateway_rest_api.example.id
   stage_name  = "prod"
@@ -184,7 +185,8 @@ resource "aws_api_gateway_deployment" "example" {
 ```
 
 **After (v6+, using explicit stage):**
-```hcl
+
+```terraform
 resource "aws_api_gateway_deployment" "example" {
   rest_api_id = aws_api_gateway_rest_api.example.id
 }

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -154,9 +154,9 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - ID of the deployment
-* `invoke_url` - URL to invoke the API pointing to the stage,
+* `invoke_url` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** URL to invoke the API pointing to the stage,
   e.g., `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/prod`
-* `execution_arn` - Execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
+* `execution_arn` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** Execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
   when allowing API Gateway to invoke a Lambda function,
   e.g., `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `created_date` - Creation date of the deployment

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -154,11 +154,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `id` - ID of the deployment
-* `invoke_url` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** URL to invoke the API pointing to the stage,
-  e.g., `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/prod`
-* `execution_arn` - **DEPRECATED: Use the `aws_api_gateway_stage` resource instead.** Execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
-  when allowing API Gateway to invoke a Lambda function,
-  e.g., `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `created_date` - Creation date of the deployment
 
 ## Import

--- a/website/docs/r/api_gateway_deployment.html.markdown
+++ b/website/docs/r/api_gateway_deployment.html.markdown
@@ -15,8 +15,6 @@ To properly capture all REST API configuration in a deployment, this resource mu
 * For REST APIs that are configured via OpenAPI specification ([`aws_api_gateway_rest_api` resource](api_gateway_rest_api.html) `body` argument), no special dependency setup is needed beyond referencing the  `id` attribute of that resource unless additional Terraform resources have further customized the REST API.
 * When the REST API configuration involves other Terraform resources ([`aws_api_gateway_integration` resource](api_gateway_integration.html), etc.), the dependency setup can be done with implicit resource references in the `triggers` argument or explicit resource references using the [resource `depends_on` meta-argument](https://www.terraform.io/docs/configuration/meta-arguments/depends_on.html). The `triggers` argument should be preferred over `depends_on`, since `depends_on` can only capture dependency ordering and will not cause the resource to recreate (redeploy the REST API) with upstream configuration changes.
 
-!> **WARNING:** We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead of managing an API Gateway Stage via the `stage_name` argument of this resource. When this resource is recreated (REST API redeployment) with the `stage_name` configured, the stage is deleted and recreated. This will cause a temporary service interruption, increase Terraform plan differences, and can require a second Terraform apply to recreate any downstream stage configuration such as associated `aws_api_method_settings` resources.
-
 ~> **NOTE:** Enable the [resource `lifecycle` configuration block `create_before_destroy` argument](https://www.terraform.io/language/meta-arguments/lifecycle#create_before_destroy) in this resource configuration to properly order redeployments in Terraform. Without enabling `create_before_destroy`, API Gateway can return errors such as `BadRequestException: Active stages pointing to this deployment must be moved or deleted` on recreation.
 
 ## Example Usage
@@ -130,24 +128,10 @@ resource "aws_api_gateway_stage" "example" {
 
 This resource supports the following arguments:
 
-* `canary_settings` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Input configuration for the canary deployment when the deployment is a canary release deployment.
-  See [`canary_settings](#canary_settings-argument-reference) below.
-  Has no effect when `stage_name` is not set.
-* `description` - (Optional) Description of the deployment
+* `description` - (Optional) Description of the deployment.
 * `rest_api_id` - (Required) REST API identifier.
-* `stage_description` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Description to set on the stage managed by the `stage_name` argument.
-  Has no effect when `stage_name` is not set.
-* `stage_name` - (Optional, **Deprecated** Use an explicit [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead) Name of the stage to create with this deployment.
-  If the specified stage already exists, it will be updated to point to the new deployment.
-  We recommend using the [`aws_api_gateway_stage` resource](api_gateway_stage.html) instead to manage stages.
 * `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`-replace` option](https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address) with `terraform plan` or `terraform apply`.
-* `variables` - (Optional) Map to set on the stage managed by the `stage_name` argument.
-
-### `canary_settings` Argument Reference
-
-* `percent_traffic` - Percentage (0.0-100.0) of traffic routed to the canary deployment.
-* `stage_variable_overrides` - Stage variable overrides used for the canary release deployment. They can override existing stage variables or add new stage variables for the canary release deployment. These stage variables are represented as a string-to-string map between stage variable names and their values.
-* `use_stage_cache` - Boolean flag to indicate whether the canary release deployment uses the stage cache or not.
+* `variables` - (Optional) Map to set on the related stage.
 
 ## Attribute Reference
 
@@ -173,6 +157,6 @@ Using `terraform import`, import `aws_api_gateway_deployment` using `REST-API-ID
 % terraform import aws_api_gateway_deployment.example aabbccddee/1122334
 ```
 
-The `stage_name`, `stage_description`, and `variables` arguments cannot be imported. Use the [`aws_api_gateway_stage` resource](api_gateway_stage.html) to import and manage stages.
+The `variables` arguments cannot be imported. Use the [`aws_api_gateway_stage` resource](api_gateway_stage.html) to import and manage stages.
 
 The `triggers` argument cannot be imported.

--- a/website/docs/r/api_gateway_stage.html.markdown
+++ b/website/docs/r/api_gateway_stage.html.markdown
@@ -112,8 +112,8 @@ This resource supports the following arguments:
 * `canary_settings` - (Optional) Configuration settings of a canary deployment. See [Canary Settings](#canary-settings) below.
 * `client_certificate_id` - (Optional) Identifier of a client certificate for the stage.
 * `description` - (Optional) Description of the stage.
-* `documentation_version` - (Optional) Version of the associated API documentation
-* `variables` - (Optional) Map that defines the stage variables
+* `documentation_version` - (Optional) Version of the associated API documentation.
+* `variables` - (Optional) Map that defines the stage variables.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `xray_tracing_enabled` - (Optional) Whether active tracing with X-ray is enabled. Defaults to `false`.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR removes implicit stage management from the `aws_api_gateway_deployment` resource by deleting the following attributes:

- `stage_name`
- `stage_description`
- `canary_settings`
- `execution_arn`
- `invoke_url`

These attributes were previously deprecated in #39957 and #42244.

#### Rationale

This change finalizes the deprecation of the legacy behavior where a stage could be implicitly created or updated through the `aws_api_gateway_deployment` resource.

Maintaining private state to silently manage an implicitly created stage is not sustainable—especially in the context of state upgrades. Continuing to do so would essentially be a "deprecation of the deprecation," postponing the inevitable removal of the behavior and prolonging user confusion. It’s time to rip off the bandaid.

Users have been advised for some time to migrate to explicit stage management using the `aws_api_gateway_stage` resource, which provides clearer intent and more predictable infrastructure management.

#### User Impact & Migration

Users who are still relying on `stage_name`, `stage_description`, or `canary_settings` within `aws_api_gateway_deployment` will need to migrate to using an explicit `aws_api_gateway_stage` resource.

We will add a note to the upgrade guide with a recommendation for how to import implicitly created stages into Terraform-managed `aws_api_gateway_stage` resources to ease this transition.

#### Behavior Previously Causing Confusion

The deprecated behavior silently created a stage if `stage_name` was set and no corresponding `aws_api_gateway_stage` resource existed. Deleting the deployment would also delete the implicitly created stage, while setting `stage_name` to an existing stage would modify it. This ambiguity frequently caused user confusion around resource ownership and lifecycle.

#### Benefits of Explicit Stage Management

Explicitly creating and managing `aws_api_gateway_stage` resources:

- Makes resource ownership and lifecycle clearer
- Avoids side effects during deployment updates
- Aligns with current best practices for Terraform configuration

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #39958

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccAPIGatewayDeployment_ K=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayDeployment_'  -timeout 360m -vet=off
2025/04/15 19:15:37 Initializing Terraform AWS Provider...
=== RUN   TestAccAPIGatewayDeployment_basic
=== PAUSE TestAccAPIGatewayDeployment_basic
=== RUN   TestAccAPIGatewayDeployment_disappears
=== PAUSE TestAccAPIGatewayDeployment_disappears
=== RUN   TestAccAPIGatewayDeployment_Disappears_restAPI
=== PAUSE TestAccAPIGatewayDeployment_Disappears_restAPI
=== RUN   TestAccAPIGatewayDeployment_triggers
=== PAUSE TestAccAPIGatewayDeployment_triggers
=== RUN   TestAccAPIGatewayDeployment_description
=== PAUSE TestAccAPIGatewayDeployment_description
=== RUN   TestAccAPIGatewayDeployment_stageDescription
=== PAUSE TestAccAPIGatewayDeployment_stageDescription
=== RUN   TestAccAPIGatewayDeployment_stageName
=== PAUSE TestAccAPIGatewayDeployment_stageName
=== RUN   TestAccAPIGatewayDeployment_variables
=== PAUSE TestAccAPIGatewayDeployment_variables
=== RUN   TestAccAPIGatewayDeployment_conflictingConnectionType
=== PAUSE TestAccAPIGatewayDeployment_conflictingConnectionType
=== CONT  TestAccAPIGatewayDeployment_basic
=== CONT  TestAccAPIGatewayDeployment_stageDescription
=== CONT  TestAccAPIGatewayDeployment_conflictingConnectionType
=== CONT  TestAccAPIGatewayDeployment_triggers
=== CONT  TestAccAPIGatewayDeployment_description
=== CONT  TestAccAPIGatewayDeployment_variables
=== CONT  TestAccAPIGatewayDeployment_stageName
=== CONT  TestAccAPIGatewayDeployment_Disappears_restAPI
=== CONT  TestAccAPIGatewayDeployment_disappears
--- PASS: TestAccAPIGatewayDeployment_variables (18.54s)
--- PASS: TestAccAPIGatewayDeployment_stageDescription (30.96s)
--- PASS: TestAccAPIGatewayDeployment_disappears (65.98s)
--- PASS: TestAccAPIGatewayDeployment_stageName (128.13s)
--- PASS: TestAccAPIGatewayDeployment_triggers (152.68s)
--- PASS: TestAccAPIGatewayDeployment_Disappears_restAPI (353.49s)
--- PASS: TestAccAPIGatewayDeployment_description (763.53s)
--- PASS: TestAccAPIGatewayDeployment_basic (804.89s)
--- PASS: TestAccAPIGatewayDeployment_conflictingConnectionType (1079.02s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	1084.444s
```
