### PR TITLE
r/aws_elastictranscoder_*: deprecate resources

### DIFF
--- a/.changelog/42313.txt
+++ b/.changelog/42313.txt
@@ -1,0 +1,6 @@
+```release-note:note
+resource/aws_elastictranscoder_pipeline: This resource is deprecated. Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead.
+```
+```release-note:note
+resource/aws_elastictranscoder_preset: This resource is deprecated. Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead.
+```

--- a/internal/service/elastictranscoder/pipeline.go
+++ b/internal/service/elastictranscoder/pipeline.go
@@ -34,6 +34,8 @@ func ResourcePipeline() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "This resource is deprecated. Use AWS Elemental MediaConvert instead.",
+
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
 				Type:     schema.TypeString,

--- a/internal/service/elastictranscoder/preset.go
+++ b/internal/service/elastictranscoder/preset.go
@@ -31,6 +31,8 @@ func ResourcePreset() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		DeprecationMessage: "This resource is deprecated. Use AWS Elemental MediaConvert instead.",
+
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
 				Type:     schema.TypeString,

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -20,6 +20,7 @@ Upgrade topics:
 - [Dropping Support For Amazon Worklink](#dropping-support-for-amazon-worklink)
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
 - [AWS CloudWatch Evidently Deprecation](#aws-cloudwatch-evidently-deprecation)
+- [Amazon Elastic Transcoder Deprecation](#amazon-elastic-transcoder-deprecation)
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
@@ -148,6 +149,16 @@ The following resources have been deprecated and will be removed in a future maj
 * `aws_evidently_segment`
 
 Use [AWS AppConfig Feature Flags](https://aws.amazon.com/blogs/mt/using-aws-appconfig-feature-flags/) instead.
+
+## Amazon Elastic Transcoder Deprecation
+
+AWS has made the decision to [discontinue Amazon Elastic Transcoder](https://aws.amazon.com/blogs/media/support-for-amazon-elastic-transcoder-ending-soon/), effective November 13, 2025.
+The following resources have been deprecated and will be removed in a future major version.
+
+* `aws_elastictranscoder_pipeline`
+* `aws_elastictranscoder_preset`
+
+Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead.
 
 ## data-source/aws_ami
 

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an Elastic Transcoder pipeline resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead. AWS will [discontinue support for Amazon Elastic Transcoder](https://aws.amazon.com/blogs/media/support-for-amazon-elastic-transcoder-ending-soon/), effective November 13, 2025.
+
 ## Example Usage
 
 ```terraform

--- a/website/docs/r/elastictranscoder_preset.html.markdown
+++ b/website/docs/r/elastictranscoder_preset.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an Elastic Transcoder preset resource.
 
+~> **Warning:** This resource is deprecated. Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead. AWS will [discontinue support for Amazon Elastic Transcoder](https://aws.amazon.com/blogs/media/support-for-amazon-elastic-transcoder-ending-soon/), effective November 13, 2025.
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In accordance with the AWS announcement that support for Amazon Elastic Transcoder will be discontinued effective, November 13, 2025, the corresponding Terraform resources are being deprecated.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40318
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://aws.amazon.com/blogs/media/support-for-amazon-elastic-transcoder-ending-soon/

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

N/a
