### PR TITLE
provider: deprecate support for s3 global endpoints

### DIFF
--- a/.changelog/42375.txt
+++ b/.changelog/42375.txt
@@ -1,0 +1,3 @@
+```release-note:note
+provider: Support for the global S3 endpoint is deprecated, along with the `s3_us_east_1_regional_endpoint` argument. The ability to use the global S3 endpoint will be removed in `v7.0.0`.
+```

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -491,7 +491,20 @@ func configure(ctx context.Context, provider *schema.Provider, d *schema.Resourc
 	}
 
 	if v, ok := d.Get("s3_us_east_1_regional_endpoint").(string); ok && v != "" {
-		config.S3USEast1RegionalEndpoint = conns.NormalizeS3USEast1RegionalEndpoint(v)
+		endpoint := conns.NormalizeS3USEast1RegionalEndpoint(v)
+		if endpoint == "legacy" {
+			diags = append(diags,
+				errs.NewAttributeWarningDiagnostic(
+					cty.GetAttrPath("s3_us_east_1_regional_endpoint"),
+					"Global S3 Endpoint Support Deprecated",
+					"Support for the global S3 endpoint is deprecated. The \"s3_us_east_1_regional_endpoint\" "+
+						"argument will be removed in a future major version. Remove this argument from the "+
+						"configuration, or set it to \"regional\" to verify connectivity with the regional "+
+						"S3 endpoint instead.",
+				),
+			)
+		}
+		config.S3USEast1RegionalEndpoint = endpoint
 	}
 
 	if v, ok := d.GetOk("allowed_account_ids"); ok && v.(*schema.Set).Len() > 0 {

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -21,6 +21,7 @@ Upgrade topics:
 - [AWS OpsWorks Stacks End of Life](#aws-opsworks-stacks-end-of-life)
 - [AWS CloudWatch Evidently Deprecation](#aws-cloudwatch-evidently-deprecation)
 - [Amazon Elastic Transcoder Deprecation](#amazon-elastic-transcoder-deprecation)
+- [S3 Global Endpoint Support Deprecation](#s3-global-endpoint-support-deprecation)
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
@@ -171,6 +172,13 @@ The following resources have been deprecated and will be removed in a future maj
 * `aws_elastictranscoder_preset`
 
 Use [AWS Elemental MediaConvert](https://aws.amazon.com/blogs/media/migrating-workflows-from-amazon-elastic-transcoder-to-aws-elemental-mediaconvert/) instead.
+
+## S3 Global Endpoint Support Deprecation
+
+Support for the global S3 endpoint is deprecated, along with the `s3_us_east_1_regional_endpoint` argument.
+The ability to use the global S3 endpoint will be removed in `v7.0.0`.
+This change only affects S3 resources in `us-east-1` (excluding directory buckets), where `s3_us_east_1_regional_endpoint` is set to `legacy` in the provider configuration.
+Impacted configurations can remove the `s3_us_east_1_regional_endpoint` provider argument, or switch the value to `regional` to verify connectivity with the regional S3 endpoint in `us-east-1` prior to this option being removed.
 
 ## data-source/aws_ami
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -365,11 +365,12 @@ In addition to [generic `provider` arguments](https://www.terraform.io/docs/conf
 * `s3_use_path_style` - (Optional) Whether to enable the request to use path-style addressing, i.e., `https://s3.amazonaws.com/BUCKET/KEY`.
   By default, the S3 client will use virtual hosted bucket addressing, `https://BUCKET.s3.amazonaws.com/KEY`, when possible.
   Specific to the Amazon S3 service.
-* `s3_us_east_1_regional_endpoint` - (Optional) Specifies whether S3 API calls in the `us-east-1` Region use the legacy global endpoint or a regional endpoint.
+* `s3_us_east_1_regional_endpoint` - (Optional, **Deprecated**) Specifies whether S3 API calls in the `us-east-1` Region use the legacy global endpoint or a regional endpoint.
   Valid values are `legacy` or `regional`.
   If omitted, the default behavior in the `us-east-1` Region is to use the global endpoint for general purpose buckets and the regional endpoint for directory buckets.
   Can also be configured using the `AWS_S3_US_EAST_1_REGIONAL_ENDPOINT` environment variable or the `s3_us_east_1_regional_endpoint` shared config file parameter.
   Specific to the Amazon S3 service.
+  This argument and the ability to use the global S3 endpoint are deprecated and will be removed in `v7.0.0`.
 * `secret_key` - (Optional) AWS secret key. Can also be set with the `AWS_SECRET_ACCESS_KEY` environment variable, or via a shared configuration and credentials files if `profile` is used. See also `access_key`.
 * `shared_config_files` - (Optional) List of paths to AWS shared config files. If not set, the default is `[~/.aws/config]`. A single value can also be set with the `AWS_CONFIG_FILE` environment variable.
 * `shared_credentials_files` - (Optional) List of paths to the shared credentials file. If not set and a profile is used, the default value is `[~/.aws/credentials]`. A single value can also be set with the `AWS_SHARED_CREDENTIALS_FILE` environment variable.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
In `v6.0.0` support for the `s3_us_east_1_regional_endpoint` provider argument, and the ability to use the global S3 endpoint is being deprecated. This argument will be removed in `v7.0.0`.

If `s3_us_east_1_regional_endpoint` is configured with a value of `legacy`, a warning diagnostic will now be returned indicating that support for the global S3 endpoint is deprecated and instructions on how to validate that the regional S3 endpoint is functional in a given AWS environment.

<img width="803" alt="image" src="https://github.com/user-attachments/assets/4302e33e-3cc4-4ccf-830f-1d41aa4b154a" />

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #33305
Relates https://github.com/hashicorp/terraform-provider-aws/issues/33028

