### PR TITLE
r/aws_elasticache_replication_group: malformed version error

### DIFF
--- a/.changelog/42346.txt
+++ b/.changelog/42346.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix `malformed version` error when parsing 7.x redis engine versions
+```

--- a/internal/service/elasticache/engine_version.go
+++ b/internal/service/elasticache/engine_version.go
@@ -116,7 +116,7 @@ type getChangeDiffer interface {
 
 func engineVersionIsDowngrade(diff getChangeDiffer) (bool, error) {
 	o, n := diff.GetChange(names.AttrEngineVersion)
-	if o == "6.x" {
+	if o == "6.x" || o == "7.x" {
 		actual := diff.Get("engine_version_actual")
 		aVersion, err := gversion.NewVersion(actual.(string))
 		if err != nil {

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -979,6 +979,11 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		if requestUpdate {
 			updateFuncs = append(updateFuncs, func() error {
 				_, err := conn.ModifyReplicationGroup(ctx, &input)
+				// modifying to match out of band operations may result n this error
+				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+					return nil
+				}
+
 				if err != nil {
 					return fmt.Errorf("modifying ElastiCache Replication Group (%s): %s", d.Id(), err)
 				}
@@ -996,6 +1001,11 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 
 			updateFuncs = append(updateFuncs, func() error {
 				_, err := conn.ModifyReplicationGroup(ctx, &authInput)
+				// modifying to match out of band operations may result n this error
+				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
+					return nil
+				}
+
 				if err != nil {
 					return fmt.Errorf("modifying ElastiCache Replication Group (%s) authentication: %s", d.Id(), err)
 				}

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -979,7 +979,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		if requestUpdate {
 			updateFuncs = append(updateFuncs, func() error {
 				_, err := conn.ModifyReplicationGroup(ctx, &input)
-				// modifying to match out of band operations may result n this error
+				// modifying to match out of band operations may result in this error
 				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
 					return nil
 				}
@@ -1001,7 +1001,7 @@ func resourceReplicationGroupUpdate(ctx context.Context, d *schema.ResourceData,
 
 			updateFuncs = append(updateFuncs, func() error {
 				_, err := conn.ModifyReplicationGroup(ctx, &authInput)
-				// modifying to match out of band operations may result n this error
+				// modifying to match out of band operations may result in this error
 				if errs.IsAErrorMessageContains[*awstypes.InvalidParameterCombinationException](err, "No modifications were requested") {
 					return nil
 				}

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -233,6 +233,67 @@ func TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheReplicationGroup_OutOfBandUpgrade(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var replicationGroup awstypes.ReplicationGroup
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_elasticache_replication_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccReplicationGroupConfig_v6(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.x"),
+				),
+			},
+			{
+				PreConfig: func() {
+					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					timeout := 40 * time.Minute
+					engineVersion := "7.1"
+
+					// Upgrade to engine version 7.x
+					if err := resourceReplicationGroupUpgradeEngineVersion(ctx, conn, rName, engineVersion, timeout); err != nil {
+						t.Fatalf("error upgrading cluster: %s", err)
+					}
+				},
+				RefreshState: true,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "7.x"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: testAccReplicationGroupConfig_v7(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "7.1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						// sets engine_version 7.1 in state
+						// no-op on actual cluster
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -3518,6 +3579,30 @@ resource "aws_elasticache_replication_group" "test" {
 `, rName)
 }
 
+func testAccReplicationGroupConfig_v6(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  engine_version       = "6.x"
+  engine               = "redis"
+}
+`, rName)
+}
+
+func testAccReplicationGroupConfig_v7_upgraded(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_replication_group" "test" {
+  replication_group_id = %[1]q
+  description          = "test description"
+  node_type            = "cache.t3.small"
+  engine_version       = "7.1"
+  engine               = "redis"
+}
+`, rName)
+}
+
 func testAccReplicationGroupConfig_v7(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_elasticache_replication_group" "test" {
@@ -4938,6 +5023,14 @@ func resourceReplicationGroupSetPrimaryClusterID(ctx context.Context, conn *elas
 		ReplicationGroupId: aws.String(replicationGroupID),
 		ApplyImmediately:   aws.Bool(true),
 		PrimaryClusterId:   aws.String(primaryClusterID),
+	})
+}
+
+func resourceReplicationGroupUpgradeEngineVersion(ctx context.Context, conn *elasticache.Client, replicationGroupID, engineVersion string, timeout time.Duration) error {
+	return resourceReplicationGroupModify(ctx, conn, timeout, &elasticache.ModifyReplicationGroupInput{
+		ReplicationGroupId: aws.String(replicationGroupID),
+		ApplyImmediately:   aws.Bool(true),
+		EngineVersion:      aws.String(engineVersion),
 	})
 }
 

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -276,7 +276,7 @@ func TestAccElastiCacheReplicationGroup_OutOfBandUpgrade(t *testing.T) {
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				Config: testAccReplicationGroupConfig_v7(rName),
+				Config: testAccReplicationGroupConfig_v7_upgraded(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The provider can fail to parse a  v7.x `engine_version` upgrade.

```console
% make testacc TESTARGS='-run=TestAccElastiCacheReplicationGroup_OutOfBandUpgrade' PKG=elasticache    

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20  -run=TestAccElastiCacheReplicationGroup_OutOfBandUpgrade -timeout 360m -vet=off
2025/04/23 14:49:25 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
    replication_group_test.go:246: Step 2/2 error running refresh: exit status 1

        Error: parsing old engine_version: Malformed version: 7.x

          with aws_elasticache_replication_group.test,
          on terraform_plugin_test.tf line 12, in resource "aws_elasticache_replication_group" "test":
          12: resource "aws_elasticache_replication_group" "test" {

--- FAIL: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (1516.98s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	1522.577s
FAIL
make: *** [testacc] Error 1
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #36605

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccElastiCacheReplicationGroup_OutOfBandUpgrade\|TestAccElastiCacheReplicationGroup_Redis_basic\|TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7\|TestAccElastiCacheReplicationGroup_disappears' PKG=elasticache

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/elasticache/... -v -count 1 -parallel 20  -run=TestAccElastiCacheReplicationGroup_OutOfBandUpgrade\|TestAccElastiCacheReplicationGroup_Redis_basic\|TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7\|TestAccElastiCacheReplicationGroup_disappears -timeout 360m -vet=off
2025/04/23 18:17:55 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic
=== RUN   TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== RUN   TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== PAUSE TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== RUN   TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== PAUSE TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== RUN   TestAccElastiCacheReplicationGroup_disappears
=== PAUSE TestAccElastiCacheReplicationGroup_disappears
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== CONT  TestAccElastiCacheReplicationGroup_disappears
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (730.77s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (731.46s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (792.95s)
--- PASS: TestAccElastiCacheReplicationGroup_disappears (807.51s)
--- PASS: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (1608.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elasticache	1614.245s
```
