### PR TITLE
Removes `filter` from `data.aws_identitystore_group` and `data.aws_identitystore_user`

### DIFF
--- a/.changelog/42325.txt
+++ b/.changelog/42325.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/aws_identitystore_group: `filter` has been removed
+```
+
+```release-note:breaking-change
+data-source/aws_identitystore_user: `filter` has been removed
+```

--- a/internal/service/identitystore/group.go
+++ b/internal/service/identitystore/group.go
@@ -217,12 +217,12 @@ func groupParseResourceID(id string) (string, string, error) {
 }
 
 func findGroupByTwoPartKey(ctx context.Context, conn *identitystore.Client, identityStoreID, groupID string) (*identitystore.DescribeGroupOutput, error) {
-	input := &identitystore.DescribeGroupInput{
+	input := identitystore.DescribeGroupInput{
 		GroupId:         aws.String(groupID),
 		IdentityStoreId: aws.String(identityStoreID),
 	}
 
-	return findGroup(ctx, conn, input)
+	return findGroup(ctx, conn, &input)
 }
 
 func findGroup(ctx context.Context, conn *identitystore.Client, input *identitystore.DescribeGroupInput) (*identitystore.DescribeGroupOutput, error) {

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -125,12 +125,12 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	var groupID string
 
 	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]any)) > 0 {
-		input := &identitystore.GetGroupIdInput{
+		input := identitystore.GetGroupIdInput{
 			AlternateIdentifier: expandAlternateIdentifier(v.([]any)[0].(map[string]any)),
 			IdentityStoreId:     aws.String(identityStoreID),
 		}
 
-		output, err := conn.GetGroupId(ctx, input)
+		output, err := conn.GetGroupId(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading IdentityStore Group (%s): %s", identityStoreID, err)

--- a/internal/service/identitystore/group_data_source.go
+++ b/internal/service/identitystore/group_data_source.go
@@ -9,13 +9,11 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
-	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -69,7 +67,7 @@ func dataSourceGroup() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{names.AttrFilter, "group_id"},
+				ConflictsWith: []string{"group_id"},
 			},
 			names.AttrDescription: {
 				Type:     schema.TypeString,
@@ -95,26 +93,6 @@ func dataSourceGroup() *schema.Resource {
 					},
 				},
 			},
-			names.AttrFilter: {
-				Deprecated:    "filter is deprecated. Use alternate_identifier instead.",
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				AtLeastOneOf:  []string{"alternate_identifier", names.AttrFilter, "group_id"},
-				ConflictsWith: []string{"alternate_identifier"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute_path": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"attribute_value": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-					},
-				},
-			},
 			"group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -123,7 +101,7 @@ func dataSourceGroup() *schema.Resource {
 					validation.StringLenBetween(1, 47),
 					validation.StringMatch(regexache.MustCompile(`^([0-9a-f]{10}-|)[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`), "must match ([0-9a-f]{10}-|)[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"),
 				),
-				AtLeastOneOf:  []string{"alternate_identifier", names.AttrFilter, "group_id"},
+				AtLeastOneOf:  []string{"alternate_identifier", "group_id"},
 				ConflictsWith: []string{"alternate_identifier"},
 			},
 			"identity_store_id": {
@@ -143,48 +121,6 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	identityStoreID := d.Get("identity_store_id").(string)
-
-	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]any)) > 0 {
-		// Use ListGroups for backwards compat.
-		var output []types.Group
-		input := &identitystore.ListGroupsInput{
-			IdentityStoreId: aws.String(identityStoreID),
-			Filters:         expandFilters(d.Get(names.AttrFilter).([]any)),
-		}
-
-		pages := identitystore.NewListGroupsPaginator(conn, input)
-		for pages.HasMorePages() {
-			page, err := pages.NextPage(ctx)
-
-			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "reading IdentityStore Groups (%s): %s", identityStoreID, err)
-			}
-
-			for _, group := range page.Groups {
-				if v, ok := d.GetOk("group_id"); ok && v.(string) != aws.ToString(group.GroupId) {
-					continue
-				}
-
-				output = append(output, group)
-			}
-		}
-
-		group, err := tfresource.AssertSingleValueResult(output)
-
-		if err != nil {
-			return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("IdentityStore Group", err))
-		}
-
-		d.SetId(aws.ToString(group.GroupId))
-		d.Set(names.AttrDescription, group.Description)
-		d.Set(names.AttrDisplayName, group.DisplayName)
-		if err := d.Set("external_ids", flattenExternalIDs(group.ExternalIds)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting external_ids: %s", err)
-		}
-		d.Set("group_id", group.GroupId)
-
-		return diags
-	}
 
 	var groupID string
 
@@ -227,33 +163,4 @@ func dataSourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("group_id", group.GroupId)
 
 	return diags
-}
-
-func expandFilters(tfList []any) []types.Filter {
-	if len(tfList) == 0 || tfList[0] == nil {
-		return nil
-	}
-
-	apiObjects := make([]types.Filter, 0, len(tfList))
-
-	for _, v := range tfList {
-		tfMap, ok := v.(map[string]any)
-		if !ok {
-			continue
-		}
-
-		apiObject := types.Filter{}
-
-		if v, ok := tfMap["attribute_path"].(string); ok && v != "" {
-			apiObject.AttributePath = aws.String(v)
-		}
-
-		if v, ok := tfMap["attribute_value"].(string); ok && v != "" {
-			apiObject.AttributeValue = aws.String(v)
-		}
-
-		apiObjects = append(apiObjects, apiObject)
-	}
-
-	return apiObjects
 }

--- a/internal/service/identitystore/group_data_source_test.go
+++ b/internal/service/identitystore/group_data_source_test.go
@@ -13,33 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccIdentityStoreGroupDataSource_filterDisplayName(t *testing.T) {
-	ctx := acctest.Context(t)
-	resourceName := "aws_identitystore_group.test"
-	dataSourceName := "data.aws_identitystore_group.test"
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckSSOAdminInstances(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.IdentityStoreServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGroupDataSourceConfig_filterDisplayName(name),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
-					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
-					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
-					resource.TestCheckResourceAttr(dataSourceName, "external_ids.#", "0"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_identitystore_group.test"
@@ -67,7 +40,7 @@ func TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName(t *testing.T
 	})
 }
 
-func TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupID(t *testing.T) {
+func TestAccIdentityStoreGroupDataSource_groupID(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_identitystore_group.test"
 	dataSourceName := "data.aws_identitystore_group.test"
@@ -82,7 +55,7 @@ func TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupID(t *testing.
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGroupDataSourceConfig_filterDisplayNameAndGroupID(name),
+				Config: testAccGroupDataSourceConfig_groupID(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
@@ -106,19 +79,6 @@ resource "aws_identitystore_group" "test" {
 `, name)
 }
 
