### PR TITLE
Add check to notify if a changelog entry is needed

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -227,6 +227,19 @@ jobs:
             changelog:
               - 'CHANGELOG.md'
 
+      - name: Determine Changelog Update Need
+        if: ${{ !contains(toJSON(github.event.pull_request.labels.*.name), 'no-changelog') }}
+        id: changelog-update-needed
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            needs
+              - 'internal/service/**'
+              - '!internal/service/**/*_test.go'
+            has
+              - '.changelog/**'
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         id: checkout
         if: |
@@ -274,11 +287,23 @@ jobs:
           && steps.community_check.outputs.maintainer == 'false'
         shell: bash
         run: |
-          echo '#### Changelog Changes
+          echo '#### Unneccessary Changelog Changes
 
           The `CHANGELOG.md` file contents are handled by the maintainers during merge. This is to prevent pull request merge conflicts, especially for contributions which may not be merged immediately. Please see the [Changelog Process](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) section of the contributing guide for additional information.
 
           Remove any changes to the `CHANGELOG.md` file and commit them in this pull request to prevent delays with reviewing and potentially merging it.
+          ' >> note.md
+
+      - name: Needs Changelog
+        id: needs-changelog-entry
+        if: |
+          steps.changelog-update-needed.outputs.needs == 'true'
+          && steps.changelog-update-needed.outputs.has == 'false'
+        shell: bash
+        run: |
+          echo '#### Changelog Entry Required
+
+          The proposed change requires a changelog entry. Please see the [Changelog Process](https://hashicorp.github.io/terraform-provider-aws/changelog-process/) section of the contributing guide for information on the changelog generation process.
           ' >> note.md
 
       - name: Start Message
@@ -287,6 +312,7 @@ jobs:
           steps.maintainer_editability.outcome != 'skipped'
           || steps.dependencies.outcome != 'skipped'
           || steps.changelog.outcome != 'skipped'
+          || steps.changelog-update-needed.outcome != 'skipped'
         shell: bash
         run: |
           { echo $START_TEXT; echo ; cat note.md; } > tmpnote && mv tmpnote note.md

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -228,7 +228,7 @@ jobs:
               - 'CHANGELOG.md'
 
       - name: Determine Changelog Update Need
-        if: ${{ !contains(toJSON(github.event.pull_request.labels.*.name), 'no-changelog') }}
+        if: ${{ !contains(toJSON(github.event.pull_request.labels.*.name), 'no-changelog-needed') }}
         id: changelog-update-needed
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         with:

--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -125,7 +125,7 @@ variable "workflow_labels" {
       color       = "ac72f0", # color:terraform (link on black)
       description = "Introduces a new service."
     },
-    "no-changelog" = {
+    "no-changelog-needed" = {
       color       = "828a90", # color:stale grey
       description = "Indicates that a changelog entry is not necessary"
     }

--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -128,7 +128,7 @@ variable "workflow_labels" {
     "no-changelog-needed" = {
       color       = "828a90", # color:stale grey
       description = "Indicates that a changelog entry is not necessary"
-    }
+    },
     "partner" = {
       color       = "ff9900", # color:aws
       description = "Contribution from a partner."

--- a/infrastructure/repository/labels-workflow.tf
+++ b/infrastructure/repository/labels-workflow.tf
@@ -125,6 +125,10 @@ variable "workflow_labels" {
       color       = "ac72f0", # color:terraform (link on black)
       description = "Introduces a new service."
     },
+    "no-changelog" = {
+      color       = "828a90", # color:stale grey
+      description = "Indicates that a changelog entry is not necessary"
+    }
     "partner" = {
       color       = "ff9900", # color:aws
       description = "Contribution from a partner."


### PR DESCRIPTION
### Description

Adds a section to the warning comment workflow to indicate that a changelog entry is needed on non-test changes to files within `internal/service/` subdirectories

Also adds the requisite `no-changelog-needed` label to help with exclusions where the general check provides a false-positive.

### Output from Acceptance Testing

N/a, workflow
