### PR TITLE
feat: add missing target key in aws_fis_experiment_template

### DIFF
--- a/.changelog/42376.txt
+++ b/.changelog/42376.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_fis_experiment_template: Add support for `ManagedResources` to `action.*.target`
+```

--- a/internal/service/fis/experiment_template.go
+++ b/internal/service/fis/experiment_template.go
@@ -1330,6 +1330,7 @@ func validExperimentTemplateActionTargetKey() schema.SchemaValidateFunc {
 		"Clusters",
 		"DBInstances",
 		"Instances",
+		"ManagedResources",
 		"Nodegroups",
 		"Pods",
 		"ReplicationGroups",

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -1258,7 +1258,7 @@ resource "aws_fis_experiment_template" "test" {
 
     parameter {
       key   = "availabilityZoneIdentifier"
-      value = data.aws_availability_zones.available.names[0] 
+      value = data.aws_availability_zones.available.names[0]
     }
 
     parameter {

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -284,7 +284,7 @@ func TestAccFISExperimentTemplate_managedResource(t *testing.T) {
 		CheckDestroy:             testAccCheckExperimentTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, "nlb custom resource creation", "nlb-zonal-shift", "nlb zonal shift", "aws:arc:start-zonal-autoshift", "ManagedResources", "target_0", "duration", "PT1M", "managedResourceTypes", "NLB", "availabilityZoneIdentifier", "us-west-2a", "aws:arc:zonal-shift-managed-resource", "ALL"),
+				Config: testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, "nlb custom resource creation", "nlb-zonal-shift", "nlb zonal shift", "aws:arc:start-zonal-autoshift", "ManagedResources", "target_0", names.AttrDuration, "PT1M", "managedResourceTypes", "NLB", "availabilityZoneIdentifier", "us-west-2a", "aws:arc:zonal-shift-managed-resource", "ALL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccExperimentTemplateExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "nlb custom resource creation"),
@@ -298,7 +298,7 @@ func TestAccFISExperimentTemplate_managedResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.key", "availabilityZoneIdentifier"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.value", "us-west-2a"),
-					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.1.key", "duration"),
+					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.1.key", names.AttrDuration),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.1.value", "PT1M"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.start_after.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.target.0.key", "ManagedResources"),

--- a/internal/service/fis/experiment_template_test.go
+++ b/internal/service/fis/experiment_template_test.go
@@ -284,7 +284,7 @@ func TestAccFISExperimentTemplate_managedResource(t *testing.T) {
 		CheckDestroy:             testAccCheckExperimentTemplateDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, "nlb custom resource creation", "nlb-zonal-shift", "nlb zonal shift", "aws:arc:start-zonal-autoshift", "ManagedResources", "target_0", names.AttrDuration, "PT1M", "managedResourceTypes", "NLB", "availabilityZoneIdentifier", "us-west-2a", "aws:arc:zonal-shift-managed-resource", "ALL"),
+				Config: testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, "nlb custom resource creation", "nlb-zonal-shift", "nlb zonal shift", "aws:arc:start-zonal-autoshift", "ManagedResources", "target_0", names.AttrDuration, "PT1M", "aws:arc:zonal-shift-managed-resource", "ALL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccExperimentTemplateExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "nlb custom resource creation"),
@@ -297,7 +297,6 @@ func TestAccFISExperimentTemplate_managedResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.0.action_id", "aws:arc:start-zonal-autoshift"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.key", "availabilityZoneIdentifier"),
-					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.0.value", "us-west-2a"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.1.key", names.AttrDuration),
 					resource.TestCheckResourceAttr(resourceName, "action.0.parameter.1.value", "PT1M"),
 					resource.TestCheckResourceAttr(resourceName, "action.0.start_after.#", "0"),
@@ -1207,7 +1206,7 @@ resource "aws_fis_experiment_template" "test" {
 `, rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, targetResType, targetSelectMode, targetResTagK, targetResTagV)
 }
 