-func testAccGroupDataSourceConfig_filterDisplayName(name string) string {
-	return acctest.ConfigCompose(testAccGroupDataSourceConfig_base(name), `
-data "aws_identitystore_group" "test" {
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = aws_identitystore_group.test.display_name
-  }
-
-  identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
-}
-`)
-}
-
 func testAccGroupDataSourceConfig_uniqueAttributeDisplayName(name string) string {
 	return acctest.ConfigCompose(testAccGroupDataSourceConfig_base(name), `
 data "aws_identitystore_group" "test" {
@@ -134,14 +94,9 @@ data "aws_identitystore_group" "test" {
 `)
 }
 
-func testAccGroupDataSourceConfig_filterDisplayNameAndGroupID(name string) string {
+func testAccGroupDataSourceConfig_groupID(name string) string {
 	return acctest.ConfigCompose(testAccGroupDataSourceConfig_base(name), `
 data "aws_identitystore_group" "test" {
-  filter {
-    attribute_path  = "DisplayName"
-    attribute_value = aws_identitystore_group.test.display_name
-  }
-
   group_id          = aws_identitystore_group.test.group_id
   identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
 }

--- a/internal/service/identitystore/group_data_source_test.go
+++ b/internal/service/identitystore/group_data_source_test.go
@@ -29,7 +29,7 @@ func TestAccIdentityStoreGroupDataSource_filterDisplayName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupDataSourceConfig_filterDisplayName(name),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
@@ -56,7 +56,7 @@ func TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName(t *testing.T
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupDataSourceConfig_uniqueAttributeDisplayName(name),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),
@@ -83,7 +83,7 @@ func TestAccIdentityStoreGroupDataSource_filterDisplayNameAndGroupID(t *testing.
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGroupDataSourceConfig_filterDisplayNameAndGroupID(name),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "group_id", resourceName, "group_id"),

--- a/internal/service/identitystore/user.go
+++ b/internal/service/identitystore/user.go
@@ -650,12 +650,12 @@ func userParseResourceID(id string) (string, string, error) {
 }
 
 func findUserByTwoPartKey(ctx context.Context, conn *identitystore.Client, identityStoreID, userID string) (*identitystore.DescribeUserOutput, error) {
-	input := &identitystore.DescribeUserInput{
+	input := identitystore.DescribeUserInput{
 		IdentityStoreId: aws.String(identityStoreID),
 		UserId:          aws.String(userID),
 	}
 
-	return findUser(ctx, conn, input)
+	return findUser(ctx, conn, &input)
 }
 
 func findUser(ctx context.Context, conn *identitystore.Client, input *identitystore.DescribeUserInput) (*identitystore.DescribeUserOutput, error) {

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -9,13 +9,11 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/identitystore"
-	"github.com/aws/aws-sdk-go-v2/service/identitystore/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -263,68 +261,6 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	conn := meta.(*conns.AWSClient).IdentityStoreClient(ctx)
 
 	identityStoreID := d.Get("identity_store_id").(string)
-
-	if v, ok := d.GetOk(names.AttrFilter); ok && len(v.([]any)) > 0 {
-		// Use ListUsers for backwards compat.
-		var output []types.User
-		input := &identitystore.ListUsersInput{
-			Filters:         expandFilters(d.Get(names.AttrFilter).([]any)),
-			IdentityStoreId: aws.String(identityStoreID),
-		}
-
-		pages := identitystore.NewListUsersPaginator(conn, input)
-		for pages.HasMorePages() {
-			page, err := pages.NextPage(ctx)
-
-			if err != nil {
-				return sdkdiag.AppendErrorf(diags, "reading IdentityStore Users (%s): %s", identityStoreID, err)
-			}
-
-			for _, user := range page.Users {
-				if v, ok := d.GetOk("user_id"); ok && v.(string) != aws.ToString(user.UserId) {
-					continue
-				}
-
-				output = append(output, user)
-			}
-		}
-
-		user, err := tfresource.AssertSingleValueResult(output)
-
-		if err != nil {
-			return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("IdentityStore User", err))
-		}
-
-		d.SetId(aws.ToString(user.UserId))
-		if err := d.Set("addresses", flattenAddresses(user.Addresses)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting addresses: %s", err)
-		}
-		d.Set(names.AttrDisplayName, user.DisplayName)
-		if err := d.Set("emails", flattenEmails(user.Emails)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting emails: %s", err)
-		}
-		if err := d.Set("external_ids", flattenExternalIDs(user.ExternalIds)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting external_ids: %s", err)
-		}
-		d.Set("identity_store_id", user.IdentityStoreId)
-		d.Set("locale", user.Locale)
-		if err := d.Set(names.AttrName, []any{flattenName(user.Name)}); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting name: %s", err)
-		}
-		d.Set("nickname", user.NickName)
-		if err := d.Set("phone_numbers", flattenPhoneNumbers(user.PhoneNumbers)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting phone_numbers: %s", err)
-		}
-		d.Set("preferred_language", user.PreferredLanguage)
-		d.Set("profile_url", user.ProfileUrl)
-		d.Set("timezone", user.Timezone)
-		d.Set("title", user.Title)
-		d.Set("user_id", user.UserId)
-		d.Set(names.AttrUserName, user.UserName)
-		d.Set("user_type", user.UserType)
-
-		return diags
-	}
 
 	var userID string
 

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -265,12 +265,12 @@ func dataSourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	var userID string
 
 	if v, ok := d.GetOk("alternate_identifier"); ok && len(v.([]any)) > 0 {
-		input := &identitystore.GetUserIdInput{
+		input := identitystore.GetUserIdInput{
 			AlternateIdentifier: expandAlternateIdentifier(v.([]any)[0].(map[string]any)),
 			IdentityStoreId:     aws.String(identityStoreID),
 		}
 
-		output, err := conn.GetUserId(ctx, input)
+		output, err := conn.GetUserId(ctx, &input)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "reading IdentityStore User (%s): %s", identityStoreID, err)

--- a/internal/service/identitystore/user_data_source.go
+++ b/internal/service/identitystore/user_data_source.go
@@ -109,7 +109,7 @@ func dataSourceUser() *schema.Resource {
 						},
 					},
 				},
-				ConflictsWith: []string{names.AttrFilter, "user_id"},
+				ConflictsWith: []string{"user_id"},
 			},
 			names.AttrDisplayName: {
 				Type:     schema.TypeString,
@@ -147,26 +147,6 @@ func dataSourceUser() *schema.Resource {
 						names.AttrIssuer: {
 							Type:     schema.TypeString,
 							Computed: true,
-						},
-					},
-				},
-			},
-			names.AttrFilter: {
-				Deprecated:    "filter is deprecated. Use alternate_identifier instead.",
-				Type:          schema.TypeList,
-				Optional:      true,
-				MaxItems:      1,
-				AtLeastOneOf:  []string{"alternate_identifier", names.AttrFilter, "user_id"},
-				ConflictsWith: []string{"alternate_identifier"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"attribute_path": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"attribute_value": {
-							Type:     schema.TypeString,
-							Required: true,
 						},
 					},
 				},
@@ -263,7 +243,7 @@ func dataSourceUser() *schema.Resource {
 					validation.StringLenBetween(1, 47),
 					validation.StringMatch(regexache.MustCompile(`^([0-9a-f]{10}-|)[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$`), "must match ([0-9a-f]{10}-|)[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}"),
 				),
-				AtLeastOneOf:  []string{"alternate_identifier", names.AttrFilter, "user_id"},
+				AtLeastOneOf:  []string{"alternate_identifier", "user_id"},
 				ConflictsWith: []string{"alternate_identifier"},
 			},
 			names.AttrUserName: {

--- a/internal/service/identitystore/user_data_source_test.go
+++ b/internal/service/identitystore/user_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccIdentityStoreUserDataSource_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserDataSourceConfig_basic(name, email),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDisplayName, resourceName, names.AttrDisplayName),
 					resource.TestCheckResourceAttrPair(dataSourceName, "addresses.0", resourceName, "addresses.0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "emails.0", resourceName, "emails.0"),
@@ -71,7 +71,7 @@ func TestAccIdentityStoreUserDataSource_filterUserName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserDataSourceConfig_filterUserName(name, email),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrUserName, name),
 				),
@@ -97,7 +97,7 @@ func TestAccIdentityStoreUserDataSource_uniqueAttributeUserName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserDataSourceConfig_uniqueAttributeUserName(name, email),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrUserName, name),
 				),
@@ -123,7 +123,7 @@ func TestAccIdentityStoreUserDataSource_email(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserDataSourceConfig_email(name, email),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, names.AttrUserName, name),
 				),
@@ -149,7 +149,7 @@ func TestAccIdentityStoreUserDataSource_userID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserDataSourceConfig_id(name, email),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrUserName, resourceName, names.AttrUserName),
 				),

--- a/internal/service/identitystore/user_data_source_test.go
+++ b/internal/service/identitystore/user_data_source_test.go
@@ -54,32 +54,6 @@ func TestAccIdentityStoreUserDataSource_basic(t *testing.T) {
 	})
 }
 
-func TestAccIdentityStoreUserDataSource_filterUserName(t *testing.T) {
-	ctx := acctest.Context(t)
-	dataSourceName := "data.aws_identitystore_user.test"
-	resourceName := "aws_identitystore_user.test"
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	email := acctest.RandomEmailAddress(acctest.RandomDomainName())
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckSSOAdminInstances(ctx, t)
-		},
-		ErrorCheck:               acctest.ErrorCheck(t, names.IdentityStoreServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccUserDataSourceConfig_filterUserName(name, email),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "user_id", resourceName, "user_id"),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrUserName, name),
-				),
-			},
-		},
-	})
-}
-
 func TestAccIdentityStoreUserDataSource_uniqueAttributeUserName(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_identitystore_user.test"
@@ -238,19 +212,6 @@ data "aws_identitystore_user" "test" {
 `, name, email)
 }
 
-func testAccUserDataSourceConfig_filterUserName(name, email string) string {
-	return acctest.ConfigCompose(testAccUserDataSourceConfig_base(name, email), `
-data "aws_identitystore_user" "test" {
-  identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
-
-  filter {
-    attribute_path  = "UserName"
-    attribute_value = aws_identitystore_user.test.user_name
-  }
-}
-`)
-}
-
 func testAccUserDataSourceConfig_uniqueAttributeUserName(name, email string) string {
 	return acctest.ConfigCompose(testAccUserDataSourceConfig_base(name, email), `
 data "aws_identitystore_user" "test" {
@@ -285,11 +246,6 @@ func testAccUserDataSourceConfig_id(name, email string) string {
 	return acctest.ConfigCompose(testAccUserDataSourceConfig_base(name, email), `
 data "aws_identitystore_user" "test" {
   identity_store_id = tolist(data.aws_ssoadmin_instances.test.identity_store_ids)[0]
-
-  filter {
-    attribute_path  = "UserName"
-    attribute_value = aws_identitystore_user.test.user_name
-  }
 
   user_id = aws_identitystore_user.test.user_id
 }

--- a/website/docs/d/identitystore_group.html.markdown
+++ b/website/docs/d/identitystore_group.html.markdown
@@ -40,7 +40,6 @@ The following arguments are required:
 The following arguments are optional:
 
 * `alternate_identifier` (Optional) A unique identifier for the group that is not the primary identifier. Conflicts with `group_id` and `filter`. Detailed below.
-* `filter` - (Optional, **Deprecated** use the `alternate_identifier` attribute instead) Configuration block for filtering by a unique attribute of the group. Detailed below.
 * `group_id` - (Optional) The identifier for a group in the Identity Store.
 
 -> Exactly one of the above arguments must be provided. Passing both `filter` and `group_id` is allowed for backwards compatibility.
@@ -60,15 +59,6 @@ The `external_id` configuration block supports the following arguments:
 
 * `id` - (Required) The identifier issued to this resource by an external identity provider.
 * `issuer` - (Required) The issuer for an external identifier.
-
-### `filter` Configuration Block
-
-~> The `filter` configuration block has been deprecated. Use `alternate_identifier` instead.
-
-The following arguments are supported by the `filter` configuration block:
-
-* `attribute_path` - (Required) Attribute path that is used to specify which attribute name to search. Currently, `DisplayName` is the only valid attribute path.
-* `attribute_value` - (Required) Value for an attribute.
 
 ### `unique_attribute` Configuration Block
 

--- a/website/docs/d/identitystore_user.html.markdown
+++ b/website/docs/d/identitystore_user.html.markdown
@@ -40,7 +40,6 @@ The following arguments are required:
 The following arguments are optional:
 
 * `alternate_identifier` (Optional) A unique identifier for a user or group that is not the primary identifier. Conflicts with `user_id` and `filter`. Detailed below.
-* `filter` - (Optional, **Deprecated** use the `alternate_identifier` attribute instead) Configuration block for filtering by a unique attribute of the user. Detailed below.
 * `user_id` - (Optional) The identifier for a user in the Identity Store.
 
 -> Exactly one of the above arguments must be provided. Passing both `filter` and `user_id` is allowed for backwards compatibility.
@@ -60,15 +59,6 @@ The `external_id` configuration block supports the following arguments:
 
 * `id` - (Required) The identifier issued to this resource by an external identity provider.
 * `issuer` - (Required) The issuer for an external identifier.
-
-### `filter` Configuration Block
-
-~> The `filter` configuration block has been deprecated. Use `alternate_identifier` instead.
-
-The following arguments are supported by the `filter` configuration block:
-
-* `attribute_path` - (Required) Attribute path that is used to specify which attribute name to search. Currently, `UserName` is the only valid attribute path.
-* `attribute_value` - (Required) Value for an attribute.
 
 ### `unique_attribute` Configuration Block
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -27,7 +27,8 @@ Upgrade topics:
 - [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
 - [data-source/aws_elbv2_listener_rule](#data-sourceaws_elbv2_listener_rule)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
-- [data-source/aws_identitystore_user](#data-sourceaws_instance)
+- [data-source/aws_identitystore_user](#data-sourceaws_identitystore_group)
+- [data-source/aws_identitystore_user](#data-sourceaws_identitystore_user)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_opensearch_domain](#data-sourceaws_opensearch_domain)
 - [data-source/aws_opensearchserverless_security_config](#data-sourceaws_opensearchserverless_security_config)
@@ -179,6 +180,11 @@ This is not recommended.
 ## data-source/aws_globalaccelerator_accelerator
 
 `id` is now computed only.
+
+## data-source/aws_identitystore_group
+
+`filter` has been removed.
+Use `alternate_identifier` instead.
 
 ## data-source/aws_identitystore_user
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -27,6 +27,7 @@ Upgrade topics:
 - [data-source/aws_ecs_task_execution](#data-sourceaws_ecs_task_execution)
 - [data-source/aws_elbv2_listener_rule](#data-sourceaws_elbv2_listener_rule)
 - [data-source/aws_globalaccelerator_accelerator](#data-sourceaws_globalaccelerator_accelerator)
+- [data-source/aws_identitystore_user](#data-sourceaws_instance)
 - [data-source/aws_launch_template](#data-sourceaws_launch_template)
 - [data-source/aws_opensearch_domain](#data-sourceaws_opensearch_domain)
 - [data-source/aws_opensearchserverless_security_config](#data-sourceaws_opensearchserverless_security_config)
@@ -178,6 +179,11 @@ This is not recommended.
 ## data-source/aws_globalaccelerator_accelerator
 
 `id` is now computed only.
+
+## data-source/aws_identitystore_user
+
+`filter` has been removed.
+Use `alternate_identifier` instead.
 
 ## data-source/aws_opensearchserverless_security_config
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Removes `filter` from `data.aws_identitystore_group` and `data.aws_identitystore_user`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33312
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=identitystore TESTS=TestAccIdentityStoreGroupDataSource_

--- PASS: TestAccIdentityStoreGroupDataSource_groupID (14.36s)
--- PASS: TestAccIdentityStoreGroupDataSource_uniqueAttributeDisplayName (14.47s)
```

```console
% make testacc PKG=identitystore TESTS=TestAccIdentityStoreUserDataSource_

--- PASS: TestAccIdentityStoreUserDataSource_userID (14.96s)
--- PASS: TestAccIdentityStoreUserDataSource_basic (15.01s)
--- PASS: TestAccIdentityStoreUserDataSource_email (15.24s)
--- PASS: TestAccIdentityStoreUserDataSource_uniqueAttributeUserName (15.35s)
```
