### PR TITLE
`aws-sdk-go-v2` updates (Release 2025-04-29)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -247,7 +247,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssmsap v1.20.2
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.3
 	github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.30.2
-	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.0
+	github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.19
 	github.com/aws/aws-sdk-go-v2/service/swf v1.28.3
 	github.com/aws/aws-sdk-go-v2/service/synthetics v1.32.3

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/computeoptimizer v1.42.3
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3
 	github.com/aws/aws-sdk-go-v2/service/connect v1.128.0
-	github.com/aws/aws-sdk-go-v2/service/connectcases v1.24.0
+	github.com/aws/aws-sdk-go-v2/service/connectcases v1.25.0
 	github.com/aws/aws-sdk-go-v2/service/controltower v1.21.2
 	github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.49.0

--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/healthlake v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.41.1
 	github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.2
-	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.41.2
+	github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.36.1
 	github.com/aws/aws-sdk-go-v2/service/internetmonitor v1.21.2

--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.34.2
 	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2
-	github.com/aws/aws-sdk-go-v2/service/datasync v1.47.1
+	github.com/aws/aws-sdk-go-v2/service/datasync v1.47.2
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/dax v1.24.2
 	github.com/aws/aws-sdk-go-v2/service/detective v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30
-	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.73
+	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/acm v1.31.3
@@ -218,7 +218,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/route53recoveryreadiness v1.22.2
 	github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.3
 	github.com/aws/aws-sdk-go-v2/service/rum v1.24.2
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.3.0
@@ -328,7 +328,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -86,7 +86,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/customerprofiles v1.45.2
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.51.3
 	github.com/aws/aws-sdk-go-v2/service/databrew v1.34.2
-	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.2
+	github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3
 	github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/datasync v1.47.1
 	github.com/aws/aws-sdk-go-v2/service/datazone v1.29.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.39.0
 	github.com/aws/aws-sdk-go-v2/service/account v1.24.0
-	github.com/aws/aws-sdk-go-v2/service/acm v1.31.3
+	github.com/aws/aws-sdk-go-v2/service/acm v1.32.0
 	github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.2
 	github.com/aws/aws-sdk-go-v2/service/amp v1.33.0
 	github.com/aws/aws-sdk-go-v2/service/amplify v1.32.1

--- a/go.mod
+++ b/go.mod
@@ -149,7 +149,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.23.2
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.56.2
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.18.1
-	github.com/aws/aws-sdk-go-v2/service/kinesis v1.33.3
+	github.com/aws/aws-sdk-go-v2/service/kinesis v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.26.3
 	github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.32.3
 	github.com/aws/aws-sdk-go-v2/service/kinesisvideo v1.28.2

--- a/go.mod
+++ b/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pcaconnectorad v1.11.1
 	github.com/aws/aws-sdk-go-v2/service/pcs v1.4.2
 	github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.2
-	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.4
+	github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.20.0
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.19.3
 	github.com/aws/aws-sdk-go-v2/service/polly v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.34.3

--- a/go.mod
+++ b/go.mod
@@ -222,7 +222,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3control v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/s3tables v1.3.0
-	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.188.0
+	github.com/aws/aws-sdk-go-v2/service/sagemaker v1.189.0
 	github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.3
 	github.com/aws/aws-sdk-go-v2/service/schemas v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.4

--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/pipes v1.19.3
 	github.com/aws/aws-sdk-go-v2/service/polly v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/pricing v1.34.3
-	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.25.0
+	github.com/aws/aws-sdk-go-v2/service/qbusiness v1.26.0
 	github.com/aws/aws-sdk-go-v2/service/qldb v1.26.2
 	github.com/aws/aws-sdk-go-v2/service/quicksight v1.86.0
 	github.com/aws/aws-sdk-go-v2/service/ram v1.30.3

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloud9 v1.29.2
 	github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.24.3
 	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2
-	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.45.3
+	github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0
 	github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.9.2
 	github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.30.2
 	github.com/aws/aws-sdk-go-v2/service/cloudsearch v1.27.2

