### PR TITLE
r/aws_paymentcryptography_key: `key_attributes` and `key_attributes.key_modes_of_use` to list nested blocks

### DIFF
--- a/.changelog/42264.txt
+++ b/.changelog/42264.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_paymentcryptography_key: `key_attributes` and `key_attributes.key_modes_of_use` are now list nested blocks instead of single nested blocks.
+```

--- a/internal/service/paymentcryptography/key.go
+++ b/internal/service/paymentcryptography/key.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-// Function annotations are used for resource registration to the Provider. DO NOT EDIT.
 // @FrameworkResource("aws_paymentcryptography_key", name="Key")
 // @Tags(identifierAttribute="arn")
 func newResourceKey(_ context.Context) (resource.ResourceWithConfigure, error) {
@@ -59,6 +58,7 @@ type resourceKey struct {
 
 func (r *resourceKey) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			names.AttrID:  framework.IDAttribute(),
@@ -116,105 +116,109 @@ func (r *resourceKey) Schema(ctx context.Context, request resource.SchemaRequest
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			"key_attributes": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-				CustomType: fwtypes.NewObjectTypeOf[keyAttributesModel](ctx),
-				Attributes: map[string]schema.Attribute{
-					"key_algorithm": schema.StringAttribute{
-						Required:   true,
-						CustomType: fwtypes.StringEnumType[awstypes.KeyAlgorithm](),
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
+			"key_attributes": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[keyAttributesModel](ctx),
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"key_algorithm": schema.StringAttribute{
+							Required:   true,
+							CustomType: fwtypes.StringEnumType[awstypes.KeyAlgorithm](),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"key_class": schema.StringAttribute{
+							Required:   true,
+							CustomType: fwtypes.StringEnumType[awstypes.KeyClass](),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"key_usage": schema.StringAttribute{
+							Required:   true,
+							CustomType: fwtypes.StringEnumType[awstypes.KeyUsage](),
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
 						},
 					},
-					"key_class": schema.StringAttribute{
-						Required:   true,
-						CustomType: fwtypes.StringEnumType[awstypes.KeyClass](),
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
-					},
-					"key_usage": schema.StringAttribute{
-						Required:   true,
-						CustomType: fwtypes.StringEnumType[awstypes.KeyUsage](),
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
-					},
-				},
-				Blocks: map[string]schema.Block{
-					"key_modes_of_use": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-						CustomType: fwtypes.NewObjectTypeOf[keyModesOfUseModel](ctx),
-						Attributes: map[string]schema.Attribute{
-							"decrypt": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"derive_key": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"encrypt": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"generate": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"no_restrictions": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"sign": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"unwrap": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"verify": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
-								},
-							},
-							"wrap": schema.BoolAttribute{
-								Optional: true,
-								Computed: true,
-								PlanModifiers: []planmodifier.Bool{
-									boolplanmodifier.RequiresReplace(),
-									boolplanmodifier.UseStateForUnknown(),
+					Blocks: map[string]schema.Block{
+						"key_modes_of_use": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[keyModesOfUseModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"decrypt": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"derive_key": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"encrypt": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"generate": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"no_restrictions": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"sign": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"unwrap": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"verify": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
+									"wrap": schema.BoolAttribute{
+										Optional: true,
+										Computed: true,
+										PlanModifiers: []planmodifier.Bool{
+											boolplanmodifier.RequiresReplace(),
+											boolplanmodifier.UseStateForUnknown(),
+										},
+									},
 								},
 							},
 						},
@@ -226,6 +230,17 @@ func (r *resourceKey) Schema(ctx context.Context, request resource.SchemaRequest
 				Update: true,
 				Delete: true,
 			}),
+		},
+	}
+}
+
+func (r *resourceKey) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := keySchemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeKeyStateV0toV1,
 		},
 	}
 }
@@ -498,7 +513,7 @@ type resourceKeyModel struct {
 	Enabled                types.Bool                                          `tfsdk:"enabled"`
 	Exportable             types.Bool                                          `tfsdk:"exportable"`
 	ID                     types.String                                        `tfsdk:"id"`
-	KeyAttributes          fwtypes.ObjectValueOf[keyAttributesModel]           `tfsdk:"key_attributes"`
+	KeyAttributes          fwtypes.ListNestedObjectValueOf[keyAttributesModel] `tfsdk:"key_attributes"`
 	KeyCheckValue          types.String                                        `tfsdk:"key_check_value"`
 	KeyCheckValueAlgorithm fwtypes.StringEnum[awstypes.KeyCheckValueAlgorithm] `tfsdk:"key_check_value_algorithm"`
 	KeyOrigin              fwtypes.StringEnum[awstypes.KeyOrigin]              `tfsdk:"key_origin"`
@@ -513,10 +528,10 @@ func (k *resourceKeyModel) setId() {
 }
 
 type keyAttributesModel struct {
-	KeyAlgorithm  fwtypes.StringEnum[awstypes.KeyAlgorithm] `tfsdk:"key_algorithm"`
-	KeyClass      fwtypes.StringEnum[awstypes.KeyClass]     `tfsdk:"key_class"`
-	KeyModesOfUse fwtypes.ObjectValueOf[keyModesOfUseModel] `tfsdk:"key_modes_of_use"`
-	KeyUsage      fwtypes.StringEnum[awstypes.KeyUsage]     `tfsdk:"key_usage"`
+	KeyAlgorithm  fwtypes.StringEnum[awstypes.KeyAlgorithm]           `tfsdk:"key_algorithm"`
+	KeyClass      fwtypes.StringEnum[awstypes.KeyClass]               `tfsdk:"key_class"`
+	KeyModesOfUse fwtypes.ListNestedObjectValueOf[keyModesOfUseModel] `tfsdk:"key_modes_of_use"`
+	KeyUsage      fwtypes.StringEnum[awstypes.KeyUsage]               `tfsdk:"key_usage"`
 }
 
 type keyModesOfUseModel struct {

--- a/internal/service/paymentcryptography/key_migrate.go
+++ b/internal/service/paymentcryptography/key_migrate.go
@@ -1,0 +1,228 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package paymentcryptography
+
+import (
+	"context"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/paymentcryptography/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func keySchemaV0(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			names.AttrID:  framework.IDAttribute(),
+			"deletion_window_in_days": schema.Int64Attribute{
+				Optional: true,
+				Computed: true,
+				Default:  int64default.StaticInt64(defaultDeletionWindowInDays),
+			},
+			names.AttrEnabled: schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+			},
+			"exportable": schema.BoolAttribute{
+				Required: true,
+			},
+			"key_check_value": schema.StringAttribute{
+				Computed: true,
+			},
+			"key_check_value_algorithm": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.KeyCheckValueAlgorithm](),
+				Optional:   true,
+				Computed:   true,
+			},
+			"key_origin": schema.StringAttribute{
+				Computed:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.KeyOrigin](),
+			},
+			"key_state": schema.StringAttribute{
+				Computed:   true,
+				CustomType: fwtypes.StringEnumType[awstypes.KeyState](),
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"key_attributes": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+				CustomType: fwtypes.NewObjectTypeOf[keyAttributesModelV0](ctx),
+				Attributes: map[string]schema.Attribute{
+					"key_algorithm": schema.StringAttribute{
+						Required:   true,
+						CustomType: fwtypes.StringEnumType[awstypes.KeyAlgorithm](),
+					},
+					"key_class": schema.StringAttribute{
+						Required:   true,
+						CustomType: fwtypes.StringEnumType[awstypes.KeyClass](),
+					},
+					"key_usage": schema.StringAttribute{
+						Required:   true,
+						CustomType: fwtypes.StringEnumType[awstypes.KeyUsage](),
+					},
+				},
+				Blocks: map[string]schema.Block{
+					"key_modes_of_use": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+						CustomType: fwtypes.NewObjectTypeOf[keyModesOfUseModel](ctx),
+						Attributes: map[string]schema.Attribute{
+							"decrypt": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"derive_key": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"encrypt": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"generate": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"no_restrictions": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"sign": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"unwrap": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"verify": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+							"wrap": schema.BoolAttribute{
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+type resourceKeyModelV0 struct {
+	KeyArn                 types.String                                        `tfsdk:"arn"`
+	DeletionWindowInDays   types.Int64                                         `tfsdk:"deletion_window_in_days"`
+	Enabled                types.Bool                                          `tfsdk:"enabled"`
+	Exportable             types.Bool                                          `tfsdk:"exportable"`
+	ID                     types.String                                        `tfsdk:"id"`
+	KeyAttributes          fwtypes.ObjectValueOf[keyAttributesModelV0]         `tfsdk:"key_attributes"`
+	KeyCheckValue          types.String                                        `tfsdk:"key_check_value"`
+	KeyCheckValueAlgorithm fwtypes.StringEnum[awstypes.KeyCheckValueAlgorithm] `tfsdk:"key_check_value_algorithm"`
+	KeyOrigin              fwtypes.StringEnum[awstypes.KeyOrigin]              `tfsdk:"key_origin"`
+	KeyState               fwtypes.StringEnum[awstypes.KeyState]               `tfsdk:"key_state"`
+	Tags                   tftags.Map                                          `tfsdk:"tags"`
+	TagsAll                tftags.Map                                          `tfsdk:"tags_all"`
+	Timeouts               timeouts.Value                                      `tfsdk:"timeouts"`
+}
+
+type keyAttributesModelV0 struct {
+	KeyAlgorithm  fwtypes.StringEnum[awstypes.KeyAlgorithm] `tfsdk:"key_algorithm"`
+	KeyClass      fwtypes.StringEnum[awstypes.KeyClass]     `tfsdk:"key_class"`
+	KeyModesOfUse fwtypes.ObjectValueOf[keyModesOfUseModel] `tfsdk:"key_modes_of_use"`
+	KeyUsage      fwtypes.StringEnum[awstypes.KeyUsage]     `tfsdk:"key_usage"`
+}
+
+func upgradeKeyStateV0toV1(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var keyDataV0 resourceKeyModelV0
+	response.Diagnostics.Append(request.State.Get(ctx, &keyDataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	keyDataV1 := resourceKeyModel{
+		KeyArn:                 keyDataV0.KeyArn,
+		DeletionWindowInDays:   keyDataV0.DeletionWindowInDays,
+		Enabled:                keyDataV0.Enabled,
+		Exportable:             keyDataV0.Exportable,
+		ID:                     keyDataV0.ID,
+		KeyAttributes:          upgradeKeyAttributesStateFromV0(ctx, keyDataV0.KeyAttributes, &response.Diagnostics),
+		KeyCheckValue:          keyDataV0.KeyCheckValue,
+		KeyCheckValueAlgorithm: keyDataV0.KeyCheckValueAlgorithm,
+		KeyOrigin:              keyDataV0.KeyOrigin,
+		KeyState:               keyDataV0.KeyState,
+		Tags:                   keyDataV0.Tags,
+		TagsAll:                keyDataV0.TagsAll,
+		Timeouts:               keyDataV0.Timeouts,
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, keyDataV1)...)
+}
+
+func upgradeKeyAttributesStateFromV0(ctx context.Context, old fwtypes.ObjectValueOf[keyAttributesModelV0], diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[keyAttributesModel] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[keyAttributesModel](ctx)
+	}
+
+	var oldObj keyAttributesModelV0
+	diags.Append(old.As(ctx, &oldObj, basetypes.ObjectAsOptions{})...)
+
+	newObj := []keyAttributesModel{
+		{
+			KeyAlgorithm:  oldObj.KeyAlgorithm,
+			KeyClass:      oldObj.KeyClass,
+			KeyModesOfUse: upgradeKeyModesOfUseModelStateFromV0(ctx, oldObj.KeyModesOfUse, diags),
+			KeyUsage:      oldObj.KeyUsage,
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newObj)
+	diags.Append(d...)
+
+	return result
+}
+
+func upgradeKeyModesOfUseModelStateFromV0(ctx context.Context, old fwtypes.ObjectValueOf[keyModesOfUseModel], diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[keyModesOfUseModel] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[keyModesOfUseModel](ctx)
+	}
+
+	var oldObj keyModesOfUseModel
+	diags.Append(old.As(ctx, &oldObj, basetypes.ObjectAsOptions{})...)
+
+	newObj := []keyModesOfUseModel{
+		{
+			Decrypt:        oldObj.Decrypt,
+			DeriveKey:      oldObj.DeriveKey,
+			Encrypt:        oldObj.Encrypt,
+			Generate:       oldObj.Generate,
+			NoRestrictions: oldObj.NoRestrictions,
+			Sign:           oldObj.Sign,
+			Unwrap:         oldObj.Unwrap,
+			Verify:         oldObj.Verify,
+			Wrap:           oldObj.Wrap,
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newObj)
+	diags.Append(d...)
+
+	return result
+}

--- a/internal/service/paymentcryptography/key_test.go
+++ b/internal/service/paymentcryptography/key_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/paymentcryptography/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -48,6 +49,16 @@ func TestAccPaymentCryptographyKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckKeyExists(ctx, resourceName, &key),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "exportable", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_algorithm", "TDES_3KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_class", "SYMMETRIC_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_usage", "TR31_P0_PIN_ENCRYPTION_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.decrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.encrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.wrap", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.unwrap", acctest.CtTrue),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "payment-cryptography", regexache.MustCompile(`key/.+`)),
 				),
 			},
@@ -194,6 +205,79 @@ func TestAccPaymentCryptographyKey_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfpaymentcryptography.ResourceKey, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccPaymentCryptographyKey_upgradeV6_0_0(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var key paymentcryptography.GetKeyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_paymentcryptography_key.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.PaymentCryptographyServiceID),
+		CheckDestroy: testAccCheckKeyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.94.1",
+					},
+				},
+				Config: testAccKeyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "exportable", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_algorithm", "TDES_3KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_class", "SYMMETRIC_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_usage", "TR31_P0_PIN_ENCRYPTION_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_modes_of_use.decrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_modes_of_use.encrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_modes_of_use.wrap", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.key_modes_of_use.unwrap", acctest.CtTrue),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "payment-cryptography", regexache.MustCompile(`key/.+`)),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccKeyConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeyExists(ctx, resourceName, &key),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEnabled, acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "exportable", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_algorithm", "TDES_3KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_class", "SYMMETRIC_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_usage", "TR31_P0_PIN_ENCRYPTION_KEY"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.decrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.encrypt", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.wrap", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "key_attributes.0.key_modes_of_use.0.unwrap", acctest.CtTrue),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "payment-cryptography", regexache.MustCompile(`key/.+`)),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -36,6 +36,7 @@ Upgrade topics:
 - [resource/aws_kinesis_analytics_application](#resourceaws_kinesis_analytics_application)
 - [resource/aws_launch_template](#resourceaws_launch_template)
 - [resource/aws_networkmanager_core_network](#resourceaws_networkmanager_core_network)
+- [resource/aws_paymentcryptography_key](#resourceaws_paymentcryptography_key)
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
 - [resource/aws_rekognition_stream_processor](#resourceaws_rekognition_stream_processor)
@@ -202,6 +203,12 @@ This resource is deprecated and will be removed in a future version. [Effective 
 
 The `base_policy_region` argument has been removed. Use `base_policy_regions` instead.
 
+## resource/aws_paymentcryptography_key
+
+The `key_attributes` and `key_attributes.key_modes_of_use` arguments are now list nested blocks instead of single nested blocks.
+When referencing these arguments, the indicies must now be included in the attribute address.
+For example, `key_attributes.key_modes_of_use.decrypt` would now be referenced as `key_attributes[0].key_modes_of_use[0].decrypt`.
+
 ## resource/aws_redshift_cluster
 
 * The `publicly_accessible` attribute now defaults to `false`.
@@ -217,7 +224,7 @@ The `aws_redshift_service_account` resource has been removed. AWS [recommends](h
 
 The `regions_of_interest.bounding_box` argument is now a list nested block instead of a single nested block.
 When referencing this argument, the index must now be included in the attribute address.
-For example, `regions_of_interest[0].bounding_box.height` would now be referenced as `regions_of_interest[0].bounding_box[0].height`
+For example, `regions_of_interest[0].bounding_box.height` would now be referenced as `regions_of_interest[0].bounding_box[0].height`.
 
 ## resource/aws_sagemaker_notebook_instance
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These changes are part of a larger effort to remove the use of `SingleNestedBlock` arguments. A state upgrader has been added to make the update seamless across the major version upgrade.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35813
Relates #41379
Relates #41402
Relates https://github.com/hashicorp/terraform-provider-aws/issues/41101

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=paymentcryptography TESTS=TestAccPaymentCryptographyKey_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/paymentcryptography/... -v -count 1 -parallel 20 -run='TestAccPaymentCryptographyKey_'  -timeout 360m -vet=off
2025/04/16 13:43:11 Initializing Terraform AWS Provider...

--- PASS: TestAccPaymentCryptographyKey_disappears (14.02s)
--- PASS: TestAccPaymentCryptographyKey_basic (17.00s)
--- PASS: TestAccPaymentCryptographyKey_tags (24.39s)
--- PASS: TestAccPaymentCryptographyKey_update (34.50s)
--- PASS: TestAccPaymentCryptographyKey_upgradeV6_0_0 (38.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/paymentcryptography        45.124s
```
