### PR TITLE
resource/aws_lb_listener: Updates validation for `mutual_authentication` attributes

### DIFF
--- a/.changelog/42326.txt
+++ b/.changelog/42326.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+resource/aws_lb_listener: `mutual_authentication` attributes `advertise_trust_store_ca_names`, `ignore_client_certificate_expiry`, and `trust_store_arn` are only valid if `mode` is `verify`
+```
+
+```release-note:enhancement
+resource/aws_lb_listener: `mutual_authentication` attribute `trust_store_arn` is required if `mode` is `verify`
+```

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -1937,13 +1937,13 @@ func validateMutualAuthenticationCustomDiff(_ context.Context, d *schema.Resourc
 	var diags diag.Diagnostics
 
 	configRaw := d.GetRawConfig()
-	if !configRaw.IsWhollyKnown() || configRaw.IsNull() {
+	if !configRaw.IsKnown() || configRaw.IsNull() {
 		return nil
 	}
 
 	mutualAuthPath := cty.GetAttrPath("mutual_authentication")
 	mutualAuth := configRaw.GetAttr("mutual_authentication")
-	if mutualAuth.IsKnown() && !mutualAuth.IsNull() {
+	if mutualAuth.IsWhollyKnown() && !mutualAuth.IsNull() {
 		mutualAuthListPlantimeValidate(mutualAuthPath, mutualAuth, &diags)
 	}
 

--- a/internal/service/elbv2/listener.go
+++ b/internal/service/elbv2/listener.go
@@ -361,7 +361,6 @@ func resourceListener() *schema.Resource {
 						"ignore_client_certificate_expiry": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
 						},
 						names.AttrMode: {
 							Type:         schema.TypeString,
@@ -542,6 +541,7 @@ func resourceListener() *schema.Resource {
 
 		CustomizeDiff: customdiff.All(
 			validateListenerActionsCustomDiff(names.AttrDefaultAction),
+			validateMutualAuthenticationCustomDiff,
 		),
 	}
 }
@@ -1334,16 +1334,7 @@ func expandMutualAuthenticationAttributes(tfList []any) *awstypes.MutualAuthenti
 	}
 
 	switch mode := tfMap[names.AttrMode].(string); mode {
-	case mutualAuthenticationOff:
-		return &awstypes.MutualAuthenticationAttributes{
-			Mode: aws.String(mode),
-		}
-	case mutualAuthenticationPassthrough:
-		return &awstypes.MutualAuthenticationAttributes{
-			Mode:          aws.String(mode),
-			TrustStoreArn: aws.String(tfMap["trust_store_arn"].(string)),
-		}
-	default:
+	case mutualAuthenticationVerify:
 		apiObject := &awstypes.MutualAuthenticationAttributes{
 			IgnoreClientCertificateExpiry: aws.Bool(tfMap["ignore_client_certificate_expiry"].(bool)),
 			Mode:                          aws.String(mode),
@@ -1354,6 +1345,11 @@ func expandMutualAuthenticationAttributes(tfList []any) *awstypes.MutualAuthenti
 		}
 
 		return apiObject
+
+	default:
+		return &awstypes.MutualAuthenticationAttributes{
+			Mode: aws.String(mode),
+		}
 	}
 }
 
@@ -1514,28 +1510,28 @@ func flattenMutualAuthenticationAttributes(apiObject *awstypes.MutualAuthenticat
 		return []any{}
 	}
 
-	if mode := aws.ToString(apiObject.Mode); mode == mutualAuthenticationOff {
+	switch mode := aws.ToString(apiObject.Mode); mode {
+	case mutualAuthenticationVerify:
+		tfMap := map[string]any{
+			"advertise_trust_store_ca_names": apiObject.AdvertiseTrustStoreCaNames,
+			names.AttrMode:                   mode,
+		}
+		if apiObject.IgnoreClientCertificateExpiry != nil {
+			tfMap["ignore_client_certificate_expiry"] = aws.ToBool(apiObject.IgnoreClientCertificateExpiry)
+		}
+		if apiObject.TrustStoreArn != nil {
+			tfMap["trust_store_arn"] = aws.ToString(apiObject.TrustStoreArn)
+		}
+
+		return []any{tfMap}
+
+	default:
 		return []any{
 			map[string]any{
 				names.AttrMode: mode,
 			},
 		}
 	}
-
-	tfMap := map[string]any{
-		"advertise_trust_store_ca_names": apiObject.AdvertiseTrustStoreCaNames,
-	}
-	if apiObject.IgnoreClientCertificateExpiry != nil {
-		tfMap["ignore_client_certificate_expiry"] = aws.ToBool(apiObject.IgnoreClientCertificateExpiry)
-	}
-	if apiObject.Mode != nil {
-		tfMap[names.AttrMode] = aws.ToString(apiObject.Mode)
-	}
-	if apiObject.TrustStoreArn != nil {
-		tfMap["trust_store_arn"] = aws.ToString(apiObject.TrustStoreArn)
-	}
-
-	return []any{tfMap}
 }
 
 func flattenAuthenticateOIDCActionConfig(apiObject *awstypes.AuthenticateOidcActionConfig, clientSecret string) []any {
@@ -1748,7 +1744,7 @@ func alpnPolicyEnum_Values() []string {
 }
 
 func validateListenerActionsCustomDiff(attrName string) schema.CustomizeDiffFunc {
-	return func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+	return func(_ context.Context, d *schema.ResourceDiff, _ any) error {
 		var diags diag.Diagnostics
 
 		configRaw := d.GetRawConfig()
@@ -1933,6 +1929,71 @@ func listenerActionRuntimeValidate(actionPath cty.Path, action map[string]any, d
 				actionPath.GetAttr(names.AttrType),
 				string(actionType),
 			))
+		}
+	}
+}
+
+func validateMutualAuthenticationCustomDiff(_ context.Context, d *schema.ResourceDiff, _ any) error {
+	var diags diag.Diagnostics
+
+	configRaw := d.GetRawConfig()
+	if !configRaw.IsWhollyKnown() || configRaw.IsNull() {
+		return nil
+	}
+
+	mutualAuthPath := cty.GetAttrPath("mutual_authentication")
+	mutualAuth := configRaw.GetAttr("mutual_authentication")
+	if mutualAuth.IsKnown() && !mutualAuth.IsNull() {
+		mutualAuthListPlantimeValidate(mutualAuthPath, mutualAuth, &diags)
+	}
+
+	return sdkdiag.DiagnosticsError(diags)
+}
+
+func mutualAuthListPlantimeValidate(mutualAuthPath cty.Path, mutualAuth cty.Value, diags *diag.Diagnostics) {
+	it := mutualAuth.ElementIterator()
+	for it.Next() {
+		i, mutualAuth := it.Element()
+		mutualAuthPath := mutualAuthPath.Index(i)
+
+		mutualAuthPlantimeValidate(mutualAuthPath, mutualAuth, diags)
+	}
+}
+
+func mutualAuthPlantimeValidate(mutualAuthPath cty.Path, mutualAuth cty.Value, diags *diag.Diagnostics) {
+	modePath := mutualAuthPath.GetAttr(names.AttrMode)
+	mode := mutualAuth.GetAttr(names.AttrMode)
+	if !mode.IsKnown() {
+		return
+	}
+	if mode.IsNull() {
+		return
+	}
+
+	trustStoreARNPath := mutualAuthPath.GetAttr("trust_store_arn")
+	trustStoreARN := mutualAuth.GetAttr("trust_store_arn")
+
+	switch mode := mode.AsString(); mode {
+	case mutualAuthenticationVerify:
+		if trustStoreARN.IsNull() {
+			*diags = append(*diags, errs.NewAttributeRequiredWhenError(trustStoreARNPath, modePath, mode))
+		}
+
+	default:
+		advertisePath := mutualAuthPath.GetAttr("advertise_trust_store_ca_names")
+		advertise := mutualAuth.GetAttr("advertise_trust_store_ca_names")
+		if !advertise.IsNull() {
+			*diags = append(*diags, errs.NewAttributeConflictsWhenError(advertisePath, modePath, mode))
+		}
+
+		ignorePath := mutualAuthPath.GetAttr("ignore_client_certificate_expiry")
+		ignore := mutualAuth.GetAttr("ignore_client_certificate_expiry")
+		if !ignore.IsNull() {
+			*diags = append(*diags, errs.NewAttributeConflictsWhenError(ignorePath, modePath, mode))
+		}
+
+		if !trustStoreARN.IsNull() {
+			*diags = append(*diags, errs.NewAttributeConflictsWhenError(trustStoreARNPath, modePath, mode))
 		}
 	}
 }

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -3946,7 +3946,7 @@ resource "aws_lb_listener" "test" {
 
   mutual_authentication {
     mode                           = %[1]q
-	advertise_trust_store_ca_names = "on"
+    advertise_trust_store_ca_names = "on"
   }
 }
 `, mode))