--- a/go.mod
+++ b/go.mod
@@ -240,7 +240,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signer v1.27.2
 	github.com/aws/aws-sdk-go-v2/service/sns v1.34.4
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5
-	github.com/aws/aws-sdk-go-v2/service/ssm v1.58.2
+	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0
 	github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.27.2
 	github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.35.2
 	github.com/aws/aws-sdk-go-v2/service/ssmquicksetup v1.4.2

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/docdbelastic v1.15.2
 	github.com/aws/aws-sdk-go-v2/service/drs v1.31.2
 	github.com/aws/aws-sdk-go-v2/service/dsql v1.2.0
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.0
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.32.2

--- a/go.sum
+++ b/go.sum
@@ -405,8 +405,8 @@ github.com/aws/aws-sdk-go-v2/service/pcs v1.4.2 h1:SUSSqOK/Vu+ja/qk1YQwdbpNTQlfP
 github.com/aws/aws-sdk-go-v2/service/pcs v1.4.2/go.mod h1:CX99CnPyFWfXFOQYf5NhHOzdJjCxhPo39DoChDi32jE=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.2 h1:i2dp7vloIJSRW9YBPy2F4pdisb7DNmLUBpsHxzdXqD4=
 github.com/aws/aws-sdk-go-v2/service/pinpoint v1.35.2/go.mod h1:O3MV3jUxQNsjM46TGJ4DwPqfuqUgywJpmHua8CCx/zE=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.4 h1:BCCWP785/4juJYxJ8oUOX5YtgcRMpK0EZ5zg09XXuYk=
-github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.19.4/go.mod h1:UfJ+CG2eqRldWl1lLd2e1/glFbp7Ln3ZZgSkvMHvNh4=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.20.0 h1:A6Cne4eO0U2sj82VNWsnCtlliWQXjQ24voDRi/Yt/iI=
+github.com/aws/aws-sdk-go-v2/service/pinpointsmsvoicev2 v1.20.0/go.mod h1:UfJ+CG2eqRldWl1lLd2e1/glFbp7Ln3ZZgSkvMHvNh4=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.3 h1:vaclOQiHNtp0ss1aSXNiwFf/eRUm2WbLtyxahQJDdqc=
 github.com/aws/aws-sdk-go-v2/service/pipes v1.19.3/go.mod h1:2EbU5EjVT3Gu9OevmKa2nLT3daim8GIqnAHtGDcowvw=
 github.com/aws/aws-sdk-go-v2/service/polly v1.48.2 h1:Ltj0p0KCjPd7nrDTlkAH+AQbKlIDuvIigkLGsCuc4Eo=

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/aws/aws-sdk-go-v2/service/iam v1.41.1 h1:Kq3R+K49y23CGC5UQF3Vpw5oZEQk
 github.com/aws/aws-sdk-go-v2/service/iam v1.41.1/go.mod h1:mPJkGQzeCoPs82ElNILor2JzZgYENr4UaSKUT8K27+c=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.2 h1:hWqvzMaaiHhwndQhy1rF/qoHidaa4KzevkiDaMvjk3Q=
 github.com/aws/aws-sdk-go-v2/service/identitystore v1.28.2/go.mod h1:7nGvrQXBNp7k5yYpwpmxGucYTPY39d0cxjmANAeWwYE=
-github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.41.2 h1:+Gc3AKxI5OKiWk6U+hd5AXFmE+iZ2IQs9kyTSoJC1go=
-github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.41.2/go.mod h1:YUAfy2RTn0rtvZT7oSDXE5yamhX9zCCcBqqfz8d7Wbc=
+github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.42.0 h1:nDfEmJSJmHPLoQxdd9psJKCXQKZ2Tj0u89uZSkuezNU=
+github.com/aws/aws-sdk-go-v2/service/imagebuilder v1.42.0/go.mod h1:YUAfy2RTn0rtvZT7oSDXE5yamhX9zCCcBqqfz8d7Wbc=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.26.2 h1:ok1ktm0OpWm1TsXTW3tDqgnf4oZLCXkMS5ZjBLd7PW4=
 github.com/aws/aws-sdk-go-v2/service/inspector v1.26.2/go.mod h1:J8ZDkDoEAR+mLFmI2gXOZ+kUdry4Mkx3FKbNSCV6M/U=
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.36.1 h1:aAR6SFuJMfJvX05Vm4SEelFsVxjSpFg37THFLF8jCCI=

