### PR TITLE
[Bug fix] Fix `aws_ec2_network_insights_path` failure when `filter_at_source.source_address` is unspecified (related to recently merged PR #42214)

### DIFF
--- a/.changelog/42369.txt
+++ b/.changelog/42369.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_network_insights_path: Fix failure when `filter_at_source.source_address` is unspecified.
+```

--- a/internal/service/ec2/vpc_network_insights_path.go
+++ b/internal/service/ec2/vpc_network_insights_path.go
@@ -320,14 +320,14 @@ func expandPathRequestFilter(tfMap map[string]any) *awstypes.PathRequestFilter {
 	if v, ok := tfMap["destination_address"].(string); ok && v != "" {
 		apiObject.DestinationAddress = aws.String(v)
 	}
-	if v, ok := tfMap["destination_port_range"]; ok && len(v.([]any)) > 0 {
-		apiObject.DestinationPortRange = expandRequestFilterPortRange(v.([]any)[0].(map[string]any))
+	if v, ok := tfMap["destination_port_range"].([]any); ok && len(v) > 0 {
+		apiObject.DestinationPortRange = expandRequestFilterPortRange(v[0].(map[string]any))
 	}
 	if v, ok := tfMap["source_address"].(string); ok && v != "" {
 		apiObject.SourceAddress = aws.String(v)
 	}
-	if v, ok := tfMap["source_port_range"]; ok && len(v.([]any)) > 0 {
-		apiObject.SourcePortRange = expandRequestFilterPortRange(v.([]any)[0].(map[string]any))
+	if v, ok := tfMap["source_port_range"].([]any); ok && len(v) > 0 {
+		apiObject.SourcePortRange = expandRequestFilterPortRange(v[0].(map[string]any))
 	}
 
 	return apiObject

--- a/internal/service/ec2/vpc_network_insights_path.go
+++ b/internal/service/ec2/vpc_network_insights_path.go
@@ -317,14 +317,14 @@ func expandPathRequestFilter(tfMap map[string]any) *awstypes.PathRequestFilter {
 
 	apiObject := &awstypes.PathRequestFilter{}
 
-	if v, ok := tfMap["destination_address"]; ok {
-		apiObject.DestinationAddress = aws.String(v.(string))
+	if v, ok := tfMap["destination_address"].(string); ok && v != "" {
+		apiObject.DestinationAddress = aws.String(v)
 	}
 	if v, ok := tfMap["destination_port_range"]; ok && len(v.([]any)) > 0 {
 		apiObject.DestinationPortRange = expandRequestFilterPortRange(v.([]any)[0].(map[string]any))
 	}
-	if v, ok := tfMap["source_address"]; ok {
-		apiObject.SourceAddress = aws.String(v.(string))
+	if v, ok := tfMap["source_address"].(string); ok && v != "" {
+		apiObject.SourceAddress = aws.String(v)
 	}
 	if v, ok := tfMap["source_port_range"]; ok && len(v.([]any)) > 0 {
 		apiObject.SourcePortRange = expandRequestFilterPortRange(v.([]any)[0].(map[string]any))


### PR DESCRIPTION
### Description

* The recently merged PR #42214 has an issue where resource creation fails when `filter_at_source.source_address` is unspecified, as reported in https://github.com/hashicorp/terraform-provider-aws/issues/38132#issuecomment-2829327235.
* This PR fixes incorrect handling of deserialization for the `source_address` string argument in `filter_at_source`.
  * When `source_address` is not specified in the Terraform configuration, the `SourceAddress` field in the AWS SDK for Go structure should be set to `nil` by ignoring the empty string resulting from deserialization. However, the empty string was incorrectly passed instead of being ignored.
  * As a result, an empty string was passed to the AWS API parameter, leading to the error: `api error InvalidParameterValue: FilterAtSource.SourceAddress () is not valid`. (Confirmed by inspecting the request parameters with `TF_LOG=DEBUG`)
* The main fix in this PR is:
  https://github.com/tabito-hara/terraform-provider-aws/commit/961479319dc82b69d7c0d212862bf73c61374e59  
  * It adds a check to ensure `tfMap["source_address"]` is not an empty string.
* Code style in the affected function has also been unified.
* An acceptance test has been added for the case where `source_address` is not specified.

### Relations
Closes #38132
Relates #42214

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccVPCNetworkInsightsPath_ PKG=ec2                               
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInsightsPath_'  -timeout 360m -vet=off
2025/04/25 17:55:13 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNetworkInsightsPath_basic
=== PAUSE TestAccVPCNetworkInsightsPath_basic
=== RUN   TestAccVPCNetworkInsightsPath_disappears
=== PAUSE TestAccVPCNetworkInsightsPath_disappears
=== RUN   TestAccVPCNetworkInsightsPath_tags
=== PAUSE TestAccVPCNetworkInsightsPath_tags
=== RUN   TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== PAUSE TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== RUN   TestAccVPCNetworkInsightsPath_sourceIP
=== PAUSE TestAccVPCNetworkInsightsPath_sourceIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationIP
=== PAUSE TestAccVPCNetworkInsightsPath_destinationIP
=== RUN   TestAccVPCNetworkInsightsPath_destinationPort
=== PAUSE TestAccVPCNetworkInsightsPath_destinationPort
=== RUN   TestAccVPCNetworkInsightsPath_filterAtSource
=== PAUSE TestAccVPCNetworkInsightsPath_filterAtSource
=== RUN   TestAccVPCNetworkInsightsPath_filterAtSourceWithoutSourceInfo
=== PAUSE TestAccVPCNetworkInsightsPath_filterAtSourceWithoutSourceInfo
=== RUN   TestAccVPCNetworkInsightsPath_filterAtDestination
=== PAUSE TestAccVPCNetworkInsightsPath_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPath_basic
=== CONT  TestAccVPCNetworkInsightsPath_destinationIP
=== CONT  TestAccVPCNetworkInsightsPath_sourceAndDestinationARN
=== CONT  TestAccVPCNetworkInsightsPath_sourceIP
=== CONT  TestAccVPCNetworkInsightsPath_filterAtSourceWithoutSourceInfo
=== CONT  TestAccVPCNetworkInsightsPath_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPath_filterAtSource
=== CONT  TestAccVPCNetworkInsightsPath_tags
=== CONT  TestAccVPCNetworkInsightsPath_disappears
=== CONT  TestAccVPCNetworkInsightsPath_destinationPort
--- PASS: TestAccVPCNetworkInsightsPath_sourceAndDestinationARN (43.84s)
--- PASS: TestAccVPCNetworkInsightsPath_basic (43.94s)
--- PASS: TestAccVPCNetworkInsightsPath_filterAtSource (44.12s)
--- PASS: TestAccVPCNetworkInsightsPath_filterAtSourceWithoutSourceInfo (44.31s)
--- PASS: TestAccVPCNetworkInsightsPath_filterAtDestination (44.35s)
--- PASS: TestAccVPCNetworkInsightsPath_disappears (45.40s)
--- PASS: TestAccVPCNetworkInsightsPath_destinationIP (59.49s)
--- PASS: TestAccVPCNetworkInsightsPath_sourceIP (60.00s)
--- PASS: TestAccVPCNetworkInsightsPath_destinationPort (63.83s)
--- PASS: TestAccVPCNetworkInsightsPath_tags (79.63s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        83.919s

```

```console
$ make testacc TESTS=TestAccVPCNetworkInsightsPathDataSource_ PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCNetworkInsightsPathDataSource_'  -timeout 360m -vet=off
2025/04/25 18:18:20 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCNetworkInsightsPathDataSource_basic
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_basic
=== RUN   TestAccVPCNetworkInsightsPathDataSource_filterAtSource
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_filterAtSource
=== RUN   TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== PAUSE TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPathDataSource_basic
=== CONT  TestAccVPCNetworkInsightsPathDataSource_filterAtDestination
=== CONT  TestAccVPCNetworkInsightsPathDataSource_filterAtSource
--- PASS: TestAccVPCNetworkInsightsPathDataSource_basic (30.41s)
--- PASS: TestAccVPCNetworkInsightsPathDataSource_filterAtDestination (30.67s)
--- PASS: TestAccVPCNetworkInsightsPathDataSource_filterAtSource (30.68s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        35.309s

```
