### PR TITLE
r/aws_elasticache_replication_group: remove `auth_token_update_strategy` default

### DIFF
--- a/.changelog/42336.txt
+++ b/.changelog/42336.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_elasticache_replication_group: `auth_token_update_strategy` no longer has a default value. If `auth_token` is set, `auth_token_update_strategy` must also be explicitly configured.
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -85,7 +85,7 @@ func resourceReplicationGroup() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: enum.Validate[awstypes.AuthTokenUpdateStrategyType](),
-				Default:          awstypes.AuthTokenUpdateStrategyTypeRotate,
+				RequiredWith:     []string{"auth_token"},
 			},
 			names.AttrAutoMinorVersionUpgrade: {
 				Type:         nullable.TypeNullableBool,
@@ -371,7 +371,7 @@ func resourceReplicationGroup() *schema.Resource {
 			},
 		},
 
-		SchemaVersion: 2,
+		SchemaVersion: 3,
 		// SchemaVersion: 1 did not include any state changes via MigrateState.
 		// Perform a no-operation state upgrade for Terraform 0.12 compatibility.
 		// Future state migrations should be performed with StateUpgraders.
@@ -386,8 +386,15 @@ func resourceReplicationGroup() *schema.Resource {
 			// must be written to state via a state upgrader.
 			{
 				Type:    resourceReplicationGroupConfigV1().CoreConfigSchema().ImpliedType(),
-				Upgrade: replicationGroupStateUpgradeV1,
+				Upgrade: replicationGroupStateUpgradeFromV1,
 				Version: 1,
+			},
+			// v6.0.0 removed the default auth_token_update_strategy value. To prevent
+			// differences, the default value is removed when auth_token is not set.
+			{
+				Type:    resourceReplicationGroupConfigV2().CoreConfigSchema().ImpliedType(),
+				Upgrade: replicationGroupStateUpgradeFromV2,
+				Version: 2,
 			},
 		},
 

--- a/internal/service/elasticache/replication_group_migrate.go
+++ b/internal/service/elasticache/replication_group_migrate.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func replicationGroupStateUpgradeV1(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+func replicationGroupStateUpgradeFromV1(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
 	if rawState == nil {
 		rawState = map[string]any{}
 	}
@@ -282,4 +282,39 @@ func resourceReplicationGroupConfigV1() *schema.Resource {
 			},
 		},
 	}
+}
+
+func replicationGroupStateUpgradeFromV2(ctx context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	if rawState == nil {
+		rawState = map[string]any{}
+	}
+
+	// Remove auth_token_update_strategy default value if auth_token is not set
+	if v, ok := rawState["auth_token"].(string); !ok || v == "" {
+		delete(rawState, "auth_token_update_strategy")
+	}
+
+	return rawState, nil
+}
+
+func resourceReplicationGroupConfigV2() *schema.Resource {
+	s := resourceReplicationGroupConfigV1()
+
+	// Attributes added in V2 of the schema
+	s.Schema["auth_token_update_strategy"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+	}
+	s.Schema["cluster_mode"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+	}
+	s.Schema["transit_encryption_mode"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+	}
+
+	return s
 }

