### PR TITLE
[Enhancement] aws_cognito_user_pool_client:  Support `refresh_token_rotation` block

### DIFF
--- a/internal/service/cognitoidp/user_pool_client.go
+++ b/internal/service/cognitoidp/user_pool_client.go
@@ -6,6 +6,7 @@ package cognitoidp
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"strings"
 	"time"
 
@@ -289,6 +290,26 @@ func (r *userPoolClientResource) Schema(ctx context.Context, request resource.Sc
 						"user_data_shared": schema.BoolAttribute{
 							Optional: true,
 							Computed: true,
+						},
+					},
+				},
+			},
+			"refresh_token_rotation": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[refreshTokenRotationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"feature": schema.StringAttribute{
+							CustomType: fwtypes.StringEnumType[awstypes.FeatureType](),
+							Required:   true,
+						},
+						"retry_grace_period_seconds": schema.Int32Attribute{
+							Optional: true,
+							Validators: []validator.Int32{
+								int32validator.Between(0, 60),
+							},
 						},
 					},
 				},
@@ -587,6 +608,7 @@ type resourceUserPoolClientModel struct {
 	Name                                     types.String                                                 `tfsdk:"name"`
 	PreventUserExistenceErrors               fwtypes.StringEnum[awstypes.PreventUserExistenceErrorTypes]  `tfsdk:"prevent_user_existence_errors" autoflex:",legacy"`
 	ReadAttributes                           types.Set                                                    `tfsdk:"read_attributes" autoflex:",legacy"`
+	RefreshTokenRotation                     fwtypes.ListNestedObjectValueOf[refreshTokenRotationModel]   `tfsdk:"refresh_token_rotation"`
 	RefreshTokenValidity                     types.Int64                                                  `tfsdk:"refresh_token_validity"`
 	SupportedIdentityProviders               types.Set                                                    `tfsdk:"supported_identity_providers" autoflex:",legacy"`
 	TokenValidityUnits                       fwtypes.ListNestedObjectValueOf[tokenValidityUnitsModel]     `tfsdk:"token_validity_units"`
@@ -607,6 +629,11 @@ type analyticsConfigurationModel struct {
 	ExternalID     types.String `tfsdk:"external_id"`
 	RoleARN        fwtypes.ARN  `tfsdk:"role_arn"`
 	UserDataShared types.Bool   `tfsdk:"user_data_shared"`
+}
+
+type refreshTokenRotationModel struct {
+	Feature                 fwtypes.StringEnum[awstypes.FeatureType] `tfsdk:"feature"`
+	RetryGracePeriodSeconds types.Int32                              `tfsdk:"retry_grace_period_seconds"`
 }
 
 type tokenValidityUnitsModel struct {

--- a/internal/service/cognitoidp/user_pool_client_data_source.go
+++ b/internal/service/cognitoidp/user_pool_client_data_source.go
@@ -136,6 +136,22 @@ func dataSourceUserPoolClient() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"refresh_token_rotation": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"feature": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"retry_grace_period_seconds": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"refresh_token_validity": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -212,6 +228,9 @@ func dataSourceUserPoolClientRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrName, userPoolClient.ClientName)
 	d.Set("prevent_user_existence_errors", userPoolClient.PreventUserExistenceErrors)
 	d.Set("read_attributes", userPoolClient.ReadAttributes)
+	if err := d.Set("refresh_token_rotation", flattenUserPoolClientRefreshTokenRotation(userPoolClient.RefreshTokenRotation)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting refresh_token_rotation: %s", err)
+	}
 	d.Set("refresh_token_validity", userPoolClient.RefreshTokenValidity)
 	d.Set("supported_identity_providers", userPoolClient.SupportedIdentityProviders)
 	if err := d.Set("token_validity_units", flattenUserPoolClientTokenValidityUnitsType(userPoolClient.TokenValidityUnits)); err != nil {
@@ -266,6 +285,23 @@ func flattenUserPoolClientTokenValidityUnitsType(apiObject *awstypes.TokenValidi
 		"access_token":  apiObject.AccessToken,
 		"id_token":      apiObject.IdToken,
 		"refresh_token": apiObject.RefreshToken,
+	}
+
+	return []any{tfMap}
+}
+
+func flattenUserPoolClientRefreshTokenRotation(apiObject *awstypes.RefreshTokenRotationType) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	if apiObject.Feature == "" && *apiObject.RetryGracePeriodSeconds == 0 {
+		return nil
+	}
+
+	tfMap := map[string]any{
+		"feature":                    apiObject.Feature,
+		"retry_grace_period_seconds": apiObject.RetryGracePeriodSeconds,
 	}
 
 	return []any{tfMap}

--- a/internal/service/cognitoidp/user_pool_client_data_source_test.go
+++ b/internal/service/cognitoidp/user_pool_client_data_source_test.go
@@ -33,6 +33,36 @@ func TestAccCognitoIDPUserPoolClientDataSource_basic(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "ADMIN_NO_SRP_AUTH"),
 					resource.TestCheckResourceAttr(resourceName, "token_validity_units.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccCognitoIDPUserPoolClientDataSource_refreshTokenRotation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var client awstypes.UserPoolClientType
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "data.aws_cognito_user_pool_client.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckIdentityProvider(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolClientDataSourceConfig_refreshTokenRotation(rName, 10),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolClientExists(ctx, resourceName, &client),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "explicit_auth_flows.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "explicit_auth_flows.*", "ADMIN_NO_SRP_AUTH"),
+					resource.TestCheckResourceAttr(resourceName, "token_validity_units.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "analytics_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.0.feature", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "refresh_token_rotation.0.retry_grace_period_seconds", "10"),
 				),
 			},
 		},
