### PR TITLE
[Enhancement] WAFv2: Support URI fragment field matching in aws_wafv2_web_acl and aws_wafv2_rule_group resources

### DIFF
--- a/.changelog/42407.txt
+++ b/.changelog/42407.txt
@@ -1,0 +1,8 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Add `uri_fragment` argument into `field_to_match` block.
+```
+
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Add `uri_fragment` argument into `field_to_match` block.
+```
+

--- a/.changelog/42407.txt
+++ b/.changelog/42407.txt
@@ -1,8 +1,8 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Add `uri_fragment` argument into `field_to_match` block.
+resource/aws_wafv2_web_acl: Add `uri_fragment` to `field_to_match` configuration blocks
 ```
 
 ```release-note:enhancement
-resource/aws_wafv2_rule_group: Add `uri_fragment` argument into `field_to_match` block.
+resource/aws_wafv2_rule_group: Add `uri_fragment` to `field_to_match` configuration blocks
 ```
 

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -594,6 +594,10 @@ func expandFieldToMatch(l []any) *awstypes.FieldToMatch {
 		f.SingleQueryArgument = expandSingleQueryArgument(m["single_query_argument"].([]any))
 	}
 
+	if v, ok := m["uri_fragment"]; ok && len(v.([]any)) > 0 {
+		f.UriFragment = expandUriFragment(v.([]any))
+	}
+
 	if v, ok := m["uri_path"]; ok && len(v.([]any)) > 0 {
 		f.UriPath = &awstypes.UriPath{}
 	}
@@ -775,6 +779,21 @@ func expandSingleQueryArgument(l []any) *awstypes.SingleQueryArgument {
 	return &awstypes.SingleQueryArgument{
 		Name: aws.String(m[names.AttrName].(string)),
 	}
+}
+
+func expandUriFragment(tfList []any) *awstypes.UriFragment {
+	if len(tfList) == 0 || tfList[0] == nil {
+		return nil
+	}
+	tfMap := tfList[0].(map[string]any)
+
+	apiObject := &awstypes.UriFragment{}
+
+	if v, ok := tfMap["fallback_behavior"].(string); ok && v != "" {
+		apiObject.FallbackBehavior = awstypes.FallbackBehavior(v)
+	}
+
+	return apiObject
 }
 
 func expandTextTransformations(l []any) []awstypes.TextTransformation {
@@ -2193,6 +2212,10 @@ func flattenFieldToMatch(f *awstypes.FieldToMatch) any {
 		m["single_query_argument"] = flattenSingleQueryArgument(f.SingleQueryArgument)
 	}
 
+	if f.UriFragment != nil {
+		m["uri_fragment"] = flattenUriFragment(f.UriFragment)
+	}
+
 	if f.UriPath != nil {
 		m["uri_path"] = make([]map[string]any, 1)
 	}
@@ -2347,6 +2370,19 @@ func flattenSingleQueryArgument(s *awstypes.SingleQueryArgument) any {
 	}
 
 	return []any{m}
+}
+
+func flattenUriFragment(apiObject *awstypes.UriFragment) any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfMap := map[string]any{}
+
+	if v := apiObject.FallbackBehavior; v != "" {
+		tfMap["fallback_behavior"] = v
+	}
+	return []any{tfMap}
 }
 
 func flattenTextTransformations(l []awstypes.TextTransformation) []any {

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -595,7 +595,7 @@ func expandFieldToMatch(l []any) *awstypes.FieldToMatch {
 	}
 
 	if v, ok := m["uri_fragment"]; ok && len(v.([]any)) > 0 {
-		f.UriFragment = expandUriFragment(v.([]any))
+		f.UriFragment = expandURIFragment(v.([]any))
 	}
 
 	if v, ok := m["uri_path"]; ok && len(v.([]any)) > 0 {
@@ -781,7 +781,7 @@ func expandSingleQueryArgument(l []any) *awstypes.SingleQueryArgument {
 	}
 }
 
-func expandUriFragment(tfList []any) *awstypes.UriFragment {
+func expandURIFragment(tfList []any) *awstypes.UriFragment {
 	if len(tfList) == 0 || tfList[0] == nil {
 		return nil
 	}
@@ -2213,7 +2213,7 @@ func flattenFieldToMatch(f *awstypes.FieldToMatch) any {
 	}
 
 	if f.UriFragment != nil {
-		m["uri_fragment"] = flattenUriFragment(f.UriFragment)
+		m["uri_fragment"] = flattenURIFragment(f.UriFragment)
 	}
 
 	if f.UriPath != nil {
@@ -2372,7 +2372,7 @@ func flattenSingleQueryArgument(s *awstypes.SingleQueryArgument) any {
 	return []any{m}
 }
 
-func flattenUriFragment(apiObject *awstypes.UriFragment) any {
+func flattenURIFragment(apiObject *awstypes.UriFragment) any {
 	if apiObject == nil {
 		return nil
 	}

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -471,6 +471,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":              "0",
 					}),
 				),
@@ -496,6 +497,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":              "0",
 					}),
 				),
@@ -526,6 +528,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                              "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                                   "0",
 					}),
 				),
@@ -573,6 +576,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                  "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":          "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                   "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                       "0",
 					}),
 				),
@@ -604,6 +608,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                              "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                                   "0",
 					}),
 				),
@@ -637,6 +642,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                              "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                                   "0",
 					}),
 				),
@@ -670,6 +676,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                              "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                                   "0",
 					}),
 				),
@@ -699,6 +706,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":              "0",
 					}),
 				),
@@ -724,6 +732,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":          "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":              "0",
 					}),
 				),
@@ -750,6 +759,7 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":         "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.0.name":    "a-forty-character-long-header-name-40-40",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#": "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":          "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":              "0",
 					}),
 				),
@@ -776,7 +786,35 @@ func TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch(t *testing.T) {
 						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":              "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":      "1",
 						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.0.name": "a-max-30-characters-long-name-",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":               "0",
 						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                   "0",
+					}),
+				),
+			},
+			{
+				Config: testAccRuleGroupConfig_byteMatchStatementFieldToMatchURIFragment(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#":                                         "1",
+						"statement.0.byte_match_statement.#":                  "1",
+						"statement.0.byte_match_statement.0.field_to_match.#": "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.all_query_arguments.#":            "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.body.#":                           "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.cookies.#":                        "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.header_order.#":                   "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.headers.#":                        "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.ja3_fingerprint.#":                "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.json_body.#":                      "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.method.#":                         "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.query_string.#":                   "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.single_header.#":                  "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.single_query_argument.#":          "0",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.0.fallback_behavior": "MATCH",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_path.#":                       "0",
 					}),
 				),
 			},
@@ -3830,6 +3868,53 @@ resource "aws_wafv2_rule_group" "test" {
 
         field_to_match {
           uri_path {}
+        }
+
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_byteMatchStatementFieldToMatchURIFragment(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 15
+  name     = %[1]q
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "CONTAINS"
+        search_string         = "word"
+
+        field_to_match {
+          uri_fragment {}
         }
 
         text_transformation {

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -422,6 +422,21 @@ var fieldToMatchBaseSchema = sync.OnceValue(func() *schema.Resource {
 					},
 				},
 			},
+			"uri_fragment": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"fallback_behavior": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Default:          awstypes.FallbackBehaviorMatch,
+							ValidateDiagFunc: enum.Validate[awstypes.FallbackBehavior](),
+						},
+					},
+				},
+			},
 			"uri_path": emptySchema(),
 		},
 	}

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -431,7 +431,7 @@ var fieldToMatchBaseSchema = sync.OnceValue(func() *schema.Resource {
 						"fallback_behavior": {
 							Type:             schema.TypeString,
 							Optional:         true,
-							Default:          awstypes.FallbackBehaviorMatch,
+							Computed:         true,
 							ValidateDiagFunc: enum.Validate[awstypes.FallbackBehavior](),
 						},
 					},

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -1497,6 +1497,54 @@ func TestAccWAFV2WebACL_ByteMatchStatement_headerOrder(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACL_ByteMatchStatement_urlFragment(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_byteMatchStatementUriFragment(webACLName, string(awstypes.FallbackBehaviorMatch)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.0.fallback_behavior": "MATCH",
+					}),
+				),
+			},
+			{
+				Config: testAccWebACLConfig_byteMatchStatementUriFragment(webACLName, string(awstypes.OversizeHandlingNoMatch)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.#":                   "1",
+						"statement.0.byte_match_statement.0.field_to_match.0.uri_fragment.0.fallback_behavior": "NO_MATCH",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func TestAccWAFV2WebACL_GeoMatch_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.WebACL
@@ -3899,6 +3947,57 @@ resource "aws_wafv2_web_acl" "test" {
   }
 }
 `, rName, oversizeHandling)
