### PR TITLE
Add synchonize to triggers for AutoTriage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,6 +11,7 @@ on:
       - closed
       - edited
       - opened
+      - synchronize
 
   issues:
     types:
@@ -27,7 +28,7 @@ env:
 jobs:
   labelers:
     name: Labelers
-    if: contains(fromJSON('["opened", "edited"]'), github.event.action)
+    if: contains(fromJSON('["opened", "edited", "synchronize"]'), github.event.action)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -196,7 +197,7 @@ jobs:
     name: Warn of Potential Issues
     if: |
       github.event_name == 'pull_request_target'
-      && contains(fromJSON('["opened", "edited"]'), github.event.action)
+      && contains(fromJSON('["opened", "edited", "synchronize"]'), github.event.action)
     runs-on: ubuntu-latest
     env:
       START_TEXT: "### :warning: We've detected the following potential issues with your pull request"


### PR DESCRIPTION
### Description

Adds `synchronize` to the list of triggers for the AutoTriage action. 

Where `edited` means:

> The title or body of a pull request was edited, or the base branch of a pull request was changed.

`synchronize` means:

> A pull request's head branch was updated. For example, the head branch was updated from the base branch or new commits were pushed to the head branch.

This is useful for the labeler job, where labels will be updated if later commits introduce changes that affect additional services, or make the PR large enough to require a different size label. For the warning comment job, this enables the PR to be reevaluated on new commits to update the comment if an issue is resolved by later commits (e.g. when a changelog entry is added where one was not present before).

### References

[GitHub documentation](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request)

### Output from Acceptance Testing

N/a, workflows
