### PR TITLE
D imagebuilder infrastructure configuration placement

### DIFF
--- a/internal/service/imagebuilder/infrastructure_configuration_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_test.go
@@ -347,6 +347,150 @@ func TestAccImageBuilderInfrastructureConfiguration_LoggingS3Logs_s3KeyPrefix(t 
 	})
 }
 
+func TestAccImageBuilderInfrastructureConfiguration_placementTenancy(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInfrastructureConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementTenancy(rName, "default"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "default"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementTenancy(rName, "dedicated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "dedicated"),
+				),
+			},
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementTenancy(rName, "host"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "host"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderInfrastructureConfiguration_placementAvailabilityZone(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	availabilityZonesDataSourceName := "data.aws_availability_zones.available"
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInfrastructureConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementAvailabilityZone(rName, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "placement.0.availability_zone", availabilityZonesDataSourceName, "names.0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementAvailabilityZone(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "placement.0.availability_zone", availabilityZonesDataSourceName, "names.1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderInfrastructureConfiguration_placementHostResourceGroupArn(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceGroupNme := "aws_resourcegroups_group.test"
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInfrastructureConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementHostResourceGroupArn(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "host"),
+					resource.TestCheckResourceAttrPair(resourceName, "placement.0.host_resource_group_arn", resourceGroupNme, names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccImageBuilderInfrastructureConfiguration_placementHostId(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	hostName := "aws_ec2_host.test"
+	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInfrastructureConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInfrastructureConfigurationConfig_placementHostId(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "host"),
+					resource.TestCheckResourceAttrPair(resourceName, "placement.0.host_id", hostName, names.AttrID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccImageBuilderInfrastructureConfiguration_resourceTags(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -571,42 +715,6 @@ func TestAccImageBuilderInfrastructureConfiguration_terminateInstanceOnFailure(t
 					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
 					acctest.CheckResourceAttrRFC3339(resourceName, "date_updated"),
 					resource.TestCheckResourceAttr(resourceName, "terminate_instance_on_failure", acctest.CtFalse),
-				),
-			},
-		},
-	})
-}
-
-func TestAccImageBuilderInfrastructureConfiguration_placement(t *testing.T) {
-	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_imagebuilder_infrastructure_configuration.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.ImageBuilderServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckInfrastructureConfigurationDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInfrastructureConfigurationConfig_placement(rName, "dedicated"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "dedicated"),
-					resource.TestCheckResourceAttr(resourceName, "placement.0.availability_zone", acctest.Region()+"a"),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccInfrastructureConfigurationConfig_placement(rName, "default"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckInfrastructureConfigurationExists(ctx, resourceName),
-					resource.TestCheckResourceAttr(resourceName, "placement.0.tenancy", "default"),
-					resource.TestCheckResourceAttr(resourceName, "placement.0.availability_zone", acctest.Region()+"a"),
 				),
 			},
 		},
@@ -885,6 +993,91 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
 `, rName))
 }
 
+func testAccInfrastructureConfigurationConfig_placementTenancy(rName string, tenancy string) string {
+	return acctest.ConfigCompose(
+		testAccInfrastructureConfigurationConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+
+  placement {
+    tenancy = %[2]q
+  }
+}
+`, rName, tenancy))
+}
+
+func testAccInfrastructureConfigurationConfig_placementAvailabilityZone(rName string, azIndex int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptIn(),
+		testAccInfrastructureConfigurationConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+
+  placement {
+    availability_zone = data.aws_availability_zones.available.names[%[2]d]
+  }
+}
+`, rName, azIndex))
+}
+
+func testAccInfrastructureConfigurationConfig_placementHostResourceGroupArn(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInfrastructureConfigurationConfig_base(rName),
+		fmt.Sprintf(`
+resource "aws_resourcegroups_group" "test" {
+  name = %[1]q
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = ["AWS::EC2::Instance"]
+      TagFilters = [
+        {
+          Key    = "Stage"
+          Values = ["Test"]
+        },
+      ]
+    })
+  }
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+
+  placement {
+    tenancy                 = "host"
+    host_resource_group_arn = aws_resourcegroups_group.test.arn
+  }
+}
+`, rName))
+}
+
+func testAccInfrastructureConfigurationConfig_placementHostId(rName string) string {
+	return acctest.ConfigCompose(
+		testAccInfrastructureConfigurationConfig_base(rName),
+		acctest.ConfigAvailableAZsNoOptIn(),
+		fmt.Sprintf(`
+resource "aws_ec2_host" "test" {
+  availability_zone = data.aws_availability_zones.available.names[1]
+  instance_type     = "a1.medium"
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "test" {
+  instance_profile_name = aws_iam_instance_profile.test.name
+  name                  = %[1]q
+
+  placement {
+    tenancy = "host"
+    host_id = aws_ec2_host.test.id
+  }
+}
+`, rName))
+}
+
 func testAccInfrastructureConfigurationConfig_resourceTags(rName string, resourceTagKey string, resourceTagValue string) string {
 	return acctest.ConfigCompose(
 		testAccInfrastructureConfigurationConfig_base(rName),
@@ -1065,22 +1258,4 @@ resource "aws_imagebuilder_infrastructure_configuration" "test" {
   terminate_instance_on_failure = %[2]t
 }
 `, rName, terminateInstanceOnFailure))
