### PR TITLE
d/aws_quicksight_data_set: remove `tags_all`

### DIFF
--- a/.changelog/42260.txt
+++ b/.changelog/42260.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_quicksight_data_set: `tags_all` has been removed
+```

--- a/internal/service/quicksight/data_set_data_source.go
+++ b/internal/service/quicksight/data_set_data_source.go
@@ -57,13 +57,6 @@ func dataSourceDataSet() *schema.Resource {
 				"row_level_permission_data_set":          quicksightschema.DataSetRowLevelPermissionDataSetSchemaDataSourceSchema(),
 				"row_level_permission_tag_configuration": quicksightschema.DataSetRowLevelPermissionTagConfigurationSchemaDataSourceSchema(),
 				names.AttrTags:                           tftags.TagsSchemaComputed(),
-				names.AttrTagsAll: {
-					Type:       schema.TypeMap,
-					Optional:   true,
-					Computed:   true,
-					Elem:       &schema.Schema{Type: schema.TypeString},
-					Deprecated: "tags_all is deprecated. This argument will be removed in a future major version.",
-				},
 			}
 		},
 	}
@@ -130,10 +123,6 @@ func dataSourceDataSetRead(ctx context.Context, d *schema.ResourceData, meta any
 
 	if err := d.Set(names.AttrTags, tags.Map()); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting tags: %s", err)
-	}
-
-	if err := d.Set(names.AttrTagsAll, tags.Map()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting tags_all: %s", err)
 	}
 
 	permissions, err := findDataSetPermissionsByTwoPartKey(ctx, conn, awsAccountID, dataSetID)

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -25,6 +25,7 @@ Upgrade topics:
 - [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
+- [data-source/aws_quicksight_data_set](#data-sourceaws_quicksight_data_set)
 - [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
 - [resource/aws_api_gateway_account](#resourceaws_api_gateway_account)
 - [resource/aws_batch_compute_environment](#resourceaws_batch_compute_environment)
@@ -139,6 +140,10 @@ This is not recommended.
 ## data-source/aws_globalaccelerator_accelerator
 
 `id` is now computed only.
+
+## data-source/aws_quicksight_data_set
+
+`tags_all` has been removed.
 
 ## data-source/aws_service_discovery_service
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
The previously deprecated `tags_all` attribute has now been removed. Configurations referencing this argument should use the `tags` attribute instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31164
Relates #30710 
Relates #41101 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=quicksight TESTS=TestAccQuickSightDataSetDataSource_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightDataSetDataSource_basic'  -timeout 360m -vet=off
2025/04/16 10:59:05 Initializing Terraform AWS Provider...

--- PASS: TestAccQuickSightDataSetDataSource_basic (32.93s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 39.859s
```
