### PR TITLE
resource/aws_guardduty_organization_configuration: Remove deprecated `auto_enable` attribute

### DIFF
--- a/internal/service/guardduty/detector_test.go
+++ b/internal/service/guardduty/detector_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -36,12 +35,13 @@ func testAccDetector_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckDetectorExists(ctx, resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrAccountID),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "guardduty", regexache.MustCompile("detector/.+$")),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "guardduty", "detector/{id}"),
 					resource.TestCheckResourceAttr(resourceName, "enable", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "datasources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.s3_logs.0.enable", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "datasources.0.kubernetes.0.audit_logs.0.enable", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "finding_publishing_frequency", "SIX_HOURS"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},

--- a/internal/service/guardduty/exports_test.go
+++ b/internal/service/guardduty/exports_test.go
@@ -9,4 +9,6 @@ var (
 	ResourceMalwareProtectionPlan = newResourceMalwareProtectionPlan
 
 	FindMemberDetectorFeatureByThreePartKey = findMemberDetectorFeatureByThreePartKey
+
+	GetOrganizationAdminAccount = getOrganizationAdminAccount
 )

--- a/internal/service/guardduty/filter_test.go
+++ b/internal/service/guardduty/filter_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/acmpca"
 	acmpca_types "github.com/aws/aws-sdk-go-v2/service/acmpca/types"
@@ -50,7 +49,7 @@ func testAccFilter_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, names.AttrAction, "ARCHIVE"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "rank", "1"),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "guardduty", regexache.MustCompile("detector/[0-9a-z]{32}/filter/test-filter$")),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "guardduty", "detector/{detector_id}/filter/{name}"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "finding_criteria.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "finding_criteria.0.criterion.#", "3"),

--- a/internal/service/guardduty/ipset.go
+++ b/internal/service/guardduty/ipset.go
@@ -104,7 +104,7 @@ func resourceIPSetCreate(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "creating GuardDuty IPSet (%s): waiting for completion: %s", d.Get(names.AttrName).(string), err)
 	}
 
-	d.SetId(fmt.Sprintf("%s:%s", detectorID, *resp.IpSetId))
+	d.SetId(fmt.Sprintf("%s:%s", detectorID, aws.ToString(resp.IpSetId)))
 
 	return append(diags, resourceIPSetRead(ctx, d, meta)...)
 }

--- a/internal/service/guardduty/organization_admin_account.go
+++ b/internal/service/guardduty/organization_admin_account.go
@@ -68,7 +68,7 @@ func resourceOrganizationAdminAccountRead(ctx context.Context, d *schema.Resourc
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).GuardDutyClient(ctx)
 
-	adminAccount, err := GetOrganizationAdminAccount(ctx, conn, d.Id())
+	adminAccount, err := getOrganizationAdminAccount(ctx, conn, d.Id())
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading GuardDuty Organization Admin Account (%s): %s", d.Id(), err)
@@ -106,25 +106,24 @@ func resourceOrganizationAdminAccountDelete(ctx context.Context, d *schema.Resou
 	return diags
 }
 
