### PR TITLE
[TFLint] update tflint-ruleset-aws version to fix CI failure

### DIFF
--- a/.ci/.tflint.hcl
+++ b/.ci/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.37.0"
+  version = "0.39.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 


### PR DESCRIPTION
### Description
* Update `tflint-ruleset-aws` to version 0.39.0  
  * In this version, `defaultLogDriverMode` in `aws_ecs_account_setting_default`—introduced by PR #42418—is recognized as a valid value.  
    * https://github.com/terraform-linters/tflint-ruleset-aws/blob/5ca13abb32c573530ad00895d0ce32d66aa24952/rules/models/aws_ecs_account_setting_default_invalid_name.go#L37
  * This resolves the CI failure observed in #42418.  
* In my local environment, I ran TFLint with the updated `tflint-ruleset-aws`, using a branch that combines this change with the one from #42418, and confirmed that no errors (including the one related to `defaultLogDriverMode`) were reported.

### Relations

Relates #42418