@@ -41,6 +71,15 @@ func TestAccCognitoIDPUserPoolClientDataSource_basic(t *testing.T) {
 
 func testAccUserPoolClientDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccUserPoolClientConfig_basic(rName), `
+data "aws_cognito_user_pool_client" "test" {
+  user_pool_id = aws_cognito_user_pool.test.id
+  client_id    = aws_cognito_user_pool_client.test.id
+}
+`)
+}
+
+func testAccUserPoolClientDataSourceConfig_refreshTokenRotation(rName string, retryGracePeriodSeconds int32) string {
+	return acctest.ConfigCompose(testAccUserPoolClientConfig_refreshTokenRotation(rName, retryGracePeriodSeconds), `
 data "aws_cognito_user_pool_client" "test" {
   user_pool_id = aws_cognito_user_pool.test.id
   client_id    = aws_cognito_user_pool_client.test.id

--- a/website/docs/d/cognito_user_pool_client.html.markdown
+++ b/website/docs/d/cognito_user_pool_client.html.markdown
@@ -45,6 +45,7 @@ This data source exports the following attributes in addition to the arguments a
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers.
 * `prevent_user_existence_errors` - (Optional) Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to `ENABLED` and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to `LEGACY`, those APIs will return a `UserNotFoundException` exception if the user does not exist in the user pool.
 * `read_attributes` - (Optional) List of user pool attributes the application client can read from.
+* `refresh_token_rotation` - (Optional) A block that specifies the configuration of refresh token rotation. [Detailed below](#refresh_token_rotation).
 * `refresh_token_validity` - (Optional) Time limit in days refresh tokens are valid for.
 * `supported_identity_providers` - (Optional) List of provider names for the identity providers that are supported on this client. Uses the `provider_name` attribute of `aws_cognito_identity_provider` resource(s), or the equivalent string(s).
 * `token_validity_units` - (Optional) Configuration block for units in which the validity times are represented in. [Detailed below](#token_validity_units).
@@ -59,6 +60,11 @@ Either `application_arn` or `application_id` is required.
 * `external_id` - (Optional) ID for the Analytics Configuration. Conflicts with `application_arn`.
 * `role_arn` - (Optional) ARN of an IAM role that authorizes Amazon Cognito to publish events to Amazon Pinpoint analytics. Conflicts with `application_arn`.
 * `user_data_shared` (Optional) If set to `true`, Amazon Cognito will include user data in the events it publishes to Amazon Pinpoint analytics.
+
+### refresh_token_rotation
+
+* `feature` - (Required) The state of refresh token rotation for the current app client. Valid values are `ENABLED` or `DISABLED`.
+* `retry_grace_period_seconds` - (Optional) A period of time in seconds that the user has to use the old refresh token before it is invalidated. Valid values are between `0` and `60`.
 
 ### token_validity_units
 

--- a/website/docs/r/cognito_user_pool_client.html.markdown
+++ b/website/docs/r/cognito_user_pool_client.html.markdown
@@ -127,6 +127,24 @@ resource "aws_cognito_user_pool" "pool" {
 }
 ```
 
+### Create a user pool client with refresh token rotation
+
+```terraform
+resource "aws_cognito_user_pool_client" "userpool_client" {
+  name                = "client"
+  user_pool_id        = aws_cognito_user_pool.pool.id
+  explicit_auth_flows = ["ADMIN_NO_SRP_AUTH"]
+  refresh_token_rotation {
+    feature                    = "ENABLED"
+    retry_grace_period_seconds = 10
+  }
+}
+
+resource "aws_cognito_user_pool" "pool" {
+  name = "pool"
+}
+```
+
 ## Argument Reference
 
 The following arguments are required:
@@ -152,6 +170,7 @@ The following arguments are optional:
 * `logout_urls` - (Optional) List of allowed logout URLs for the identity providers. `allowed_oauth_flows_user_pool_client` must be set to `true` before you can configure this option.
 * `prevent_user_existence_errors` - (Optional) Setting determines the errors and responses returned by Cognito APIs when a user does not exist in the user pool during authentication, account confirmation, and password recovery.
 * `read_attributes` - (Optional) List of user pool attributes that the application client can read from.
+* `refresh_token_rotation` - (Optional) A block that specifies the configuration of refresh token rotation. [Detailed below](#refresh_token_rotation).
 * `refresh_token_validity` - (Optional) Time limit, between 60 minutes and 10 years, after which the refresh token is no longer valid and cannot be used. By default, the unit is days. The unit can be overridden by a value in `token_validity_units.refresh_token`.
 * `supported_identity_providers` - (Optional) List of provider names for the identity providers that are supported on this client. It uses the `provider_name` attribute of the `aws_cognito_identity_provider` resource(s), or the equivalent string(s).
 * `token_validity_units` - (Optional) Configuration block for representing the validity times in units. See details below. [Detailed below](#token_validity_units).
@@ -166,6 +185,11 @@ Either `application_arn` or `application_id` is required.
 * `external_id` - (Optional) ID for the Analytics Configuration. Conflicts with `application_arn`.
 * `role_arn` - (Optional) ARN of an IAM role that authorizes Amazon Cognito to publish events to Amazon Pinpoint analytics. Conflicts with `application_arn`.
 * `user_data_shared` (Optional) If set to `true`, Amazon Cognito will include user data in the events it publishes to Amazon Pinpoint analytics.
+
+### refresh_token_rotation
+
+* `feature` - (Required) The state of refresh token rotation for the current app client. Valid values are `ENABLED` or `DISABLED`.
+* `retry_grace_period_seconds` - (Optional) A period of time in seconds that the user has to use the old refresh token before it is invalidated. Valid values are between `0` and `60`.
 
 ### token_validity_units
 


### PR DESCRIPTION
### Description
* Add `refresh_token_rotation` block to `aws_cognito_user_pool` resource and data source.

### Relations

Closes #42398

### References
https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolClient.html#CognitoUserPools-CreateUserPoolClient-request-RefreshTokenRotation

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccCognitoIDPUserPoolClientDataSource_ PKG=cognitoidp              
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolClientDataSource_'  -timeout 360m -vet=off
2025/05/01 00:52:43 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPUserPoolClientDataSource_basic
=== PAUSE TestAccCognitoIDPUserPoolClientDataSource_basic
=== RUN   TestAccCognitoIDPUserPoolClientDataSource_refreshTokenRotation
=== PAUSE TestAccCognitoIDPUserPoolClientDataSource_refreshTokenRotation
=== CONT  TestAccCognitoIDPUserPoolClientDataSource_basic
=== CONT  TestAccCognitoIDPUserPoolClientDataSource_refreshTokenRotation
--- PASS: TestAccCognitoIDPUserPoolClientDataSource_refreshTokenRotation (27.32s)
--- PASS: TestAccCognitoIDPUserPoolClientDataSource_basic (27.35s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 31.801s
```

```console
$ make testacc TESTS=TestAccCognitoIDPUserPoolClient_ PKG=cognitoidp
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolClient_'  -timeout 360m -vet=off
2025/05/01 00:53:56 Initializing Terraform AWS Provider...
=== RUN   TestAccCognitoIDPUserPoolClient_basic
=== PAUSE TestAccCognitoIDPUserPoolClient_basic
=== RUN   TestAccCognitoIDPUserPoolClient_enableRevocation
=== PAUSE TestAccCognitoIDPUserPoolClient_enableRevocation
=== RUN   TestAccCognitoIDPUserPoolClient_accessTokenValidity
=== PAUSE TestAccCognitoIDPUserPoolClient_accessTokenValidity
=== RUN   TestAccCognitoIDPUserPoolClient_accessTokenValidity_error
=== PAUSE TestAccCognitoIDPUserPoolClient_accessTokenValidity_error
=== RUN   TestAccCognitoIDPUserPoolClient_idTokenValidity
=== PAUSE TestAccCognitoIDPUserPoolClient_idTokenValidity
=== RUN   TestAccCognitoIDPUserPoolClient_idTokenValidity_error
=== PAUSE TestAccCognitoIDPUserPoolClient_idTokenValidity_error
=== RUN   TestAccCognitoIDPUserPoolClient_refreshTokenValidity
=== PAUSE TestAccCognitoIDPUserPoolClient_refreshTokenValidity
=== RUN   TestAccCognitoIDPUserPoolClient_refreshTokenValidity_error
=== PAUSE TestAccCognitoIDPUserPoolClient_refreshTokenValidity_error
=== RUN   TestAccCognitoIDPUserPoolClient_tokenValidityUnits
=== PAUSE TestAccCognitoIDPUserPoolClient_tokenValidityUnits
=== RUN   TestAccCognitoIDPUserPoolClient_tokenValidityUnits_explicitDefaults
=== PAUSE TestAccCognitoIDPUserPoolClient_tokenValidityUnits_explicitDefaults
=== RUN   TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken
=== PAUSE TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken
=== RUN   TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity
=== PAUSE TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity
=== RUN   TestAccCognitoIDPUserPoolClient_name
=== PAUSE TestAccCognitoIDPUserPoolClient_name
=== RUN   TestAccCognitoIDPUserPoolClient_allFields
=== PAUSE TestAccCognitoIDPUserPoolClient_allFields
=== RUN   TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField
=== PAUSE TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField
=== RUN   TestAccCognitoIDPUserPoolClient_analyticsApplicationID
=== PAUSE TestAccCognitoIDPUserPoolClient_analyticsApplicationID
=== RUN   TestAccCognitoIDPUserPoolClient_analyticsWithARN
=== PAUSE TestAccCognitoIDPUserPoolClient_analyticsWithARN
=== RUN   TestAccCognitoIDPUserPoolClient_authSessionValidity
=== PAUSE TestAccCognitoIDPUserPoolClient_authSessionValidity
=== RUN   TestAccCognitoIDPUserPoolClient_disappears
=== PAUSE TestAccCognitoIDPUserPoolClient_disappears
=== RUN   TestAccCognitoIDPUserPoolClient_Disappears_userPool
=== PAUSE TestAccCognitoIDPUserPoolClient_Disappears_userPool
=== RUN   TestAccCognitoIDPUserPoolClient_emptySets
=== PAUSE TestAccCognitoIDPUserPoolClient_emptySets
=== RUN   TestAccCognitoIDPUserPoolClient_nulls
=== PAUSE TestAccCognitoIDPUserPoolClient_nulls
=== RUN   TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls
=== PAUSE TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls
=== RUN   TestAccCognitoIDPUserPoolClient_frameworkMigration_basic
=== PAUSE TestAccCognitoIDPUserPoolClient_frameworkMigration_basic
=== RUN   TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet
=== PAUSE TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet
=== RUN   TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
=== PAUSE TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
=== RUN   TestAccCognitoIDPUserPoolClient_urls_utf8
=== PAUSE TestAccCognitoIDPUserPoolClient_urls_utf8
=== RUN   TestAccCognitoIDPUserPoolClient_refreshTokenRotation
=== PAUSE TestAccCognitoIDPUserPoolClient_refreshTokenRotation
=== CONT  TestAccCognitoIDPUserPoolClient_basic
=== CONT  TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField
=== CONT  TestAccCognitoIDPUserPoolClient_refreshTokenValidity_error
=== CONT  TestAccCognitoIDPUserPoolClient_allFields
=== CONT  TestAccCognitoIDPUserPoolClient_name
=== CONT  TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity
=== CONT  TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken
=== CONT  TestAccCognitoIDPUserPoolClient_tokenValidityUnits_explicitDefaults
=== CONT  TestAccCognitoIDPUserPoolClient_tokenValidityUnits
=== CONT  TestAccCognitoIDPUserPoolClient_nulls
=== CONT  TestAccCognitoIDPUserPoolClient_refreshTokenRotation
=== CONT  TestAccCognitoIDPUserPoolClient_urls_utf8
=== CONT  TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8
=== CONT  TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet
=== CONT  TestAccCognitoIDPUserPoolClient_frameworkMigration_basic
=== CONT  TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls
=== CONT  TestAccCognitoIDPUserPoolClient_idTokenValidity
=== CONT  TestAccCognitoIDPUserPoolClient_refreshTokenValidity
=== CONT  TestAccCognitoIDPUserPoolClient_idTokenValidity_error
=== CONT  TestAccCognitoIDPUserPoolClient_enableRevocation
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity_error (12.24s)
=== CONT  TestAccCognitoIDPUserPoolClient_disappears
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity_error (12.67s)
=== CONT  TestAccCognitoIDPUserPoolClient_emptySets
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits_explicitDefaults (52.37s)
=== CONT  TestAccCognitoIDPUserPoolClient_Disappears_userPool
--- PASS: TestAccCognitoIDPUserPoolClient_disappears (40.79s)
=== CONT  TestAccCognitoIDPUserPoolClient_accessTokenValidity_error
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity_error (5.57s)
=== CONT  TestAccCognitoIDPUserPoolClient_analyticsWithARN
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_emptySet (60.72s)
=== CONT  TestAccCognitoIDPUserPoolClient_authSessionValidity
--- PASS: TestAccCognitoIDPUserPoolClient_supportedIdentityProviders_utf8 (61.00s)
=== CONT  TestAccCognitoIDPUserPoolClient_analyticsApplicationID
--- PASS: TestAccCognitoIDPUserPoolClient_allFields (61.99s)
=== CONT  TestAccCognitoIDPUserPoolClient_accessTokenValidity
--- PASS: TestAccCognitoIDPUserPoolClient_basic (62.21s)
--- PASS: TestAccCognitoIDPUserPoolClient_urls_utf8 (62.26s)
--- PASS: TestAccCognitoIDPUserPoolClient_emptySets (57.94s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_basic (70.63s)
--- PASS: TestAccCognitoIDPUserPoolClient_frameworkMigration_nulls (71.19s)
--- PASS: TestAccCognitoIDPUserPoolClient_nulls (71.93s)
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenRotation (77.94s)
--- PASS: TestAccCognitoIDPUserPoolClient_allFieldsUpdatingOneField (80.22s)
--- PASS: TestAccCognitoIDPUserPoolClient_enableRevocation (82.37s)
--- PASS: TestAccCognitoIDPUserPoolClient_Disappears_userPool (30.03s)
--- PASS: TestAccCognitoIDPUserPoolClient_name (82.61s)
--- PASS: TestAccCognitoIDPUserPoolClient_idTokenValidity (84.77s)
--- PASS: TestAccCognitoIDPUserPoolClient_refreshTokenValidity (85.25s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnitsWTokenValidity (88.35s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits_AccessToken (88.37s)
--- PASS: TestAccCognitoIDPUserPoolClient_tokenValidityUnits (105.30s)
--- PASS: TestAccCognitoIDPUserPoolClient_accessTokenValidity (46.13s)
--- PASS: TestAccCognitoIDPUserPoolClient_authSessionValidity (47.48s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsWithARN (51.70s)
--- PASS: TestAccCognitoIDPUserPoolClient_analyticsApplicationID (65.89s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 131.012s
```
