### PR TITLE
r/aws_resiliencehub_resiliency_policy: `SingleNestedBlock` to `ListNestedBlock`

### DIFF
--- a/.changelog/42297.txt
+++ b/.changelog/42297.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_resiliencehub_resiliency_policy: `policy`, `policy.az`, `policy.hardware`, `policy.software`, and `policy.region` are now list nested blocks instead of single nested blocks
+```

--- a/internal/service/resiliencehub/resiliency_policy.go
+++ b/internal/service/resiliencehub/resiliency_policy.go
@@ -15,7 +15,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/resiliencehub/types"
 	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -65,21 +65,16 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 			Description: "Recovery Time Objective (RTO) as a Go duration.",
 			CustomType:  timetypes.GoDurationType{},
 			Required:    true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
 		},
 		"rpo": schema.StringAttribute{
 			Description: "Recovery Point Objective (RPO) as a Go duration.",
 			CustomType:  timetypes.GoDurationType{},
 			Required:    true,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
 		},
 	}
 
 	resp.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN: framework.ARNAttributeComputedOnly(),
 			"data_location_constraint": schema.StringAttribute{
@@ -94,9 +89,6 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 			names.AttrDescription: schema.StringAttribute{
 				Description: "The description for the policy.",
 				Optional:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(500),
 				},
@@ -104,9 +96,6 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 			names.AttrName: schema.StringAttribute{
 				Description: "The name of the policy.",
 				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(2, 60),
 					stringvalidator.RegexMatches(regexache.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]+$`), "Must start with an alphanumeric character and contain alphanumeric characters, underscores, or hyphens"),
@@ -116,9 +105,6 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 				Description: "The tier for the resiliency policy, ranging from the highest severity (MissionCritical) to lowest (NonCritical).",
 				CustomType:  fwtypes.StringEnumType[awstypes.ResiliencyPolicyTier](),
 				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"estimated_cost_tier": schema.StringAttribute{
 				Description: "Specifies the estimated cost tier of the resiliency policy.",
@@ -129,61 +115,62 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
 		},
 		Blocks: map[string]schema.Block{
-			names.AttrPolicy: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+			names.AttrPolicy: schema.ListNestedBlock{
 				Description: "The resiliency failure policy.",
-				CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyPolicyModel](ctx),
-				Validators: []validator.Object{
-					objectvalidator.IsRequired(),
+				CustomType:  fwtypes.NewListNestedObjectTypeOf[policyData](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
 				},
-				Blocks: map[string]schema.Block{
-					"az": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
-						Description: "The RTO and RPO target to measure resiliency for potential availability zone disruptions.",
-						Validators: []validator.Object{
-							objectvalidator.IsRequired(),
-						},
-						Attributes: requiredObjAttrs,
-					},
-					"hardware": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
-						Description: "The RTO and RPO target to measure resiliency for potential infrastructure disruptions.",
-						Validators: []validator.Object{
-							objectvalidator.IsRequired(),
-						},
-						Attributes: requiredObjAttrs,
-					},
-					"software": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
-						Description: "The RTO and RPO target to measure resiliency for potential application disruptions.",
-						Validators: []validator.Object{
-							objectvalidator.IsRequired(),
-						},
-						Attributes: requiredObjAttrs,
-					},
-					names.AttrRegion: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-						CustomType:  fwtypes.NewObjectTypeOf[resourceResiliencyObjectiveModel](ctx),
-						Description: "The RTO and RPO target to measure resiliency for potential region disruptions.",
-						Validators: []validator.Object{
-							objectvalidator.AlsoRequires(
-								path.MatchRelative().AtName("rto"),
-								path.MatchRelative().AtName("rpo"),
-							),
-						},
-						Attributes: map[string]schema.Attribute{
-							"rto": schema.StringAttribute{
-								Description: "Recovery Time Objective (RTO) as a Go duration.",
-								CustomType:  timetypes.GoDurationType{},
-								Optional:    true,
-								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.UseStateForUnknown(),
-								},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"az": schema.ListNestedBlock{
+							CustomType:  fwtypes.NewListNestedObjectTypeOf[resiliencyObjectiveData](ctx),
+							Description: "The RTO and RPO target to measure resiliency for potential availability zone disruptions.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
 							},
-							"rpo": schema.StringAttribute{
-								Description: "Recovery Point Objective (RPO) as a Go duration.",
-								CustomType:  timetypes.GoDurationType{},
-								Optional:    true,
-								PlanModifiers: []planmodifier.String{
-									stringplanmodifier.UseStateForUnknown(),
+							NestedObject: schema.NestedBlockObject{
+								Attributes: requiredObjAttrs,
+							},
+						},
+						"hardware": schema.ListNestedBlock{
+							CustomType:  fwtypes.NewListNestedObjectTypeOf[resiliencyObjectiveData](ctx),
+							Description: "The RTO and RPO target to measure resiliency for potential infrastructure disruptions.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: requiredObjAttrs,
+							},
+						},
+						"software": schema.ListNestedBlock{
+							CustomType:  fwtypes.NewListNestedObjectTypeOf[resiliencyObjectiveData](ctx),
+							Description: "The RTO and RPO target to measure resiliency for potential application disruptions.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: requiredObjAttrs,
+							},
+						},
+						names.AttrRegion: schema.ListNestedBlock{
+							CustomType:  fwtypes.NewListNestedObjectTypeOf[resiliencyObjectiveData](ctx),
+							Description: "The RTO and RPO target to measure resiliency for potential region disruptions.",
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"rto": schema.StringAttribute{
+										Description: "Recovery Time Objective (RTO) as a Go duration.",
+										CustomType:  timetypes.GoDurationType{},
+										Optional:    true,
+									},
+									"rpo": schema.StringAttribute{
+										Description: "Recovery Point Objective (RPO) as a Go duration.",
+										CustomType:  timetypes.GoDurationType{},
+										Optional:    true,
+									},
 								},
 							},
 						},