@@ -3969,8 +3969,8 @@ resource "aws_lb_listener" "test" {
   }
 
   mutual_authentication {
-    mode                           = %[1]q
-	ignore_client_certificate_expiry = true
+    mode                             = %[1]q
+    ignore_client_certificate_expiry = true
   }
 }
 `, mode))
@@ -3994,8 +3994,8 @@ resource "aws_lb_listener" "test" {
   }
 
   mutual_authentication {
-    mode                           = %[1]q
-	trust_store_arn = aws_lb_trust_store.test.arn
+    mode            = %[1]q
+    trust_store_arn = aws_lb_trust_store.test.arn
   }
 }
 

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1541,15 +1541,15 @@ func TestAccELBV2Listener_mutualAuthenticationPassthrough_validate(t *testing.T)
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccListenerConfig_mutualAuthenticationPassthrough_validate_Advertise(rName, "passthrough", key, certificate),
+				Config:      testAccListenerConfig_mutualAuthentication_validate_Advertise(rName, "passthrough", key, certificate),
 				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.advertise_trust_store_ca_names" cannot be specified when "mutual_authentication\[0\]\.mode" is "passthrough"`),
 			},
 			{
-				Config:      testAccListenerConfig_mutualAuthenticationPassthrough_validate_IgnoreClient(rName, "passthrough", key, certificate),
+				Config:      testAccListenerConfig_mutualAuthentication_validate_IgnoreClient(rName, "passthrough", key, certificate),
 				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.ignore_client_certificate_expiry" cannot be specified when "mutual_authentication\[0\]\.mode" is "passthrough"`),
 			},
 			{
-				Config:      testAccListenerConfig_mutualAuthenticationPassthrough_validate_TrustStore(rName, "passthrough", key, certificate),
+				Config:      testAccListenerConfig_mutualAuthentication_validate_TrustStore(rName, "passthrough", key, certificate),
 				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.trust_store_arn" cannot be specified when "mutual_authentication\[0\]\.mode" is "passthrough"`),
 			},
 		},
