### PR TITLE
Adding new DynamoDB data source to retrieve all tables

### DIFF
--- a/internal/service/dynamodb/service_package_gen.go
+++ b/internal/service/dynamodb/service_package_gen.go
@@ -15,7 +15,13 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
-	return []*types.ServicePackageFrameworkDataSource{}
+	return []*types.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceTables,
+			TypeName: "aws_dynamodb_tables",
+			Name:     "Tables",
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*types.ServicePackageFrameworkResource {

--- a/internal/service/dynamodb/tables_data_source.go
+++ b/internal/service/dynamodb/tables_data_source.go
@@ -1,0 +1,97 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb
+
+import (
+	"context"
+
+	// "github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	// awstypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	// fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	// tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_dynamodb_tables", name="Tables")
+func newDataSourceTables(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceTables{}, nil
+}
+
+const (
+	DSNameTables = "Tables Data Source"
+)
+
+type dataSourceTables struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceTables) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			names.AttrIDs: schema.ListAttribute{
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func (d *dataSourceTables) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+
+	conn := d.Meta().DynamoDBClient(ctx)
+
+	var data dataSourceTablesModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := dynamodb.ListTablesInput{}
+	out, err := findTables(ctx, conn, &input)
+
+	if err != nil {
+		resp.Diagnostics.AddError("reading DynamoDB Tables", err.Error())
+		return
+	}
+
+	// tableIDs := tfslices.ApplyToAll(out, func(v string) string {
+	// 	return aws.ToString(v)
+	// })
+
+	data.ID = types.StringValue(d.Meta().Region(ctx))
+	data.TableIDs = fwflex.FlattenFrameworkStringValueList(ctx, out)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func findTables(ctx context.Context, conn *dynamodb.Client, input *dynamodb.ListTablesInput) ([]string, error) {
+	var output []string
+
+	pages := dynamodb.NewListTablesPaginator(conn, input)
+	for pages.HasMorePages() {
+		page, err := pages.NextPage(ctx)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, v := range page.TableNames {
+			output = append(output, v)
+		}
+	}
+
+	return output, nil
+}
+
+type dataSourceTablesModel struct {
+	ID       types.String `tfsdk:"id"`
+	TableIDs types.List   `tfsdk:"ids"`
+}

--- a/internal/service/dynamodb/tables_data_source_test.go
+++ b/internal/service/dynamodb/tables_data_source_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package dynamodb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccDynamoDBTables_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	tableName := "test-table"
+	dataSourceName := "data.aws_dynamodb_tables.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTablesDataSourceConfig_basic(tableName),
+				Check: resource.ComposeTestCheckFunc(
+					acctest.CheckResourceAttrGreaterThanOrEqualValue(dataSourceName, "ids.#", 1),
+				),
+			},
+		},
+	})
+}
+
+func testAccTablesDataSourceConfig_basic(tableName string) string {
+	return fmt.Sprintf(`
+resource "aws_dynamodb_table" "test" {
+  name         = "%[1]s."
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "TestId"
+
+  attribute {
+    name = "TestId"
+    type = "S"
+  }
+}
+
+data "aws_dynamodb_tables" "test" {
+  depends_on = [aws_dynamodb_table.test]
+}
+`, tableName)
+}

--- a/website/docs/d/dynamodb_tables.html.markdown
+++ b/website/docs/d/dynamodb_tables.html.markdown
@@ -1,0 +1,29 @@
+---
+subcategory: "DynamoDB"
+layout: "aws"
+page_title: "AWS: aws_dynamodb_tables"
+description: |-
+  Provides a list of all AWS DynamoDB Table Names in a Region
+---
+
+# Data Source: aws_dynamodb_tables
+
+Returns a list of all AWS DynamoDB table names in a region.
+
+## Example Usage
+
+The following example retrieves a list of all DynamoDB table names in a region.
+
+```hcl
+data "aws_dynamodb_tables" "all" {}
+
+output "table_names" {
+  value = data.aws_dynamodb_tables.all.ids
+}
+```
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `ids` - A list of all the DynamoDB table names found.


### PR DESCRIPTION
### Description

Adds new `aws_dynamodb_tables` data source that retrieves a list of all DynamoDB tables within a region.

```hcl
data "aws_dynamodb_tables" "all" {}

output "tables" {
  value = data.aws_dynamodb_tables.all.ids
}
```

### Relations

Closes #40922

### References

https://awscli.amazonaws.com/v2/documentation/api/latest/reference/dynamodb/list-tables.html
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/dynamodb#Client.ListTables

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccDynamoDBTables PKG=dynamodb

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/dynamodb/... -v -count 1 -parallel 20 -run='TestAccDynamoDBTables'  -timeout 360m -vet=off
2025/04/23 20:38:34 Initializing Terraform AWS Provider...
=== RUN   TestAccDynamoDBTables_basic
=== PAUSE TestAccDynamoDBTables_basic
=== CONT  TestAccDynamoDBTables_basic
--- PASS: TestAccDynamoDBTables_basic (24.39s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/dynamodb	24.541s
```