@@ -195,6 +182,17 @@ func (r *resourceResiliencyPolicy) Schema(ctx context.Context, req resource.Sche
 				Update: true,
 				Delete: true,
 			}),
+		},
+	}
+}
+
+func (r *resourceResiliencyPolicy) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := resiliencePolicySchemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeResiliencyPolicyStateFromV0,
 		},
 	}
 }
@@ -360,7 +358,7 @@ func (r *resourceResiliencyPolicy) Update(ctx context.Context, req resource.Upda
 
 		_, err := conn.UpdateResiliencyPolicy(ctx, &in)
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("reading Resilience Hub policy ID (%s)", plan.PolicyARN.String()), err.Error())
+			resp.Diagnostics.AddError(fmt.Sprintf("updating Resilience Hub policy ID (%s)", plan.PolicyARN.String()), err.Error())
 			return
 		}
 
@@ -380,6 +378,9 @@ func (r *resourceResiliencyPolicy) Update(ctx context.Context, req resource.Upda
 		}
 
 		state.flattenPolicy(ctx, updated.Policy)
+	} else {
+		// Explicitly copy computed arguments for tag-only updates
+		plan.EstimatedCostTier = state.EstimatedCostTier
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
@@ -522,12 +523,12 @@ func findResiliencyPolicyByARN(ctx context.Context, conn *resiliencehub.Client, 
 	return out.Policy, nil
 }
 
-func (m *resourceResiliencyPolicyModel) expandPolicy(ctx context.Context) (result map[string]awstypes.FailurePolicy, diags diag.Diagnostics) {
+func (m *policyData) expandPolicy(ctx context.Context) (result map[string]awstypes.FailurePolicy, diags diag.Diagnostics) {
 	failurePolicy := make(map[string]awstypes.FailurePolicy)
 
 	// Policy key case must be modified to align with key case in CreateResiliencyPolicy API documentation.
 	// See https://docs.aws.amazon.com/resilience-hub/latest/APIReference/API_CreateResiliencyPolicy.html
-	failurePolicyKeyMap := map[awstypes.TestType]fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel]{
+	failurePolicyKeyMap := map[awstypes.TestType]fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData]{
 		awstypes.TestTypeAz:       m.AZ,
 		awstypes.TestTypeHardware: m.Hardware,
 		awstypes.TestTypeSoftware: m.Software,
@@ -562,49 +563,53 @@ func (m *resourceResiliencyPolicyModel) expandPolicy(ctx context.Context) (resul
 
 func (m *resourceResiliencyPolicyData) flattenPolicy(ctx context.Context, failurePolicy map[string]awstypes.FailurePolicy) {
 	if len(failurePolicy) == 0 {
-		m.Policy = fwtypes.NewObjectValueOfNull[resourceResiliencyPolicyModel](ctx)
+		m.Policy = fwtypes.NewListNestedObjectValueOfNull[policyData](ctx)
 	}
 
-	newResObjModel := func(policyType awstypes.TestType, failurePolicy map[string]awstypes.FailurePolicy) fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel] {
+	newResObjModel := func(policyType awstypes.TestType, failurePolicy map[string]awstypes.FailurePolicy) fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] {
 		if pv, exists := failurePolicy[string(policyType)]; exists {
-			return fwtypes.NewObjectValueOfMust(ctx, &resourceResiliencyObjectiveModel{
-				Rpo: timetypes.NewGoDurationValue(time.Duration(pv.RpoInSecs) * time.Second),
-				Rto: timetypes.NewGoDurationValue(time.Duration(pv.RtoInSecs) * time.Second),
+			return fwtypes.NewListNestedObjectValueOfSliceMust(ctx, []*resiliencyObjectiveData{
+				{
+					Rpo: timetypes.NewGoDurationValue(time.Duration(pv.RpoInSecs) * time.Second),
+					Rto: timetypes.NewGoDurationValue(time.Duration(pv.RtoInSecs) * time.Second),
+				},
 			})
 		} else {
-			return fwtypes.NewObjectValueOfNull[resourceResiliencyObjectiveModel](ctx)
+			return fwtypes.NewListNestedObjectValueOfNull[resiliencyObjectiveData](ctx)
 		}
 	}
 
-	m.Policy = fwtypes.NewObjectValueOfMust(ctx, &resourceResiliencyPolicyModel{
-		newResObjModel(awstypes.TestTypeAz, failurePolicy),
-		newResObjModel(awstypes.TestTypeHardware, failurePolicy),
-		newResObjModel(awstypes.TestTypeSoftware, failurePolicy),
-		newResObjModel(awstypes.TestTypeRegion, failurePolicy),
+	m.Policy = fwtypes.NewListNestedObjectValueOfSliceMust(ctx, []*policyData{
+		{
+			newResObjModel(awstypes.TestTypeAz, failurePolicy),
+			newResObjModel(awstypes.TestTypeHardware, failurePolicy),
+			newResObjModel(awstypes.TestTypeSoftware, failurePolicy),
+			newResObjModel(awstypes.TestTypeRegion, failurePolicy),
+		},
 	})
 }
 
 type resourceResiliencyPolicyData struct {
-	DataLocationConstraint fwtypes.StringEnum[awstypes.DataLocationConstraint]  `tfsdk:"data_location_constraint"`
-	EstimatedCostTier      fwtypes.StringEnum[awstypes.EstimatedCostTier]       `tfsdk:"estimated_cost_tier"`
-	Policy                 fwtypes.ObjectValueOf[resourceResiliencyPolicyModel] `tfsdk:"policy"`
-	PolicyARN              types.String                                         `tfsdk:"arn"`
-	PolicyDescription      types.String                                         `tfsdk:"description"`
-	PolicyName             types.String                                         `tfsdk:"name"`
-	Tier                   fwtypes.StringEnum[awstypes.ResiliencyPolicyTier]    `tfsdk:"tier"`
-	Tags                   tftags.Map                                           `tfsdk:"tags"`
-	TagsAll                tftags.Map                                           `tfsdk:"tags_all"`
-	Timeouts               timeouts.Value                                       `tfsdk:"timeouts"`
+	DataLocationConstraint fwtypes.StringEnum[awstypes.DataLocationConstraint] `tfsdk:"data_location_constraint"`
+	EstimatedCostTier      fwtypes.StringEnum[awstypes.EstimatedCostTier]      `tfsdk:"estimated_cost_tier"`
+	Policy                 fwtypes.ListNestedObjectValueOf[policyData]         `tfsdk:"policy"`
+	PolicyARN              types.String                                        `tfsdk:"arn"`
+	PolicyDescription      types.String                                        `tfsdk:"description"`
+	PolicyName             types.String                                        `tfsdk:"name"`
+	Tier                   fwtypes.StringEnum[awstypes.ResiliencyPolicyTier]   `tfsdk:"tier"`
+	Tags                   tftags.Map                                          `tfsdk:"tags"`
+	TagsAll                tftags.Map                                          `tfsdk:"tags_all"`
+	Timeouts               timeouts.Value                                      `tfsdk:"timeouts"`
 }
 
-type resourceResiliencyPolicyModel struct {
-	AZ       fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel] `tfsdk:"az"`
-	Hardware fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel] `tfsdk:"hardware"`
-	Software fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel] `tfsdk:"software"`
-	Region   fwtypes.ObjectValueOf[resourceResiliencyObjectiveModel] `tfsdk:"region"`
+type policyData struct {
+	AZ       fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] `tfsdk:"az"`
+	Hardware fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] `tfsdk:"hardware"`
+	Software fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] `tfsdk:"software"`
+	Region   fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] `tfsdk:"region"`
 }
 
-type resourceResiliencyObjectiveModel struct {
+type resiliencyObjectiveData struct {
 	Rpo timetypes.GoDuration `tfsdk:"rpo"`
 	Rto timetypes.GoDuration `tfsdk:"rto"`
 }

--- a/internal/service/resiliencehub/resiliency_policy_migrate.go
+++ b/internal/service/resiliencehub/resiliency_policy_migrate.go
@@ -1,0 +1,186 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package resiliencehub
+
+import (
+	"context"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/resiliencehub/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func resiliencePolicySchemaV0(ctx context.Context) schema.Schema {
+	requiredObjAttrs := map[string]schema.Attribute{
+		"rto": schema.StringAttribute{
+			CustomType: timetypes.GoDurationType{},
+			Required:   true,
+		},
+		"rpo": schema.StringAttribute{
+			CustomType: timetypes.GoDurationType{},
+			Required:   true,
+		},
+	}
+
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: framework.ARNAttributeComputedOnly(),
+			"data_location_constraint": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.DataLocationConstraint](),
+				Computed:   true,
+				Optional:   true,
+			},
+			names.AttrDescription: schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrName: schema.StringAttribute{
+				Required: true,
+			},
+			"tier": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.ResiliencyPolicyTier](),
+				Required:   true,
+			},
+			"estimated_cost_tier": schema.StringAttribute{
+				CustomType: fwtypes.StringEnumType[awstypes.EstimatedCostTier](),
+				Computed:   true,
+			},
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrPolicy: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+				CustomType: fwtypes.NewObjectTypeOf[policyDataV0](ctx),
+				Blocks: map[string]schema.Block{
+					"az": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+						CustomType: fwtypes.NewObjectTypeOf[resiliencyObjectiveData](ctx),
+						Attributes: requiredObjAttrs,
+					},
+					"hardware": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+						CustomType: fwtypes.NewObjectTypeOf[resiliencyObjectiveData](ctx),
+						Attributes: requiredObjAttrs,
+					},
+					"software": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+						CustomType: fwtypes.NewObjectTypeOf[resiliencyObjectiveData](ctx),
+						Attributes: requiredObjAttrs,
+					},
+					names.AttrRegion: schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+						CustomType: fwtypes.NewObjectTypeOf[resiliencyObjectiveData](ctx),
+						Attributes: map[string]schema.Attribute{
+							"rto": schema.StringAttribute{
+								CustomType: timetypes.GoDurationType{},
+								Optional:   true,
+							},
+							"rpo": schema.StringAttribute{
+								CustomType: timetypes.GoDurationType{},
+								Optional:   true,
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+type resourceResiliencyPolicyDataV0 struct {
+	DataLocationConstraint fwtypes.StringEnum[awstypes.DataLocationConstraint] `tfsdk:"data_location_constraint"`
+	EstimatedCostTier      fwtypes.StringEnum[awstypes.EstimatedCostTier]      `tfsdk:"estimated_cost_tier"`
+	Policy                 fwtypes.ObjectValueOf[policyDataV0]                 `tfsdk:"policy"`
+	PolicyARN              types.String                                        `tfsdk:"arn"`
+	PolicyDescription      types.String                                        `tfsdk:"description"`
+	PolicyName             types.String                                        `tfsdk:"name"`
+	Tier                   fwtypes.StringEnum[awstypes.ResiliencyPolicyTier]   `tfsdk:"tier"`
+	Tags                   tftags.Map                                          `tfsdk:"tags"`
+	TagsAll                tftags.Map                                          `tfsdk:"tags_all"`
+	Timeouts               timeouts.Value                                      `tfsdk:"timeouts"`
+}
+
+type policyDataV0 struct {
+	AZ       fwtypes.ObjectValueOf[resiliencyObjectiveData] `tfsdk:"az"`
+	Hardware fwtypes.ObjectValueOf[resiliencyObjectiveData] `tfsdk:"hardware"`
+	Software fwtypes.ObjectValueOf[resiliencyObjectiveData] `tfsdk:"software"`
+	Region   fwtypes.ObjectValueOf[resiliencyObjectiveData] `tfsdk:"region"`
+}
+
+func upgradeResiliencyPolicyStateFromV0(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var resiliencyPolicyDataV0 resourceResiliencyPolicyDataV0
+	response.Diagnostics.Append(request.State.Get(ctx, &resiliencyPolicyDataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	resiliencyPolicyDataV1 := resourceResiliencyPolicyData{
+		DataLocationConstraint: resiliencyPolicyDataV0.DataLocationConstraint,
+		EstimatedCostTier:      resiliencyPolicyDataV0.EstimatedCostTier,
+		Policy:                 upgradePolicyStateFromV0(ctx, resiliencyPolicyDataV0.Policy, &response.Diagnostics),
+		PolicyARN:              resiliencyPolicyDataV0.PolicyARN,
+		PolicyDescription:      resiliencyPolicyDataV0.PolicyDescription,
+		PolicyName:             resiliencyPolicyDataV0.PolicyName,
+		Tier:                   resiliencyPolicyDataV0.Tier,
+		Tags:                   resiliencyPolicyDataV0.Tags,
+		TagsAll:                resiliencyPolicyDataV0.TagsAll,
+		Timeouts:               resiliencyPolicyDataV0.Timeouts,
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, resiliencyPolicyDataV1)...)
+}
+
+func upgradePolicyStateFromV0(ctx context.Context, old fwtypes.ObjectValueOf[policyDataV0], diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[policyData] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[policyData](ctx)
+	}
+
+	var oldObj policyDataV0
+	diags.Append(old.As(ctx, &oldObj, basetypes.ObjectAsOptions{})...)
+
+	newList := []policyData{
+		{
+			AZ:       upgradeResiliencyObjectiveFromV0(ctx, oldObj.AZ, diags),
+			Hardware: upgradeResiliencyObjectiveFromV0(ctx, oldObj.Hardware, diags),
+			Software: upgradeResiliencyObjectiveFromV0(ctx, oldObj.Software, diags),
+			Region:   upgradeResiliencyObjectiveFromV0(ctx, oldObj.Region, diags),
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newList)
+	diags.Append(d...)
+
+	return result
+}
+
+func upgradeResiliencyObjectiveFromV0(ctx context.Context, old fwtypes.ObjectValueOf[resiliencyObjectiveData], diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[resiliencyObjectiveData] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[resiliencyObjectiveData](ctx)
+	}
+
+	var oldObj resiliencyObjectiveData
+	diags.Append(old.As(ctx, &oldObj, basetypes.ObjectAsOptions{})...)
+
+	newList := []resiliencyObjectiveData{
+		{
+			Rpo: oldObj.Rpo,
+			Rto: oldObj.Rto,
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newList)
+	diags.Append(d...)
+
+	return result
+}

--- a/internal/service/resiliencehub/resiliency_policy_test.go
+++ b/internal/service/resiliencehub/resiliency_policy_test.go
@@ -51,21 +51,21 @@ func TestAccResilienceHubResiliencyPolicy_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, names.ResilienceHubServiceID, regexache.MustCompile(`resiliency-policy/.+$`)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttr(resourceName, "tier", "NotApplicable"),
 					resource.TestCheckResourceAttr(resourceName, "data_location_constraint", "AnyLocation"),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", "1h0m0s"),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", "1h0m0s"),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", "1h0m0s"),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", "1h0m0s"),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rpo"),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rto"),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", "1h0m0s"),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", "1h0m0s"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", "1h0m0s"),
 				),
 			},
 			{
@@ -103,7 +103,7 @@ func TestAccResilienceHubResiliencyPolicy_dataLocationConstraint(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_dataLocationConstraint(rName, awstypes.DataLocationConstraintSameContinent),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
 					resource.TestCheckResourceAttr(resourceName, "data_location_constraint", string(awstypes.DataLocationConstraintSameContinent)),
 				),
@@ -125,7 +125,7 @@ func TestAccResilienceHubResiliencyPolicy_dataLocationConstraint(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_dataLocationConstraint(rName, awstypes.DataLocationConstraintSameCountry),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
 					resource.TestCheckResourceAttr(resourceName, "data_location_constraint", string(awstypes.DataLocationConstraintSameCountry)),
 				),
@@ -178,7 +178,7 @@ func TestAccResilienceHubResiliencyPolicy_description(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_description(rName, initial),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, initial),
 				),