@@ -3900,7 +3900,7 @@ resource "aws_lb_listener" "test" {
 `)
 }
 
-func testAccListenerConfig_mutualAuthenticationPassthrough_validate_Advertise(rName, mode, key, certificate string) string {
+func testAccListenerConfig_mutualAuthentication_validate_Advertise(rName, mode, key, certificate string) string {
 	return acctest.ConfigCompose(
 		testAccListenerConfig_baseHTTPS(rName, key, certificate),
 		fmt.Sprintf(`
@@ -3924,7 +3924,7 @@ resource "aws_lb_listener" "test" {
 `, mode))
 }
 
-func testAccListenerConfig_mutualAuthenticationPassthrough_validate_IgnoreClient(rName, mode, key, certificate string) string {
+func testAccListenerConfig_mutualAuthentication_validate_IgnoreClient(rName, mode, key, certificate string) string {
 	return acctest.ConfigCompose(
 		testAccListenerConfig_baseHTTPS(rName, key, certificate),
 		fmt.Sprintf(`
@@ -3948,7 +3948,7 @@ resource "aws_lb_listener" "test" {
 `, mode))
 }
 
-func testAccListenerConfig_mutualAuthenticationPassthrough_validate_TrustStore(rName, mode, key, certificate string) string {
+func testAccListenerConfig_mutualAuthentication_validate_TrustStore(rName, mode, key, certificate string) string {
 	return acctest.ConfigCompose(
 		testAccListenerConfig_baseHTTPS(rName, key, certificate),
 		testAccTrustStoreConfig_baseS3BucketCA(rName),

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -3900,7 +3900,7 @@ resource "aws_lb_listener" "test" {
 
   mutual_authentication {
     mode                             = "verify"
-	ignore_client_certificate_expiry = true
+    ignore_client_certificate_expiry = true
     trust_store_arn                  = aws_lb_trust_store.test.arn
   }
 }

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1556,6 +1556,34 @@ func TestAccELBV2Listener_mutualAuthenticationPassthrough_validate(t *testing.T)
 	})
 }
 
+func TestAccELBV2Listener_mutualAuthenticationOff_validate(t *testing.T) {
+	ctx := acctest.Context(t)
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccListenerConfig_mutualAuthentication_validate_Advertise(rName, "off", key, certificate),
+				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.advertise_trust_store_ca_names" cannot be specified when "mutual_authentication\[0\]\.mode" is "off"`),
+			},
+			{
+				Config:      testAccListenerConfig_mutualAuthentication_validate_IgnoreClient(rName, "off", key, certificate),
+				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.ignore_client_certificate_expiry" cannot be specified when "mutual_authentication\[0\]\.mode" is "off"`),
+			},
+			{
+				Config:      testAccListenerConfig_mutualAuthentication_validate_TrustStore(rName, "off", key, certificate),
+				ExpectError: regexache.MustCompile(`Attribute "mutual_authentication\[0\]\.trust_store_arn" cannot be specified when "mutual_authentication\[0\]\.mode" is "off"`),
+			},
+		},
+	})
+}
+
 func TestAccELBV2Listener_mutualAuthenticationAdvertiseCASubject(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Listener

--- a/internal/service/elbv2/listener_test.go
+++ b/internal/service/elbv2/listener_test.go
@@ -1565,6 +1565,43 @@ func TestAccELBV2Listener_mutualAuthenticationAdvertiseCASubject(t *testing.T) {
 	})
 }
 