-func GetOrganizationAdminAccount(ctx context.Context, conn *guardduty.Client, adminAccountID string) (*awstypes.AdminAccount, error) {
-	input := &guardduty.ListOrganizationAdminAccountsInput{}
-	result := awstypes.AdminAccount{}
+func getOrganizationAdminAccount(ctx context.Context, conn *guardduty.Client, adminAccountID string) (*awstypes.AdminAccount, error) {
+	var input guardduty.ListOrganizationAdminAccountsInput
 
-	pages := guardduty.NewListOrganizationAdminAccountsPaginator(conn, input)
+	pages := guardduty.NewListOrganizationAdminAccountsPaginator(conn, &input)
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
 
 		if err != nil {
-			return &result, err
+			return nil, err
 		}
-		for _, adminAccount := range page.AdminAccounts {
-			if aws.ToString(adminAccount.AdminAccountId) == adminAccountID {
-				result = adminAccount
-				break
+
+		for _, account := range page.AdminAccounts {
+			if aws.ToString(account.AdminAccountId) == adminAccountID {
+				return &account, nil
 			}
 		}
 	}
 
-	return &result, nil
+	return nil, nil
 }

--- a/internal/service/guardduty/organization_admin_account_test.go
+++ b/internal/service/guardduty/organization_admin_account_test.go
@@ -25,7 +25,7 @@ func testAccOrganizationAdminAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -103,21 +103,10 @@ func testAccCheckOrganizationAdminAccountExists(ctx context.Context, resourceNam
 
 func testAccOrganizationAdminAccountConfig_self() string {
 	return `
-data "aws_caller_identity" "current" {}
-
-data "aws_partition" "current" {}
-
-resource "aws_organizations_organization" "test" {
-  aws_service_access_principals = ["guardduty.${data.aws_partition.current.dns_suffix}"]
-  feature_set                   = "ALL"
-}
-
 resource "aws_guardduty_detector" "test" {}
 
 resource "aws_guardduty_organization_admin_account" "test" {
-  depends_on = [aws_organizations_organization.test, aws_guardduty_detector.test]
-
-  admin_account_id = data.aws_caller_identity.current.account_id
+  admin_account_id = aws_guardduty_detector.test.account_id
 }
 `
 }

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,18 +34,9 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"auto_enable": {
-				Type:         schema.TypeBool,
-				Optional:     true,
-				Computed:     true,
-				ExactlyOneOf: []string{"auto_enable", "auto_enable_organization_members"},
-				Deprecated:   "auto_enable is deprecated. Use auto_enable_organization_members instead.",
-			},
 			"auto_enable_organization_members": {
 				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ExactlyOneOf:     []string{"auto_enable", "auto_enable_organization_members"},
+				Required:         true,
 				ValidateDiagFunc: enum.Validate[awstypes.AutoEnableMembers](),
 			},
 			"datasources": {
@@ -135,35 +125,6 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 		},
-
-		CustomizeDiff: customdiff.Sequence(
-			func(_ context.Context, d *schema.ResourceDiff, _ any) error {
-				// When creating an organization configuration with AutoEnable=true,
-				// AWS will automatically set AutoEnableOrganizationMembers=NEW.
-				//
-				// When configuring AutoEnableOrganizationMembers=ALL or NEW,
-				// AWS will automatically set AutoEnable=true.
-				//
-				// This diff customization keeps things consistent when configuring
-				// the resource against deprecation advice from AutoEnableOrganizationMembers=ALL
-				// to AutoEnable=true, and it also removes the need to use
-				// AutoEnable in the resource update function.
-
-				if attr := d.GetRawConfig().GetAttr("auto_enable_organization_members"); attr.IsKnown() && !attr.IsNull() {
-					return d.SetNew("auto_enable", attr.AsString() != string(awstypes.AutoEnableMembersNone))
-				}
-
-				if attr := d.GetRawConfig().GetAttr("auto_enable"); attr.IsKnown() && !attr.IsNull() {
-					if attr.True() {
-						return d.SetNew("auto_enable_organization_members", string(awstypes.AutoEnableMembersNew))
-					} else {
-						return d.SetNew("auto_enable_organization_members", string(awstypes.AutoEnableMembersNone))
-					}
-				}
-
-				return nil
-			},
-		),
 	}
 }
 
@@ -219,7 +180,6 @@ func resourceOrganizationConfigurationRead(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "reading GuardDuty Organization Configuration (%s): empty response", d.Id())
 	}
 
