### PR TITLE
resource/aws_db_instance: Makes attribute conflict warnings for `character_set_name` errors

### DIFF
--- a/.changelog/42348.txt
+++ b/.changelog/42348.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+resource/aws_db_instance: `character_set_name` now cannot be set with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier`.
+```

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -189,11 +189,11 @@ func resourceInstance() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 				ConflictsWith: []string{
+					"replicate_source_db",
 					"s3_import",
 				},
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					for _, conflictAttr := range []string{
-						"replicate_source_db",
 						// s3_import is handled by the schema ConflictsWith
 						"snapshot_identifier",
 						"restore_to_point_in_time",
@@ -774,7 +774,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 	if _, ok := d.GetOk("character_set_name"); ok {
 		charSetPath := cty.GetAttrPath("character_set_name")
 		for _, conflictAttr := range []string{
-			"replicate_source_db",
 			// s3_import is handled by the schema ConflictsWith
 			"snapshot_identifier",
 			"restore_to_point_in_time",

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -191,17 +191,8 @@ func resourceInstance() *schema.Resource {
 				ConflictsWith: []string{
 					"replicate_source_db",
 					"s3_import",
+					"restore_to_point_in_time",
 					"snapshot_identifier",
-				},
-				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
-					for _, conflictAttr := range []string{
-						"restore_to_point_in_time",
-					} {
-						if _, ok := d.GetOk(conflictAttr); ok {
-							return true
-						}
-					}
-					return false
 				},
 			},
 			"copy_tags_to_snapshot": {
@@ -769,20 +760,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 	identifier := create.Name(d.Get(names.AttrIdentifier).(string), d.Get("identifier_prefix").(string))
 
 	var resourceID string // will be assigned depending on how it is created
-
-	if _, ok := d.GetOk("character_set_name"); ok {
-		charSetPath := cty.GetAttrPath("character_set_name")
-		for _, conflictAttr := range []string{
-			"restore_to_point_in_time",
-		} {
-			if _, ok := d.GetOk(conflictAttr); ok {
-				diags = append(diags, errs.NewAttributeConflictsWillBeError(
-					charSetPath,
-					cty.GetAttrPath(conflictAttr),
-				))
-			}
-		}
-	}
 
 	// get write-only value from configuration
 	passwordWO, di := flex.GetWriteOnlyStringValue(d, cty.GetAttrPath("password_wo"))

--- a/internal/service/rds/instance.go
+++ b/internal/service/rds/instance.go
@@ -191,11 +191,10 @@ func resourceInstance() *schema.Resource {
 				ConflictsWith: []string{
 					"replicate_source_db",
 					"s3_import",
+					"snapshot_identifier",
 				},
 				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
 					for _, conflictAttr := range []string{
-						// s3_import is handled by the schema ConflictsWith
-						"snapshot_identifier",
 						"restore_to_point_in_time",
 					} {
 						if _, ok := d.GetOk(conflictAttr); ok {
@@ -774,8 +773,6 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 	if _, ok := d.GetOk("character_set_name"); ok {
 		charSetPath := cty.GetAttrPath("character_set_name")
 		for _, conflictAttr := range []string{
-			// s3_import is handled by the schema ConflictsWith
-			"snapshot_identifier",
 			"restore_to_point_in_time",
 		} {
 			if _, ok := d.GetOk(conflictAttr); ok {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -8718,8 +8718,6 @@ resource "aws_db_instance" "test" {
   username                   = "tfacctest"
   backup_retention_period    = 0
 
-  character_set_name = "WE8ISO8859P15"
-
   parameter_group_name = "default.${data.aws_rds_engine_version.default.parameter_group_family}"
   skip_final_snapshot  = true
   multi_az             = false

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -2768,43 +2768,6 @@ func TestAccRDSInstance_ReplicateSourceDB_characterSet_Source(t *testing.T) {
 	})
 }
 
-func TestAccRDSInstance_ReplicateSourceDB_characterSet_Replica(t *testing.T) {
-	ctx := acctest.Context(t)
-
-	// All RDS Instance tests should skip for testing.Short() except the 20 shortest running tests.
-	if testing.Short() {
-		t.Skip("skipping long-running test in short mode")
-	}
-
-	var dbInstance, sourceDbInstance types.DBInstance
-
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	sourceResourceName := "aws_db_instance.source"
-	resourceName := "aws_db_instance.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_11_0),
-		},
-		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceConfig_ReplicateSourceDB_characterSet_Replica(rName),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDBInstanceExists(ctx, sourceResourceName, &sourceDbInstance),
-					resource.TestCheckResourceAttr(sourceResourceName, "character_set_name", "WE8ISO8859P15"),
-					testAccCheckDBInstanceExists(ctx, resourceName, &dbInstance),
-					resource.TestCheckResourceAttrPair(resourceName, "replicate_source_db", sourceResourceName, names.AttrIdentifier),
-					resource.TestCheckResourceAttr(resourceName, "character_set_name", "WE8ISO8859P15"),
-				),
-			},
-		},
-	})
-}
-
 func TestAccRDSInstance_ReplicateSourceDB_replicaMode(t *testing.T) {
 	ctx := acctest.Context(t)
 
@@ -11883,41 +11846,6 @@ resource "aws_db_instance" "test" {
   instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
   skip_final_snapshot = true
   apply_immediately   = true
-}
-
-resource "aws_db_instance" "source" {
-  identifier              = "%[1]s-source"
-  allocated_storage       = 20
-  engine                  = data.aws_rds_orderable_db_instance.test.engine
-  engine_version          = data.aws_rds_orderable_db_instance.test.engine_version
-  instance_class          = data.aws_rds_orderable_db_instance.test.instance_class
-  storage_type            = data.aws_rds_orderable_db_instance.test.storage_type
-  db_name                 = "MAINDB"
-  username                = "oadmin"
-  password_wo             = ephemeral.aws_secretsmanager_random_password.test.random_password
-  password_wo_version     = 1
-  skip_final_snapshot     = true
-  apply_immediately       = true
-  backup_retention_period = 1
-
-  character_set_name = "WE8ISO8859P15"
-}
-`, rName))
-}
-
-func testAccInstanceConfig_ReplicateSourceDB_characterSet_Replica(rName string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigRandomPassword(),
-		testAccInstanceConfig_orderableClassOracleEnterprise(),
-		fmt.Sprintf(`
-resource "aws_db_instance" "test" {
-  identifier          = %[1]q
-  replicate_source_db = aws_db_instance.source.identifier
-  instance_class      = data.aws_rds_orderable_db_instance.test.instance_class
-  skip_final_snapshot = true
-  apply_immediately   = true
-
-  character_set_name = "NE8ISO8859P10"
 }
 
 resource "aws_db_instance" "source" {

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -38,6 +38,7 @@ Upgrade topics:
 - [resource/aws_bedrock_model_invocation_logging_configuration](#resourceaws_bedrock_model_invocation_logging_configuration)
 - [resource/aws_cloudfront_key_value_store](#resourceaws_cloudfront_key_value_store)
 - [resource/aws_cloudfront_response_headers_policy](#resourceaws_cloudfront_response_headers_policy)
+- [resource/aws_db_instance](#resourceaws_db_instance)
 - [resource/aws_dx_gateway_association](#resourceaws_dx_gateway_association)
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
 - [resource/aws_eks_addon](#resourceaws_eks_addon)
@@ -309,6 +310,10 @@ For the name, use the `name` attribute.
 ## resource/aws_cloudfront_response_headers_policy
 
 The `etag` argument is now computed only.
+
+## resource/aws_db_instance
+
+The `character_set_name` now cannot be set with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier`.
 
 ## resource/aws_dx_gateway_association
 


### PR DESCRIPTION
### Description

Attribute conflict warnings for `character_set_name` with `replicate_source_db`, `restore_to_point_in_time`, `s3_import`, or `snapshot_identifier` errors

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #36519 
Relates #41101 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=rds TESTS=TestAccRDSInstance_

--- FAIL: TestAccRDSInstance_MSSQL_domain (4.52s)
--- FAIL: TestAccRDSInstance_MSSQL_domainSnapshotRestore (4.53s)
--- FAIL: TestAccRDSInstance_dedicatedLogVolume_enableOnUpdate (17.62s)
--- PASS: TestAccRDSInstance_NewIdentifier_pending (453.59s)
--- SKIP: TestAccRDSInstance_Outposts_backupTarget (0.24s)
--- SKIP: TestAccRDSInstance_Outposts_coIPSnapshotIdentifier (0.11s)
--- SKIP: TestAccRDSInstance_Outposts_coIPRestoreToPointInTime (0.13s)
--- SKIP: TestAccRDSInstance_Outposts_coIPEnabledToDisabled (0.10s)
--- PASS: TestAccRDSInstance_basic (473.77s)
--- PASS: TestAccRDSInstance_portUpdate (581.79s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_tags (635.09s)
--- PASS: TestAccRDSInstance_NewIdentifier_immediately (660.51s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_deletionProtectionBypassesBlueGreen (751.95s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_passwordBypassesBlueGreen (763.76s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_oracle (930.25s)
--- PASS: TestAccRDSInstance_PerformanceInsights_kmsKeyID (946.82s)
--- PASS: TestAccRDSInstance_license (1069.20s)
--- PASS: TestAccRDSInstance_PerformanceInsights_disabledToEnabled (642.52s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_removedToEnabled (658.90s)
--- PASS: TestAccRDSInstance_PerformanceInsights_enabledToDisabled (778.59s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomainSingleDomainDNSIP (1289.86s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToRemoved (765.27s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring_sourceAlreadyExists (1503.12s)
--- PASS: TestAccRDSInstance_MonitoringRoleARN_enabledToDisabled (777.01s)
--- PASS: TestAccRDSInstance_MSSQL_tz (1836.31s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_basic (1317.46s)
--- SKIP: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameRAMShared (0.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_multiAZ (1969.85s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateInstanceClass (2064.47s)
--- PASS: TestAccRDSInstance_monitoringInterval (1147.87s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDsTags (1007.63s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateEngineVersion (2146.28s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateParameterGroup (2178.73s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_monitoring (1450.52s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_vpcSecurityGroupIDs (1087.47s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_tags (1039.04s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateAndEnableBackups (2356.60s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomain (2418.12s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maxAllocatedStorage (1502.06s)
--- SKIP: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameRAMShared (0.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iamDatabaseAuthenticationEnabled (1206.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_port (1066.25s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_maintenanceWindow (1430.42s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_parameterGroupName (1047.79s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_monitoring (1137.33s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupNameVPCSecurityGroupIDs (1699.41s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maxAllocatedStorage (1138.18s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_maintenanceWindow (1137.71s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_iamDatabaseAuthenticationEnabled (1077.34s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupNameVPCSecurityGroupIDs (935.63s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_deletionProtection (987.69s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameVPC (1417.64s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_sameAsSource (1345.43s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupWindow (1046.32s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_dbSubnetGroupName (1180.22s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_basic (1353.91s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZ (1745.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_dbSubnetGroupName_crossRegion (1729.85s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_autoMinorVersionUpgrade (1168.09s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupWindow (1397.61s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_availabilityZone (1331.31s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_backupRetentionPeriod (1697.78s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_availabilityZone (1026.35s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_autoMinorVersionUpgrade (1109.09s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allowMajorVersionUpgrade (1280.93s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodOverride (1360.34s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_iops (1310.30s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_backupRetentionPeriodUnset (1483.20s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorageAndIops (1451.95s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_allocatedStorage (1311.16s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_AssociationRemoved (1045.86s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_nameGenerated (1286.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_namePrefix (1320.51s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allocatedStorage (1347.61s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_addLater (1526.05s)
--- FAIL: TestAccRDSInstance_ReplicateSourceDB_mssqlDomain (1.00s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_upgradeStorageConfig (1309.63s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io2Storage (1529.26s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_io1Storage (1500.63s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_allowMajorVersionUpgrade (1739.69s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_nameGenerated (1039.37s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_sourceARN (1298.41s)
--- PASS: TestAccRDSInstance_Versions_minor (386.69s)
--- PASS: TestAccRDSInstance_Oracle_noNationalCharacterSet (853.97s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_namePrefix (1071.28s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_ManageMasterPasswordKMSKey (1067.24s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_promoteEmptyString (1386.90s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_basic (546.60s)
--- PASS: TestAccRDSInstance_Oracle_nationalCharacterSet (1055.44s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceIdentifier (1289.91s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_msSQL (819.63s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_promoteNull (1478.96s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_mySQL (869.78s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_basic (1107.09s)
--- PASS: TestAccRDSInstance_Storage_changeIOPSThroughput (677.45s)
--- PASS: TestAccRDSInstance_Storage_changeIOPSio2 (657.36s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_sourceResourceID (1144.02s)
--- PASS: TestAccRDSInstance_Storage_changeIOPSio1 (657.22s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_manageMasterPassword (1438.28s)
--- PASS: TestAccRDSInstance_RestoreToPointInTime_monitoring (1381.45s)
--- FAIL: TestAccRDSInstance_BlueGreenDeployment_updateAndPromoteReplica (6422.25s)
--- PASS: TestAccRDSInstance_Storage_postgres (669.07s)
--- PASS: TestAccRDSInstance_Storage_changeIOPSGP3 (653.74s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_multiAZSQLServer (4794.93s)
--- FAIL: TestAccRDSInstance_dedicatedLogVolume_enableOnCreate (6.21s)
--- PASS: TestAccRDSInstance_Storage_throughputSSE (923.46s)
--- SKIP: TestAccRDSInstance_DBSubnetGroupName_ramShared (0.00s)
--- PASS: TestAccRDSInstance_Storage_gp3Postgres (643.68s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_postgresql_iam_db_auth (569.98s)
--- PASS: TestAccRDSInstance_Storage_changeThroughput (651.87s)
--- PASS: TestAccRDSInstance_Storage_gp3MySQL (725.08s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_convertToManaged (432.64s)
--- PASS: TestAccRDSInstance_CloudWatchLogsExport_postgresql (584.37s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameReplicaCopiesValue (1432.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_networkType (1212.67s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNamePostgres (2316.05s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSameSetOnBoth (1372.73s)
--- PASS: TestAccRDSInstance_isAlreadyBeingDeleted (445.59s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_port (1319.72s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_vpcSecurityGroupIDs (1452.32s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_caCertificateIdentifier (1592.34s)
--- PASS: TestAccRDSInstance_Storage_gp3SQLServer (1173.17s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameSetOnReplica (1360.23s)
--- PASS: TestAccRDSInstance_Storage_maxAllocated (723.30s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupNameDifferentSetOnBoth (1706.13s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_basic (332.28s)
--- PASS: TestAccRDSInstance_ManageMasterPassword_kmsKey (468.65s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_vpcSecurityGroupIDs (463.49s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_skipFinalSnapshot (580.77s)
--- PASS: TestAccRDSInstance_passwordWriteOnly (508.21s)
--- PASS: TestAccRDSInstance_deletionProtection (582.89s)
--- PASS: TestAccRDSInstance_password (577.64s)
--- PASS: TestAccRDSInstance_engineLifecycleSupport_disabled (453.80s)
--- PASS: TestAccRDSInstance_noDeleteAutomatedBackups (695.80s)
--- PASS: TestAccRDSInstance_FinalSnapshotIdentifier_basic (832.94s)
--- PASS: TestAccRDSInstance_iamAuth (449.37s)
--- PASS: TestAccRDSInstance_Versions_allowMajor (467.43s)
--- PASS: TestAccRDSInstance_kmsKey (468.52s)
--- PASS: TestAccRDSInstance_Versions_onlyMajor (461.97s)
--- PASS: TestAccRDSInstance_ErrorOnConvertToManageOnStoppedInstance (981.56s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_parameterGroupTwoStep (2900.29s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_characterSet_Source (2602.84s)
--- PASS: TestAccRDSInstance_identifierGenerated (454.66s)
--- PASS: TestAccRDSInstance_optionGroup (524.17s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_outOfBand (1980.39s)
--- PASS: TestAccRDSInstance_disappears (479.84s)
--- PASS: TestAccRDSInstance_identifierPrefix (463.85s)
--- PASS: TestAccRDSInstance_networkType (788.74s)
--- PASS: TestAccRDSInstance_CACertificate_latest (551.37s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_replicaMode (3058.55s)
--- PASS: TestAccRDSInstance_DBSubnetGroupName_basic (791.79s)
--- PASS: TestAccRDSInstance_CACertificate_update (692.60s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_CrossRegion_parameterGroupNameEquivalent (3694.28s)
--- PASS: TestAccRDSInstance_PerformanceInsights_databaseInsightsMode (993.34s)
--- PASS: TestAccRDSInstance_PerformanceInsights_retentionPeriod (932.01s)
--- PASS: TestAccRDSInstance_SnapshotIdentifier_performanceInsightsEnabled (1209.21s)
--- PASS: TestAccRDSInstance_ReplicateSourceDB_performanceInsightsEnabled (1411.47s)
--- PASS: TestAccRDSInstance_BlueGreenDeployment_updateWithDeletionProtection (2170.97s)
--- PASS: TestAccRDSInstance_MySQL_snapshotRestoreWithEngineVersion (1369.77s)
--- PASS: TestAccRDSInstance_customIAMInstanceProfile (2921.96s)
--- PASS: TestAccRDSInstance_MSSQL_selfManagedDomainSnapshotRestore (2777.98s)
```

Errors are unrelated, and will be fixed in a separate PR on the 5.x branch