--- a/go.sum
+++ b/go.sum
@@ -465,8 +465,8 @@ github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.2 h1:vbFPxDw+La+JwZrVlAIq6
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.2/go.mod h1:P3QWrLPDXyc8813o8b7WnBpw7mwoo2LRyOYdxMVT++Y=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.3.0 h1:sQFZENns6JNemrS5s3zLfk9R61E+DGVWpFrJNOwqCjw=
 github.com/aws/aws-sdk-go-v2/service/s3tables v1.3.0/go.mod h1:u8pFMlyM6roXU/RRPYKb+07R+OoyVKO1Gu1AGlDODQk=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.188.0 h1:MbWxt/YeXQhhTmEFwcgYMLYvb7fzssMq8i1Y79moN5E=
-github.com/aws/aws-sdk-go-v2/service/sagemaker v1.188.0/go.mod h1:fp2LcfhQkz90js0Bkg5nXdCGCRy4y/FGgc14uvZ97eA=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.189.0 h1:9VfWEx/7W+IgAU6FlnOpz02eLesf6UlDDgsGg2cTBEc=
+github.com/aws/aws-sdk-go-v2/service/sagemaker v1.189.0/go.mod h1:fp2LcfhQkz90js0Bkg5nXdCGCRy4y/FGgc14uvZ97eA=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.3 h1:dwlGFf1j4Z9Sz+cX6xjvozzLSM07ZI25BSaWnNNHcFU=
 github.com/aws/aws-sdk-go-v2/service/scheduler v1.13.3/go.mod h1:DyWRoXzh5uB79qixa/wH8VBAfH06+sHGBLDR97B7Roo=
 github.com/aws/aws-sdk-go-v2/service/schemas v1.29.2 h1:kLswBLkHpvkkHpowIB58/CaqYX0Af0QSCrfOvqcg1yQ=

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.24.3 h1:67e/C9khmgT05g7OoJi
 github.com/aws/aws-sdk-go-v2/service/cloudcontrol v1.24.3/go.mod h1:ifQSgXMoHWzSB1gBIqKPDqXkp9TP/a/fmx0AIRFHVL0=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2 h1:o9cuZdZlI9VWMqsNa2mnf2IRsFAROHnaYA1BW3lHGuY=
 github.com/aws/aws-sdk-go-v2/service/cloudformation v1.59.2/go.mod h1:penaZKzGmqHGZId4EUCBIW/f9l4Y7hQ5NKd45yoCYuI=
-github.com/aws/aws-sdk-go-v2/service/cloudfront v1.45.3 h1:xQnjN34F4I3a/I3Xj0g9vmD5hAqC7u5y3SC3eC6T1E8=
-github.com/aws/aws-sdk-go-v2/service/cloudfront v1.45.3/go.mod h1:FIBJ48TS+qJb+Ne4qJ+0NeIhtPTVXItXooTeNeVI4Po=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0 h1:wdm9Pjye5PSQ+ELMHXOh7SQhiXLDk2iONZ+fDmISi28=
+github.com/aws/aws-sdk-go-v2/service/cloudfront v1.46.0/go.mod h1:FIBJ48TS+qJb+Ne4qJ+0NeIhtPTVXItXooTeNeVI4Po=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.9.2 h1:arQ8ob+Wr+WEpixxLycaXKfTKHZMldUUnEIyvxSySGI=
 github.com/aws/aws-sdk-go-v2/service/cloudfrontkeyvaluestore v1.9.2/go.mod h1:YbdzdpFpQAgFgj20i0McmLxn2UfpBNt5FYMb7b1LjxM=
 github.com/aws/aws-sdk-go-v2/service/cloudhsmv2 v1.30.2 h1:3hQdiACDNkNDO9lTFUHhiWOav0O+Fng2QlS+oLxwfdo=

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/aws/aws-sdk-go-v2/service/kendra v1.56.2 h1:zIFhuJ/v/Ir1WMFBrO7jvlZpN
 github.com/aws/aws-sdk-go-v2/service/kendra v1.56.2/go.mod h1:O1bxdW0GL2BVuXK0TxZtsFbAKZ23C/U9PMFKAiud3PQ=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.18.1 h1:0yMkmoDmpFM5dHLg4Ppi+8sfQpBn83Q0tK8y3L8ETL0=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.18.1/go.mod h1:iZVSQvAViQfIGqwR77Ff7fvsiPns7DekuGVXeyMlcUU=