@@ -200,7 +200,7 @@ func TestAccResilienceHubResiliencyPolicy_description(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_description(rName, updated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, updated),
 				),
@@ -249,7 +249,7 @@ func TestAccResilienceHubResiliencyPolicy_name(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 				),
@@ -271,7 +271,7 @@ func TestAccResilienceHubResiliencyPolicy_name(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_basic(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rNameUpdated),
 				),
@@ -324,16 +324,16 @@ func TestAccResilienceHubResiliencyPolicy_policy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_policy(rName, initialDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", initialDuration),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rpo"),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rto"),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", initialDuration),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", initialDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -353,16 +353,16 @@ func TestAccResilienceHubResiliencyPolicy_policy(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_policy(rName, updatedDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", updatedDuration),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rpo"),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rto"),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", updatedDuration),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", updatedDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -382,16 +382,16 @@ func TestAccResilienceHubResiliencyPolicy_policy(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_policyWithRegion(rName, updatedDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", updatedDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -442,16 +442,16 @@ func TestAccResilienceHubResiliencyPolicy_policyWithRegion(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_policyWithRegion(rName, initialDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rto", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", initialDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rto", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", initialDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", initialDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -471,16 +471,16 @@ func TestAccResilienceHubResiliencyPolicy_policyWithRegion(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_policyWithRegion(rName, updatedDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.region.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.region.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", updatedDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -500,16 +500,16 @@ func TestAccResilienceHubResiliencyPolicy_policyWithRegion(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_policy(rName, updatedDuration),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", updatedDuration),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rpo"),
-					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rto"),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", updatedDuration),
-					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", updatedDuration),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", updatedDuration),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", updatedDuration),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					expectNoARNChange.AddStateValue(resourceName, tfjsonpath.New(names.AttrARN)),
@@ -555,7 +555,7 @@ func TestAccResilienceHubResiliencyPolicy_tier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_tier(rName, awstypes.ResiliencyPolicyTierMissionCritical),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy1),
 					resource.TestCheckResourceAttr(resourceName, "tier", string(awstypes.ResiliencyPolicyTierMissionCritical)),
 				),
