### PR TITLE
resource/aws_dx_gateway_association: Removes deprecated attribute `vpn_gateway_id`

### DIFF
--- a/.changelog/42323.txt
+++ b/.changelog/42323.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_dx_gateway_association: `vpn_gateway_id` has been removed
+```

--- a/internal/service/directconnect/gateway_association.go
+++ b/internal/service/directconnect/gateway_association.go
@@ -114,7 +114,7 @@ func resourceGatewayAssociationCreate(ctx context.Context, d *schema.ResourceDat
 
 	if associatedGatewayOwnerAccount := d.Get("associated_gateway_owner_account_id").(string); associatedGatewayOwnerAccount != "" {
 		proposalID := d.Get("proposal_id").(string)
-		input := &directconnect.AcceptDirectConnectGatewayAssociationProposalInput{
+		input := directconnect.AcceptDirectConnectGatewayAssociationProposalInput{
 			AssociatedGatewayOwnerAccount: aws.String(associatedGatewayOwnerAccount),
 			DirectConnectGatewayId:        aws.String(directConnectGatewayID),
 			ProposalId:                    aws.String(proposalID),
@@ -124,7 +124,7 @@ func resourceGatewayAssociationCreate(ctx context.Context, d *schema.ResourceDat
 			input.OverrideAllowedPrefixesToDirectConnectGateway = expandRouteFilterPrefixes(v.(*schema.Set).List())
 		}
 
-		output, err := conn.AcceptDirectConnectGatewayAssociationProposal(ctx, input)
+		output, err := conn.AcceptDirectConnectGatewayAssociationProposal(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "accepting Direct Connect Gateway Association Proposal (%s): %s", proposalID, err)
@@ -135,7 +135,7 @@ func resourceGatewayAssociationCreate(ctx context.Context, d *schema.ResourceDat
 		d.SetId(gatewayAssociationCreateResourceID(directConnectGatewayID, aws.ToString(output.DirectConnectGatewayAssociation.AssociatedGateway.Id)))
 	} else {
 		associatedGatewayID := d.Get("associated_gateway_id").(string)
-		input := &directconnect.CreateDirectConnectGatewayAssociationInput{
+		input := directconnect.CreateDirectConnectGatewayAssociationInput{
 			DirectConnectGatewayId: aws.String(directConnectGatewayID),
 			GatewayId:              aws.String(associatedGatewayID),
 		}
@@ -144,7 +144,7 @@ func resourceGatewayAssociationCreate(ctx context.Context, d *schema.ResourceDat
 			input.AddAllowedPrefixesToDirectConnectGateway = expandRouteFilterPrefixes(v.(*schema.Set).List())
 		}
 
-		output, err := conn.CreateDirectConnectGatewayAssociation(ctx, input)
+		output, err := conn.CreateDirectConnectGatewayAssociation(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating Direct Connect Gateway Association (%s/%s): %s", directConnectGatewayID, associatedGatewayID, err)
@@ -200,7 +200,7 @@ func resourceGatewayAssociationUpdate(ctx context.Context, d *schema.ResourceDat
 	conn := meta.(*conns.AWSClient).DirectConnectClient(ctx)
 
 	associationID := d.Get("dx_gateway_association_id").(string)
-	input := &directconnect.UpdateDirectConnectGatewayAssociationInput{
+	input := directconnect.UpdateDirectConnectGatewayAssociationInput{
 		AssociationId: aws.String(associationID),
 	}
 
@@ -215,7 +215,7 @@ func resourceGatewayAssociationUpdate(ctx context.Context, d *schema.ResourceDat
 		input.RemoveAllowedPrefixesToDirectConnectGateway = expandRouteFilterPrefixes(del.List())
 	}
 
-	_, err := conn.UpdateDirectConnectGatewayAssociation(ctx, input)
+	_, err := conn.UpdateDirectConnectGatewayAssociation(ctx, &input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating Direct Connect Gateway Association (%s): %s", d.Id(), err)
@@ -285,29 +285,29 @@ func gatewayAssociationCreateResourceID(directConnectGatewayID, associatedGatewa
 }
 
 func findGatewayAssociationByID(ctx context.Context, conn *directconnect.Client, id string) (*awstypes.DirectConnectGatewayAssociation, error) {
-	input := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+	input := directconnect.DescribeDirectConnectGatewayAssociationsInput{
 		AssociationId: aws.String(id),
 	}
 
-	return findNonDisassociatedGatewayAssociation(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
+	return findNonDisassociatedGatewayAssociation(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
 }
 
 func findGatewayAssociationByGatewayIDAndAssociatedGatewayID(ctx context.Context, conn *directconnect.Client, directConnectGatewayID, associatedGatewayID string) (*awstypes.DirectConnectGatewayAssociation, error) {
-	input := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+	input := directconnect.DescribeDirectConnectGatewayAssociationsInput{
 		AssociatedGatewayId:    aws.String(associatedGatewayID),
 		DirectConnectGatewayId: aws.String(directConnectGatewayID),
 	}
 
-	return findNonDisassociatedGatewayAssociation(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
+	return findNonDisassociatedGatewayAssociation(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
 }
 
 func findGatewayAssociationByGatewayIDAndVirtualGatewayID(ctx context.Context, conn *directconnect.Client, directConnectGatewayID, virtualGatewayID string) (*awstypes.DirectConnectGatewayAssociation, error) {
-	input := &directconnect.DescribeDirectConnectGatewayAssociationsInput{
+	input := directconnect.DescribeDirectConnectGatewayAssociationsInput{
 		DirectConnectGatewayId: aws.String(directConnectGatewayID),
 		VirtualGatewayId:       aws.String(virtualGatewayID),
 	}
 
-	return findNonDisassociatedGatewayAssociation(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
+	return findNonDisassociatedGatewayAssociation(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.DirectConnectGatewayAssociation]())
 }
 
 func findNonDisassociatedGatewayAssociation(ctx context.Context, conn *directconnect.Client, input *directconnect.DescribeDirectConnectGatewayAssociationsInput, filter tfslices.Predicate[*awstypes.DirectConnectGatewayAssociation]) (*awstypes.DirectConnectGatewayAssociation, error) {

--- a/internal/service/directconnect/gateway_association.go
+++ b/internal/service/directconnect/gateway_association.go
@@ -92,15 +92,8 @@ func resourceGatewayAssociation() *schema.Resource {
 			"proposal_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"associated_gateway_id", "vpn_gateway_id"},
+				ConflictsWith: []string{"associated_gateway_id"},
 				AtLeastOneOf:  []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-			},
-			"vpn_gateway_id": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"associated_gateway_id", "associated_gateway_owner_account_id", "proposal_id"},
-				Deprecated:    "vpn_gateway_id is deprecated. Use associated_gateway_id instead.",
 			},
 		},
 

--- a/internal/service/directconnect/gateway_association_test.go
+++ b/internal/service/directconnect/gateway_association_test.go
@@ -37,7 +37,7 @@ func TestAccDirectConnectGatewayAssociation_v0StateUpgrade(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicVPNSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					testAccCheckGatewayAssociationStateUpgradeV0(ctx, resourceName),
 				),
@@ -64,7 +64,7 @@ func TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount(t *test
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicVPNSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/28"),
@@ -104,7 +104,7 @@ func TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount(t *testi
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicVPNCrossAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/28"),
@@ -139,7 +139,7 @@ func TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount(t *
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicTransitSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/30"),
@@ -180,7 +180,7 @@ func TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount(t *t
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicTransitCrossAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/30"),
@@ -215,7 +215,7 @@ func TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayConfig_associationMultiVPNSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName1, &ga, &gap),
 					testAccCheckGatewayAssociationExists(ctx, resourceName2, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName1, "allowed_prefixes.#", "1"),
@@ -248,7 +248,7 @@ func TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccou
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_allowedPrefixesVPNSingleAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/30"),
@@ -266,7 +266,7 @@ func TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccou
 			},
 			{
 				Config: testAccGatewayAssociationConfig_allowedPrefixesVPNSingleAccountUpdated(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.8/29"),
@@ -294,7 +294,7 @@ func TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccoun
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_allowedPrefixesVPNCrossAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "1"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.8/29"),
@@ -307,7 +307,7 @@ func TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccoun
 			},
 			{
 				Config: testAccGatewayAssociationConfig_allowedPrefixesVPNCrossAccountUpdated(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga, &gap),
 					resource.TestCheckResourceAttr(resourceName, "allowed_prefixes.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_prefixes.*", "10.255.255.0/30"),
@@ -337,13 +337,13 @@ func TestAccDirectConnectGatewayAssociation_recreateProposal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGatewayAssociationConfig_basicVPNCrossAccount(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga1, &gap1),
 				),
 			},
 			{
 				Config: testAccGatewayAssociationConfig_basicVPNCrossAccountUpdatedProposal(rName, rBgpAsn),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckGatewayAssociationExists(ctx, resourceName, &ga2, &gap2),
 					testAccCheckGatewayAssociationNotRecreated(&ga1, &ga2),
 					testAccCheckGatewayAssociationProposalRecreated(&gap1, &gap2),

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -38,6 +38,7 @@ Upgrade topics:
 - [resource/aws_bedrock_model_invocation_logging_configuration](#resourceaws_bedrock_model_invocation_logging_configuration)
 - [resource/aws_cloudfront_key_value_store](#resourceaws_cloudfront_key_value_store)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
+- [resource/aws_dx_gateway_association](#resourceaws_dx_gateway_association)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
 - [resource/aws_guardduty_organization_configuration](#resourceaws_guardduty_organization_configuration)
 - [resource/aws_instance](#resourceaws_instance)
@@ -307,6 +308,11 @@ For the name, use the `name` attribute.
 ## resource/aws_cloudfront_response_headers_policy
 
 The `etag` argument is now computed only.
+
+## resource/aws_dx_gateway_association
+
+The `vpn_gateway_id` attribute has been removed.
+Use the `associated_gateway_id` attribute instead.
 
 ## resource/aws_ecs_task_definition
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -110,7 +110,6 @@ Used for cross-account Direct Connect gateway associations.
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The ID of the Direct Connect gateway association resource.
 * `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 * `dx_gateway_association_id` - The ID of the Direct Connect gateway association.
 * `dx_gateway_owner_account_id` - The ID of the AWS account that owns the Direct Connect gateway.


### PR DESCRIPTION
### Description

Removes deprecate attribute `vpn_gateway_id` from `aws_dx_gateway_association`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #31383

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=directconnect TESTS=TestAccDirectConnectGatewayAssociation_

--- SKIP: TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount (0.26s)
--- SKIP: TestAccDirectConnectGatewayAssociation_recreateProposal (0.26s)
--- SKIP: TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount (0.27s)
--- SKIP: TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount (0.27s)
--- PASS: TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount (1192.60s)
--- PASS: TestAccDirectConnectGatewayAssociation_v0StateUpgrade (1199.89s)
--- PASS: TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount (1267.57s)
--- PASS: TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount (1471.74s)
--- PASS: TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccount (1572.92s)
```