-github.com/aws/aws-sdk-go-v2/service/kinesis v1.33.3 h1:brQCC27V/e3wGeJ0JFh5InpH28saxe73Xpf0GXojn8M=
-github.com/aws/aws-sdk-go-v2/service/kinesis v1.33.3/go.mod h1:dJngkoVMrq0K7QvRkdRZYM4NUp6cdWa2GBdpm8zoY8U=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.34.0 h1:6HX6bBemcic6RE5mDjHBn0Mvgl94lKsiKyMUhyxsnDg=
+github.com/aws/aws-sdk-go-v2/service/kinesis v1.34.0/go.mod h1:dJngkoVMrq0K7QvRkdRZYM4NUp6cdWa2GBdpm8zoY8U=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.26.3 h1:FbhEZpqskKOma1tIEiangtHEw/o9P69B/I9kF44gjB0=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalytics v1.26.3/go.mod h1:aexFAWICparMXJx26bt2UAJgkvRVzmbGE7rlwigj5PA=
 github.com/aws/aws-sdk-go-v2/service/kinesisanalyticsv2 v1.32.3 h1:Ti59qxN29X47WcvlFD57ISdTBw27HtiXzig8G56I9rE=

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/aws/aws-sdk-go-v2/service/sns v1.34.4 h1:ihddI5wufQQCJiujUgAvWRqZcfDm
 github.com/aws/aws-sdk-go-v2/service/sns v1.34.4/go.mod h1:PJtxxMdj747j8DeZENRTTYAz/lx/pADn/U0k7YNNiUY=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5 h1:KNgVWw8qbPzjYnIF1gL0EAszy6VKGnmUK6VSm1huYY8=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.38.5/go.mod h1:Bar4MrRxeqdn6XIh8JGfiXuFRmyrrsZNTJotxEJmWW0=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.58.2 h1:uXy3QGAw3xv0RS+OlbeMEAnOA3vFFsf7yvjUswV6N/k=
-github.com/aws/aws-sdk-go-v2/service/ssm v1.58.2/go.mod h1:PUWUl5MDiYNQkUHN9Pyd9kgtA/YhbxnSnHP+yQqzrM8=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0 h1:KWArCwA/WkuHWKfygkNz0B6YS6OvdgoJUaJHX0Qby1s=
+github.com/aws/aws-sdk-go-v2/service/ssm v1.59.0/go.mod h1:PUWUl5MDiYNQkUHN9Pyd9kgtA/YhbxnSnHP+yQqzrM8=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.27.2 h1:A8MVIOw4i2Pd7hhY0x/9K5saJrbqqkaahX8eOmQwuAU=
 github.com/aws/aws-sdk-go-v2/service/ssmcontacts v1.27.2/go.mod h1:HLM/MYuBpcE2Q/rFUNzSFFvlIR/OvZtTjE4dZCriPtM=
 github.com/aws/aws-sdk-go-v2/service/ssmincidents v1.35.2 h1:Fnb/4VldkekJWQS5pXNNWr9oQKuNm7E9iTI/dKqkskg=

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.51.3 h1:w0hlBG2
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.51.3/go.mod h1:qKLavvD5jmwvzrJFHrA3vX+UZXi8MIguEYr21bu+izA=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.34.2 h1:IaU+7gHdLk5UCCxpVNiZ77vbXTwbg7qagVJ5TCfln4w=
 github.com/aws/aws-sdk-go-v2/service/databrew v1.34.2/go.mod h1:rnSfOtbf0M1YevWpftfLBBbSGGPxUbb2kK3uQdnL6OY=
