### PR TITLE
[WIP] [bug fix] aws_nat_gateway: do not replace while changing secondary_private_ip_address_count value

### DIFF
--- a/.changelog/42328.txt
+++ b/.changelog/42328.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_nat_gateway: Fix replacing while changing secondary_private_ip_address_count value
+```

--- a/internal/service/ec2/find.go
+++ b/internal/service/ec2/find.go
@@ -1694,6 +1694,18 @@ func findNATGatewayAddressByNATGatewayIDAndPrivateIP(ctx context.Context, conn *
 	}))
 }
 
+func findNATGatewayAddressByNATGatewayIDAndCountID(ctx context.Context, conn *ec2.Client, natGatewayID string, countID int) (*awstypes.NatGatewayAddress, error) {
+	output, err := findNATGatewayByID(ctx, conn, natGatewayID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	NatGatewayAddress := &output.NatGatewayAddresses[countID]
+
+	return NatGatewayAddress, nil
+}
+
 func findNetworkACLByID(ctx context.Context, conn *ec2.Client, id string) (*awstypes.NetworkAcl, error) {
 	input := ec2.DescribeNetworkAclsInput{
 		NetworkAclIds: []string{id},

--- a/internal/service/ec2/status.go
+++ b/internal/service/ec2/status.go
@@ -1574,6 +1574,22 @@ func statusNATGatewayAddressByNATGatewayIDAndPrivateIP(ctx context.Context, conn
 	}
 }
 
+func statusNATGatewayAddressByNATGatewayIDAndCountID(ctx context.Context, conn *ec2.Client, natGatewayID string, countID int) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		output, err := findNATGatewayAddressByNATGatewayIDAndCountID(ctx, conn, natGatewayID, countID)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status), nil
+	}
+}
+
 func statusNetworkInsightsAnalysis(ctx context.Context, conn *ec2.Client, id string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		output, err := findNetworkInsightsAnalysisByID(ctx, conn, id)


### PR DESCRIPTION
### Description

This Pull Request prevents replacing the private NAT Gateway while only changing the `secondary_private_ip_address_count` value.

### Affected Resource(s)
aws_nat_gateway (private)

### Expected Behavior
Changing `secondary_private_ip_address_count` should not cause the private NAT Gateway to be replaced.

### Actual Behavior
The private NAT Gateway is marked to be replaced with ` secondary_private_ip_address_count` marked as the root cause.

Force replacement behavior is shown below while adding one secondary private ip address, increasing the `secondary_private_ip_address_count` by one.

```console
% terraform init                                                            
Initializing the backend...
Initializing provider plugins...
- Finding latest version of hashicorp/aws...
- Installing hashicorp/aws v5.95.0...
- Installed hashicorp/aws v5.95.0 (signed by HashiCorp)
Terraform has created a lock file .terraform.lock.hcl to record the provider
selections it made above. Include this file in your version control repository
so that Terraform can guarantee to make the same selections by default when
you run "terraform init" in the future.

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

%  terraform plan              
aws_nat_gateway.example: Refreshing state... [id=nat-04e0a635007915282]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_nat_gateway.example must be replaced
-/+ resource "aws_nat_gateway" "example" {
      + association_id                     = (known after apply)
      ~ id                                 = "nat-04e0a635007915282" -> (known after apply)
      ~ network_interface_id               = "eni-0e48f8ed48b2740b3" -> (known after apply)
      ~ private_ip                         = "172.31.13.159" -> (known after apply)
      + public_ip                          = (known after apply)
      - secondary_allocation_ids           = [] -> null
      ~ secondary_private_ip_address_count = 0 -> 1 # forces replacement
      ~ secondary_private_ip_addresses     = [] -> (known after apply)
      - tags                               = {} -> null
      ~ tags_all                           = {} -> (known after apply)
        # (3 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Note: You didn't use the -out option to save this plan, so Terraform can't guarantee to take exactly these actions if you run "terraform apply" now.
```

### Relations

Relates #33964

### Reference
As per AWS CloudFormation, the SecondaryPrivateIpAddressCount can be changed without interruption (replacement)
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ec2-natgateway.html#cfn-ec2-natgateway-secondaryprivateipaddresscount

Changing the secondary private IPs assignment within the AWS console is also allowed without replacing the NAT Gateway.

### Output from Acceptance Testing

```console
% make t T=TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific K=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific'  -timeout 360m -vet=off
2025/04/23 10:21:18 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific (595.91s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	601.087s
```
```console
% make t T=TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private K=ec2     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private'  -timeout 360m -vet=off
2025/04/23 10:32:50 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== PAUSE TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
=== CONT  TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private
--- PASS: TestAccVPCNATGateway_SecondaryPrivateIPAddresses_private (573.90s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	579.076s
```

```console
% make t T=TestAccVPCNATGateway_secondaryPrivateIPAddressCount K=ec2     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_secondaryPrivateIPAddressCount'  -timeout 360m -vet=off
2025/04/23 10:53:45 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCount
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCount (178.21s)
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddressCountToSpecific (555.12s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	560.301s
```

```console
% make t T=TestAccVPCNATGateway_secondaryPrivateIPAddresses K=ec2   
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNATGateway_secondaryPrivateIPAddresses'  -timeout 360m -vet=off
2025/04/23 11:24:17 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== PAUSE TestAccVPCNATGateway_secondaryPrivateIPAddresses
=== CONT  TestAccVPCNATGateway_secondaryPrivateIPAddresses
--- PASS: TestAccVPCNATGateway_secondaryPrivateIPAddresses (582.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	588.142s
```
