### PR TITLE
[r/d]/aws_launch_template: remove `elastic_gpu_specifications` attribute

### DIFF
--- a/.changelog/42312.txt
+++ b/.changelog/42312.txt
@@ -1,0 +1,6 @@
+```release-note:breaking-change
+resource/aws_launch_template: `elastic_gpu_specifications` has been removed
+```
+```release-note:breaking-change
+data-source/aws_launch_template: `elastic_gpu_specifications` has been removed
+```

--- a/internal/service/ec2/ec2_launch_template_data_source.go
+++ b/internal/service/ec2/ec2_launch_template_data_source.go
@@ -177,19 +177,6 @@ func dataSourceLaunchTemplate() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"elastic_gpu_specifications": {
-				Deprecated: "elastic_gpu_specifications is deprecated. AWS no longer supports the Elastic Graphics service.",
-				Type:       schema.TypeList,
-				Computed:   true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						names.AttrType: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"enclave_options": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -209,6 +209,8 @@ For example, `action[0].authenticate_cognito.scope` would now be referenced as `
 
 ## data-source/aws_launch_template
 
+Remove `elastic_gpu_specifications` from your configuration—it no longer exists. Amazon Elastic Graphics reached end of life in January 2024.
+
 Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
 
 ## data-source/aws_opensearch_domain
@@ -285,6 +287,8 @@ The `etag` argument is now computed only.
 Remove `inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
 
 ## resource/aws_launch_template
+
+Remove `elastic_gpu_specifications` from your configuration—it no longer exists. Amazon Elastic Graphics reached end of life in January 2024.
 
 Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
 

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -42,10 +42,6 @@ resource "aws_launch_template" "foo" {
 
   ebs_optimized = true
 
-  elastic_gpu_specifications {
-    type = "test"
-  }
-
   iam_instance_profile {
     name = "test"
   }
@@ -119,8 +115,6 @@ This resource supports the following arguments:
 * `disable_api_termination` - (Optional) If `true`, enables [EC2 Instance
   Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_ChangingDisableAPITermination.html)
 * `ebs_optimized` - (Optional) If `true`, the launched EC2 instance will be EBS-optimized.
-* `elastic_gpu_specifications` - (Optional) **DEPRECATED** The elastic GPU to attach to the instance. See [Elastic GPU](#elastic-gpu)
-  below for more details.
 * `enclave_options` - (Optional) Enable Nitro Enclaves on launched instances. See [Enclave Options](#enclave-options) below for more details.
 * `hibernation_options` - (Optional) The hibernation options for the instance. See [Hibernation Options](#hibernation-options) below for more details.
 * `iam_instance_profile` - (Optional) The IAM Instance Profile to launch the instance with. See [Instance Profile](#instance-profile)
@@ -220,14 +214,6 @@ The `credit_specification` block supports the following:
   Can be `standard` or `unlimited`.
   T3 instances are launched as `unlimited` by default.
   T2 instances are launched as `standard` by default.
-
-### Elastic GPU
-
-Attach an elastic GPU the instance.
-
-The `elastic_gpu_specifications` block supports the following:
-
-* `type` - The [Elastic GPU Type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-graphics.html#elastic-graphics-basics)
 
 ### Enclave Options
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These deprecated attributes are being removed as Amazon Elastic Graphics reached end of life on January 8, 2024.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40991
Relates #41101

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeElasticGpus.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ec2 TESTS=TestAccEC2LaunchTemplateDataSource_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplateDataSource_'  -timeout 360m -vet=off
2025/04/21 17:01:22 Initializing Terraform AWS Provider...

--- PASS: TestAccEC2LaunchTemplateDataSource_filter (18.73s)
--- PASS: TestAccEC2LaunchTemplateDataSource_id (18.79s)
--- PASS: TestAccEC2LaunchTemplateDataSource_matchTags (18.80s)
--- PASS: TestAccEC2LaunchTemplateDataSource_name (21.46s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        28.306s
```

```console
% make testacc PKG=ec2 TESTS=TestAccEC2LaunchTemplate_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2LaunchTemplate_'  -timeout 360m -vet=off
2025/04/22 09:43:00 Initializing Terraform AWS Provider...

--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6Addresses (40.58s)
=== CONT  TestAccEC2LaunchTemplate_associateCarrierIPAddress
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t2 (42.36s)
=== CONT  TestAccEC2LaunchTemplate_associatePublicIPAddress
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_nonBurstable (44.79s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_preference (44.87s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6PrefixCount (46.62s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceType
--- PASS: TestAccEC2LaunchTemplate_privateDNSNameOptions (46.65s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t3 (46.92s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount
--- PASS: TestAccEC2LaunchTemplate_data (47.14s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceCardIndex
--- PASS: TestAccEC2LaunchTemplate_basic (47.16s)
=== CONT  TestAccEC2LaunchTemplate_disappears
--- PASS: TestAccEC2LaunchTemplate_CapacityReservation_target (47.54s)
=== CONT  TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs
--- PASS: TestAccEC2LaunchTemplate_Placement_hostResourceGroupARN (47.63s)
=== CONT  TestAccEC2LaunchTemplate_Name_prefix
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_gp3 (57.67s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations
--- PASS: TestAccEC2LaunchTemplate_cpuOptions (68.36s)
=== CONT  TestAccEC2LaunchTemplate_updateDefaultVersion
--- PASS: TestAccEC2LaunchTemplate_Placement_partitionNum (70.81s)
=== CONT  TestAccEC2LaunchTemplate_defaultVersion
--- PASS: TestAccEC2LaunchTemplate_description (70.99s)
=== CONT  TestAccEC2LaunchTemplate_hibernation
--- PASS: TestAccEC2LaunchTemplate_disappears (32.50s)
=== CONT  TestAccEC2LaunchTemplate_enclaveOptions
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceConnectionTrackingSpecification (35.23s)
=== CONT  TestAccEC2LaunchTemplate_metadataOptions
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv6Prefixes (36.73s)
=== CONT  TestAccEC2LaunchTemplate_licenseSpecification
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceCardIndex (37.42s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4Prefixes (38.19s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceType (38.30s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport
--- PASS: TestAccEC2LaunchTemplate_Name_prefix (37.88s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceIPv4PrefixCount (38.66s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount
--- PASS: TestAccEC2LaunchTemplate_update (88.86s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappingsEBS_deleteOnTermination (91.78s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU
--- PASS: TestAccEC2LaunchTemplate_tags (92.43s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice
--- PASS: TestAccEC2LaunchTemplate_BlockDeviceMappings_ebs (49.51s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes
--- PASS: TestAccEC2LaunchTemplate_NetworkInterfaces_deleteOnTermination (100.11s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_localStorage
--- PASS: TestAccEC2LaunchTemplate_licenseSpecification (34.86s)
=== CONT  TestAccEC2LaunchTemplate_networkInterface
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_spotMaxPricePercentageOverLowestPrice (38.35s)
=== CONT  TestAccEC2LaunchTemplate_networkInterfaceAddresses
=== CONT  TestAccEC2LaunchTemplate_Name_generated
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_onDemandMaxPricePercentageOverLowestPrice (39.22s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_instanceGenerations (73.08s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_maxSpotPriceAsPercentageOfOptimalOnDemandPrice (38.34s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_ebsOptimized (137.65s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers
--- PASS: TestAccEC2LaunchTemplate_associateCarrierIPAddress (101.01s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance
--- PASS: TestAccEC2LaunchTemplate_associatePublicIPAddress (99.50s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps
--- PASS: TestAccEC2LaunchTemplate_defaultVersion (77.72s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_bareMetal
--- PASS: TestAccEC2LaunchTemplate_hibernation (77.67s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_requireHibernateSupport (71.45s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes
--- PASS: TestAccEC2LaunchTemplate_Name_generated (35.15s)
=== CONT  TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock
--- PASS: TestAccEC2LaunchTemplate_enclaveOptions (80.37s)
=== CONT  TestAccEC2LaunchTemplate_CreditSpecification_t4g
--- PASS: TestAccEC2LaunchTemplate_networkInterface (44.17s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount
--- PASS: TestAccEC2LaunchTemplate_networkInterfaceAddresses (41.90s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames
--- PASS: TestAccEC2LaunchTemplate_updateDefaultVersion (100.65s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorageTypes (72.04s)
=== CONT  TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount
--- PASS: TestAccEC2LaunchTemplate_metadataOptions (104.49s)
=== CONT  TestAccEC2LaunchTemplate_instanceMarketOptions
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkInterfaceCount (103.35s)
=== CONT  TestAccEC2LaunchTemplate_primaryIPv6
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_totalLocalStorageGB (104.60s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_enaSrd
--- PASS: TestAccEC2LaunchTemplate_IAMInstanceProfile_emptyBlock (31.33s)
=== CONT  TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_networkBandwidthGbps (105.97s)
--- PASS: TestAccEC2LaunchTemplate_CreditSpecification_t4g (34.83s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryGiBPerVCPU (106.08s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_excludedInstanceTypes (71.25s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_localStorage (102.79s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_cpuManufacturers (67.28s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_allowedInstanceTypes (65.33s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_ipv6AddressCount (26.18s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTypes (63.96s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_memoryMiBAndVCPUCount (63.63s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorNames (60.85s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorTotalMemoryMiB (97.76s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorManufacturers (60.57s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_baselineEBSBandwidthMbps (93.14s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_burstablePerformance (93.46s)
--- PASS: TestAccEC2LaunchTemplate_NetworkInterface_enaSrd (47.01s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_bareMetal (89.98s)
--- PASS: TestAccEC2LaunchTemplate_instanceRequirements_acceleratorCount (80.77s)
--- PASS: TestAccEC2LaunchTemplate_primaryIPv6 (67.70s)
--- PASS: TestAccEC2LaunchTemplate_instanceMarketOptions (72.27s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        263.779s
```