--- a/internal/service/elasticache/replication_group_migrate_test.go
+++ b/internal/service/elasticache/replication_group_migrate_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package elasticache
+
+import (
+	"reflect"
+	"testing"
+
+	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+func Test_replicationGroupStateUpgradeFromV1(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawState map[string]any
+		want     map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "empty rawState",
+			rawState: nil,
+			want: map[string]any{
+				"auth_token_update_strategy": awstypes.AuthTokenUpdateStrategyTypeRotate,
+			},
+		},
+		{
+			name: "auth_token",
+			rawState: map[string]any{
+				"auth_token": "foo",
+			},
+			want: map[string]any{
+				"auth_token":                 "foo",
+				"auth_token_update_strategy": awstypes.AuthTokenUpdateStrategyTypeRotate,
+			},
+		},
+		{
+			name: "cluster_mode block",
+			rawState: map[string]any{
+				"cluster_mode.num_node_groups":         "2",
+				"cluster_mode.replicas_per_node_group": "2",
+			},
+			want: map[string]any{
+				"auth_token_update_strategy": awstypes.AuthTokenUpdateStrategyTypeRotate,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := replicationGroupStateUpgradeFromV1(t.Context(), tt.rawState, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("replicationGroupStateUpgradeFromV1() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("replicationGroupStateUpgradeFromV1() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_replicationGroupStateUpgradeFromV2(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		rawState map[string]any
+		want     map[string]any
+		wantErr  bool
+	}{
+		{
+			name:     "empty rawState",
+			rawState: nil,
+			want:     map[string]any{},
+		},
+		{
+			name: "no auth_token, default auth_token_update_strategy",
+			rawState: map[string]any{
+				"auth_token_update_strategy": string(awstypes.AuthTokenUpdateStrategyTypeRotate),
+			},
+			want: map[string]any{},
+		},
+		{
+			name: "auth_token and auth_token_update_strategy",
+			rawState: map[string]any{
+				"auth_token":                 "foo",
+				"auth_token_update_strategy": string(awstypes.AuthTokenUpdateStrategyTypeSet),
+			},
+			want: map[string]any{
+				"auth_token":                 "foo",
+				"auth_token_update_strategy": string(awstypes.AuthTokenUpdateStrategyTypeSet),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := replicationGroupStateUpgradeFromV2(t.Context(), tt.rawState, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("replicationGroupStateUpgradeFromV2() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("replicationGroupStateUpgradeFromV2() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -40,6 +40,7 @@ Upgrade topics:
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
 - [resource/aws_dx_gateway_association](#resourceaws_dx_gateway_association)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
+- [resource/aws_elasticache_replication_group](#resourceaws_elasticache_replication_group)
 - [resource/aws_eks_addon](#resourceaws_eks_addon)
 - [resource/aws_guardduty_organization_configuration](#resourceaws_guardduty_organization_configuration)
 - [resource/aws_instance](#resourceaws_instance)
@@ -318,6 +319,11 @@ Use the `associated_gateway_id` attribute instead.
 ## resource/aws_ecs_task_definition
 
 Remove `inference_accelerator` from your configuration—it no longer exists. Amazon Elastic Inference reached end of life in April 2024.
+
+## resource/aws_elasticache_replication_group
+
+The `auth_token_update_strategy` argument no longer has a default value.
+If `auth_token` is set, this argument must also be explicitly configured.
 
 ## resource/aws_eks_addon
 

--- a/website/docs/r/elasticache_replication_group.html.markdown
+++ b/website/docs/r/elasticache_replication_group.html.markdown
@@ -198,7 +198,7 @@ The following arguments are optional:
   When `engine` is `redis`, default is `false`.
   When `engine` is `valkey`, default is `true`.
 * `auth_token` - (Optional) Password used to access a password protected server. Can be specified only if `transit_encryption_enabled = true`.
-* `auth_token_update_strategy` - (Optional) Strategy to use when updating the `auth_token`. Valid values are `SET`, `ROTATE`, and `DELETE`. Defaults to `ROTATE`.
+* `auth_token_update_strategy` - (Optional) Strategy to use when updating the `auth_token`. Valid values are `SET`, `ROTATE`, and `DELETE`. Required if `auth_token` is set.
 * `auto_minor_version_upgrade` - (Optional) Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
   Only supported for engine types `"redis"` and `"valkey"` and if the engine version is 6 or higher.
   Defaults to `true`.


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A state upgrader has been included to remove the default value from state in cases where `auth_token` is not configured. Practitioners will now need to explicitly set a corresponding update strategy when `auth_token` is set.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #34496
Relates https://github.com/hashicorp/terraform-provider-aws/pull/34460
Relates https://github.com/hashicorp/terraform-provider-aws/issues/33439
Relates #41104


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_'  -timeout 360m -vet=off
2025/04/23 11:30:21 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (3.73s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (4.32s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (773.01s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (896.61s)
=== CONT  TestAccElastiCacheReplicationGroup_dataTiering
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1097.36s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
--- PASS: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (1247.04s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (1305.43s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (1327.35s)
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (1345.47s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
--- PASS: TestAccElastiCacheReplicationGroup_networkType (1490.73s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (1563.23s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (848.01s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_5_27_0
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (1776.95s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_6_0_0
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1804.05s)
=== CONT  TestAccElastiCacheReplicationGroup_authToken
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (1960.00s)
=== CONT  TestAccElastiCacheReplicationGroup_updateParameterGroup
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (1257.49s)
=== CONT  TestAccElastiCacheReplicationGroup_updateNodeSize
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (2373.39s)
=== CONT  TestAccElastiCacheReplicationGroup_updateUserGroups
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1345.09s)
=== CONT  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_4_68_0 (900.15s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (2566.14s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (6.12s)
=== CONT  TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (2761.70s)
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (884.55s)
=== CONT  TestAccElastiCacheReplicationGroup_tags
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (2888.23s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (3141.56s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (3162.37s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_update
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (3240.26s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1374.31s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (1368.66s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (1355.46s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1868.97s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1177.73s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_basic
--- PASS: TestAccElastiCacheReplicationGroup_tags (1237.25s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
--- PASS: TestAccElastiCacheReplicationGroup_disappears (875.25s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_6_0_0 (2475.11s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (4287.34s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (3130.76s)
=== CONT  TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (2.09s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
--- PASS: TestAccElastiCacheReplicationGroup_authToken (2744.15s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (1003.81s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (1252.06s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== NAME  TestAccElastiCacheReplicationGroup_updateDescription
    replication_group_test.go:438: Step 1/3 error: Error running apply: exit status 1

        Error: waiting for ElastiCache Replication Group (tf-acc-test-4914003034710884471) create: timeout while waiting for state to become 'available' (last state: 'creating', timeout: 1h0m0s)

          with aws_elasticache_replication_group.test,
          on terraform_plugin_test.tf line 12, in resource "aws_elasticache_replication_group" "test":
          12: resource "aws_elasticache_replication_group" "test" {

--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (1212.57s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1344.24s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (2116.60s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (4131.99s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (4110.37s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (1357.37s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption5x
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_5_27_0 (3723.04s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (3014.18s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (0.82s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (2971.01s)
--- FAIL: TestAccElastiCacheReplicationGroup_updateDescription (4385.35s)
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (821.63s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (805.26s)
--- PASS: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (4729.34s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1639.02s)
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (816.33s)
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (2762.12s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (1013.05s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (2674.64s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (2328.77s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (2793.34s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (1647.52s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (1929.99s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (2189.66s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (2048.53s)
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (3287.41s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (2571.06s)
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (2632.16s)
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (6896.26s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        10064.069s
```

Failure is transient - the same test passed without error on a subsequent execution.

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_updateDescription
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_updateDescription'  -timeout 360m -vet=off
2025/04/23 14:29:57 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (806.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        811.785s
```