+}
+
+func testAccWebACLConfig_byteMatchStatementUriFragment(rName, fallbackBehavior string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      byte_match_statement {
+        search_string = "abc"
+        field_to_match {
+          uri_fragment { 
+            fallback_behavior = %[2]q
+          }
+        }
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+        positional_constraint = "STARTS_WITH"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName, fallbackBehavior)
 }
 
 func testAccWebACLConfig_geoMatchStatement(rName, countryCodes string) string {

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -1510,7 +1510,7 @@ func TestAccWAFV2WebACL_ByteMatchStatement_urlFragment(t *testing.T) {
 		CheckDestroy:             testAccCheckWebACLDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccWebACLConfig_byteMatchStatementUriFragment(webACLName, string(awstypes.FallbackBehaviorMatch)),
+				Config: testAccWebACLConfig_byteMatchStatementURIFragment(webACLName, string(awstypes.FallbackBehaviorMatch)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
@@ -1523,7 +1523,7 @@ func TestAccWAFV2WebACL_ByteMatchStatement_urlFragment(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccWebACLConfig_byteMatchStatementUriFragment(webACLName, string(awstypes.OversizeHandlingNoMatch)),
+				Config: testAccWebACLConfig_byteMatchStatementURIFragment(webACLName, string(awstypes.OversizeHandlingNoMatch)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckWebACLExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
@@ -3949,7 +3949,7 @@ resource "aws_wafv2_web_acl" "test" {
 `, rName, oversizeHandling)
 }
 
-func testAccWebACLConfig_byteMatchStatementUriFragment(rName, fallbackBehavior string) string {
+func testAccWebACLConfig_byteMatchStatementURIFragment(rName, fallbackBehavior string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
   name        = %[1]q
@@ -3972,7 +3972,7 @@ resource "aws_wafv2_web_acl" "test" {
       byte_match_statement {
         search_string = "abc"
         field_to_match {
-          uri_fragment { 
+          uri_fragment {
             fallback_behavior = %[2]q
           }
         }

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -581,7 +581,7 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified.
+~> **NOTE:** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, `uri_fragment` or `uri_path` can be specified.
 An empty configuration block `{}` should be used when specifying `all_query_arguments`, `body`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
@@ -596,6 +596,7 @@ An empty configuration block `{}` should be used when specifying `all_query_argu
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Inspect a single header. See [Single Header](#single-header) below for details.
 * `single_query_argument` - (Optional) Inspect a single query argument. See [Single Query Argument](#single-query-argument) below for details.
+* `uri_fragment` - (Optional) Inspect the part of a URL that follows the "#" symbol, providing additional information about the resource. See [URI Fragment](#uri-fragment) below for details.
 * `uri_path` - (Optional) Inspect the request URI path. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
 
 ### Forwarded IP Config
@@ -676,6 +677,14 @@ Inspect a single query argument. Provide the name of the query argument to inspe
 The `single_query_argument` block supports the following arguments:
 
 * `name` - (Optional) The name of the query header to inspect. This setting must be provided as lower case characters.
+
+### URI Fragment
+
+Inspect the part of a URL that follows the "#" symbol, providing additional information about the resource.
+
+The `uri_fragment` block supports the following arguments:
+
+* `fallback_behavior` - (Optional) What AWS WAF should do if it fails to completely parse the JSON body. Valid values are `MATCH` (default) and `NO_MATCH`.
 
 ### Cookies
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -875,7 +875,7 @@ The part of a web request that you want AWS WAF to inspect. Include the single `
 
 The `field_to_match` block supports the following arguments:
 
-~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `ja3_fingerprint`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
+~> **Note** Only one of `all_query_arguments`, `body`, `cookies`, `header_order`, `headers`, `ja3_fingerprint`, `json_body`, `method`, `query_string`, `single_header`, `single_query_argument`, `uri_fragment` or `uri_path` can be specified. An empty configuration block `{}` should be used when specifying `all_query_arguments`, `method`, or `query_string` attributes.
 
 * `all_query_arguments` - (Optional) Inspect all query arguments.
 * `body` - (Optional) Inspect the request body, which immediately follows the request headers. See [`body`](#body-block) below for details.
@@ -889,6 +889,7 @@ The `field_to_match` block supports the following arguments:
 * `query_string` - (Optional) Inspect the query string. This is the part of a URL that appears after a `?` character, if any.
 * `single_header` - (Optional) Inspect a single header. See [`single_header`](#single_header-block) below for details.
 * `single_query_argument` - (Optional) Inspect a single query argument. See [`single_query_argument`](#single_query_argument-block) below for details.
+* `uri_fragment` - (Optional) Inspect the part of a URL that follows the "#" symbol, providing additional information about the resource. See [`uri_fragment`](#uri_fragment-block) below for details.
 * `uri_path` - (Optional) Inspect the request URI path. This is the part of a web request that identifies a resource, for example, `/images/daily-ad.jpg`.
 
 ### `forwarded_ip_config` Block
@@ -967,6 +968,14 @@ Inspect a single query argument. Provide the name of the query argument to inspe
 The `single_query_argument` block supports the following arguments:
 
 * `name` - (Required) Name of the query header to inspect. This setting must be provided as lower case characters.
+
+### `uri_fragment` Block
+
+Inspect the part of a URL that follows the "#" symbol, providing additional information about the resource.
+
+The `uri_fragment` block supports the following arguments:
+
+* `fallback_behavior` - (Optional) What AWS WAF should do if it fails to completely parse the JSON body. Valid values are `MATCH` (default) and `NO_MATCH`.
 
 ### `body` Block
 


### PR DESCRIPTION
### Description
* Support URI fragment field matching in `aws_wafv2_web_acl` and `aws_wafv2_rule_group` resouces by introducing `uri_fragment` block into `field_to_match` block.

### Relations

Closes #41905

### References

* https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-fields-list.html#waf-rule-statement-request-component-uri-fragment
* https://docs.aws.amazon.com/ja_jp/waf/latest/APIReference/API_FieldToMatch.html#WAF-Type-FieldToMatch-UriFragment
* https://docs.aws.amazon.com/ja_jp/waf/latest/APIReference/API_UriFragment.html

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 360m -vet=off
2025/04/29 14:05:52 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_nameGenerated
=== PAUSE TestAccWAFV2WebACL_nameGenerated
=== RUN   TestAccWAFV2WebACL_namePrefix
=== PAUSE TestAccWAFV2WebACL_namePrefix
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== RUN   TestAccWAFV2WebACL_ruleJSON
=== PAUSE TestAccWAFV2WebACL_ruleJSON
=== RUN   TestAccWAFV2WebACL_ruleJSONToRule
=== PAUSE TestAccWAFV2WebACL_ruleJSONToRule
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_ruleJSONToRule
=== CONT  TestAccWAFV2WebACL_ruleJSON
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
=== CONT  TestAccWAFV2WebACL_tokenDomains
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== NAME  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:3253: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (3.06s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== NAME  TestAccWAFV2WebACL_associationConfigCloudFront
    web_acl_test.go:3156: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfigCloudFront (3.06s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (46.46s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_basic (49.87s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
--- PASS: TestAccWAFV2WebACL_tokenDomains (71.95s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (77.18s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_ruleJSONToRule (105.95s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (105.16s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (120.24s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (121.04s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (122.35s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (123.68s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (132.66s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_urlFragment (133.47s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_ruleJSON (148.13s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_tags (150.16s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (168.63s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_disappears (66.24s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint (125.83s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (133.66s)
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (184.97s)
=== CONT  TestAccWAFV2WebACL_namePrefix
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (190.32s)
=== CONT  TestAccWAFV2WebACL_nameGenerated
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (129.38s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
--- PASS: TestAccWAFV2WebACL_Custom_response (208.53s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (137.31s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (136.88s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (140.53s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (86.17s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (141.67s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (143.66s)
--- PASS: TestAccWAFV2WebACL_namePrefix (81.99s)
--- PASS: TestAccWAFV2WebACL_nameGenerated (80.18s)
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (271.12s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (124.42s)
--- PASS: TestAccWAFV2WebACL_minimal (64.72s)
--- PASS: TestAccWAFV2WebACL_RateBased_basic (140.83s)
--- PASS: TestAccWAFV2WebACL_Update_rule (142.35s)
--- PASS: TestAccWAFV2WebACL_RuleLabels (123.94s)
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (115.23s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (103.45s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (163.85s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (193.35s)
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (165.23s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (428.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      431.559s
```

```console
$ make testacc TESTS=TestAccWAFV2RuleGroup_ PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup_'  -timeout 360m -vet=off
2025/04/29 20:03:15 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_nameGenerated
=== PAUSE TestAccWAFV2RuleGroup_nameGenerated
=== RUN   TestAccWAFV2RuleGroup_namePrefix
=== PAUSE TestAccWAFV2RuleGroup_namePrefix
=== RUN   TestAccWAFV2RuleGroup_updateRule
=== PAUSE TestAccWAFV2RuleGroup_updateRule
=== RUN   TestAccWAFV2RuleGroup_updateRuleProperties
=== PAUSE TestAccWAFV2RuleGroup_updateRuleProperties
=== RUN   TestAccWAFV2RuleGroup_byteMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_byteMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== RUN   TestAccWAFV2RuleGroup_changeNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeNameForceNew
=== RUN   TestAccWAFV2RuleGroup_changeCapacityForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeCapacityForceNew
=== RUN   TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== RUN   TestAccWAFV2RuleGroup_disappears
=== PAUSE TestAccWAFV2RuleGroup_disappears
=== RUN   TestAccWAFV2RuleGroup_RuleLabels
=== PAUSE TestAccWAFV2RuleGroup_RuleLabels
=== RUN   TestAccWAFV2RuleGroup_geoMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_geoMatchStatement
=== RUN   TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== PAUSE TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== RUN   TestAccWAFV2RuleGroup_LabelMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_LabelMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== PAUSE TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== RUN   TestAccWAFV2RuleGroup_logicalRuleStatements
=== PAUSE TestAccWAFV2RuleGroup_logicalRuleStatements
=== RUN   TestAccWAFV2RuleGroup_minimal
=== PAUSE TestAccWAFV2RuleGroup_minimal
=== RUN   TestAccWAFV2RuleGroup_regexMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_regexMatchStatement
=== RUN   TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_ruleAction
=== PAUSE TestAccWAFV2RuleGroup_ruleAction
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customResponse
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customResponse
=== RUN   TestAccWAFV2RuleGroup_sizeConstraintStatement
=== PAUSE TestAccWAFV2RuleGroup_sizeConstraintStatement
=== RUN   TestAccWAFV2RuleGroup_sqliMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_sqliMatchStatement
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2RuleGroup_xssMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_xssMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement
=== RUN   TestAccWAFV2RuleGroup_RateBased_maxNested
=== PAUSE TestAccWAFV2RuleGroup_RateBased_maxNested
=== RUN   TestAccWAFV2RuleGroup_Operators_maxNested
=== PAUSE TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2RuleGroup_basic
=== CONT  TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
=== CONT  TestAccWAFV2RuleGroup_sizeConstraintStatement
=== CONT  TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2RuleGroup_RateBased_maxNested
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement
=== CONT  TestAccWAFV2RuleGroup_xssMatchStatement
=== CONT  TestAccWAFV2RuleGroup_tags
=== CONT  TestAccWAFV2RuleGroup_sqliMatchStatement
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
=== CONT  TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customResponse
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
=== CONT  TestAccWAFV2RuleGroup_geoMatchStatement
=== CONT  TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_LabelMatchStatement
=== CONT  TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
--- PASS: TestAccWAFV2RuleGroup_basic (39.37s)
=== CONT  TestAccWAFV2RuleGroup_disappears
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (56.49s)
=== CONT  TestAccWAFV2RuleGroup_RuleLabels
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (64.26s)
=== CONT  TestAccWAFV2RuleGroup_namePrefix
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (73.04s)
=== CONT  TestAccWAFV2RuleGroup_updateRule
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (74.25s)
=== CONT  TestAccWAFV2RuleGroup_ruleAction
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (75.84s)
=== CONT  TestAccWAFV2RuleGroup_changeMetricNameForceNew
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (84.07s)
=== CONT  TestAccWAFV2RuleGroup_nameGenerated
--- PASS: TestAccWAFV2RuleGroup_disappears (48.39s)
=== CONT  TestAccWAFV2RuleGroup_minimal
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (94.85s)
=== CONT  TestAccWAFV2RuleGroup_regexMatchStatement
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (102.64s)
=== CONT  TestAccWAFV2RuleGroup_logicalRuleStatements
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (110.35s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (117.56s)
--- PASS: TestAccWAFV2RuleGroup_namePrefix (54.67s)
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (123.23s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (126.74s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (130.83s)
--- PASS: TestAccWAFV2RuleGroup_minimal (46.98s)
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (136.74s)
--- PASS: TestAccWAFV2RuleGroup_nameGenerated (54.75s)
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (50.96s)
--- PASS: TestAccWAFV2RuleGroup_tags (148.54s)
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (93.62s)
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (76.02s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (152.15s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (84.47s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (159.33s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (60.77s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (101.23s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (83.09s)
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (294.62s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (319.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      323.784s


```