-	d.Set("auto_enable", output.AutoEnable)
 	d.Set("auto_enable_organization_members", output.AutoEnableOrganizationMembers)
 	if output.DataSources != nil {
 		if err := d.Set("datasources", []any{flattenOrganizationDataSourceConfigurationsResult(output.DataSources)}); err != nil {

--- a/internal/service/guardduty/organization_configuration.go
+++ b/internal/service/guardduty/organization_configuration.go
@@ -40,10 +40,11 @@ func ResourceOrganizationConfiguration() *schema.Resource {
 				ValidateDiagFunc: enum.Validate[awstypes.AutoEnableMembers](),
 			},
 			"datasources": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				MaxItems: 1,
+				Type:       schema.TypeList,
+				Optional:   true,
+				Computed:   true,
+				MaxItems:   1,
+				Deprecated: "datasources is deprecated. Use \"aws_guardduty_organization_configuration_feature\" resources instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"kubernetes": {

--- a/internal/service/guardduty/organization_configuration_feature_test.go
+++ b/internal/service/guardduty/organization_configuration_feature_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -23,7 +24,7 @@ func testAccOrganizationConfigurationFeature_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -51,7 +52,7 @@ func testAccOrganizationConfigurationFeature_additionalConfiguration(t *testing.
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -93,7 +94,7 @@ func testAccOrganizationConfigurationFeature_multiple(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -170,17 +171,12 @@ func testAccOrganizationConfigurationFeatureExists(ctx context.Context, n string
 	}
 }
 
-var testAccOrganizationConfigurationFeatureConfig_base = acctest.ConfigCompose(testAccOrganizationConfigurationConfig_base, `
-resource "aws_guardduty_organization_configuration" "test" {
-  depends_on = [aws_guardduty_organization_admin_account.test]
-
-  auto_enable_organization_members = "ALL"
-  detector_id                      = aws_guardduty_detector.test.id
-}
-`)
+var testAccOrganizationConfigurationFeatureConfig_base = testAccOrganizationConfigurationConfig_autoEnableOrganizationMembers(types.AutoEnableMembersNone)
 
 func testAccOrganizationConfigurationFeatureConfig_basic(name, autoEnable string) string {
-	return acctest.ConfigCompose(testAccOrganizationConfigurationFeatureConfig_base, fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccOrganizationConfigurationFeatureConfig_base,
+		fmt.Sprintf(`
 resource "aws_guardduty_organization_configuration_feature" "test" {
   depends_on = [aws_guardduty_organization_configuration.test]
 
@@ -192,7 +188,9 @@ resource "aws_guardduty_organization_configuration_feature" "test" {
 }
 
 func testAccOrganizationConfigurationFeatureConfig_additionalConfiguration(featureAutoEnable, additionalConfigurationAutoEnable string) string {
-	return acctest.ConfigCompose(testAccOrganizationConfigurationFeatureConfig_base, fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccOrganizationConfigurationFeatureConfig_base,
+		fmt.Sprintf(`
 resource "aws_guardduty_organization_configuration_feature" "test" {
   depends_on = [aws_guardduty_organization_configuration.test]
 
@@ -209,7 +207,9 @@ resource "aws_guardduty_organization_configuration_feature" "test" {
 }
 
 func testAccOrganizationConfigurationFeatureConfig_multiple(autoEnable1, autoEnable2, autoEnable3 string) string {
-	return acctest.ConfigCompose(testAccOrganizationConfigurationFeatureConfig_base, fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccOrganizationConfigurationFeatureConfig_base,
+		fmt.Sprintf(`
 resource "aws_guardduty_organization_configuration_feature" "test1" {
   depends_on = [aws_guardduty_organization_configuration.test]
 

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
@@ -314,7 +315,7 @@ resource "aws_guardduty_organization_configuration" "test" {
 `, autoEnable))
 }
 
-func testAccOrganizationConfigurationConfig_autoEnableOrganizationMembers(value string) string {
+func testAccOrganizationConfigurationConfig_autoEnableOrganizationMembers(value types.AutoEnableMembers) string {
 	return acctest.ConfigCompose(testAccOrganizationConfigurationConfig_base, fmt.Sprintf(`
 resource "aws_guardduty_organization_configuration" "test" {
   depends_on = [aws_guardduty_organization_admin_account.test]

--- a/internal/service/guardduty/organization_configuration_test.go
+++ b/internal/service/guardduty/organization_configuration_test.go
@@ -24,7 +24,7 @@ func testAccOrganizationConfiguration_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -66,7 +66,7 @@ func testAccOrganizationConfiguration_autoEnableOrganizationMembers(t *testing.T
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -144,7 +144,7 @@ func testAccOrganizationConfiguration_s3logs(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -190,7 +190,7 @@ func testAccOrganizationConfiguration_kubernetes(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -238,7 +238,7 @@ func testAccOrganizationConfiguration_malwareprotection(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
-			acctest.PreCheckOrganizationsAccount(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
@@ -296,25 +296,10 @@ func testAccCheckOrganizationConfigurationExists(ctx context.Context, n string) 
 }
 
 const testAccOrganizationConfigurationConfig_base = `
-data "aws_caller_identity" "current" {}
-
-data "aws_partition" "current" {}
-
-resource "aws_organizations_organization" "test" {
-  aws_service_access_principals = [
-    "guardduty.${data.aws_partition.current.dns_suffix}",
-    "malware-protection.guardduty.${data.aws_partition.current.dns_suffix}",
-  ]
-
-  feature_set = "ALL"
-}
-
 resource "aws_guardduty_detector" "test" {}
 
 resource "aws_guardduty_organization_admin_account" "test" {
-  depends_on = [aws_organizations_organization.test, aws_guardduty_detector.test]
-
-  admin_account_id = data.aws_caller_identity.current.account_id
+  admin_account_id = aws_guardduty_detector.test.account_id
 }
 `
 

--- a/internal/service/guardduty/status.go
+++ b/internal/service/guardduty/status.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
-	awstypes "github.com/aws/aws-sdk-go-v2/service/guardduty/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
@@ -61,28 +60,4 @@ func statusPublishingDestination(ctx context.Context, conn *guardduty.Client, de
 
 		return output, string(output.Status), nil
 	}
-}
-
-// TODO: Migrate to shared internal package guardduty
-func getOrganizationAdminAccount(ctx context.Context, conn *guardduty.Client, adminAccountID string) (*awstypes.AdminAccount, error) {
-	input := &guardduty.ListOrganizationAdminAccountsInput{}
-	var result *awstypes.AdminAccount
-
-	pages := guardduty.NewListOrganizationAdminAccountsPaginator(conn, input)
-
-	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx)
-
-		if err != nil {
-			return result, err
-		}
-
-		for _, account := range page.AdminAccounts {
-			if aws.ToString(account.AdminAccountId) == adminAccountID {
-				result = &account
-			}
-		}
-	}
-
-	return result, nil
 }

--- a/website/docs/r/guardduty_filter.html.markdown
+++ b/website/docs/r/guardduty_filter.html.markdown
@@ -73,7 +73,6 @@ The `criterion` block suports the following:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - The ARN of the GuardDuty filter.
-* `id` - A compound field, consisting of the ID of the GuardDuty detector and the name of the filter.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/guardduty_invite_accepter.html.markdown
+++ b/website/docs/r/guardduty_invite_accepter.html.markdown
@@ -55,9 +55,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` - GuardDuty member detector ID
+This resource exports no additional attributes.
 
 ## Timeouts
 

--- a/website/docs/r/guardduty_ipset.html.markdown
+++ b/website/docs/r/guardduty_ipset.html.markdown
@@ -58,7 +58,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) of the GuardDuty IPSet.
-* `id` - The ID of the GuardDuty IPSet.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/guardduty_member.html.markdown
+++ b/website/docs/r/guardduty_member.html.markdown
@@ -47,7 +47,6 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The ID of the GuardDuty member
 * `relationship_status` - The status of the relationship between the member account and its primary account. More information can be found in [Amazon GuardDuty API Reference](https://docs.aws.amazon.com/guardduty/latest/ug/get-members.html).
 
 ## Timeouts

--- a/website/docs/r/guardduty_organization_admin_account.html.markdown
+++ b/website/docs/r/guardduty_organization_admin_account.html.markdown
@@ -35,9 +35,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` - AWS account identifier.
+This resource exports no additional attributes.
 
 ## Import
 

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -46,12 +46,10 @@ resource "aws_guardduty_organization_configuration" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** One of `auto_enable` or `auto_enable_organization_members` must be specified.
-
 This resource supports the following arguments:
 
-* `auto_enable` - (Optional) *Deprecated:* Use `auto_enable_organization_members` instead. When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
-* `auto_enable_organization_members` - (Optional) Indicates the auto-enablement configuration of GuardDuty for the member accounts in the organization. Valid values are `ALL`, `NEW`, `NONE`.
+* `auto_enable_organization_members` - (Required) Indicates the auto-enablement configuration of GuardDuty for the member accounts in the organization.
+  Valid values are `ALL`, `NEW`, `NONE`.
 * `detector_id` - (Required) The detector ID of the GuardDuty account.
 * `datasources` - (Optional) Configuration for the collected datasources. [Deprecated](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-feature-object-api-changes-march2023.html) in favor of [`aws_guardduty_organization_configuration_feature` resources](guardduty_organization_configuration_feature.html).
 
@@ -104,9 +102,7 @@ The `ebs_volumes` block supports the following:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` - Identifier of the GuardDuty Detector.
+This resource exports no additional attributes.
 
 ## Import
 

--- a/website/docs/r/guardduty_organization_configuration_feature.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration_feature.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides a resource to manage a single Amazon GuardDuty [organization configuration feature](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-features-activation-model.html#guardduty-features).
 
-~> **NOTE:** Deleting this resource does not disable the organization configuration feature, the resource in simply removed from state instead.
+~> **NOTE:** Deleting this resource does not disable the organization configuration feature, the resource is simply removed from state instead.
 
 ## Example Usage
 

--- a/website/docs/r/guardduty_publishing_destination.html.markdown
+++ b/website/docs/r/guardduty_publishing_destination.html.markdown
@@ -137,9 +137,7 @@ This resource supports the following arguments:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` - The ID of the GuardDuty PublishingDestination and the detector ID. Format: `<DetectorID>:<PublishingDestinationID>`
+This resource exports no additional attributes.
 
 ## Import
 

--- a/website/docs/r/guardduty_threatintelset.html.markdown
+++ b/website/docs/r/guardduty_threatintelset.html.markdown
@@ -59,7 +59,6 @@ This resource supports the following arguments:
 This resource exports the following attributes in addition to the arguments above:
 
 * `arn` - Amazon Resource Name (ARN) of the GuardDuty ThreatIntelSet.
-* `id` - The ID of the GuardDuty ThreatIntelSet and the detector ID. Format: `<DetectorID>:<ThreatIntelSetID>`
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Remove deprecated `auto_enable` attribute from `aws_guardduty_organization_configuration`.

Also deprecates `datasources`, which is deprecated in the AWS API and was previously documented as deprecated in #40847.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31152

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=guardduty TESTS=TestAccGuardDuty_serial

...
```
