### PR TITLE
Support for metric period value 20 - #42389

### DIFF
--- a/.changelog/42390.txt
+++ b/.changelog/42390.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_route53_health_check: The `period` attribute for value 20s is not supported, which differs from AWS API doc. The all configurations using `period` should support 20s to align with AWS doc
+resource/aws_cloudwatch_metric_alarm: Support `20` as a valid value for `metric_query.metric.period`, `metric_query.period`, and `period`
 ```

--- a/.changelog/42390.txt
+++ b/.changelog/42390.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53_health_check: The `period` attribute for value 20s is not supported, which differs from AWS API doc. The all configurations using `period` should support 20s to align with AWS doc
+```

--- a/internal/service/cloudwatch/metric_alarm.go
+++ b/internal/service/cloudwatch/metric_alarm.go
@@ -181,7 +181,7 @@ func resourceMetricAlarm() *schema.Resource {
 										Type:     schema.TypeInt,
 										Required: true,
 										ValidateFunc: validation.Any(
-											validation.IntInSlice([]int{1, 5, 10, 30}),
+											validation.IntInSlice([]int{1, 5, 10, 20, 30}),
 											validation.IntDivisibleBy(60),
 										),
 									},
@@ -215,7 +215,7 @@ func resourceMetricAlarm() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 							ValidateFunc: validation.Any(
-								validation.IntInSlice([]int{1, 5, 10, 30}),
+								validation.IntInSlice([]int{1, 5, 10, 20, 30}),
 								validation.IntDivisibleBy(60),
 							),
 						},
@@ -253,7 +253,7 @@ func resourceMetricAlarm() *schema.Resource {
 				Optional:      true,
 				ConflictsWith: []string{"metric_query"},
 				ValidateFunc: validation.Any(
-					validation.IntInSlice([]int{10, 30}),
+					validation.IntInSlice([]int{10, 20, 30}),
 					validation.IntDivisibleBy(60),
 				),
 			},

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -183,7 +183,7 @@ This resource supports the following arguments:
 * `namespace` - (Optional) The namespace for the alarm's associated metric. See docs for the [list of namespaces](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/aws-namespaces.html).
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `period` - (Optional) The period in seconds over which the specified `statistic` is applied.
-  Valid values are `10`, `30`, or any multiple of `60`.
+  Valid values are `10`, `20`, `30`, or any multiple of `60`.
 * `statistic` - (Optional) The statistic to apply to the alarm's associated metric.
    Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`
 * `threshold` - (Optional) The value against which the specified statistic is compared. This parameter is required for alarms based on static thresholds, but should not be used for alarms based on anomaly detection models.
@@ -218,7 +218,7 @@ The following values are supported: `ignore`, and `evaluate`.
 * `metric` - (Optional) The metric to be returned, along with statistics, period, and units. Use this parameter only if this object is retrieving a metric and not performing a math expression on returned data.
 * `period` - (Optional) Granularity in seconds of returned data points.
   For metrics with regular resolution, valid values are any multiple of `60`.
-  For high-resolution metrics, valid values are `1`, `5`, `10`, `30`, or any multiple of `60`.
+  For high-resolution metrics, valid values are `1`, `5`, `10`, `20`, `30`, or any multiple of `60`.
 * `return_data` - (Optional) Specify exactly one `metric_query` to be `true` to use that `metric_query` result as the alarm.
 
 ~> **NOTE:**  You must specify either `metric` or `expression`. Not both.
@@ -232,7 +232,7 @@ The following values are supported: `ignore`, and `evaluate`.
   See docs for [supported metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CW_Support_For_AWS.html).
 * `period` - (Required) Granularity in seconds of returned data points.
   For metrics with regular resolution, valid values are any multiple of `60`.
-  For high-resolution metrics, valid values are `1`, `5`, `10`, `30`, or any multiple of `60`.
+  For high-resolution metrics, valid values are `1`, `5`, `10`, `20`, `30`, or any multiple of `60`.
 * `stat` - (Required) The statistic to apply to this metric.
    See docs for [supported statistics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html).
 * `unit` - (Optional) The unit for this metric.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

To support both API PutMetricAlarm, MetricDataQuery for period value 20

https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html

https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDataQuery.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42389

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

Will need help with acceptance test