### PR TITLE
Correctly handle unset/empty `items` for CORS configurations in response headers policies

### DIFF
--- a/.changelog/42360.txt
+++ b/.changelog/42360.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudfront_response_headers_policy: Allow empty/unset `items` in the CORS configuration
+```

--- a/internal/service/cloudfront/response_headers_policy.go
+++ b/internal/service/cloudfront/response_headers_policy.go
@@ -581,66 +581,54 @@ func expandResponseHeadersPolicyCorsConfig(tfMap map[string]any) *awstypes.Respo
 }
 
 func expandResponseHeadersPolicyAccessControlAllowHeaders(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowHeaders {
-	if tfMap == nil {
-		return nil
+	var items []string
+	if v, ok := tfMap["items"].(*schema.Set); ok {
+		items = flex.ExpandStringValueSet(v)
 	}
 
-	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowHeaders{}
-
-	if v, ok := tfMap["items"].(*schema.Set); ok && v.Len() > 0 {
-		items := flex.ExpandStringValueSet(v)
-		apiObject.Items = items
-		apiObject.Quantity = aws.Int32(int32(len(items)))
+	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowHeaders{
+		Items:    items,
+		Quantity: aws.Int32(int32(len(items))),
 	}
-
 	return apiObject
 }
 
 func expandResponseHeadersPolicyAccessControlAllowMethods(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowMethods {
-	if tfMap == nil {
-		return nil
+	var items []awstypes.ResponseHeadersPolicyAccessControlAllowMethodsValues
+	if v, ok := tfMap["items"].(*schema.Set); ok {
+		items = flex.ExpandStringyValueSet[awstypes.ResponseHeadersPolicyAccessControlAllowMethodsValues](v)
 	}
 
-	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowMethods{}
-
-	if v, ok := tfMap["items"].(*schema.Set); ok && v.Len() > 0 {
-		items := flex.ExpandStringyValueSet[awstypes.ResponseHeadersPolicyAccessControlAllowMethodsValues](v)
-		apiObject.Items = items
-		apiObject.Quantity = aws.Int32(int32(len(items)))
+	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowMethods{
+		Items:    items,
+		Quantity: aws.Int32(int32(len(items))),
 	}
-
 	return apiObject
 }
 
 func expandResponseHeadersPolicyAccessControlAllowOrigins(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlAllowOrigins {
-	if tfMap == nil {
-		return nil
+	var items []string
+	if v, ok := tfMap["items"].(*schema.Set); ok {
+		items = flex.ExpandStringValueSet(v)
 	}
 
-	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowOrigins{}
-
-	if v, ok := tfMap["items"].(*schema.Set); ok && v.Len() > 0 {
-		items := flex.ExpandStringValueSet(v)
-		apiObject.Items = items
-		apiObject.Quantity = aws.Int32(int32(len(items)))
+	apiObject := &awstypes.ResponseHeadersPolicyAccessControlAllowOrigins{
+		Items:    items,
+		Quantity: aws.Int32(int32(len(items))),
 	}
-
 	return apiObject
 }
 
 func expandResponseHeadersPolicyAccessControlExposeHeaders(tfMap map[string]any) *awstypes.ResponseHeadersPolicyAccessControlExposeHeaders {
-	if tfMap == nil {
-		return nil
+	var items []string
+	if v, ok := tfMap["items"].(*schema.Set); ok {
+		items = flex.ExpandStringValueSet(v)
 	}
 
-	apiObject := &awstypes.ResponseHeadersPolicyAccessControlExposeHeaders{}
-
-	if v, ok := tfMap["items"].(*schema.Set); ok && v.Len() > 0 {
-		items := flex.ExpandStringValueSet(v)
-		apiObject.Items = items
-		apiObject.Quantity = aws.Int32(int32(len(items)))
+	apiObject := &awstypes.ResponseHeadersPolicyAccessControlExposeHeaders{
+		Items:    items,
+		Quantity: aws.Int32(int32(len(items))),
 	}
-
 	return apiObject
 }
 

--- a/internal/service/cloudfront/response_headers_policy_test.go
+++ b/internal/service/cloudfront/response_headers_policy_test.go
@@ -22,6 +22,8 @@ func TestAccCloudFrontResponseHeadersPolicy_cors(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName4 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_cloudfront_response_headers_policy.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -94,6 +96,44 @@ func TestAccCloudFrontResponseHeadersPolicy_cors(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "remove_headers_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "security_headers_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "server_timing_headers_config.#", "0"),
+				),
+			},
+			{
+				Config: testAccResponseHeadersPolicyConfig_corsEmpty(rName3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResponseHeadersPolicyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrComment, "test empty"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_credentials", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_headers.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_methods.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cors_config.0.access_control_allow_methods.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_origins.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_origins.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_expose_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_expose_headers.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_max_age_sec", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.origin_override", acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccResponseHeadersPolicyConfig_corsUnset(rName4),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResponseHeadersPolicyExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrComment, "test unset"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_credentials", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_headers.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_methods.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cors_config.0.access_control_allow_methods.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_origins.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_allow_origins.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_expose_headers.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_expose_headers.0.items.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.access_control_max_age_sec", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "cors_config.0.origin_override", acctest.CtFalse),
 				),
 			},
 		},
@@ -478,6 +518,64 @@ resource "aws_cloudfront_response_headers_policy" "test" {
 
     access_control_expose_headers {
       items = ["HEAD"]
+    }
+
+    access_control_max_age_sec = 3600
+
+    origin_override = false
+  }
+}
+`, rName)
+}
+
+func testAccResponseHeadersPolicyConfig_corsUnset(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_response_headers_policy" "test" {
+  name    = %[1]q
+  comment = "test unset"
+
+  cors_config {
+    access_control_allow_credentials = true
+
+    access_control_allow_headers {}
+
+    access_control_allow_methods {}
+
+    access_control_allow_origins {}
+
+    access_control_expose_headers {}
+
+    access_control_max_age_sec = 3600
+
+    origin_override = false
+  }
+}
+`, rName)
+}
+
+func testAccResponseHeadersPolicyConfig_corsEmpty(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_response_headers_policy" "test" {
+  name    = %[1]q
+  comment = "test empty"
+
+  cors_config {
+    access_control_allow_credentials = true
+
+    access_control_allow_headers {
+      items = []
+    }
+
+    access_control_allow_methods {
+      items = []
+    }
+
+    access_control_allow_origins {
+      items = []
+    }
+
+    access_control_expose_headers {
+      items = []
     }
 
     access_control_max_age_sec = 3600


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-aws/issues/30440

### Description

This should fix #30440, by serializing empty/unset `items` for these elements to `Items:[], Quantity:0`.

I was thinking of also making the elements completely optional, but that might be too big a change?

### Relations

Closes #30440



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