-github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.2 h1:I/0cR+TLXLsKO3eoZY3IAxjmXTvoVJ2SlRFgBGcJqrE=
-github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.2/go.mod h1:S4l1PF61IYjCakjwMTI2HZLT8gn/nmfrcZRp5NCckX0=
+github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3 h1:w8Ip4GE31ZGEUuuhvfHJJas484+suAE4Xb5eS8h+WDg=
+github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3/go.mod h1:S4l1PF61IYjCakjwMTI2HZLT8gn/nmfrcZRp5NCckX0=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2 h1:WPI2QBUziKLSxR7cXHuIoKL016OsYPhruCtmGyOcUiI=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2/go.mod h1:AsHLBZVzMdJOZ6M73hFduNi138902gV4I9T6LWVONtk=
 github.com/aws/aws-sdk-go-v2/service/datasync v1.47.1 h1:0VuUFahnkkyyoQUNcyydLiBFWYjSBSnADFrE8H2H9qw=

--- a/go.sum
+++ b/go.sum
@@ -413,8 +413,8 @@ github.com/aws/aws-sdk-go-v2/service/polly v1.48.2 h1:Ltj0p0KCjPd7nrDTlkAH+AQbKl
 github.com/aws/aws-sdk-go-v2/service/polly v1.48.2/go.mod h1:X0rTcGb5WvdI+44CccO5/czSPJbIJovKWcE+/V/+4PQ=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.34.3 h1:vAv0hi3SWcc8cotkWRP4mPkmRbp/XqWKFyPW4Nwpzv0=
 github.com/aws/aws-sdk-go-v2/service/pricing v1.34.3/go.mod h1:giTP9ufzBQJRB6bc7P30PO8s35hCp6au5uM70zkohU4=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.25.0 h1:uYAAI1sYh4OJyLUq6hVdLFqdzx0tcI+yBm6pBGnmn4s=
-github.com/aws/aws-sdk-go-v2/service/qbusiness v1.25.0/go.mod h1:yC/gX6FcgKWmtKJU2d5fyQb1QHTUuuERAfC7HLQTPJE=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.26.0 h1:V3qZsQ8CFRL905c1x/BgOVNMGM6XCeaVR75WL7m1W8c=
+github.com/aws/aws-sdk-go-v2/service/qbusiness v1.26.0/go.mod h1:yC/gX6FcgKWmtKJU2d5fyQb1QHTUuuERAfC7HLQTPJE=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.26.2 h1:2md04eYXp5hD2n1cvlOLj73eNEkG25rpXZgSYzWyZ1U=
 github.com/aws/aws-sdk-go-v2/service/qldb v1.26.2/go.mod h1:KHgfc8tLcKSLPhzem2r90gG61VmC61AsMBvchY9G3fQ=
 github.com/aws/aws-sdk-go-v2/service/quicksight v1.86.0 h1:EKtJt8PftzMTi6b+gonHfn5eUQFhXreaW2rhZ0iIUxY=

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3 h1:w8Ip4GE31ZGEUuuhvfH
 github.com/aws/aws-sdk-go-v2/service/dataexchange v1.34.3/go.mod h1:S4l1PF61IYjCakjwMTI2HZLT8gn/nmfrcZRp5NCckX0=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2 h1:WPI2QBUziKLSxR7cXHuIoKL016OsYPhruCtmGyOcUiI=
 github.com/aws/aws-sdk-go-v2/service/datapipeline v1.26.2/go.mod h1:AsHLBZVzMdJOZ6M73hFduNi138902gV4I9T6LWVONtk=
