### PR TITLE
Fix aws_eks_cluster documentation to use correct aws_iam_role variable name (#42395)

### DIFF
--- a/website/docs/r/eks_cluster.html.markdown
+++ b/website/docs/r/eks_cluster.html.markdown
@@ -24,7 +24,7 @@ resource "aws_eks_cluster" "example" {
     authentication_mode = "API"
   }
 
-  role_arn = aws_iam_role.example.arn
+  role_arn = aws_iam_role.cluster.arn
   version  = "1.31"
 
   vpc_config {
@@ -275,7 +275,7 @@ resource "aws_eks_cluster" "example" {
     authentication_mode = "CONFIG_MAP"
   }
 
-  role_arn = aws_iam_role.example.arn
+  role_arn = aws_iam_role.cluster.arn
   version  = "1.31"
 
   vpc_config {


### PR DESCRIPTION
This PR fixes an incorrect variable name in the aws_eks_cluster documentation example.

- Replaces `aws_iam_role.example.arn` with `aws_iam_role.cluster.arn` to match the correct variable declaration.

Fixes #42395
