### PR TITLE
Correct test in auto triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -312,7 +312,7 @@ jobs:
           steps.maintainer_editability.outcome != 'skipped'
           || steps.dependencies.outcome != 'skipped'
           || steps.changelog.outcome != 'skipped'
-          || steps.changelog-update-needed.outcome != 'skipped'
+          || steps.needs-changelog-entry.outcome != 'skipped'
         shell: bash
         run: |
           { echo $START_TEXT; echo ; cat note.md; } > tmpnote && mv tmpnote note.md


### PR DESCRIPTION
### Description

Corrects the test in the warning comment to check whether the actual comment step was skipped rather than the filter step.

### Output from Acceptance Testing

N/a, workflows
