### PR TITLE
[Docs]: add example of CloudFront V2 standard logging to S3

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -272,7 +272,7 @@ resource "aws_s3_bucket" "example" {
 resource "aws_cloudwatch_log_delivery_destination" "example" {
   provider = aws.us_east_1
 
-  name          = "s3-destionation"
+  name          = "s3-destination"
   output_format = "parquet"
 
   delivery_destination_configuration {

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -236,6 +236,62 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 }
 ```
 
+### With V2 logging to S3
+
+The example below creates a CloudFront distribution with [standard logging V2 to S3](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#enable-access-logging-api).
+
+```hcl
+provider "aws" {
+  region = var.region
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+}
+
+resource "aws_cloudfront_distribution" "example" {
+  provider = aws.us_east_1
+
+  // other config...
+}
+
+resource "aws_cloudwatch_log_delivery_source" "example" {
+  provider = aws.us_east_1
+
+  name         = "example"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = aws_cloudfront_distribution.example.arn
+}
+
+resource "aws_s3_bucket" "example" {
+  bucket        = "testbucket"
+  force_destroy = true
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "example" {
+  provider = aws.us_east_1
+
+  name          = "s3-destionation"
+  output_format = "parquet"
+
+  delivery_destination_configuration {
+    destination_resource_arn = "${aws_s3_bucket.example.arn}/prefix"
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "example" {
+  provider = aws.us_east_1
+
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.example.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.example.arn
+
+  s3_delivery_configuration {
+    suffix_path = "/123456678910/{DistributionId}/{yyyy}/{MM}/{dd}/{HH}"
+  }
+}
+```
+
 ## Argument Reference
 
 The CloudFront distribution argument layout is a complex structure composed of several sub-resources - these resources are laid out below.

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -253,7 +253,7 @@ provider "aws" {
 resource "aws_cloudfront_distribution" "example" {
   provider = aws.us_east_1
 
-  // other config...
+  # other config...
 }
 
 resource "aws_cloudwatch_log_delivery_source" "example" {


### PR DESCRIPTION
### Description
Explains how to set up CloudFront v2 standard logging (to S3).

**Edit:** I can target 6.0 as well if that makes more sense and change to new region annotation! Please let me know.

### Relations
Closes #40925

### References
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/standard-logging.html#send-logs-s3

### Output from Acceptance Testing
n/a
