### PR TITLE
r/aws_elasticache[user|user_group|replication_group]: deprecate non-exact `engine` values

### DIFF
--- a/.changelog/42419.txt
+++ b/.changelog/42419.txt
@@ -1,0 +1,9 @@
+```release-note:note
+resource/aws_elasticache_replication_group: The ability to provide an uppercase `engine` value is deprecated
+```
+```release-note:note
+resource/aws_elasticache_user: The ability to provide an uppercase `engine` value is deprecated
+```
+```release-note:note
+resource/aws_elasticache_user_group: The ability to provide an uppercase `engine` value is deprecated
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -124,10 +124,18 @@ func resourceReplicationGroup() *schema.Resource {
 				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			names.AttrEngine: {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      engineRedis,
-				ValidateFunc: validation.StringInSlice([]string{engineRedis, engineValkey}, true),
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  engineRedis,
+				ValidateDiagFunc: validation.AllDiag(
+					validation.ToDiagFunc(validation.StringInSlice([]string{engineRedis, engineValkey}, true)),
+					// While the existing validator makes it technically possible to provide an
+					// uppercase engine value, the absence of a diff suppression function makes
+					// it impractical to do so (a persistent diff will be present). To be
+					// conservative we will still run the deprecation validator to notify
+					// practitioners that stricter validation will be enforced in v7.0.0.
+					verify.CaseInsensitiveMatchDeprecation([]string{engineRedis, engineValkey}),
+				),
 			},
 			names.AttrEngineVersion: {
 				Type:     schema.TypeString,

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -24,6 +24,7 @@ import (
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -85,9 +86,12 @@ func resourceUser() *schema.Resource {
 				},
 			},
 			names.AttrEngine: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringInSlice([]string{engineRedis, engineValkey}, true),
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validation.AllDiag(
+					validation.ToDiagFunc(validation.StringInSlice([]string{engineRedis, engineValkey}, true)),
+					verify.CaseInsensitiveMatchDeprecation([]string{engineRedis, engineValkey}),
+				),
 				DiffSuppressFunc: sdkv2.SuppressEquivalentStringCaseInsensitive,
 			},
 			"no_password_required": {

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -23,6 +23,7 @@ import (
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -45,9 +46,12 @@ func resourceUserGroup() *schema.Resource {
 				Computed: true,
 			},
 			names.AttrEngine: {
-				Type:             schema.TypeString,
-				Required:         true,
-				ValidateFunc:     validation.StringInSlice([]string{engineRedis, engineValkey}, true),
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateDiagFunc: validation.AllDiag(
+					validation.ToDiagFunc(validation.StringInSlice([]string{engineRedis, engineValkey}, true)),
+					verify.CaseInsensitiveMatchDeprecation([]string{engineRedis, engineValkey}),
+				),
 				DiffSuppressFunc: sdkv2.SuppressEquivalentStringCaseInsensitive,
 			},
 			names.AttrTags:    tftags.TagsSchema(),

--- a/internal/verify/validate.go
+++ b/internal/verify/validate.go
@@ -597,3 +597,32 @@ func MapSizeBetween(min, max int) schema.SchemaValidateDiagFunc {
 		return diags
 	}
 }
+
+// CaseInsensitiveMatchDeprecation returns a warning diagnostic if the argument value
+// matches a valid value using unicode case-folding, but is not an exact match
+//
+// This validator can be used to deprecate case insensitive value matching in favor
+// of exact matching. A value which is an exact match or does not match any valid
+// value will return with empty diagnostics.
+func CaseInsensitiveMatchDeprecation(valid []string) schema.SchemaValidateDiagFunc {
+	return func(v any, path cty.Path) diag.Diagnostics {
+		var diags diag.Diagnostics
+		s := v.(string)
+
+		for _, item := range valid {
+			if s != item && strings.EqualFold(s, item) {
+				diags = append(diags, diag.Diagnostic{
+					Severity: diag.Warning,
+					Summary:  "Case Insensitive Matching Deprecated",
+					Detail: fmt.Sprintf("Expected an exact match to %q, got %q. ", item, v) +
+						"Case insensitive matching is deprecated for this argument. Update the value " +
+						"to an exact match to suppress this warning and avoid breaking changes " +
+						"in a future major version.",
+					AttributePath: path,
+				})
+			}
+		}
+
+		return diags
+	}
+}

--- a/internal/verify/validate_test.go
+++ b/internal/verify/validate_test.go
@@ -940,3 +940,39 @@ func TestMapKeysAre(t *testing.T) {
 		})
 	}
 }
+
+func TestCaseInsensitiveMatchDeprecation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    any
+		wantDiag bool
+	}{
+		{
+			name:  "exact match",
+			value: "foo",
+		},
+		{
+			name:  "no match",
+			value: "baz",
+		},
+		{
+			name:     "case insensitive match",
+			value:    "FOO",
+			wantDiag: true,
+		},
+	}
+
+	f := CaseInsensitiveMatchDeprecation([]string{"foo", "bar"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			diags := f(tt.value, cty.Path{})
+			if got, want := len(diags) > 0, tt.wantDiag; got != want {
+				t.Errorf("got = %v, want = %v", got, want)
+			}
+		})
+	}
+}

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -48,6 +48,8 @@ Upgrade topics:
 - [resource/aws_ecs_task_definition](#resourceaws_ecs_task_definition)
 - [resource/aws_eip](#resourceaws_eip)
 - [resource/aws_elasticache_replication_group](#resourceaws_elasticache_replication_group)
+- [resource/aws_elasticache_user](#resourceaws_elasticache_user)
+- [resource/aws_elasticache_user_group](#resourceaws_elasticache_user_group)
 - [resource/aws_eks_addon](#resourceaws_eks_addon)
 - [resource/aws_flow_log](#resourceaws_flow_log)
 - [resource/aws_guardduty_organization_configuration](#resourceaws_guardduty_organization_configuration)
@@ -367,6 +369,19 @@ Use `domain` instead.
 
 The `auth_token_update_strategy` argument no longer has a default value.
 If `auth_token` is set, this argument must also be explicitly configured.
+
+The ability to provide an uppercase `engine` value is deprecated.
+In `v7.0.0`, plan-time validation of the `engine` argument will require an entirely lowercase value to match the returned value from the AWS API without diff suppression.
+
+## resource/aws_elasticache_user
+
+The ability to provide an uppercase `engine` value is deprecated.
+In `v7.0.0`, plan-time validation of the `engine` argument will require an entirely lowercase value to match the returned value from the AWS API without diff suppression.
+
+## resource/aws_elasticache_user_group
+
+The ability to provide an uppercase `engine` value is deprecated.
+In `v7.0.0`, plan-time validation of the `engine` argument will require an entirely lowercase value to match the returned value from the AWS API without diff suppression.
 
 ## resource/aws_eks_addon
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change deprecates the ability to provide values to the `engine` argument which do not match the casing returned by the AWS API. In `v7.0.0` these resources will require exact value matches during plan time validation.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40813
Relates #41101

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateUser.html
- https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateUserGroup.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheUser_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser_'  -timeout 360m -vet=off
2025/04/29 15:02:18 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheUser_updateEngine (33.57s)
--- PASS: TestAccElastiCacheUser_basic (35.65s)
--- PASS: TestAccElastiCacheUser_passwordAuthMode (38.07s)
--- PASS: TestAccElastiCacheUser_iamAuthMode (40.25s)
--- PASS: TestAccElastiCacheUser_tags (97.48s)
--- PASS: TestAccElastiCacheUser_update (97.78s)
--- PASS: TestAccElastiCacheUser_oobModify (163.52s)
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (165.17s)
--- PASS: TestAccElastiCacheUser_disappears (216.02s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        221.589s
```

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheUserGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUserGroup_'  -timeout 360m -vet=off
2025/04/29 15:09:40 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheUserGroup_tags (149.80s)
--- PASS: TestAccElastiCacheUserGroup_disappears (151.02s)
--- PASS: TestAccElastiCacheUserGroup_basic (153.59s)
--- PASS: TestAccElastiCacheUserGroup_update (335.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        341.074s
```

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_Redis_basic
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.2 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_Redis_basic'  -timeout 360m -vet=off
2025/04/29 15:19:53 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (785.84s)
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (786.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        792.039s
```
