### PR TITLE
d/aws_elbv2_listener_rule: `SingleNestedBlock` to `ListNestedBlock`

### DIFF
--- a/.changelog/42283.txt
+++ b/.changelog/42283.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+data-source/aws_elbv2_listener_rule: The `action.authenticate_cognito`, `action.authenticate_oidc`, `action.fixed_response`, `action.forward`, `action.forward.stickiness`, `action.redirect`, `condition.host_header`, `condition.http_header`, `condition.http_request_method`, `condition.path_pattern`, `condition.query_string`, and `condition.source_ip` attributes are now list nested blocks instead of single nested blocks
+```

--- a/internal/service/elbv2/listener_rule_data_source.go
+++ b/internal/service/elbv2/listener_rule_data_source.go
@@ -69,129 +69,147 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"authenticate_cognito": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[authenticateCognitoActionConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								"authentication_request_extra_params": schema.MapAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
-								},
-								"on_unauthenticated_request": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrScope: schema.StringAttribute{
-									Computed: true,
-								},
-								"session_cookie_name": schema.StringAttribute{
-									Computed: true,
-								},
-								"session_timeout": schema.Int64Attribute{
-									Computed: true,
-								},
-								"user_pool_arn": schema.StringAttribute{
-									Computed: true,
-								},
-								"user_pool_client_id": schema.StringAttribute{
-									Computed: true,
-								},
-								"user_pool_domain": schema.StringAttribute{
-									Computed: true,
-								},
-							},
-						},
-						"authenticate_oidc": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							Attributes: map[string]schema.Attribute{
-								"authentication_request_extra_params": schema.MapAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
-								},
-								"authorization_endpoint": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrClientID: schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrIssuer: schema.StringAttribute{
-									Computed: true,
-								},
-								"on_unauthenticated_request": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrScope: schema.StringAttribute{
-									Computed: true,
-								},
-								"session_cookie_name": schema.StringAttribute{
-									Computed: true,
-								},
-								"session_timeout": schema.Int64Attribute{
-									Computed: true,
-								},
-								"token_endpoint": schema.StringAttribute{
-									Computed: true,
-								},
-								"user_info_endpoint": schema.StringAttribute{
-									Computed: true,
-								},
-							},
-						},
-						"fixed_response": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							Attributes: map[string]schema.Attribute{
-								names.AttrContentType: schema.StringAttribute{
-									Computed: true,
-								},
-								"message_body": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrStatusCode: schema.StringAttribute{
-									Computed: true,
-								},
-							},
-						},
-						"forward": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							Blocks: map[string]schema.Block{
-								"stickiness": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-									Attributes: map[string]schema.Attribute{
-										names.AttrDuration: schema.Int32Attribute{
-											Computed: true,
-										},
-										names.AttrEnabled: schema.BoolAttribute{
-											Computed: true,
-										},
+						"authenticate_cognito": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[authenticateCognitoActionConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"authentication_request_extra_params": schema.MapAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
 									},
-								},
-								"target_group": schema.SetNestedBlock{
-									NestedObject: schema.NestedBlockObject{
-										Attributes: map[string]schema.Attribute{
-											names.AttrARN: schema.StringAttribute{
-												Computed: true,
-											},
-											names.AttrWeight: schema.Int32Attribute{
-												Computed: true,
-											},
-										},
+									"on_unauthenticated_request": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrScope: schema.StringAttribute{
+										Computed: true,
+									},
+									"session_cookie_name": schema.StringAttribute{
+										Computed: true,
+									},
+									"session_timeout": schema.Int64Attribute{
+										Computed: true,
+									},
+									"user_pool_arn": schema.StringAttribute{
+										Computed: true,
+									},
+									"user_pool_client_id": schema.StringAttribute{
+										Computed: true,
+									},
+									"user_pool_domain": schema.StringAttribute{
+										Computed: true,
 									},
 								},
 							},
 						},
-						"redirect": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							Attributes: map[string]schema.Attribute{
-								"host": schema.StringAttribute{
-									Computed: true,
+						"authenticate_oidc": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[authenticateOIDCActionConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"authentication_request_extra_params": schema.MapAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
+									"authorization_endpoint": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrClientID: schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrIssuer: schema.StringAttribute{
+										Computed: true,
+									},
+									"on_unauthenticated_request": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrScope: schema.StringAttribute{
+										Computed: true,
+									},
+									"session_cookie_name": schema.StringAttribute{
+										Computed: true,
+									},
+									"session_timeout": schema.Int64Attribute{
+										Computed: true,
+									},
+									"token_endpoint": schema.StringAttribute{
+										Computed: true,
+									},
+									"user_info_endpoint": schema.StringAttribute{
+										Computed: true,
+									},
 								},
-								names.AttrPath: schema.StringAttribute{
-									Computed: true,
+							},
+						},
+						"fixed_response": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[fixedResponseActionConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrContentType: schema.StringAttribute{
+										Computed: true,
+									},
+									"message_body": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrStatusCode: schema.StringAttribute{
+										Computed: true,
+									},
 								},
-								names.AttrPort: schema.StringAttribute{
-									Computed: true,
+							},
+						},
+						"forward": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[forwardActionConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"stickiness": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[targetGroupStickinessConfigModel](ctx),
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrDuration: schema.Int32Attribute{
+													Computed: true,
+												},
+												names.AttrEnabled: schema.BoolAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+									"target_group": schema.SetNestedBlock{
+										CustomType: fwtypes.NewSetNestedObjectTypeOf[targetGroupTupleModel](ctx),
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrARN: schema.StringAttribute{
+													Computed: true,
+												},
+												names.AttrWeight: schema.Int32Attribute{
+													Computed: true,
+												},
+											},
+										},
+									},
 								},
-								names.AttrProtocol: schema.StringAttribute{
-									Computed: true,
-								},
-								"query": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrStatusCode: schema.StringAttribute{
-									Computed: true,
+							},
+						},
+						"redirect": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[redirectActionConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"host": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrPath: schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrPort: schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrProtocol: schema.StringAttribute{
+										Computed: true,
+									},
+									"query": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrStatusCode: schema.StringAttribute{
+										Computed: true,
+									},
 								},
 							},
 						},
@@ -202,69 +220,81 @@ func (d *dataSourceListenerRule) Schema(ctx context.Context, req datasource.Sche
 				CustomType: fwtypes.NewSetNestedObjectTypeOf[ruleConditionModel](ctx),
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						"host_header": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[hostHeaderConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								names.AttrValues: schema.SetAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
+						"host_header": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[hostHeaderConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrValues: schema.SetAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
 								},
 							},
 						},
-						"http_header": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[httpHeaderConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								"http_header_name": schema.StringAttribute{
-									Computed: true,
-								},
-								names.AttrValues: schema.SetAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
-								},
-							},
-						},
-						"http_request_method": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[httpRquestMethodConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								names.AttrValues: schema.SetAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
+						"http_header": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[httpHeaderConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"http_header_name": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrValues: schema.SetAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
 								},
 							},
 						},
-						"path_pattern": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[pathPatternConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								names.AttrValues: schema.SetAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
+						"http_request_method": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[httpRquestMethodConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrValues: schema.SetAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
 								},
 							},
 						},
-						"query_string": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[queryStringConfigModel](ctx),
-							Blocks: map[string]schema.Block{
-								names.AttrValues: schema.SetNestedBlock{
-									CustomType: fwtypes.NewSetNestedObjectTypeOf[queryStringKeyValuePairModel](ctx),
-									NestedObject: schema.NestedBlockObject{
-										Attributes: map[string]schema.Attribute{
-											names.AttrKey: schema.StringAttribute{
-												Computed: true,
-											},
-											names.AttrValue: schema.StringAttribute{
-												Computed: true,
+						"path_pattern": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[pathPatternConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrValues: schema.SetAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
+								},
+							},
+						},
+						"query_string": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[queryStringConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									names.AttrValues: schema.SetNestedBlock{
+										CustomType: fwtypes.NewSetNestedObjectTypeOf[queryStringKeyValuePairModel](ctx),
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrKey: schema.StringAttribute{
+													Computed: true,
+												},
+												names.AttrValue: schema.StringAttribute{
+													Computed: true,
+												},
 											},
 										},
 									},
 								},
 							},
 						},
-						"source_ip": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-							CustomType: fwtypes.NewObjectTypeOf[pathPatternConfigModel](ctx),
-							Attributes: map[string]schema.Attribute{
-								names.AttrValues: schema.SetAttribute{
-									ElementType: types.StringType,
-									Computed:    true,
+						"source_ip": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[sourceIPConfigModel](ctx),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrValues: schema.SetAttribute{
+										ElementType: types.StringType,
+										Computed:    true,
+									},
 								},
 							},
 						},
@@ -331,7 +361,7 @@ func (d *dataSourceListenerRule) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	// The listener arn isn't in the response but can be derived from the rule arn
+	// The listener ARN isn't in the response but can be derived from the rule ARN
 	data.ListenerARN = fwtypes.ARNValue(listenerARNFromRuleARN(aws.ToString(out.RuleArn)))
 
 	priority, err := strconv.ParseInt(aws.ToString(out.Priority), 10, 32)
@@ -360,13 +390,13 @@ type dataSourceListenerRuleModel struct {
 // and there is a single target group. The read also populates the ForwardConfig with the single TargetGroup,
 // so it is redundant. Using the ForwardConfig in all cases improves consistency.
 type actionModel struct {
-	Type                      types.String                                                `tfsdk:"type"`
-	AuthenticateCognitoConfig fwtypes.ObjectValueOf[authenticateCognitoActionConfigModel] `tfsdk:"authenticate_cognito"`
-	AuthenticateOidcConfig    fwtypes.ObjectValueOf[authenticateOIDCActionConfigModel]    `tfsdk:"authenticate_oidc"`
-	FixedResponseConfig       fwtypes.ObjectValueOf[fixedResponseActionConfigModel]       `tfsdk:"fixed_response"`
-	ForwardConfig             fwtypes.ObjectValueOf[forwardActionConfigModel]             `tfsdk:"forward"`
-	Order                     types.Int32                                                 `tfsdk:"order"`
-	RedirectConfig            fwtypes.ObjectValueOf[redirectActionConfigModel]            `tfsdk:"redirect"`
+	Type                      types.String                                                          `tfsdk:"type"`
+	AuthenticateCognitoConfig fwtypes.ListNestedObjectValueOf[authenticateCognitoActionConfigModel] `tfsdk:"authenticate_cognito"`
+	AuthenticateOidcConfig    fwtypes.ListNestedObjectValueOf[authenticateOIDCActionConfigModel]    `tfsdk:"authenticate_oidc"`
+	FixedResponseConfig       fwtypes.ListNestedObjectValueOf[fixedResponseActionConfigModel]       `tfsdk:"fixed_response"`
+	ForwardConfig             fwtypes.ListNestedObjectValueOf[forwardActionConfigModel]             `tfsdk:"forward"`
+	Order                     types.Int32                                                           `tfsdk:"order"`
+	RedirectConfig            fwtypes.ListNestedObjectValueOf[redirectActionConfigModel]            `tfsdk:"redirect"`
 }
 
 type authenticateCognitoActionConfigModel struct {
@@ -381,8 +411,8 @@ type authenticateCognitoActionConfigModel struct {
 }
 
 type authenticateOIDCActionConfigModel struct {
-	AuthorizationEndpoint            types.String        `tfsdk:"authorization_endpoint"`
 	AuthenticationRequestExtraParams fwtypes.MapOfString `tfsdk:"authentication_request_extra_params"`
+	AuthorizationEndpoint            types.String        `tfsdk:"authorization_endpoint"`
 	ClientId                         types.String        `tfsdk:"client_id"`
 	Issuer                           types.String        `tfsdk:"issuer"`
 	OnUnauthenticatedRequest         types.String        `tfsdk:"on_unauthenticated_request"`
@@ -400,8 +430,8 @@ type fixedResponseActionConfigModel struct {
 }
 
 type forwardActionConfigModel struct {
-	TargetGroupStickinessConfig fwtypes.ObjectValueOf[targetGroupStickinessConfigModel] `tfsdk:"stickiness"`
-	TargetGroups                fwtypes.SetNestedObjectValueOf[targetGroupTupleModel]   `tfsdk:"target_group"`
+	TargetGroupStickinessConfig fwtypes.ListNestedObjectValueOf[targetGroupStickinessConfigModel] `tfsdk:"stickiness"`
+	TargetGroups                fwtypes.SetNestedObjectValueOf[targetGroupTupleModel]             `tfsdk:"target_group"`
 }
 
 type targetGroupStickinessConfigModel struct {
@@ -424,12 +454,12 @@ type redirectActionConfigModel struct {
 }
 
 type ruleConditionModel struct {
-	HostHeaderConfig        fwtypes.ObjectValueOf[hostHeaderConfigModel]       `tfsdk:"host_header"`
-	HttpHeaderConfig        fwtypes.ObjectValueOf[httpHeaderConfigModel]       `tfsdk:"http_header"`
-	HttpRequestMethodConfig fwtypes.ObjectValueOf[httpRquestMethodConfigModel] `tfsdk:"http_request_method"`
-	PathPatternConfig       fwtypes.ObjectValueOf[pathPatternConfigModel]      `tfsdk:"path_pattern"`
-	QueryStringConfig       fwtypes.ObjectValueOf[queryStringConfigModel]      `tfsdk:"query_string"`
-	SourceIpConfig          fwtypes.ObjectValueOf[sourceIPConfigModel]         `tfsdk:"source_ip"`
+	HostHeaderConfig        fwtypes.ListNestedObjectValueOf[hostHeaderConfigModel]       `tfsdk:"host_header"`
+	HttpHeaderConfig        fwtypes.ListNestedObjectValueOf[httpHeaderConfigModel]       `tfsdk:"http_header"`
+	HttpRequestMethodConfig fwtypes.ListNestedObjectValueOf[httpRquestMethodConfigModel] `tfsdk:"http_request_method"`
+	PathPatternConfig       fwtypes.ListNestedObjectValueOf[pathPatternConfigModel]      `tfsdk:"path_pattern"`
+	QueryStringConfig       fwtypes.ListNestedObjectValueOf[queryStringConfigModel]      `tfsdk:"query_string"`
+	SourceIpConfig          fwtypes.ListNestedObjectValueOf[sourceIPConfigModel]         `tfsdk:"source_ip"`
 }
 
 type hostHeaderConfigModel struct {

--- a/internal/service/elbv2/listener_rule_data_source_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_test.go
@@ -47,12 +47,12 @@ func TestAccELBV2ListenerRuleDataSource_byARN(t *testing.T) {
 					// action
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
-							"authenticate_oidc":    knownvalue.Null(),
-							"fixed_response":       knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
 							"forward":              knownvalue.NotNull(),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 					})),
@@ -68,10 +68,12 @@ func TestAccELBV2ListenerRuleDataSource_byARN(t *testing.T) {
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward"), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"stickiness": knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrDuration: knownvalue.Null(),
-							names.AttrEnabled:  knownvalue.Bool(false),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"stickiness": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrDuration: knownvalue.Null(),
+								names.AttrEnabled:  knownvalue.Bool(false),
+							}),
 						}),
 						"target_group": knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
@@ -82,16 +84,18 @@ func TestAccELBV2ListenerRuleDataSource_byARN(t *testing.T) {
 					})),
 
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtMapKey("target_group").AtSliceIndex(0).AtMapKey(names.AttrARN),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("target_group").AtSliceIndex(0).AtMapKey(names.AttrARN),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("target_group_arn"),
 						compare.ValuesSame(),
 					),
 
 					// condition
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("host_header", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("example.com"),
+						expectKnownCondition("host_header", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("example.com"),
+								}),
 							}),
 						})),
 					})),
@@ -133,12 +137,12 @@ func TestAccELBV2ListenerRuleDataSource_byListenerAndPriority(t *testing.T) {
 					// action
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
-							"authenticate_oidc":    knownvalue.Null(),
-							"fixed_response":       knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
 							"forward":              knownvalue.NotNull(),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 					})),
@@ -154,10 +158,12 @@ func TestAccELBV2ListenerRuleDataSource_byListenerAndPriority(t *testing.T) {
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward"), knownvalue.ObjectExact(map[string]knownvalue.Check{
-						"stickiness": knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrDuration: knownvalue.Null(),
-							names.AttrEnabled:  knownvalue.Bool(false),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
+						"stickiness": knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrDuration: knownvalue.Null(),
+								names.AttrEnabled:  knownvalue.Bool(false),
+							}),
 						}),
 						"target_group": knownvalue.SetExact([]knownvalue.Check{
 							knownvalue.ObjectExact(map[string]knownvalue.Check{
@@ -168,16 +174,18 @@ func TestAccELBV2ListenerRuleDataSource_byListenerAndPriority(t *testing.T) {
 					})),
 
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtMapKey("target_group").AtSliceIndex(0).AtMapKey(names.AttrARN),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("target_group").AtSliceIndex(0).AtMapKey(names.AttrARN),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("target_group_arn"),
 						compare.ValuesSame(),
 					),
 
 					// condition
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("host_header", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("example.com"),
+						expectKnownCondition("host_header", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("example.com"),
+								}),
 							}),
 						})),
 					})),
@@ -221,11 +229,11 @@ func TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito(t *testing.T) 
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							"authenticate_cognito": knownvalue.NotNull(),
-							"authenticate_oidc":    knownvalue.Null(),
-							"fixed_response":       knownvalue.Null(),
-							"forward":              knownvalue.Null(),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
+							"forward":              knownvalue.ListExact([]knownvalue.Check{}),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 						knownvalue.NotNull(),
@@ -242,9 +250,9 @@ func TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito(t *testing.T) 
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_cognito"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_cognito").AtSliceIndex(0), knownvalue.NotNull()),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_cognito"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_cognito").AtSliceIndex(0),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_cognito").AtSliceIndex(0),
 						compare.ValuesSame(),
 					),
@@ -284,12 +292,12 @@ func TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
 							"authenticate_oidc":    knownvalue.NotNull(),
-							"fixed_response":       knownvalue.Null(),
-							"forward":              knownvalue.Null(),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
+							"forward":              knownvalue.ListExact([]knownvalue.Check{}),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 						knownvalue.NotNull(),
@@ -306,54 +314,54 @@ func TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC(t *testing.T) {
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0), knownvalue.NotNull()),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("authentication_request_extra_params"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("authentication_request_extra_params"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("authentication_request_extra_params"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("authorization_endpoint"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("authorization_endpoint"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("authorization_endpoint"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey(names.AttrClientID),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrClientID),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrClientID),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey(names.AttrIssuer),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrIssuer),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrIssuer),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("on_unauthenticated_request"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("on_unauthenticated_request"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("on_unauthenticated_request"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey(names.AttrScope),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrScope),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey(names.AttrScope),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("session_cookie_name"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("session_cookie_name"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("session_cookie_name"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("session_timeout"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("session_timeout"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("session_timeout"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("token_endpoint"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("token_endpoint"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("token_endpoint"),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtMapKey("user_info_endpoint"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("user_info_endpoint"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("authenticate_oidc").AtSliceIndex(0).AtMapKey("user_info_endpoint"),
 						compare.ValuesSame(),
 					),
@@ -391,12 +399,12 @@ func TestAccELBV2ListenerRuleDataSource_actionFixedResponse(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
-							"authenticate_oidc":    knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
 							"fixed_response":       knownvalue.NotNull(),
-							"forward":              knownvalue.Null(),
+							"forward":              knownvalue.ListExact([]knownvalue.Check{}),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 					})),
@@ -412,9 +420,9 @@ func TestAccELBV2ListenerRuleDataSource_actionFixedResponse(t *testing.T) {
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("fixed_response"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("fixed_response").AtSliceIndex(0), knownvalue.NotNull()),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("fixed_response"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("fixed_response").AtSliceIndex(0),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("fixed_response").AtSliceIndex(0),
 						compare.ValuesSame(),
 					),
@@ -453,12 +461,12 @@ func TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness(t *testi
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
-							"authenticate_oidc":    knownvalue.Null(),
-							"fixed_response":       knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
 							"forward":              knownvalue.NotNull(),
 							"order":                knownvalue.NotNull(),
-							"redirect":             knownvalue.Null(),
+							"redirect":             knownvalue.ListExact([]knownvalue.Check{}),
 							names.AttrType:         knownvalue.NotNull(),
 						}),
 					})),
@@ -474,17 +482,17 @@ func TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness(t *testi
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward"), knownvalue.ObjectExact(map[string]knownvalue.Check{
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0), knownvalue.ObjectExact(map[string]knownvalue.Check{
 						"stickiness":   knownvalue.NotNull(),
 						"target_group": knownvalue.NotNull(),
 					})),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtMapKey("stickiness"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("stickiness").AtSliceIndex(0),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("stickiness").AtSliceIndex(0),
 						compare.ValuesSame(),
 					),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtMapKey("target_group"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("target_group"),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("forward").AtSliceIndex(0).AtMapKey("target_group"),
 						compare.ValuesSame(),
 					),
@@ -522,10 +530,10 @@ func TestAccELBV2ListenerRuleDataSource_actionRedirect(t *testing.T) {
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction), knownvalue.ListExact([]knownvalue.Check{
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"authenticate_cognito": knownvalue.Null(),
-							"authenticate_oidc":    knownvalue.Null(),
-							"fixed_response":       knownvalue.Null(),
-							"forward":              knownvalue.Null(),
+							"authenticate_cognito": knownvalue.ListExact([]knownvalue.Check{}),
+							"authenticate_oidc":    knownvalue.ListExact([]knownvalue.Check{}),
+							"fixed_response":       knownvalue.ListExact([]knownvalue.Check{}),
+							"forward":              knownvalue.ListExact([]knownvalue.Check{}),
 							"order":                knownvalue.NotNull(),
 							"redirect":             knownvalue.NotNull(),
 							names.AttrType:         knownvalue.NotNull(),
@@ -543,9 +551,9 @@ func TestAccELBV2ListenerRuleDataSource_actionRedirect(t *testing.T) {
 						compare.ValuesSame(),
 					),
 
-					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("redirect"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("redirect").AtSliceIndex(0), knownvalue.NotNull()),
 					statecheck.CompareValuePairs(
-						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("redirect"),
+						dataSourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("redirect").AtSliceIndex(0),
 						resourceName, tfjsonpath.New(names.AttrAction).AtSliceIndex(0).AtMapKey("redirect").AtSliceIndex(0),
 						compare.ValuesSame(),
 					),
@@ -578,10 +586,12 @@ func TestAccELBV2ListenerRuleDataSource_conditionHostHeader(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("host_header", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("example.com"),
-								knownvalue.StringExact("www.example.com"),
+						expectKnownCondition("host_header", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("example.com"),
+									knownvalue.StringExact("www.example.com"),
+								}),
 							}),
 						})),
 					})),
@@ -614,11 +624,13 @@ func TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("http_header", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							"http_header_name": knownvalue.StringExact("X-Forwarded-For"),
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("192.168.1.*"),
-								knownvalue.StringExact("10.0.0.*"),
+						expectKnownCondition("http_header", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"http_header_name": knownvalue.StringExact("X-Forwarded-For"),
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("192.168.1.*"),
+									knownvalue.StringExact("10.0.0.*"),
+								}),
 							}),
 						})),
 					})),
@@ -651,10 +663,12 @@ func TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod(t *testing.T)
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("http_request_method", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("GET"),
-								knownvalue.StringExact("POST"),
+						expectKnownCondition("http_request_method", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("GET"),
+									knownvalue.StringExact("POST"),
+								}),
 							}),
 						})),
 					})),
@@ -687,10 +701,12 @@ func TestAccELBV2ListenerRuleDataSource_conditionPathPattern(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("path_pattern", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("/public/*"),
-								knownvalue.StringExact("/cgi-bin/*"),
+						expectKnownCondition("path_pattern", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("/public/*"),
+									knownvalue.StringExact("/cgi-bin/*"),
+								}),
 							}),
 						})),
 					})),
@@ -723,15 +739,17 @@ func TestAccELBV2ListenerRuleDataSource_conditionQueryString(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("query_string", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.ObjectExact(map[string]knownvalue.Check{
-									names.AttrKey:   knownvalue.StringExact("one"),
-									names.AttrValue: knownvalue.StringExact("un"),
-								}),
-								knownvalue.ObjectExact(map[string]knownvalue.Check{
-									names.AttrKey:   knownvalue.StringExact("two"),
-									names.AttrValue: knownvalue.StringExact("deux"),
+						expectKnownCondition("query_string", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										names.AttrKey:   knownvalue.StringExact("one"),
+										names.AttrValue: knownvalue.StringExact("un"),
+									}),
+									knownvalue.ObjectExact(map[string]knownvalue.Check{
+										names.AttrKey:   knownvalue.StringExact("two"),
+										names.AttrValue: knownvalue.StringExact("deux"),
+									}),
 								}),
 							}),
 						})),
@@ -765,10 +783,12 @@ func TestAccELBV2ListenerRuleDataSource_conditionSourceIP(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(dataSourceName, tfjsonpath.New(names.AttrCondition), knownvalue.SetExact([]knownvalue.Check{
-						expectKnownCondition("source_ip", knownvalue.ObjectExact(map[string]knownvalue.Check{
-							names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
-								knownvalue.StringExact("192.168.0.0/16"),
-								knownvalue.StringExact("dead:cafe::/64"),
+						expectKnownCondition("source_ip", knownvalue.ListExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								names.AttrValues: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("192.168.0.0/16"),
+									knownvalue.StringExact("dead:cafe::/64"),
+								}),
 							}),
 						})),
 					})),
@@ -780,12 +800,12 @@ func TestAccELBV2ListenerRuleDataSource_conditionSourceIP(t *testing.T) {
 
 func expectKnownCondition(key string, check knownvalue.Check) knownvalue.Check {
 	checks := map[string]knownvalue.Check{
-		"host_header":         knownvalue.Null(),
-		"http_header":         knownvalue.Null(),
-		"http_request_method": knownvalue.Null(),
-		"path_pattern":        knownvalue.Null(),
-		"query_string":        knownvalue.Null(),
-		"source_ip":           knownvalue.Null(),
+		"host_header":         knownvalue.ListExact([]knownvalue.Check{}),
+		"http_header":         knownvalue.ListExact([]knownvalue.Check{}),
+		"http_request_method": knownvalue.ListExact([]knownvalue.Check{}),
+		"path_pattern":        knownvalue.ListExact([]knownvalue.Check{}),
+		"query_string":        knownvalue.ListExact([]knownvalue.Check{}),
+		"source_ip":           knownvalue.ListExact([]knownvalue.Check{}),
 	}
 	checks[key] = check
 	return knownvalue.ObjectExact(checks)

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -23,6 +23,7 @@ Upgrade topics:
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
 - [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
+- [data-source/aws_elbv2_listener_rule](#data-sourceaws_elbv2_listener_rule)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_opensearch_domain](#data-sourceaws_opensearch_domain)
@@ -171,6 +172,26 @@ Remove `inference_accelerator` from your configuration—it no longer exists. Am
 ## data-source/aws_ecs_task_execution
 
 Remove `inference_accelerator_overrides` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## data-source/aws_elbv2_listener_rule
+
+The following attributes are now list nested blocks instead of single nested blocks.
+
+- `action.authenticate_cognito`
+- `action.authenticate_oidc`
+- `action.fixed_response`
+- `action.forward`
+- `action.forward.stickiness`
+- `action.redirect`
+- `condition.host_header`
+- `condition.http_header`
+- `condition.http_request_method`
+- `condition.path_pattern`
+- `condition.query_string`
+- `condition.source_ip`
+
+When referencing these attributes, the indicies must now be included in the attribute address.
+For example, `action[0].authenticate_cognito.scope` would now be referenced as `action[0].authenticate_cognito[0].scope`.
 
 ## data-source/aws_launch_template
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These changes are part of a larger effort to remove the use of `SingleNestedBlock` arguments. As this is a data source, no state upgrader is necessary because the state is refreshed on each execution.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35813
Relates https://github.com/hashicorp/terraform-provider-aws/issues/41101


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2ListenerRuleDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elbv2/... -v -count 1 -parallel 20 -run='TestAccELBV2ListenerRuleDataSource_'  -timeout 360m -vet=off
2025/04/17 15:05:28 Initializing Terraform AWS Provider...

--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHTTPRequestMethod (225.98s)
--- PASS: TestAccELBV2ListenerRuleDataSource_byListenerAndPriority (227.43s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionForwardWeightedStickiness (231.13s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionRedirect (232.61s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags (233.53s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionAuthenticateOIDC (244.34s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHTTPHeader (264.11s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags_DefaultTags_nonOverlapping (275.00s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags_IgnoreTags_Overlap_DefaultTag (276.06s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionFixedResponse (279.75s)
--- PASS: TestAccELBV2ListenerRuleDataSource_byARN (281.82s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags_NullMap (292.66s)
--- PASS: TestAccELBV2ListenerRuleDataSource_actionAuthenticateCognito (295.13s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionSourceIP (297.81s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionQueryString (313.99s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionHostHeader (323.96s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags_IgnoreTags_Overlap_ResourceTag (324.97s)
--- PASS: TestAccELBV2ListenerRuleDataSource_tags_EmptyMap (335.18s)
--- PASS: TestAccELBV2ListenerRuleDataSource_conditionPathPattern (338.87s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      345.737s
```