### PR TITLE
docs(aws_bedrockagent_data_source): update valid values for data_source_configuration.type

### DIFF
--- a/website/docs/r/bedrockagent_data_source.html.markdown
+++ b/website/docs/r/bedrockagent_data_source.html.markdown
@@ -46,7 +46,7 @@ The following arguments are optional:
 
 The `data_source_configuration` configuration block supports the following arguments:
 
-* `type` - (Required) Type of storage for the data source. Valid values: `S3`.
+* `type` - (Required) Type of storage for the data source. Valid values: `S3`, `WEB`, `CONFLUENCE`, `SALESFORCE`, `SHAREPOINT`, `CUSTOM`, `REDSHIFT_METADATA`.
 * `confluence_configuration` - (Optional) Details about the configuration of the Confluence data source. See [`confluence_data_source_configuration` block](#confluence_data_source_configuration-block) for details.
 * `s3_configuration` - (Optional) Details about the configuration of the S3 object containing the data source. See [`s3_data_source_configuration` block](#s3_data_source_configuration-block) for details.
 * `salesforce_configuration` - (Optional) Details about the configuration of the Salesforce data source. See [`salesforce_data_source_configuration` block](#salesforce_data_source_configuration-block) for details.


### PR DESCRIPTION
### Description
This PR updates the documentation for `aws_bedrockagent_data_source` to include all valid values for `data_source_configuration.type`. Previously, only `S3` was listed, but additional valid types are available.

### References
Link to AWS Documentation -https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent_DataSourceConfiguration.html#API_agent_DataSourceConfiguration_Contents
