### PR TITLE
r/aws_verifiedpermissions_schema: `SingleNestedBlock` to `ListNestedBlock`

### DIFF
--- a/.changelog/42305.txt
+++ b/.changelog/42305.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_verifiedpermissions_schema: `definition` is now a list nested block instead of a single nested block
+```

--- a/internal/service/verifiedpermissions/schema.go
+++ b/internal/service/verifiedpermissions/schema.go
@@ -10,14 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/verifiedpermissions"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/verifiedpermissions/types"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
-	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -31,9 +31,7 @@ import (
 
 // @FrameworkResource("aws_verifiedpermissions_schema", name="Schema")
 func newResourceSchema(context.Context) (resource.ResourceWithConfigure, error) {
-	r := &resourceSchema{}
-
-	return r, nil
+	return &resourceSchema{}, nil
 }
 
 const (
@@ -46,7 +44,8 @@ type resourceSchema struct {
 }
 
 func (r *resourceSchema) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
-	s := schema.Schema{
+	response.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			names.AttrID: framework.IDAttribute(),
 			"namespaces": schema.SetAttribute{
@@ -55,24 +54,40 @@ func (r *resourceSchema) Schema(ctx context.Context, request resource.SchemaRequ
 			},
 			"policy_store_id": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"definition": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
-				Validators: []validator.Object{
-					objectvalidator.IsRequired(),
+			"definition": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[definitionData](ctx),
+				Validators: []validator.List{
+					listvalidator.IsRequired(),
+					listvalidator.SizeAtMost(1),
 				},
-				Attributes: map[string]schema.Attribute{
-					names.AttrValue: schema.StringAttribute{
-						CustomType: jsontypes.NormalizedType{},
-						Required:   true,
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrValue: schema.StringAttribute{
+							CustomType: jsontypes.NormalizedType{},
+							Required:   true,
+						},
 					},
 				},
 			},
 		},
 	}
+}
 
-	response.Schema = s
+func (r *resourceSchema) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := schemaSchemaV0()
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeSchemaStateFromV0,
+		},
+	}
 }
 
 func (r *resourceSchema) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
@@ -80,22 +95,17 @@ func (r *resourceSchema) Create(ctx context.Context, request resource.CreateRequ
 	var plan resourceSchemaData
 
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	input := &verifiedpermissions.PutSchemaInput{
-		PolicyStoreId: flex.StringFromFramework(ctx, plan.PolicyStoreID),
-		Definition:    expandDefinition(ctx, plan.Definition, &response.Diagnostics),
-	}
-
+	input := verifiedpermissions.PutSchemaInput{}
+	response.Diagnostics.Append(flex.Expand(ctx, plan, &input)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	output, err := conn.PutSchema(ctx, input)
-
+	out, err := conn.PutSchema(ctx, &input)
 	if err != nil {
 		response.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.VerifiedPermissions, create.ErrActionCreating, ResNamePolicyStoreSchema, plan.PolicyStoreID.ValueString(), err),
@@ -104,12 +114,13 @@ func (r *resourceSchema) Create(ctx context.Context, request resource.CreateRequ
 		return
 	}
 
-	state := plan
-	state.ID = flex.StringToFramework(ctx, output.PolicyStoreId)
+	response.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	plan.ID = flex.StringToFramework(ctx, out.PolicyStoreId)
 
-	state.Namespaces = flex.FlattenFrameworkStringValueSet(ctx, output.Namespaces)
-
-	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
 }
 
 func (r *resourceSchema) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
@@ -117,12 +128,11 @@ func (r *resourceSchema) Read(ctx context.Context, request resource.ReadRequest,
 	var state resourceSchemaData
 
 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
-	output, err := findSchemaByPolicyStoreID(ctx, conn, state.ID.ValueString())
+	out, err := findSchemaByPolicyStoreID(ctx, conn, state.ID.ValueString())
 
 	if tfresource.NotFound(err) {
 		response.State.RemoveResource(ctx)
@@ -137,13 +147,18 @@ func (r *resourceSchema) Read(ctx context.Context, request resource.ReadRequest,
 		return
 	}
 
-	state.PolicyStoreID = flex.StringToFramework(ctx, output.PolicyStoreId)
-	state.Namespaces = flex.FlattenFrameworkStringValueSet(ctx, output.Namespaces)
-	state.Definition = flattenDefinition(ctx, output)
-
+	response.Diagnostics.Append(flex.Flatten(ctx, out, &state)...)
 	if response.Diagnostics.HasError() {
 		return
 	}
+
+	// Misalignment between input and output data structures requires manual value assignment
+	definition, d := flattenDefinition(ctx, out)
+	response.Diagnostics.Append(d...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+	state.Definition = definition
 
 	response.Diagnostics.Append(response.State.Set(ctx, &state)...)
 }
@@ -153,29 +168,20 @@ func (r *resourceSchema) Update(ctx context.Context, request resource.UpdateRequ
 	var state, plan resourceSchemaData
 
 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-
-	if response.Diagnostics.HasError() {
-		return
-	}
-
 	response.Diagnostics.Append(request.Plan.Get(ctx, &plan)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
 
 	if !plan.Definition.Equal(state.Definition) {
-		input := &verifiedpermissions.PutSchemaInput{
-			PolicyStoreId: flex.StringFromFramework(ctx, state.ID),
-			Definition:    expandDefinition(ctx, plan.Definition, &response.Diagnostics),
-		}
+		input := verifiedpermissions.PutSchemaInput{}
 
+		response.Diagnostics.Append(flex.Expand(ctx, plan, &input)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
 
-		_, err := conn.PutSchema(ctx, input)
-
+		_, err := conn.PutSchema(ctx, &input)
 		if err != nil {
 			response.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.VerifiedPermissions, create.ErrActionUpdating, ResNamePolicyStoreSchema, state.PolicyStoreID.ValueString(), err),
@@ -185,7 +191,6 @@ func (r *resourceSchema) Update(ctx context.Context, request resource.UpdateRequ
 		}
 
 		out, err := findSchemaByPolicyStoreID(ctx, conn, state.ID.ValueString())
-
 		if err != nil {
 			response.Diagnostics.AddError(
 				create.ProblemStandardMessage(names.VerifiedPermissions, create.ErrActionUpdating, ResNamePolicyStoreSchema, state.PolicyStoreID.ValueString(), err),
@@ -194,8 +199,18 @@ func (r *resourceSchema) Update(ctx context.Context, request resource.UpdateRequ
 			return
 		}
 
-		plan.Namespaces = flex.FlattenFrameworkStringValueSet(ctx, out.Namespaces)
-		plan.Definition = flattenDefinition(ctx, out)
+		response.Diagnostics.Append(flex.Flatten(ctx, out, &plan)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		// Misalignment between input and output data structures requires manual value assignment
+		definition, d := flattenDefinition(ctx, out)
+		response.Diagnostics.Append(d...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+		plan.Definition = definition
 	}
 
 	response.Diagnostics.Append(response.State.Set(ctx, &plan)...)
@@ -206,7 +221,6 @@ func (r *resourceSchema) Delete(ctx context.Context, request resource.DeleteRequ
 	var state resourceSchemaData
 
 	response.Diagnostics.Append(request.State.Get(ctx, &state)...)
-
 	if response.Diagnostics.HasError() {
 		return
 	}
@@ -215,15 +229,14 @@ func (r *resourceSchema) Delete(ctx context.Context, request resource.DeleteRequ
 		names.AttrID: state.ID.ValueString(),
 	})
 
-	input := &verifiedpermissions.PutSchemaInput{
+	input := verifiedpermissions.PutSchemaInput{
 		PolicyStoreId: flex.StringFromFramework(ctx, state.ID),
 		Definition: &awstypes.SchemaDefinitionMemberCedarJson{
 			Value: "{}",
 		},
 	}
 
-	_, err := conn.PutSchema(ctx, input)
-
+	_, err := conn.PutSchema(ctx, &input)
 	if err != nil {
 		response.Diagnostics.AddError(
 			create.ProblemStandardMessage(names.VerifiedPermissions, create.ErrActionDeleting, ResNamePolicyStoreSchema, state.PolicyStoreID.ValueString(), err),
@@ -234,13 +247,13 @@ func (r *resourceSchema) Delete(ctx context.Context, request resource.DeleteRequ
 }
 
 type resourceSchemaData struct {
-	ID            types.String `tfsdk:"id"`
-	Definition    types.Object `tfsdk:"definition"`
-	Namespaces    types.Set    `tfsdk:"namespaces"`
-	PolicyStoreID types.String `tfsdk:"policy_store_id"`
+	ID            types.String                                    `tfsdk:"id"`
+	Definition    fwtypes.ListNestedObjectValueOf[definitionData] `tfsdk:"definition"`
+	Namespaces    types.Set                                       `tfsdk:"namespaces"`
+	PolicyStoreID types.String                                    `tfsdk:"policy_store_id"`
 }
 
-type definition struct {
+type definitionData struct {
 	Value jsontypes.Normalized `tfsdk:"value"`
 }
 
@@ -267,28 +280,23 @@ func findSchemaByPolicyStoreID(ctx context.Context, conn *verifiedpermissions.Cl
 	return out, nil
 }
 
-func expandDefinition(ctx context.Context, object types.Object, diags *diag.Diagnostics) *awstypes.SchemaDefinitionMemberCedarJson {
-	var de definition
-	diags.Append(object.As(ctx, &de, basetypes.ObjectAsOptions{})...)
-	if diags.HasError() {
-		return nil
-	}
-
-	out := &awstypes.SchemaDefinitionMemberCedarJson{
-		Value: de.Value.ValueString(),
-	}
-
-	return out
+func (m definitionData) Expand(ctx context.Context) (result any, diags diag.Diagnostics) {
+	return &awstypes.SchemaDefinitionMemberCedarJson{
+		Value: m.Value.ValueString(),
+	}, diags
 }
 
-func flattenDefinition(ctx context.Context, input *verifiedpermissions.GetSchemaOutput) types.Object {
+func flattenDefinition(ctx context.Context, input *verifiedpermissions.GetSchemaOutput) (fwtypes.ListNestedObjectValueOf[definitionData], diag.Diagnostics) {
+	var diags diag.Diagnostics
 	if input == nil {
-		return fwtypes.NewObjectValueOfNull[definition](ctx).ObjectValue
+		return fwtypes.NewListNestedObjectValueOfNull[definitionData](ctx), diags
 	}
 
-	attributeTypes := fwtypes.AttributeTypesMust[definition](ctx)
-	attrs := map[string]attr.Value{}
-	attrs[names.AttrValue] = jsontypes.NewNormalizedPointerValue(input.Schema)
+	data := []definitionData{
+		{
+			Value: jsontypes.NewNormalizedPointerValue(input.Schema),
+		},
+	}
 
-	return types.ObjectValueMust(attributeTypes, attrs)
+	return fwtypes.NewListNestedObjectValueOfValueSlice(ctx, data)
 }

--- a/internal/service/verifiedpermissions/schema_migrate.go
+++ b/internal/service/verifiedpermissions/schema_migrate.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package verifiedpermissions
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func schemaSchemaV0() schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"namespaces": schema.SetAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			"policy_store_id": schema.StringAttribute{
+				Required: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"definition": schema.SingleNestedBlock{ // nosemgrep:ci.avoid-SingleNestedBlock pre-existing, will be converted
+				Attributes: map[string]schema.Attribute{
+					names.AttrValue: schema.StringAttribute{
+						CustomType: jsontypes.NormalizedType{},
+						Required:   true,
+					},
+				},
+			},
+		},
+	}
+}
+
+type resourceSchemaDataV0 struct {
+	ID            types.String `tfsdk:"id"`
+	Definition    types.Object `tfsdk:"definition"`
+	Namespaces    types.Set    `tfsdk:"namespaces"`
+	PolicyStoreID types.String `tfsdk:"policy_store_id"`
+}
+
+func upgradeSchemaStateFromV0(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var schemaDataV0 resourceSchemaDataV0
+	response.Diagnostics.Append(request.State.Get(ctx, &schemaDataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	schemaDataV1 := resourceSchemaData{
+		ID:            schemaDataV0.ID,
+		Definition:    upgradeDefinitionStateFromV0(ctx, schemaDataV0.Definition, &response.Diagnostics),
+		Namespaces:    schemaDataV0.Namespaces,
+		PolicyStoreID: schemaDataV0.PolicyStoreID,
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, schemaDataV1)...)
+}
+
+func upgradeDefinitionStateFromV0(ctx context.Context, old types.Object, diags *diag.Diagnostics) fwtypes.ListNestedObjectValueOf[definitionData] {
+	if old.IsNull() {
+		return fwtypes.NewListNestedObjectValueOfNull[definitionData](ctx)
+	}
+
+	var definitionDataV0 definitionData
+	diags.Append(old.As(ctx, &definitionDataV0, basetypes.ObjectAsOptions{})...)
+
+	newList := []definitionData{
+		{
+			Value: definitionDataV0.Value,
+		},
+	}
+
+	result, d := fwtypes.NewListNestedObjectValueOfValueSlice(ctx, newList)
+	diags.Append(d...)
+
+	return result
+}

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -53,6 +53,7 @@ Upgrade topics:
 - [resource/aws_sagemaker_notebook_instance](#resourceaws_sagemaker_notebook_instance)
 - [resource/aws_spot_instance_request](#resourceaws_spot_instance_request)
 - [resource/aws_ssm_association](#resourceaws_ssm_association)
+- [resource/aws_verifiedpermissions_schema](#resourceaws_verifiedpermissions_schema)
 
 <!-- /TOC -->
 
@@ -367,3 +368,9 @@ Remove `block_duration_minutes` from your configuration—it no longer exists.
 ## resource/aws_ssm_association
 
 Remove `instance_id` from configuration—it no longer exists. Use `targets` instead.
+
+## resource/aws_verifiedpermissions_schema
+
+The `definition` argument is now a list nested block instead of a single nested block.
+When referencing this argument, the index must now be included in the attribute address.
+For example, `definition.value` would now be referenced as `definition[0].value`.


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These changes are part of a larger effort to remove the use of `SingleNestedBlock` arguments. A state upgrader has been added to make the update seamless across the major version upgrade.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/35813
Relates https://github.com/hashicorp/terraform-provider-aws/issues/41101



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=verifiedpermissions TESTS=TestAccVerifiedPermissionsSchema_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/verifiedpermissions/... -v -count 1 -parallel 20 -run='TestAccVerifiedPermissionsSchema_'  -timeout 360m -vet=off
2025/04/21 15:08:50 Initializing Terraform AWS Provider...

--- PASS: TestAccVerifiedPermissionsSchema_disappears (13.72s)
--- PASS: TestAccVerifiedPermissionsSchema_basic (15.02s)
--- PASS: TestAccVerifiedPermissionsSchema_update (21.05s)
--- PASS: TestAccVerifiedPermissionsSchema_upgrade_V6_0_0 (37.37s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/verifiedpermissions        44.066s
```
