### PR TITLE
Clarify accepted values for kms_key_id in aws_cloudwatch_log_group documentation (#41606)

### DIFF
--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -34,8 +34,10 @@ This resource supports the following arguments:
 * `retention_in_days` - (Optional) Specifies the number of days
   you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0.
   If you select 0, the events in the log group are always retained and never expire.
-* `kms_key_id` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
-AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
+* `kms_key_id` - (Optional) The Amazon Resource Name (ARN), Key ID, or alias ARN of the AWS KMS Key to use when encrypting log data. 
+Please note, after the AWS KMS CMK is disassociated from the log group, 
+AWS CloudWatch Logs stops encrypting newly ingested data for the log group. 
+All previously ingested data remains encrypted, and AWS CloudWatch Logs requires 
 permissions for the CMK whenever the encrypted data is requested.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 


### PR DESCRIPTION
This PR improves the documentation for the `kms_key_id` attribute of the `aws_cloudwatch_log_group` resource.

Changes:
- Clarifies that the `kms_key_id` field accepts a Key ID, full ARN, or alias ARN.
- Keeps the existing description about the behavior after key disassociation.

This clarification aligns the documentation with AWS's accepted input formats for KMS keys in CloudWatch Logs.

Fixes #41606
