### PR TITLE
Add note to `aws_shield_proactive_engagement` regarding phone number requirement

### DIFF
--- a/website/docs/r/shield_proactive_engagement.html.markdown
+++ b/website/docs/r/shield_proactive_engagement.html.markdown
@@ -76,6 +76,8 @@ The following arguments are required:
 
 ### emergency_contacts
 
+~> **Note:** The contacts that you provide here replace any contacts that were already configured within AWS. While `contact_notes` and `phone_number` are optional, to enable proactive engagement, the contact list must include at least one phone number. If a phone number is not already configured within AWS, one must be provided in order to prevent errors.
+
 * `contact_notes` - (Optional) Additional notes regarding the contact.
 * `email_address` - (Required) A valid email address that will be used for this contact.
 * `phone_number` - (Optional) A phone number, starting with `+` and up to 15 digits that will be used for this contact.

--- a/website/docs/r/shield_proactive_engagement.html.markdown
+++ b/website/docs/r/shield_proactive_engagement.html.markdown
@@ -76,7 +76,7 @@ The following arguments are required:
 
 ### emergency_contacts
 
-~> **Note:** The contacts that you provide here replace any contacts that were already configured within AWS. While `contact_notes` and `phone_number` are optional, to enable proactive engagement, the contact list must include at least one phone number. If a phone number is not already configured within AWS, one must be provided in order to prevent errors.
+~> **Note:** The contacts that you provide here replace any contacts that were already configured within AWS. While `phone_number` is marked as optional, to enable proactive engagement, the contact list must include at least one phone number. If a phone number is not already configured within AWS, one must be provided in order to prevent errors.
 
 * `contact_notes` - (Optional) Additional notes regarding the contact.
 * `email_address` - (Required) A valid email address that will be used for this contact.


### PR DESCRIPTION
### Description

While the `phone_number` argument is optional, one must be defined (either within the configuration or within AWS) in order to prevent errors.

Note: I'm waiting to hear back from the user who initially reported the linked issue to make sure that my understanding is correct here, since I'm not able to test in my test account.

### Relations

Closes #42266

### References

[Note in the Go SDK](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/shield#AssociateProactiveEngagementDetailsInput)


### Output from Acceptance Testing

n/a, docs