@@ -577,7 +577,7 @@ func TestAccResilienceHubResiliencyPolicy_tier(t *testing.T) {
 			},
 			{
 				Config: testAccResiliencyPolicyConfig_tier(rName, awstypes.ResiliencyPolicyTierCoreServices),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy2),
 					resource.TestCheckResourceAttr(resourceName, "tier", string(awstypes.ResiliencyPolicyTierCoreServices)),
 				),
@@ -623,11 +623,89 @@ func TestAccResilienceHubResiliencyPolicy_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResiliencyPolicyConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfresiliencehub.ResourceResiliencyPolicy, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccResilienceHubResiliencyPolicy_upgradeV6_0_0(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var policy resiliencehub.DescribeResiliencyPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_resiliencehub_resiliency_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
+		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.95.0",
+					},
+				},
+				Config: testAccResiliencyPolicyConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, names.ResilienceHubServiceID, regexache.MustCompile(`resiliency-policy/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttr(resourceName, "tier", "NotApplicable"),
+					resource.TestCheckResourceAttr(resourceName, "data_location_constraint", "AnyLocation"),
+					resource.TestCheckResourceAttr(resourceName, "policy.az.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.az.rto", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.hardware.rto", "1h0m0s"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.region.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.software.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.software.rto", "1h0m0s"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccResiliencyPolicyConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckResiliencyPolicyExists(ctx, resourceName, &policy),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, names.ResilienceHubServiceID, regexache.MustCompile(`resiliency-policy/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckNoResourceAttr(resourceName, names.AttrDescription),
+					resource.TestCheckResourceAttr(resourceName, "tier", "NotApplicable"),
+					resource.TestCheckResourceAttr(resourceName, "data_location_constraint", "AnyLocation"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.az.0.rto", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.hardware.0.rto", "1h0m0s"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rpo"),
+					resource.TestCheckNoResourceAttr(resourceName, "policy.0.region.0.rto"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rpo", "1h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "policy.0.software.0.rto", "1h0m0s"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -48,6 +48,7 @@ Upgrade topics:
 - [resource/aws_redshift_cluster](#resourceaws_redshift_cluster)
 - [resource/aws_redshift_service_account](#resourceaws_redshift_service_account)
 - [resource/aws_rekognition_stream_processor](#resourceaws_rekognition_stream_processor)
+- [resource/aws_resiliencehub_resiliency_policy](#resourceaws_resiliencehub_resiliency_policy)
 - [resource/aws_sagemaker_notebook_instance](#resourceaws_sagemaker_notebook_instance)
 - [resource/aws_spot_instance_request](#resourceaws_spot_instance_request)
 - [resource/aws_ssm_association](#resourceaws_ssm_association)
@@ -328,6 +329,19 @@ The `aws_redshift_service_account` resource has been removed. AWS [recommends](h
 The `regions_of_interest.bounding_box` argument is now a list nested block instead of a single nested block.
 When referencing this argument, the index must now be included in the attribute address.
 For example, `regions_of_interest[0].bounding_box.height` would now be referenced as `regions_of_interest[0].bounding_box[0].height`.
+
+## resource/aws_resiliencehub_resiliency_policy
+
+The following arguments are now list nested blocks instead of single nested blocks.
+
+- `policy`
+- `policy.az`
+- `policy.hardware`
+- `policy.software`
+- `policy.region`
+
+When referencing these arguments, the indicies must now be included in the attribute address.
+For example, `policy.az.rpo` would now be referenced as `policy[0].az[0].rpo`.
 
 ## resource/aws_sagemaker_notebook_instance
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


These changes are part of a larger effort to remove the use of `SingleNestedBlock` arguments. A state upgrader has been added to make the update seamless across the major version upgrade.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35813
Relates https://github.com/hashicorp/terraform-provider-aws/issues/41101



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=resiliencehub ACCTEST_PARALLELISM=8 TESTS=TestAccResilienceHubResiliencyPolicy_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/resiliencehub/... -v -count 1 -parallel 8 -run='TestAccResilienceHubResiliencyPolicy_'  -timeout 360m -vet=off
2025/04/18 14:44:56 Initializing Terraform AWS Provider...

--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nullNonOverlappingResourceTag (22.00s)
=== CONT  TestAccResilienceHubResiliencyPolicy_disappears
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnUpdate_Replace (34.76s)
=== CONT  TestAccResilienceHubResiliencyPolicy_policy
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnCreate (36.92s)
=== CONT  TestAccResilienceHubResiliencyPolicy_name
--- PASS: TestAccResilienceHubResiliencyPolicy_disappears (16.20s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccResilienceHubResiliencyPolicy_description (38.36s)
--- PASS: TestAccResilienceHubResiliencyPolicy_upgradeV6_0_0 (44.74s)
=== CONT  TestAccResilienceHubResiliencyPolicy_policyWithRegion
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nonOverlapping (54.49s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyResourceTag (19.39s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccResilienceHubResiliencyPolicy_tags (68.23s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tier
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_providerOnly (70.09s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccResilienceHubResiliencyPolicy_name (34.97s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_overlapping
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nullOverlappingResourceTag (19.04s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyProviderOnlyTag (19.19s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_AddOnUpdate
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnUpdate_Add (45.72s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_EmptyMap
--- PASS: TestAccResilienceHubResiliencyPolicy_policy (50.81s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccResilienceHubResiliencyPolicy_policyWithRegion (49.90s)
=== CONT  TestAccResilienceHubResiliencyPolicy_basic
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToProviderOnly (31.24s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccResilienceHubResiliencyPolicy_tier (34.65s)
=== CONT  TestAccResilienceHubResiliencyPolicy_dataLocationConstraint
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToResourceOnly (29.78s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_null
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_EmptyMap (19.49s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_AddOnUpdate (30.90s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccResilienceHubResiliencyPolicy_basic (17.02s)
=== CONT  TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnCreate
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_null (19.12s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_overlapping (51.98s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_DefaultTag (38.93s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnCreate (20.82s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Add (32.12s)
--- PASS: TestAccResilienceHubResiliencyPolicy_dataLocationConstraint (32.78s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Replace (30.95s)
--- PASS: TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_ResourceTag (39.51s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/resiliencehub      147.519s
```

