### PR TITLE
Clarify single administrative user limitation for RabbitMQ brokers #41374

### DIFF
--- a/website/docs/r/mq_broker.html.markdown
+++ b/website/docs/r/mq_broker.html.markdown
@@ -8,11 +8,19 @@ description: |-
 
 # Resource: aws_mq_broker
 
-Provides an Amazon MQ broker resource. This resources also manages users for the broker.
+Provides an Amazon MQ broker resource. This resource manages broker users at creation time. For RabbitMQ brokers, only one administrative user can be created during provisioning.
 
 -> For more information on Amazon MQ, see [Amazon MQ documentation](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/welcome.html).
 
 ~> **NOTE:** Amazon MQ currently places limits on **RabbitMQ** brokers. For example, a RabbitMQ broker cannot have: instances with an associated IP address of an ENI attached to the broker, an associated LDAP server to authenticate and authorize broker connections, storage type `EFS`, or audit logging. Although this resource allows you to create RabbitMQ users, RabbitMQ users cannot have console access or groups. Also, Amazon MQ does not return information about RabbitMQ users so drift detection is not possible.
+
+~> **NOTE:** When using Amazon MQ with `engine_type = "RabbitMQ"`:
+>
+> - Only **one administrative user** can be created during the broker's initial provisioning.
+> - Additional users must be created via the [RabbitMQ Management API](https://www.rabbitmq.com/management.html) or the Amazon MQ console after the broker is provisioned.
+> - Terraform cannot update or manage users after broker creation. Any changes to the `user` block will trigger full broker recreation (`ForceNew` behavior).
+> - Amazon MQ does not return RabbitMQ user information via APIs, making drift detection for users impossible.
+
 
 ~> **NOTE:** Changes to an MQ Broker can occur when you change a parameter, such as `configuration` or `user`, and are reflected in the next maintenance window. Because of this, Terraform may report a difference in its planning phase because a modification has not yet taken place. You can use the `apply_immediately` flag to instruct the service to apply the change immediately (see documentation below). Using `apply_immediately` can result in a brief downtime as the broker reboots.
 
@@ -203,7 +211,6 @@ The following arguments are required:
 * `replication_user` - (Optional) Whether to set set replication user. Defaults to `false`.
 * `username` - (Required) Username of the user.
 
-~> **NOTE:** AWS currently does not support updating RabbitMQ users. Updates to users can only be in the RabbitMQ UI.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Fixes [#41374](https://github.com/hashicorp/terraform-provider-aws/issues/41374).

This PR updates the documentation for the `aws_mq_broker` resource to clarify that when using Amazon MQ with `engine_type = "RabbitMQ"`, only **one administrative user** can be created during broker provisioning.

Specifically:
- Adds a new detailed note explaining that:
  - Only one admin user is allowed at creation time for RabbitMQ brokers.
  - Additional users must be created after provisioning via the RabbitMQ Management API or Amazon MQ console.
  - Terraform cannot manage users post-provisioning; modifying the `user` block triggers full broker recreation (`ForceNew` behavior).
  - Amazon MQ does not expose RabbitMQ users via APIs, making drift detection impossible.
- Updates the initial resource description to clarify that user management happens only at creation time.
- Removes the redundant `NOTE` at the end of the `user` block, now covered by the more detailed note earlier in the documentation.

References:
- [AWS CloudFormation documentation for AWS::AmazonMQ::Broker.User](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-amazonmq-broker-user.html)
