### PR TITLE
added example - route53-targetgroup-alb-integration

### DIFF
--- a/examples/route53-targetgroup-alb-integration/main.tf
+++ b/examples/route53-targetgroup-alb-integration/main.tf
@@ -1,0 +1,48 @@
+provider "aws" {
+  region = "ap-south-1"
+}
+# Route53 A record creation
+resource "aws_route53_record" "new_record" {
+  zone_id = var.hostedzone_id
+  name    = var.record_name
+  type    = "A"
+
+  alias {
+    name                   = var.loadbalancer_name
+    zone_id                = var.loadbalancer_zoneid
+    evaluate_target_health = true
+  }
+}
+
+# Target group creation
+resource "aws_lb_target_group" "new_target_group" {
+  name        = var.target_group_name
+  port        = var.target_group_port
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+}
+
+# Attaching target group to the ALB
+resource "aws_lb_target_group_attachment" "attach_target_group" {
+  target_group_arn = aws_lb_target_group.new_target_group.arn
+  target_id        = var.target_ins_ip
+  port             = var.target_group_port
+}
+
+
+# Adding rule to alb listener
+resource "aws_lb_listener_rule" "host_header_rule" {
+  listener_arn = var.alb_https_listener_arn
+  priority     = var.rule_priority
+  condition {
+    host_header {
+      values = [var.record_name]
+    }
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.new_target_group.arn
+  }
+}

--- a/examples/route53-targetgroup-alb-integration/readme.md
+++ b/examples/route53-targetgroup-alb-integration/readme.md
@@ -1,0 +1,57 @@
+# Example: Route53 + Target Group + ALB Listener Integration
+
+This example demonstrates how to create a Route53 DNS record, a Target Group, and associate them with an ALB Listener using Terraform. It's a complete setup to expose your application behind an Application Load Balancer with a custom domain.
+
+## Components
+
+- **Route53 Record** – Points your domain (e.g., `app.example.com`) to the ALB
+- **Target Group** – Forwards traffic to registered targets (EC2 instances)
+- **ALB Listener** – Listens for HTTP/HTTPS traffic on the ALB
+
+## 🛠️ Getting Started
+
+1. **Clone this repository** or copy the example into your Terraform project.
+
+2. **Modify `terraform.tfvars`**
+   Update the variables such as:
+   - `alb_listener_arn`
+   - `vpc_id`
+   - `domain_name`
+   - `hosted_zone_id`
+   - `targets` (IP or instance IDs)
+
+3. **Initialize Terraform**
+
+   ```hcl
+   terraform init
+   ```
+
+4. **Format File**
+
+   ```hcl
+   terraform fmt
+   ```
+
+5. **Validate Terraform**
+
+   ```hcl
+   terraform validate
+   ```
+
+6. **Review the execution plan**
+
+   ```hcl
+   terraform plan
+   ```
+
+7. **Apply the configuration**
+
+   ```hcl
+   terraform apply
+   ```
+
+8. **Verify**
+   - The ALB listener should forward traffic to the registered targets.
+   - A Route53 DNS record should be created pointing to the ALB.
+
+---

--- a/examples/route53-targetgroup-alb-integration/terraform.template.tfvars
+++ b/examples/route53-targetgroup-alb-integration/terraform.template.tfvars
@@ -1,0 +1,12 @@
+# All variables in this file are dummy values for example and should be replaced with actual values before use.
+
+hostedzone_id          = "5UW8UXQ4EHXQ4E"
+record_name            = "terraform.example.com"
+loadbalancer_name      = "alb-2.ap-south-1.elb.amazonaws.com"
+loadbalancer_zoneid    = "SIOSIUHBXB"
+target_group_name      = "terraform-demo-tg"
+target_group_port      = "8102"
+vpc_id                 = "vpc-9jdjojohcniuee"
+target_ins_ip          = "10.30.0.1"
+alb_https_listener_arn = "arn:aws:elasticloadbalancing:ap-south-1:88180000:listener/app/alb-2/ecsdqwe/3fwdq36c4"
+rule_priority          = "26"

--- a/examples/route53-targetgroup-alb-integration/variables.tf
+++ b/examples/route53-targetgroup-alb-integration/variables.tf
@@ -1,0 +1,52 @@
+# Route53 variables
+variable "hostedzone_id" {
+  description = "value of hosted zone id"
+  type        = string
+}
+
+variable "record_name" {
+  description = "value of record name"
+  type        = string
+}
+
+variable "loadbalancer_name" {
+  description = "value of load balancer name"
+  type        = string
+}
+
+variable "loadbalancer_zoneid" {
+  description = "value of load balancer zone id"
+  type        = string
+}
+
+# Target group variables
+variable "target_group_name" {
+  description = "value of target group name"
+  type        = string
+}
+
+variable "target_group_port" {
+  description = "value of target group port"
+  type        = number
+}
+
+variable "vpc_id" {
+  description = "value of vpc id"
+  type        = string
+}
+
+variable "target_ins_ip" {
+  description = "value of target instance ip"
+  type        = string
+}
+
+# ALB variables
+variable "alb_https_listener_arn" {
+  description = "value of alb https listener arn"
+  type        = string
+}
+
+variable "rule_priority" {
+  description = "value of rule priority"
+  type        = string
+}


### PR DESCRIPTION
# Description

This pull request adds a new example to demonstrate how to integrate **Route53 DNS record**, **Target Group**, and an **ALB Listener** using Terraform. The example includes a fully working setup to expose your application behind an AWS Application Load Balancer with a custom domain.