-}
-
-func testAccInfrastructureConfigurationConfig_placement(rName, tenancy string) string {
-	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptIn(),
-		testAccInfrastructureConfigurationConfig_base(rName),
-		fmt.Sprintf(`
-data "aws_region" "current" {}
-
-resource "aws_imagebuilder_infrastructure_configuration" "test" {
-  instance_profile_name = aws_iam_instance_profile.test.name
-  name                  = %[1]q
-  placement {
-    tenancy           = %[2]q
-    availability_zone = data.aws_availability_zones.available.names[0]
-  }
-}
-`, rName, tenancy))
 }

--- a/internal/service/imagebuilder/infrastructure_configuration_test.go
+++ b/internal/service/imagebuilder/infrastructure_configuration_test.go
@@ -43,6 +43,7 @@ func TestAccImageBuilderInfrastructureConfiguration_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "instance_types.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "key_pair", ""),
 					resource.TestCheckResourceAttr(resourceName, "logging.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "placement.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "resource_tags.%", "0"),
 					resource.TestCheckResourceAttr(resourceName, "security_group_ids.#", "0"),

--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -72,7 +72,7 @@ The following arguments are required:
 
 * `s3_logs` - (Required) Configuration block with S3 logging settings. Detailed below.
 
-### s3_logs
+#### s3_logs
 
 The following arguments are required:
 

--- a/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
+++ b/website/docs/r/imagebuilder_infrastructure_configuration.html.markdown
@@ -51,7 +51,7 @@ The following arguments are optional:
 * `instance_types` - (Optional) Set of EC2 Instance Types.
 * `key_pair` - (Optional) Name of EC2 Key Pair.
 * `logging` - (Optional) Configuration block with logging settings. Detailed below.
-* `placement` - (Optional) Configuration block with placement settings that define where the instances that are launched from your image will run. Detailed below.
+* `placement` - (Optional) Configuration block with placement settings that define where the build and test instances for your image will run. Detailed below.
 * `resource_tags` - (Optional) Key-value map of resource tags to assign to infrastructure created by the configuration.
 * `security_group_ids` - (Optional) Set of EC2 Security Group identifiers.
 * `sns_topic_arn` - (Optional) Amazon Resource Name (ARN) of SNS Topic.
@@ -84,12 +84,14 @@ The following arguments are optional:
 
 ### placement
 
+~> **NOTE:**  If tenancy is set to `host`, then you can optionally specify one target for placement – either `host_id` or `host_resource_group_arn`. If automatic placement is enabled for your host, and you don't specify any placement target, Amazon EC2 will try to find an available host for your build and test instances.
+
 The following arguments are optional:
 
 * `availability_zone` - (Optional) Availability Zone where your build and test instances will launch.
-* `host_id` - (Optional) ID of the Dedicated Host on which build and test instances run. Conflicts with `host_resource_group_arn`.
-* `host_resource_group_arn` - (Optional) ARN of the host resource group in which to launch build and test instances. Conflicts with `host_id`.
-* `tenancy` - (Optional) Placement tenancy of the instance. Valid values: `default`, `dedicated` and `host`.
+* `host_id` - (Optional) ID of the Dedicated Host on which build and test instances run.
+* `host_resource_group_arn` - (Optional) ARN of the host resource group in which to launch build and test instances.
+* `tenancy` - (Optional) Placement tenancy of the instance. Valid Values: `default`, `dedicated`, `host`. An instance with `default` tenancy runs on shared tenancy hardware. An instance with a tenancy of `dedicated` runs on single-tenant hardware. An instance with a tenancy of `host` runs on a Dedicated Host.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Improves the documentation and acceptance tests for the `placement` argument block on the `aws_imagebuilder_infrastructure_configuration` resource.  

I had been working on changes very similar to PR #42347 so I refactored this one to just the meaningful improvements.   This PR improves the website docs for the new argument block with information from the API spec--including a warning about conflicting settings between the `host_resource_group_arn` and `host_id` sub-arguments.  The current acceptance tests for the placement block are also incomplete (doesn't test all arguments) and potentially faulty due to a static "a" string.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40361

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
[Image Builder API Docs - Placement Object](https://docs.aws.amazon.com/imagebuilder/latest/APIReference/API_Placement.html)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccImageBuilderInfrastructureConfiguration PKG=imagebuilder

...
```