+func TestAccELBV2Listener_mutualAuthentication_IgnoreClientCertificateExpiry(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf awstypes.Listener
+	key := acctest.TLSRSAPrivateKeyPEM(t, 2048)
+	resourceName := "aws_lb_listener.test"
+	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, "example.com")
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckListenerDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccListenerConfig_mutualAuthentication_IgnoreClientCertificateExpiry(rName, key, certificate),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckListenerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.advertise_trust_store_ca_names", "off"),
+					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.ignore_client_certificate_expiry", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "mutual_authentication.0.mode", tfelbv2.MutualAuthenticationVerify),
+					resource.TestCheckResourceAttrPair(resourceName, "mutual_authentication.0.trust_store_arn", "aws_lb_trust_store.test", names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"default_action.0.forward",
+				},
+			},
+		},
+	})
+}
+
 func TestAccELBV2Listener_Gateway_lbARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf awstypes.Listener
@@ -3791,6 +3828,80 @@ resource "aws_lb_listener" "test" {
 
   mutual_authentication {
     mode = "passthrough"
+  }
+}
+
+resource "aws_lb" "test" {
+  name            = %[1]q
+  internal        = true
+  security_groups = [aws_security_group.test.id]
+  subnets         = aws_subnet.test[*].id
+
+  idle_timeout               = 30
+  enable_deletion_protection = false
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_lb_target_group" "test" {
+  name     = %[1]q
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.test.id
+
+  health_check {
+    path                = "/health"
+    interval            = 60
+    port                = 8081
+    protocol            = "HTTP"
+    timeout             = 3
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    matcher             = "200-299"
+  }
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_iam_server_certificate" "test" {
+  name             = %[1]q
+  certificate_body = "%[2]s"
+  private_key      = "%[3]s"
+}
+`, rName, acctest.TLSPEMEscapeNewlines(certificate), acctest.TLSPEMEscapeNewlines(key)))
+}
+
+func testAccListenerConfig_mutualAuthentication_IgnoreClientCertificateExpiry(rName, key, certificate string) string {
+	return acctest.ConfigCompose(
+		testAccListenerConfig_base(rName),
+		testAccTrustStoreConfig_baseS3BucketCA(rName),
+		fmt.Sprintf(`
+resource "aws_lb_trust_store" "test" {
+  name                             = %[1]q
+  ca_certificates_bundle_s3_bucket = aws_s3_bucket.test.bucket
+  ca_certificates_bundle_s3_key    = aws_s3_object.test.key
+}
+
+resource "aws_lb_listener" "test" {
+  load_balancer_arn = aws_lb.test.id
+  protocol          = "HTTPS"
+  port              = "443"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = aws_iam_server_certificate.test.arn
+
+  default_action {
+    target_group_arn = aws_lb_target_group.test.id
+    type             = "forward"
+  }
+
+  mutual_authentication {
+    mode                             = "verify"
+	ignore_client_certificate_expiry = true
+    trust_store_arn                  = aws_lb_trust_store.test.arn
   }
 }
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -43,6 +43,7 @@ Upgrade topics:
 - [resource/aws_instance](#resourceaws_instance)
 - [resource/aws_kinesis_analytics_application](#resourceaws_kinesis_analytics_application)
 - [resource/aws_launch_template](#resourceaws_launch_template)
+- [resource/aws_lb_listener](#resourceaws_lb_listener)
 - [resource/aws_media_store_container](#resourceaws_media_store_container)
 - [resource/aws_media_store_container_policy](#resourceaws_media_store_container_policy)
 - [resource/aws_networkmanager_core_network](#resourceaws_networkmanager_core_network)
@@ -323,6 +324,11 @@ The `auto_enable` attribute has been removed and the `auto_enable_organization_m
 Remove `elastic_gpu_specifications` from your configuration—it no longer exists. Amazon Elastic Graphics reached end of life in January 2024.
 
 Remove `elastic_inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## resource/aws_lb_listener
+
+The `mutual_authentication` attributes `advertise_trust_store_ca_names`, `ignore_client_certificate_expiry`, and `trust_store_arn` can now only be set when `mode` is `verify`.
+The attribute `trust_store_arn` is now required  when `mode` is `verify`.
 
 ## resource/aws_media_store_container
 

--- a/website/docs/r/lb_listener.html.markdown
+++ b/website/docs/r/lb_listener.html.markdown
@@ -403,17 +403,17 @@ The following arguments are optional:
 
 ### mutual_authentication
 
-* `advertise_trust_store_ca_names` - (Optional) Valid values are `off` and `on`.
-* `ignore_client_certificate_expiry` - (Optional) Whether client certificate expiry is ignored. Default is `false`.
-* `mode` - (Required) Valid values are `off`, `verify` and `passthrough`.
-* `trust_store_arn` - (Required) ARN of the elbv2 Trust Store.
+* `advertise_trust_store_ca_names` - (Optional when `mode` is `verify`, invalid otherwise) Valid values are `off` and `on`.
+* `ignore_client_certificate_expiry` - (Optional when `mode` is `verify`, invalid otherwise) Whether client certificate expiry is ignored.
+  Default is `false`.
+* `mode` - (Required) Valid values are `off`, `passthrough`, and `verify`.
+* `trust_store_arn` - (Required when `mode` is `verify`, invalid otherwise) ARN of the elbv2 Trust Store.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - ARN of the listener (matches `id`).
-* `id` - ARN of the listener (matches `arn`).
+* `arn` - ARN of the listener.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ~> **Note:** When importing a listener with a forward-type default action, you must include both a top-level target group ARN and a `forward` block with a `target_group` and `arn` to avoid import differences.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Updates validation for `mutual_authentication` attributes in `aws_lb_listener`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #35452
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elbv2 TESTS=TestAccELBV2Listener_

--- PASS: TestAccELBV2Listener_Gateway_basic (195.61s)
--- PASS: TestAccELBV2Listener_DefaultAction_actionDisappears (229.58s)
--- PASS: TestAccELBV2Listener_oidc (241.30s)
--- PASS: TestAccELBV2Listener_Application_basic (248.00s)
--- PASS: TestAccELBV2Listener_redirectWithTargetGroupARN (253.53s)
--- PASS: TestAccELBV2Listener_DefaultAction_defaultOrder (254.12s)
--- PASS: TestAccELBV2Listener_DefaultAction_specifyOrder (260.50s)
--- PASS: TestAccELBV2Listener_Forward_ingest (260.82s)
--- PASS: TestAccELBV2Listener_Forward_update (266.36s)
--- PASS: TestAccELBV2Listener_disappears (267.22s)
--- PASS: TestAccELBV2Listener_Forward_tgARNAndForward (267.76s)
--- PASS: TestAccELBV2Listener_Network_basic (269.37s)
--- PASS: TestAccELBV2Listener_Forward_weighted (286.00s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag (287.32s)
--- PASS: TestAccELBV2Listener_Forward_addStickiness (295.74s)
--- PASS: TestAccELBV2Listener_Forward_TGARNToForward_noChanges (299.78s)
--- PASS: TestAccELBV2Listener_tags (303.94s)
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnCreate (222.48s)
--- PASS: TestAccELBV2Listener_attributes_gwlb_TCPIdleTimeoutSeconds (184.54s)
--- PASS: TestAccELBV2Listener_attributes_alb_HTTPSRequestHeaders (202.10s)
--- PASS: TestAccELBV2Listener_Protocol_upd (214.84s)
--- PASS: TestAccELBV2Listener_backwardsCompatibility (222.32s)
--- PASS: TestAccELBV2Listener_Protocol_https (222.78s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnCreate (238.65s)
--- PASS: TestAccELBV2Listener_attributes_alb_HTTPRequestHeaders (215.37s)
--- PASS: TestAccELBV2Listener_Gateway_lbARN (185.15s)
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Add (253.23s)
--- PASS: TestAccELBV2Listener_attributes_nlb_TCPIdleTimeoutSeconds (238.48s)
--- PASS: TestAccELBV2Listener_Forward_ignoreFields (206.71s)
--- PASS: TestAccELBV2Listener_Forward_ToTGARN_weightStickiness (227.37s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToProviderOnly (290.46s)
--- PASS: TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Replace (253.84s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Replace (241.54s)
--- PASS: TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Add (253.41s)
--- PASS: TestAccELBV2Listener_fixedResponse (214.43s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_providerOnly (370.52s)
--- PASS: TestAccELBV2Listener_redirect (233.35s)
--- PASS: TestAccELBV2Listener_tags_AddOnUpdate (217.84s)
--- PASS: TestAccELBV2Listener_tags_EmptyMap (224.33s)
--- PASS: TestAccELBV2Listener_DefaultAction_empty (0.00s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/authenticate-oidc (2.26s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/fixed-response (2.11s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/forward (1.67s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/redirect (1.71s)
    --- PASS: TestAccELBV2Listener_DefaultAction_empty/authenticate-cognito (1.65s)
--- PASS: TestAccELBV2Listener_tags_IgnoreTags_Overlap_ResourceTag (249.97s)
--- PASS: TestAccELBV2Listener_Forward_TGARNToForward_weightAndStickiness (241.80s)
--- PASS: TestAccELBV2Listener_Forward_addAction (252.44s)
--- PASS: TestAccELBV2Listener_mutualAuthenticationAdvertiseCASubject (211.98s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nullOverlappingResourceTag (215.86s)
--- PASS: TestAccELBV2Listener_Forward_removeStickiness (247.74s)
--- PASS: TestAccELBV2Listener_Forward_ToTGARN_noChanges (233.99s)
--- PASS: TestAccELBV2Listener_tags_null (246.79s)
--- PASS: TestAccELBV2Listener_mutualAuthentication_IgnoreClientCertificateExpiry (229.42s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyProviderOnlyTag (218.84s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_nonOverlapping (309.23s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_emptyResourceTag (205.25s)
--- PASS: TestAccELBV2Listener_mutualAuthenticationPassthrough (214.22s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_updateToResourceOnly (257.98s)
--- PASS: TestAccELBV2Listener_Protocol_tls (482.88s)
--- PASS: TestAccELBV2Listener_tags_DefaultTags_overlapping (326.99s)
--- PASS: TestAccELBV2Listener_mutualAuthentication (221.22s)
```