-github.com/aws/aws-sdk-go-v2/service/datasync v1.47.1 h1:0VuUFahnkkyyoQUNcyydLiBFWYjSBSnADFrE8H2H9qw=
-github.com/aws/aws-sdk-go-v2/service/datasync v1.47.1/go.mod h1:Cl1F1d83JEmNC22jPyRexP6mNnWSpIzQg8gy7lnjIUU=
+github.com/aws/aws-sdk-go-v2/service/datasync v1.47.2 h1:piM76t2XJ4b52xhXl3ts3vGnKtwtyw1vzIZAoV73niE=
+github.com/aws/aws-sdk-go-v2/service/datasync v1.47.2/go.mod h1:Cl1F1d83JEmNC22jPyRexP6mNnWSpIzQg8gy7lnjIUU=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.29.1 h1:YpwrBYhh2/DiLMQrJ7wPryrRo5B4Gd75usUDkyRnL3c=
 github.com/aws/aws-sdk-go-v2/service/datazone v1.29.1/go.mod h1:3a69kSZREiFCWUvaV+8wZ6y43trMz2hjCjPjxJHw2Bg=
 github.com/aws/aws-sdk-go-v2/service/dax v1.24.2 h1:QFdCeROg/LwFkKOpM4TrzOPt9vcsbuu2WibzjiKTZqA=

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/aws/aws-sdk-go-v2/credentials v1.17.67 h1:9KxtdcIA/5xPNQyZRgUSpYOE6j9
 github.com/aws/aws-sdk-go-v2/credentials v1.17.67/go.mod h1:p3C44m+cfnbv763s52gCqrjaqyPikj9Sg47kUVaNZQQ=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 h1:x793wxmUWVDhshP8WW2mlnXuFrO4cOd3HLBroh1paFw=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30/go.mod h1:Jpne2tDnYiFascUEs2AWHJL9Yp7A5ZVy3TNyxaAjD6M=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.73 h1:I91eIdOJMVK9oNiH2jvhp/AxMW+Gff8Rb5VjVHMhcJU=
-github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.73/go.mod h1:vq7/m7dahFXcdzWVOvvjasDI9RcsD3RsTfHmDundJYg=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74 h1:+1lc5oMFFHlVBclPXQf/POqlvdpBzjLaN2c3ujDCcZw=
+github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74/go.mod h1:EiskBoFr4SpYnFIbw8UM7DP7CacQXDHEmJqLI1xpRFI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 h1:ZK5jHhnrioRkUNOc+hOgQKlUL5JeC3S6JgLxtQ+Rm0Q=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34/go.mod h1:p4VfIceZokChbA9FzMbRGz5OV+lekcVtHlPKEO0gSZY=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 h1:SZwFm17ZUNNg5Np0ioo/gq8Mn6u9w19Mri8DnJ15Jf0=
@@ -289,8 +289,8 @@ github.com/aws/aws-sdk-go-v2/service/inspector2 v1.36.1 h1:aAR6SFuJMfJvX05Vm4SEe
 github.com/aws/aws-sdk-go-v2/service/inspector2 v1.36.1/go.mod h1:3Jj431wKTKKRgUj9unCuSgfbQzpSuQbOzHUyjmWt1oI=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 h1:eAh2A4b5IzM/lum78bZ590jy36+d/aFLgKF/4Vd1xPE=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3/go.mod h1:0yKJC/kb8sAnmlYa6Zs3QVYqaC8ug2AbnNChv5Ox3uA=
-github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 h1:lguz0bmOoGzozP9XfRJR1QIayEYo+2vP/No3OfLF0pU=
-github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0/go.mod h1:iu6FSzgt+M2/x3Dk8zhycdIcHjEFb36IS8HVUVFoMg0=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1 h1:4nm2G6A4pV9rdlWzGMPv4BNtQp22v1hg3yrtkYpeLl8=
+github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.1/go.mod h1:iu6FSzgt+M2/x3Dk8zhycdIcHjEFb36IS8HVUVFoMg0=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15 h1:M1R1rud7HzDrfCdlBQ7NjnRsDNEhXO/vGhuD189Ggmk=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.15/go.mod h1:uvFKBSq9yMPV4LGAi7N4awn4tLY+hKE35f8THes2mzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 h1:dM9/92u2F1JbDaGooxTq18wmmFzbJRfXfVfy96/1CXM=
@@ -457,8 +457,8 @@ github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.3 h1:9PYkcqQCDp5eGk3T
 github.com/aws/aws-sdk-go-v2/service/route53resolver v1.35.3/go.mod h1:0xjGNqPmjnmstn6DD5RTVfp6Ds1t2L0UbHndl/PIxfE=
 github.com/aws/aws-sdk-go-v2/service/rum v1.24.2 h1:iSftLQJd8BtQvwlBdx3n5PN0uOeZc+NU9EquZjnowJI=
 github.com/aws/aws-sdk-go-v2/service/rum v1.24.2/go.mod h1:epo2m9j8JQQdXVfSa6kRCu7U5reVhgdq/MsbZR/ouPg=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2 h1:tWUG+4wZqdMl/znThEk9tcCy8tTMxq8dW0JTgamohrY=
