### PR TITLE
feat: add new argument to kinesis configuration of aws_dms_endpoint

### DIFF
--- a/.changelog/42300.txt
+++ b/.changelog/42300.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_dms_endpoint: Add `kinesis_settings.use_large_integer_value` argument
+```
+
+```release-note:enhancement
+data-source/aws_dms_endpoint: Add `kinesis_settings.use_large_integer_value` attribute
+```

--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -286,6 +286,11 @@ func resourceEndpoint() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: verify.ValidARN,
 						},
+						"use_large_integer_value": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
 					},
 				},
 			},
@@ -2034,6 +2039,10 @@ func expandKinesisSettings(tfMap map[string]any) *awstypes.KinesisSettings {
 		apiObject.StreamArn = aws.String(v)
 	}
 
+	if v, ok := tfMap["use_large_integer_value"].(bool); ok {
+		apiObject.UseLargeIntegerValue = aws.Bool(v)
+	}
+
 	return apiObject
 }
 
@@ -2076,6 +2085,10 @@ func flattenKinesisSettings(apiObject *awstypes.KinesisSettings) map[string]any 
 
 	if v := apiObject.StreamArn; v != nil {
 		tfMap[names.AttrStreamARN] = aws.ToString(v)
+	}
+
+	if v := apiObject.UseLargeIntegerValue; v != nil {
+		tfMap["use_large_integer_value"] = aws.ToBool(v)
 	}
 
 	return tfMap

--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -199,6 +199,10 @@ func dataSourceEndpoint() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"use_large_integer_value": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
 					},
 				},
 			},

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3518,7 +3518,7 @@ resource "aws_dms_endpoint" "test" {
     include_transaction_details    = true
     partition_include_schema_table = true
     use_large_integer_value        = false
-    
+
     service_access_role_arn = aws_iam_role.test.arn
     stream_arn              = aws_kinesis_stream.test1.arn
   }

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3518,6 +3518,7 @@ resource "aws_dms_endpoint" "test" {
     include_transaction_details    = true
     partition_include_schema_table = true
     use_large_integer_value        = false
+    
     service_access_role_arn = aws_iam_role.test.arn
     stream_arn              = aws_kinesis_stream.test1.arn
   }

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -823,6 +823,7 @@ func TestAccDMSEndpoint_kinesis(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.include_transaction_details", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.message_format", names.AttrJSON),
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.partition_include_schema_table", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.use_large_integer_value", acctest.CtFalse),
 					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.service_access_role_arn", iamRoleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.stream_arn", stream1ResourceName, names.AttrARN),
 				),
@@ -845,6 +846,7 @@ func TestAccDMSEndpoint_kinesis(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.include_transaction_details", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.message_format", names.AttrJSON),
 					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.partition_include_schema_table", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "kinesis_settings.0.use_large_integer_value", acctest.CtTrue),
 					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.service_access_role_arn", iamRoleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "kinesis_settings.0.stream_arn", stream2ResourceName, names.AttrARN),
 				),
@@ -3515,7 +3517,7 @@ resource "aws_dms_endpoint" "test" {
     include_table_alter_operations = true
     include_transaction_details    = true
     partition_include_schema_table = true
-
+    use_large_integer_value        = false
     service_access_role_arn = aws_iam_role.test.arn
     stream_arn              = aws_kinesis_stream.test1.arn
   }
@@ -3539,6 +3541,7 @@ resource "aws_dms_endpoint" "test" {
     include_table_alter_operations = false
     include_transaction_details    = false
     partition_include_schema_table = false
+    use_large_integer_value        = true
 
     service_access_role_arn = aws_iam_role.test.arn
     stream_arn              = aws_kinesis_stream.test2.arn

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -121,6 +121,7 @@ The following arguments are optional:
 * `partition_include_schema_table` - (Optional) Prefixes schema and table names to partition values, when the partition type is primary-key-type. Default is `false`.
 * `service_access_role_arn` - (Optional) ARN of the IAM Role with permissions to write to the Kinesis data stream.
 * `stream_arn` - (Optional) ARN of the Kinesis data stream.
+* `use_large_integer_value` - (Optional) Use up to 18 digit int instead of casting ints as doubles, available from AWS DMS version 3.5.4. Default is `false`.
 
 ### mongodb_settings
 


### PR DESCRIPTION
### Description
As mentioned in #42178 the Kinesis configuration for DMS support a new option

> useLargeIntegerValue – Use up to 18 digit int instead of casting ints as doubles, available from AWS DMS version 3.5.4. The default is false.

This pull requests adds this option to 

- resource `aws_dms_endpoint` 
- data source `aws_dms_endpoint`

### Relations

Closes #42178 

### References

- [AWS SDK Go v2 Docs](https://github.com/aws/aws-sdk-go-v2/blob/a7e1ecdfe59ec95482796a75d99a1ad8cdf919d5/service/databasemigrationservice/types/types.go#L1721)
- [Using Amazon Kinesis Data Streams as a target for AWS Database Migration Service](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Kinesis.html)

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccDMSEndpoint_kinesis PKG=dms
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_kinesis'  -timeout 360m -vet=off
2025/04/19 17:57:20 Initializing Terraform AWS Provider...
=== RUN   TestAccDMSEndpoint_kinesis
=== PAUSE TestAccDMSEndpoint_kinesis
=== CONT  TestAccDMSEndpoint_kinesis
--- PASS: TestAccDMSEndpoint_kinesis (186.42s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        186.638s
```
