### PR TITLE
[Enhancement] aws_imagebuilder_infrastructure_configuration: add `placement` configuration block

### DIFF
--- a/.changelog/42347.txt
+++ b/.changelog/42347.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_imagebuilder_infrastructure_configuration: Add `placement` configuration block.
+```
+
+```release-note:enhancement
+data-source/aws_imagebuilder_infrastructure_configuration: Add `placement` attribute.
+```

--- a/.changelog/42347.txt
+++ b/.changelog/42347.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_imagebuilder_infrastructure_configuration: Add `placement` configuration block.
+resource/aws_imagebuilder_infrastructure_configuration: Add `placement` argument
 ```
 
 ```release-note:enhancement
-data-source/aws_imagebuilder_infrastructure_configuration: Add `placement` attribute.
+data-source/aws_imagebuilder_infrastructure_configuration: Add `placement` attribute
 ```

--- a/internal/service/imagebuilder/infrastructure_configuration.go
+++ b/internal/service/imagebuilder/infrastructure_configuration.go
@@ -133,7 +133,7 @@ func resourceInfrastructureConfiguration() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"availability_zone": {
+						names.AttrAvailabilityZone: {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringLenBetween(1, 1024),
@@ -515,7 +515,7 @@ func expandPlacement(tfMap map[string]any) *awstypes.Placement {
 
 	apiObject := &awstypes.Placement{}
 
-	if v, ok := tfMap["availability_zone"].(string); ok && v != "" {
+	if v, ok := tfMap[names.AttrAvailabilityZone].(string); ok && v != "" {
 		apiObject.AvailabilityZone = aws.String(v)
 	}
 
@@ -592,7 +592,7 @@ func flattenPlacement(apiObject *awstypes.Placement) map[string]any {
 	tfMap := map[string]any{}
 
 	if v := apiObject.AvailabilityZone; v != nil {
-		tfMap["availability_zone"] = aws.ToString(v)
+		tfMap[names.AttrAvailabilityZone] = aws.ToString(v)
 	}
 
 	if v := apiObject.HostId; v != nil {

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source.go
@@ -5,6 +5,7 @@ package imagebuilder
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source.go
@@ -5,7 +5,6 @@ package imagebuilder
 
 import (
 	"context"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -97,6 +96,30 @@ func dataSourceInfrastructureConfiguration() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"placement": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"availability_zone": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"host_resource_group_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"tenancy": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrResourceTags: tftags.TagsSchemaComputed(),
 			names.AttrSecurityGroupIDs: {
 				Type:     schema.TypeSet,
@@ -154,6 +177,13 @@ func dataSourceInfrastructureConfigurationRead(ctx context.Context, d *schema.Re
 		d.Set("logging", nil)
 	}
 	d.Set(names.AttrName, infrastructureConfiguration.Name)
+	if infrastructureConfiguration.Placement != nil {
+		if err := d.Set("placement", []any{flattenPlacement(infrastructureConfiguration.Placement)}); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting placement: %s", err)
+		}
+	} else {
+		d.Set("placement", nil)
+	}
 	d.Set(names.AttrResourceTags, keyValueTags(ctx, infrastructureConfiguration.ResourceTags).Map())
 	d.Set(names.AttrSecurityGroupIDs, infrastructureConfiguration.SecurityGroupIds)
 	d.Set(names.AttrSNSTopicARN, infrastructureConfiguration.SnsTopicArn)

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source.go
@@ -102,7 +102,7 @@ func dataSourceInfrastructureConfiguration() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"availability_zone": {
+						names.AttrAvailabilityZone: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/service/imagebuilder/infrastructure_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_data_source_test.go
@@ -38,6 +38,7 @@ func TestAccImageBuilderInfrastructureConfigurationDataSource_arn(t *testing.T) 
 					resource.TestCheckResourceAttrPair(dataSourceName, "key_pair", resourceName, "key_pair"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "logging.#", resourceName, "logging.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "placement.#", resourceName, "placement.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "resource_tags.%", resourceName, "resource_tags.%"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_group_ids.#", resourceName, "security_group_ids.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSNSTopicARN, resourceName, names.AttrSNSTopicARN),

--- a/internal/service/imagebuilder/infrastructure_configuration_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_test.go
@@ -653,7 +653,7 @@ func testAccCheckInfrastructureConfigurationExists(ctx context.Context, n string
 	}
 }
 
-func testAccInfrastructureConfigurationBaseConfig(rName string) string {
+func testAccInfrastructureConfigurationConfig_base(rName string) string {
 	return fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -681,7 +681,7 @@ resource "aws_iam_role" "role" {
 
 func testAccInfrastructureConfigurationConfig_description(rName string, description string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   description           = %[2]q
@@ -693,7 +693,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_instanceMetadataOptions(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -709,7 +709,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_instanceProfileName1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -720,7 +720,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_instanceProfileName2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_iam_instance_profile" "test2" {
   name = aws_iam_role.role2.name
@@ -751,7 +751,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_instanceTypes1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.medium", "t2.medium"),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
@@ -764,7 +764,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_instanceTypes2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		acctest.AvailableEC2InstanceTypeForRegion("t3.large", "t2.large"),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
@@ -777,7 +777,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_keyPair1(rName, publicKey string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_key_pair" "test" {
   key_name   = %[1]q
@@ -794,7 +794,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_keyPair2(rName, publicKey string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_key_pair" "test2" {
   key_name   = "%[1]s-2"
@@ -811,7 +811,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_loggingS3LogsS3BucketName1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -832,7 +832,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_loggingS3LogsS3BucketName2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test2" {
   bucket = "%[1]s-2"
@@ -853,7 +853,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_loggingS3LogsS3KeyPrefix(rName string, s3KeyPrefix string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -875,7 +875,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_name(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -886,7 +886,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_resourceTags(rName string, resourceTagKey string, resourceTagValue string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -901,7 +901,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_securityGroupIDs1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -921,7 +921,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_securityGroupIDs2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -941,7 +941,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_subnetID1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -967,7 +967,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_subnetID2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_vpc" "test" {
   cidr_block = "10.0.0.0/16"
@@ -993,7 +993,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_snsTopicARN1(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_sns_topic" "test" {
   name = %[1]q
@@ -1009,7 +1009,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_snsTopicARN2(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_sns_topic" "test2" {
   name = "%[1]s-2"
@@ -1025,7 +1025,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_tags1(rName string, tagKey1 string, tagValue1 string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -1040,7 +1040,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_tags2(rName string, tagKey1 string, tagValue1 string, tagKey2 string, tagValue2 string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name = aws_iam_instance_profile.test.name
@@ -1056,7 +1056,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_terminateInstanceOnFailure(rName string, terminateInstanceOnFailure bool) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_imagebuilder_infrastructure_configuration" "test" {
   instance_profile_name         = aws_iam_instance_profile.test.name
@@ -1068,7 +1068,8 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 
 func testAccInfrastructureConfigurationConfig_placement(rName, tenancy string) string {
 	return acctest.ConfigCompose(
-		testAccInfrastructureConfigurationBaseConfig(rName),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		testAccInfrastructureConfigurationConfig_base(rName),
 		fmt.Sprintf(`
 data "aws_region" "current" {}
 
@@ -1077,7 +1078,7 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
   name                  = %[1]q
   placement {
     tenancy           = %[2]q
-    availability_zone = "${data.aws_region.current.name}a"
+    availability_zone = data.aws_availability_zones.available.names[0]
   }
 }
 `, rName, tenancy))

--- a/website/docs/d/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/d/imagebuilder_infrastructure_configuration.html.markdown
@@ -42,6 +42,11 @@ This data source exports the following attributes in addition to the arguments a
         * `s3_bucket_name` - Name of the S3 Bucket for logging.
         * `s3_key_prefix` - Key prefix for S3 Bucket logging.
 * `name` - Name of the infrastructure configuration.
+* `placement` - Placement settings that define where the instances that are launched from your image will run.
+    * `availability_zone` - Availability Zone where your build and test instances will launch.
+    * `host_id` - ID of the Dedicated Host on which build and test instances run.
+    * `host_resource_group_arn` - ARN of the host resource group in which to launch build and test instances.
+    * `tenancy` - Placement tenancy of the instance.
 * `resource_tags` - Key-value map of resource tags for the infrastructure created by the infrastructure configuration.
 * `security_group_ids` - Set of EC2 Security Group identifiers associated with the configuration.
 * `sns_topic_arn` - ARN of the SNS Topic associated with the configuration.

--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -51,6 +51,7 @@ The following arguments are optional:
 * `instance_types` - (Optional) Set of EC2 Instance Types.
 * `key_pair` - (Optional) Name of EC2 Key Pair.
 * `logging` - (Optional) Configuration block with logging settings. Detailed below.
+* `placement` - (Optional) Configuration block with placement settings that define where the instances that are launched from your image will run. Detailed below.
 * `resource_tags` - (Optional) Key-value map of resource tags to assign to infrastructure created by the configuration.
 * `security_group_ids` - (Optional) Set of EC2 Security Group identifiers.
 * `sns_topic_arn` - (Optional) Amazon Resource Name (ARN) of SNS Topic.
@@ -80,6 +81,15 @@ The following arguments are required:
 The following arguments are optional:
 
 * `s3_key_prefix` - (Optional) Prefix to use for S3 logs. Defaults to `/`.
+
+### placement
+
+The following arguments are optional:
+
+* `availability_zone` - (Optional) Availability Zone where your build and test instances will launch.
+* `host_id` - (Optional) ID of the Dedicated Host on which build and test instances run. Conflicts with `host_resource_group_arn`.
+* `host_resource_group_arn` - (Optional) ARN of the host resource group in which to launch build and test instances. Conflicts with `host_id`.
+* `tenancy` - (Optional) Placement tenancy of the instance. Valid values: `default`, `dedicated` and `host`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
### Description
* Add `placement` configuration block, which enables to specify tenancy (dedicated, host) and availability zone to launch instances, to resource and data source.

### Relations
Closes #40361

### References
https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Placement.html

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccImageBuilderInfrastructureConfiguration_ PKG=imagebuilder
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderInfrastructureConfiguration_'  -timeout 360m -vet=off
2025/04/24 10:49:30 Initializing Terraform AWS Provider...
=== RUN   TestAccImageBuilderInfrastructureConfiguration_basic
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_basic
=== RUN   TestAccImageBuilderInfrastructureConfiguration_disappears
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_disappears
=== RUN   TestAccImageBuilderInfrastructureConfiguration_description
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_description
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
=== RUN   TestAccImageBuilderInfrastructureConfiguration_instanceTypes
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_instanceTypes
=== RUN   TestAccImageBuilderInfrastructureConfiguration_keyPair
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_keyPair
=== RUN   TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
=== RUN   TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
=== RUN   TestAccImageBuilderInfrastructureConfiguration_resourceTags
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_resourceTags
=== RUN   TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
=== RUN   TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
=== RUN   TestAccImageBuilderInfrastructureConfiguration_subnetID
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_subnetID
=== RUN   TestAccImageBuilderInfrastructureConfiguration_tags
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_tags
=== RUN   TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
=== RUN   TestAccImageBuilderInfrastructureConfiguration_placement
=== PAUSE TestAccImageBuilderInfrastructureConfiguration_placement
=== CONT  TestAccImageBuilderInfrastructureConfiguration_basic
=== CONT  TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix
=== CONT  TestAccImageBuilderInfrastructureConfiguration_subnetID
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceProfileName
=== CONT  TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure
=== CONT  TestAccImageBuilderInfrastructureConfiguration_tags
=== CONT  TestAccImageBuilderInfrastructureConfiguration_placement
=== CONT  TestAccImageBuilderInfrastructureConfiguration_description
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions
=== CONT  TestAccImageBuilderInfrastructureConfiguration_keyPair
=== CONT  TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs
=== CONT  TestAccImageBuilderInfrastructureConfiguration_snsTopicARN
=== CONT  TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName
=== CONT  TestAccImageBuilderInfrastructureConfiguration_instanceTypes
=== CONT  TestAccImageBuilderInfrastructureConfiguration_disappears
=== CONT  TestAccImageBuilderInfrastructureConfiguration_resourceTags
--- PASS: TestAccImageBuilderInfrastructureConfiguration_disappears (48.50s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceMetadataOptions (53.48s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_basic (53.78s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_description (68.66s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_keyPair (72.09s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_resourceTags (72.26s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_snsTopicARN (73.22s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceTypes (73.65s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure (73.84s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix (74.69s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_placement (75.21s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_subnetID (75.79s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3BucketName (78.45s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_securityGroupIDs (78.82s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_instanceProfileName (80.52s)
--- PASS: TestAccImageBuilderInfrastructureConfiguration_tags (89.45s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       94.042s

```

```console
$ make testacc TESTS=TestAccImageBuilderInfrastructureConfigurationDataSource_ PKG=imagebuilder                     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/imagebuilder/... -v -count 1 -parallel 20 -run='TestAccImageBuilderInfrastructureConfigurationDataSource_'  -timeout 360m -vet=off
2025/04/24 11:26:57 Initializing Terraform AWS Provider...
=== RUN   TestAccImageBuilderInfrastructureConfigurationDataSource_arn
=== PAUSE TestAccImageBuilderInfrastructureConfigurationDataSource_arn
=== CONT  TestAccImageBuilderInfrastructureConfigurationDataSource_arn
--- PASS: TestAccImageBuilderInfrastructureConfigurationDataSource_arn (39.06s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/imagebuilder       43.113s

```