-github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2/go.mod h1:U5SNqwhXB3Xe6F47kXvWihPl/ilGaEDe8HD/50Z9wxc=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3 h1:BRXS0U76Z8wfF+bnkilA2QwpIch6URlm++yPUt9QPmQ=
+github.com/aws/aws-sdk-go-v2/service/s3 v1.79.3/go.mod h1:bNXKFFyaiVvWuR6O16h/I1724+aXe/tAkA9/QS01t5k=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.57.0 h1:/D8awksgwy5ik5vnTh4uHCZf09sochlk9r6Z3ew48js=
 github.com/aws/aws-sdk-go-v2/service/s3control v1.57.0/go.mod h1:hqimoWPQe+lvweuYZ2c1Fn4q3UyAFhbjSoABSl8Y7Pw=
 github.com/aws/aws-sdk-go-v2/service/s3outposts v1.29.2 h1:vbFPxDw+La+JwZrVlAIq6RWmDBhof3RocFQqFVM+rVE=

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.39.0 h1:ItVZNlhZl8pi4GGXz
 github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.39.0/go.mod h1:VHnLGHxJtS1zGiyfDVC4xpBECsaZA8h8XntrHH81yDs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0 h1:bxsS3BE+wpRBd4B0//h/ZOo8Ay55jyb9zprax9rCSYs=
 github.com/aws/aws-sdk-go-v2/service/account v1.24.0/go.mod h1:BwMkMxZPTVtRT9zRKpB92ljsRFX0EXk2WoLQmCnNuRs=
-github.com/aws/aws-sdk-go-v2/service/acm v1.31.3 h1:GwlU39usxM7E1LIhZchk93PtTQm2j3jb63of/YkBd+o=
-github.com/aws/aws-sdk-go-v2/service/acm v1.31.3/go.mod h1:3sKYAgRbuBa2QMYGh/WEclwnmfx+QoPhhX25PdSQSQM=
+github.com/aws/aws-sdk-go-v2/service/acm v1.32.0 h1:Ik/TAn4TBw/t3JhQJKtwjgoOf6kg5nXc190TiGhNrmI=
+github.com/aws/aws-sdk-go-v2/service/acm v1.32.0/go.mod h1:3sKYAgRbuBa2QMYGh/WEclwnmfx+QoPhhX25PdSQSQM=
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.2 h1:eer4qV5+FUwxPwvRTlUWVC32M6b0Zc9N73sZTW5b26c=
 github.com/aws/aws-sdk-go-v2/service/acmpca v1.40.2/go.mod h1:v0S5xoRSVzO4z09Fyqm6zkpeYU20qRBXwVS+BOejpcE=
 github.com/aws/aws-sdk-go-v2/service/amp v1.33.0 h1:IyU106YAgAulN9/+I7pgzOXxjcczVf/2XhMiVU24qCM=

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.30.2 h1:j3YvW9+qUFIzshXoPclOEUO
 github.com/aws/aws-sdk-go-v2/service/ssoadmin v1.30.2/go.mod h1:znVkl7Y14sZKEL/sbRQ6qgD8wj8VdTcVVQp5iRaKXcc=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1 h1:hXmVKytPfTy5axZ+fYbR5d0cFmC3JvwLm5kM83luako=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.0 h1:HBRYvrmyS0PfbMO/BIljieMkJuN1N7aZmJnYVn8EpD4=
