### PR TITLE
[r|d]/aws_opensearchserverless_security_config: `saml_options` to list nested block

### DIFF
--- a/.changelog/42270.txt
+++ b/.changelog/42270.txt
@@ -1,0 +1,6 @@
+```release-note:breaking-change
+resource/aws_opensearchserverless_security_config: `saml_options` is now a list nested block instead of a single nested block
+```
+```release-note:breaking-change
+data-source/aws_opensearchserverless_security_config: `saml_options` is now a list nested block instead of a single nested block
+```

--- a/internal/service/opensearchserverless/security_config_migrate.go
+++ b/internal/service/opensearchserverless/security_config_migrate.go
@@ -1,0 +1,110 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package opensearchserverless
+
+import (
+	"context"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func securityConfigSchemaV0() schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"config_version": schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrName: schema.StringAttribute{
+				Required: true,
+			},
+			names.AttrType: schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.SecurityConfigType](),
+				Required:   true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"saml_options": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+				Attributes: map[string]schema.Attribute{
+					"group_attribute": schema.StringAttribute{
+						Optional: true,
+					},
+					"metadata": schema.StringAttribute{
+						Required: true,
+					},
+					"session_timeout": schema.Int64Attribute{
+						Optional: true,
+						Computed: true,
+					},
+					"user_attribute": schema.StringAttribute{
+						Optional: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+type resourceSecurityConfigDataV0 struct {
+	ID            types.String                                    `tfsdk:"id"`
+	ConfigVersion types.String                                    `tfsdk:"config_version"`
+	Description   types.String                                    `tfsdk:"description"`
+	Name          types.String                                    `tfsdk:"name"`
+	SamlOptions   types.Object                                    `tfsdk:"saml_options"`
+	Type          fwtypes.StringEnum[awstypes.SecurityConfigType] `tfsdk:"type"`
+}
+
+func upgradeSecurityConfigStateFromV0(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var securityConfigDataV0 resourceSecurityConfigDataV0
+	response.Diagnostics.Append(request.State.Get(ctx, &securityConfigDataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	securityConfigDataV1 := resourceSecurityConfigData{
+		ID:            securityConfigDataV0.ID,
+		ConfigVersion: securityConfigDataV0.ConfigVersion,
+		Description:   securityConfigDataV0.Description,
+		Name:          securityConfigDataV0.Name,
+		SamlOptions:   upgradeSAMLOptionsStateFromV0(ctx, securityConfigDataV0.SamlOptions, &response.Diagnostics),
+		Type:          securityConfigDataV0.Type,
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, securityConfigDataV1)...)
+}
+
+func upgradeSAMLOptionsStateFromV0(ctx context.Context, old types.Object, diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[samlOptionsData] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[samlOptionsData](ctx)
+	}
+
+	var oldObj samlOptionsData
+	diags.Append(old.As(ctx, &oldObj, basetypes.ObjectAsOptions{})...)
+
+	newList := []samlOptionsData{
+		{
+			GroupAttribute: oldObj.GroupAttribute,
+			Metadata:       oldObj.Metadata,
+			SessionTimeout: oldObj.SessionTimeout,
+			UserAttribute:  oldObj.UserAttribute,
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newList)
+	diags.Append(d...)
+
+	return result
+}

--- a/internal/service/opensearchserverless/security_config_test.go
+++ b/internal/service/opensearchserverless/security_config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/opensearchserverless/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -44,7 +45,8 @@ func TestAccOpenSearchServerlessSecurityConfig_basic(t *testing.T) {
 					testAccCheckSecurityConfigExists(ctx, resourceName, &securityconfig),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "saml"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttrSet(resourceName, "saml_options.session_timeout"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "saml_options.0.session_timeout"),
 				),
 			},
 			{
@@ -78,7 +80,8 @@ func TestAccOpenSearchServerlessSecurityConfig_update(t *testing.T) {
 					testAccCheckSecurityConfigExists(ctx, resourceName, &securityconfig),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "saml"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "saml_options.session_timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout", "60"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, names.AttrDescription),
 				),
 			},
@@ -88,7 +91,8 @@ func TestAccOpenSearchServerlessSecurityConfig_update(t *testing.T) {
 					testAccCheckSecurityConfigExists(ctx, resourceName, &securityconfig),
 					resource.TestCheckResourceAttr(resourceName, names.AttrType, "saml"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
-					resource.TestCheckResourceAttr(resourceName, "saml_options.session_timeout", "40"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout", "40"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description updated"),
 				),
 			},
@@ -119,6 +123,61 @@ func TestAccOpenSearchServerlessSecurityConfig_disappears(t *testing.T) {
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfopensearchserverless.ResourceSecurityConfig, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccOpenSearchServerlessSecurityConfig_upgradeV6_0_0(t *testing.T) {
+	ctx := acctest.Context(t)
+	var securityconfig types.SecurityConfigDetail
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_opensearchserverless_security_config.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.OpenSearchServerlessEndpointID)
+			testAccPreCheckSecurityConfig(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.OpenSearchServerlessServiceID),
+		CheckDestroy: testAccCheckSecurityConfigDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.94.1",
+					},
+				},
+				Config: testAccSecurityConfig_samlOptions(rName, "test-fixtures/idp-metadata.xml", 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityConfigExists(ctx, resourceName, &securityconfig),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "saml"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.session_timeout", "60"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccSecurityConfig_samlOptions(rName, "test-fixtures/idp-metadata.xml", 60),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSecurityConfigExists(ctx, resourceName, &securityconfig),
+					resource.TestCheckResourceAttr(resourceName, names.AttrType, "saml"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "saml_options.0.session_timeout", "60"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -216,4 +275,18 @@ resource "aws_opensearchserverless_security_config" "test" {
   }
 }
 `, rName, samlOptions, description, sessionTimeout)
+}
+
+func testAccSecurityConfig_samlOptions(rName, samlOptions string, sessionTimeout int) string {
+	return fmt.Sprintf(`
+resource "aws_opensearchserverless_security_config" "test" {
+  name = %[1]q
+  type = "saml"
+
+  saml_options {
+    metadata        = file("%[2]s")
+    session_timeout = %[3]d
+  }
+}
+`, rName, samlOptions, sessionTimeout)
 }

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -25,6 +25,7 @@ Upgrade topics:
 - [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
+- [data-source/aws_opensearchserverless_security_config](#data-sourceaws_opensearchserverless_security_config)
 - [data-source/aws_quicksight_data_set](#data-sourceaws_quicksight_data_set)
 - [data-source/aws_service_discovery_service](#data-sourceaws_service_discovery_service)
 - [resource/aws_api_gateway_account](#resourceaws_api_gateway_account)
@@ -37,6 +38,7 @@ Upgrade topics:
 - [resource/aws_kinesis_analytics_application](#resourceaws_kinesis_analytics_application)
 - [resource/aws_launch_template](#resourceaws_launch_template)
 - [resource/aws_networkmanager_core_network](#resourceaws_networkmanager_core_network)
+- [resource/aws_opensearchserverless_security_config](#resourceaws_opensearchserverless_security_config)
 - [resource/aws_paymentcryptography_key](#resourceaws_paymentcryptography_key)
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
@@ -144,6 +146,12 @@ This is not recommended.
 
 `id` is now computed only.
 
+## data-source/aws_opensearchserverless_security_config
+
+The `saml_options` attribute is now a list nested block instead of a single nested block.
+When referencing this attribute, the index must now be included in the attribute address.
+For example, `saml_options.session_timeout` would now be referenced as `saml_options[0].session_timeout`.
+
 ## data-source/aws_quicksight_data_set
 
 `tags_all` has been removed.
@@ -246,6 +254,12 @@ This resource is deprecated and will be removed in a future version. [Effective 
 ## resource/aws_networkmanager_core_network
 
 The `base_policy_region` argument has been removed. Use `base_policy_regions` instead.
+
+## resource/aws_opensearchserverless_security_config
+
+The `saml_options` argument is now a list nested block instead of a single nested block.
+When referencing this argument, the index must now be included in the attribute address.
+For example, `saml_options.session_timeout` would now be referenced as `saml_options[0].session_timeout`.
 
 ## resource/aws_paymentcryptography_key
 


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These changes are part of a larger effort to remove the use of `SingleNestedBlock` arguments. A state upgrader has been added to make the update seamless across the major version upgrade.



### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35813
Relates https://github.com/hashicorp/terraform-provider-aws/issues/41101



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=opensearchserverless TESTS="TestAccOpenSearchServerlessSecurityConfig_|TestAccOpenSearchServerlessSecurityConfigDataSource_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/opensearchserverless/... -v -count 1 -parallel 20 -run='TestAccOpenSearchServerlessSecurityConfig_|TestAccOpenSearchServerlessSecurityConfigDataSource_'  -timeout 360m -vet=off
2025/04/16 16:12:48 Initializing Terraform AWS Provider...

--- PASS: TestAccOpenSearchServerlessSecurityConfigDataSource_basic (13.12s)
--- PASS: TestAccOpenSearchServerlessSecurityConfig_disappears (13.52s)
--- PASS: TestAccOpenSearchServerlessSecurityConfig_basic (15.15s)
--- PASS: TestAccOpenSearchServerlessSecurityConfig_update (20.72s)
--- PASS: TestAccOpenSearchServerlessSecurityConfig_upgradeV6_0_0 (36.80s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/opensearchserverless       43.384s
```