-func testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, paramK2, paramV2, paramK3, paramV3, targetResType, targetSelectMode string) string {
+func testAccExperimentTemplateConfig_managedResource_loadbalancer(rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, targetResType, targetSelectMode string) string {
 	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 2), fmt.Sprintf(`
 data "aws_partition" "current" {}
 
@@ -1258,20 +1257,20 @@ resource "aws_fis_experiment_template" "test" {
     }
 
     parameter {
-      key   = %[8]q
-      value = %[9]q
+      key   = "availabilityZoneIdentifier"
+      value = data.aws_availability_zones.available.names[0] 
     }
 
     parameter {
-      key   = %[12]q
-      value = %[13]q
+      key   = %[8]q
+      value = %[9]q
     }
   }
 
   target {
     name           = %[7]q
-    resource_type  = %[14]q
-    selection_mode = %[15]q
+    resource_type  = %[10]q
+    selection_mode = %[11]q
 
     resource_arns = tolist([aws_lb.nlb_test.arn])
   }
@@ -1280,7 +1279,7 @@ resource "aws_fis_experiment_template" "test" {
     Name = %[1]q
   }
 }
-`, rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, paramK2, paramV2, paramK3, paramV3, targetResType, targetSelectMode))
+`, rName, desc, actionName, actionDesc, actionID, actionTargetK, actionTargetV, paramK1, paramV1, targetResType, targetSelectMode))
 }
 
 func testAccExperimentTemplateConfig_ExperimentOptions(rName, mode string) string {

--- a/website/docs/r/fis_experiment_template.html.markdown
+++ b/website/docs/r/fis_experiment_template.html.markdown
@@ -207,7 +207,7 @@ For a list of parameters supported by each action, see [AWS FIS actions referenc
 
 #### `target` (`action.*.target`)
 
-* `key` - (Required) Target type. Valid values are `AutoScalingGroups` (EC2 Auto Scaling groups), `Buckets` (S3 Buckets), `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `Nodegroups` (EKS Node groups), `Pods` (EKS Pods), `ReplicationGroups`(ElastiCache Redis Replication Groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets), `Tables` (DynamoDB encrypted global tables), `Tasks` (ECS Tasks), `TransitGateways` (Transit gateways), `Volumes` (EBS Volumes). See the [documentation](https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets) for more details.
+* `key` - (Required) Target type. Valid values are `AutoScalingGroups` (EC2 Auto Scaling groups), `Buckets` (S3 Buckets), `Cluster` (EKS Cluster), `Clusters` (ECS Clusters), `DBInstances` (RDS DB Instances), `Instances` (EC2 Instances), `ManagedResources` (EKS clusters, Application and Network Load Balancers, and EC2 Auto Scaling groups that are enabled for ARC zonal shift), `Nodegroups` (EKS Node groups), `Pods` (EKS Pods), `ReplicationGroups`(ElastiCache Redis Replication Groups), `Roles` (IAM Roles), `SpotInstances` (EC2 Spot Instances), `Subnets` (VPC Subnets), `Tables` (DynamoDB encrypted global tables), `Tasks` (ECS Tasks), `TransitGateways` (Transit gateways), `Volumes` (EBS Volumes). See the [documentation](https://docs.aws.amazon.com/fis/latest/userguide/actions.html#action-targets) for more details.
 * `value` - (Required) Target name, referencing a corresponding target.
 
 ### `stop_condition`


### PR DESCRIPTION
### Description

The resource `aws_fis_experiment_templates` is missing support for a specific action target: `ManagedResources`

### Relations

Closes #42368 

### References

- [Supported action targets](https://docs.aws.amazon.com/fis/latest/userguide/action-sequence.html#action-targets)
- [Validation in Provider](https://github.com/hashicorp/terraform-provider-aws/blob/cb6263a24341a385cd929a477416140389c8c48d/internal/service/fis/experiment_template.go#L1324) missing the relevant action target

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccFISExperimentTemplate_managedResource PKG=fis
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/fis/... -v -count 1 -parallel 20 -run='TestAccFISExperimentTemplate_managedResource'  -timeout 360m -vet=off
2025/04/26 15:16:31 Initializing Terraform AWS Provider...
=== RUN   TestAccFISExperimentTemplate_managedResource
=== PAUSE TestAccFISExperimentTemplate_managedResource
=== CONT  TestAccFISExperimentTemplate_managedResource
--- PASS: TestAccFISExperimentTemplate_managedResource (216.00s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/fis        216.148s
```