-github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.0/go.mod h1:3x66RNxaBE2J2qWLL5pK9v09iPx3rMuYNz/hujPmSag=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.1 h1:6sf3sT8ykBCKEg7QAk1AtSHP+GdtNf8iBAAMcoJ4it8=
+github.com/aws/aws-sdk-go-v2/service/storagegateway v1.37.1/go.mod h1:3x66RNxaBE2J2qWLL5pK9v09iPx3rMuYNz/hujPmSag=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19 h1:1XuUZ8mYJw9B6lzAkXhqHlJd/XvaX32evhproijJEZY=
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/aws-sdk-go-v2/service/swf v1.28.3 h1:wpKZqKyVSI8tciKsSLZC6czSyHeUBzly/gIZV8dLUyE=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3 h1:Gw9GpbCShTzWPezPKd
 github.com/aws/aws-sdk-go-v2/service/configservice v1.52.3/go.mod h1:nJdDaoBiWBPdMaARQFA5xXHS0CHpxRzGbdp7QYqAVK0=
 github.com/aws/aws-sdk-go-v2/service/connect v1.128.0 h1:uJAondUZeK2akXSQkEYvwjyfAwYGDcOyHtlCvvo+Tgo=
 github.com/aws/aws-sdk-go-v2/service/connect v1.128.0/go.mod h1:14yMyj0OXfzTJjoxqDViol5TFwgegjgOVYL+7j0fw6g=
-github.com/aws/aws-sdk-go-v2/service/connectcases v1.24.0 h1:v7cbn6NPD8nDz6J9of8kt8s//y0sPJSQqhksGNTFQkE=
-github.com/aws/aws-sdk-go-v2/service/connectcases v1.24.0/go.mod h1:K9AzR1s6nIUDuXmlvg3sLuFJCsDl5Pvk1JBn6qru328=
+github.com/aws/aws-sdk-go-v2/service/connectcases v1.25.0 h1:DUNe6q5mJ0LmdKZfPTlV9bWqvhG7sC+pgEUhsfBdRjk=
+github.com/aws/aws-sdk-go-v2/service/connectcases v1.25.0/go.mod h1:K9AzR1s6nIUDuXmlvg3sLuFJCsDl5Pvk1JBn6qru328=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.21.2 h1:GSPR3SnBiLBPplNy71EmAPlgtdbovDetyWXg7tv+FiE=
 github.com/aws/aws-sdk-go-v2/service/controltower v1.21.2/go.mod h1:XLcoWfF9d2lO4nhMOehzZ7joRV5Eeb9XbskH9VzrJyg=
 github.com/aws/aws-sdk-go-v2/service/costandusagereportservice v1.29.2 h1:D666olsTyg9hBaGKHwxz0CKxVg9L17t9lYnHbtdcnRQ=

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/aws/aws-sdk-go-v2/service/drs v1.31.2 h1:u/krG7I/sQncHUPJRC00HeRDBRln
 github.com/aws/aws-sdk-go-v2/service/drs v1.31.2/go.mod h1:nQRaL4v9kL/iWu6Qh0f5OsT3KsUQM/xESdp9c5aReM4=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.2.0 h1:Bt5fx8LwBCJOrn1hKgIO6B3EFCFxvhx+PZoc4yFhFFs=
 github.com/aws/aws-sdk-go-v2/service/dsql v1.2.0/go.mod h1:StDU/D7R42LhrKp24PGzvxyKjjDm0lwo9JMwuy2qbo4=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.0 h1:w0Evr7ssE6gP/EjN6UpAvLyWEdv9NGPbW6awu5OGQc0=
-github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.0/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1 h1:YYjNTAyPL0425ECmq6Xm48NSXdT6hDVQmLOJZxyhNTM=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.43.1/go.mod h1:yYaWRnVSPyAmexW5t7G3TcuYoalYfT+xQwzWsvtUQ7M=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0 h1:z5thR/zKUlw7gd1OT59xBHm4AKBf2kPXKHFvVzLMfBk=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.212.0/go.mod h1:ouvGEfHbLaIlWwpDpOVWPWR+YwO0HDv3vm5tYLq8ImY=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.43.3 h1:YyH8Hk73bYzdbvf6S8NF5z/fb/1stpiMnFSfL6jSfRA=


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Manual update of `github.com/aws/aws-sdk-go-v2/aws` dependencies to [`Release 2025-04-29`](https://github.com/aws/aws-sdk-go-v2/commit/67a3bbf2ddee4b5ecb1731a553ed280ed63a7800) due to dependabot failures.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/41898.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
