### PR TITLE
fix(route53): correct traffic policy behavior (#27767)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BUG FIXES:
 * resource/aws_elasticache_replication_group: Fix `malformed version` error when parsing 7.x redis engine versions ([#42346](https://github.com/hashicorp/terraform-provider-aws/issues/42346))
 * resource/aws_iam_user: Retry `ConcurrentModificationException`s during user creation ([#42081](https://github.com/hashicorp/terraform-provider-aws/issues/42081))
 * resource/aws_rds_cluster: Fix `InvalidParameterValue: SecondsUntilAutoPause can only be specified when minimum capacity is 0` errors when removing `serverlessv2_scaling_configuration.seconds_until_auto_pause` ([#41180](https://github.com/hashicorp/terraform-provider-aws/issues/41180))
+* resource/aws_route53_traffic_policy: Fix bug preventing updates to create new versions of traffic policy while preserving previous versions ([#27767](https://github.com/hashicorp/terraform-provider-aws/issues/27767))
 
 ## 5.95.0 (April 17, 2025)
 


### PR DESCRIPTION
### Description
This PR enhances the `aws_route53_traffic_policy` resource to properly support versioning when updating traffic policy documents. Previously, updates to the traffic policy document would overwrite existing versions rather than creating a new version as expected. This change ensures that when a traffic policy document is modified, a new version is created while preserving previous versions, aligning with AWS Route53 API behavior and user expectations.

### Relations
Closes #27767

### References
- AWS Route53 API documentation on [CreateTrafficPolicyVersion](https://docs.aws.amazon.com/Route53/latest/APIReference/API_CreateTrafficPolicyVersion.html)
- AWS Route53 behavior maintains historical versions of traffic policies which this PR now correctly models

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccRoute53TrafficPolicy_updateDocument PKG=route53
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/route53/... -v -count 1 -parallel 20 -run=TestAccRoute53TrafficPolicy_updateDocument -timeout 360m
2025/04/24 15:28:42 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53TrafficPolicy_updateDocument
=== PAUSE TestAccRoute53TrafficPolicy_updateDocument
=== CONT  TestAccRoute53TrafficPolicy_updateDocument
--- PASS: TestAccRoute53TrafficPolicy_updateDocument (19.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	23.751s


### Credits
Credit to @IamEnTm for the original fork and implementation of the versioned update approach.
This PR is being submitted on behalf of Palo Alto Networks CDSS DNS Security team, where the issue was reproduced, fixed and validated.