### PR TITLE
internal/sdkv2/types/nullable: refine `TypeNullableBool` validation

### DIFF
--- a/.changelog/42434.txt
+++ b/.changelog/42434.txt
@@ -1,0 +1,36 @@
+```release-note:breaking-change
+resource/aws_accessanalyzer_archive_rule: `filter.exists` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_cloudtrail_event_data_store: `suspend` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_ec2_spot_instance_fleet: `terminate_instances_on_delete` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_elasticache_cluster: `auto_minor_version_upgrade` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_elasticache_replication_group: `at_rest_encryption_enabled` and `auto_minor_version_upgrade` now only accept one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_evidently_feature: `variations.value.bool_value` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_imagebuilder_container_recipe: `instance_configuration.block_device_mapping.ebs.delete_on_termination` and `instance_configuration.block_device_mapping.ebs.encrypted` now only accept one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_imagebuilder_image_recipe: `block_device_mapping.ebs.delete_on_termination` and `block_device_mapping.ebs.encrypted` now only accept one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_launch_template:  `block_device_mappings.ebs.delete_on_termination`, `block_device_mappings.ebs.encrypted`, `ebs_optimized`, `network_interfaces.associate_carrier_ip_address`, `network_interfaces.associate_public_ip_address`, `network_interfaces.delete_on_termination`, and `network_interfaces.primary_ipv6` now only accept one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_lb_target_group: `preserve_client_ip` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_alb_target_group: `preserve_client_ip` now only accepts one of `""` (empty string), `true`, or `false`
+```
+```release-note:breaking-change
+resource/aws_mq_broker: `logs.audit` now only accepts one of `""` (empty string), `true`, or `false`
+```

--- a/internal/sdkv2/types/nullable/bool.go
+++ b/internal/sdkv2/types/nullable/bool.go
@@ -45,19 +45,12 @@ func ValidateTypeStringNullableBool(v any, k string) (ws []string, es []error) {
 		return
 	}
 
-	if value == "" {
+	switch value {
+	case "", "true", "false":
 		return
 	}
 
-	if _, err := strconv.ParseBool(value); err != nil {
-		es = append(es, fmt.Errorf("%s: cannot parse '%s' as boolean: %w", k, value, err))
-		return
-	}
-
-	if value != "true" && value != "false" {
-		ws = append(ws, fmt.Sprintf(`%s: the use of values other than "true" and "false" is deprecated and will be removed in a future version of the provider`, k))
-	}
-
+	es = append(es, fmt.Errorf("expected %s to be one of '', 'true', or 'false', got '%s'", k, value))
 	return
 }
 

--- a/internal/sdkv2/types/nullable/bool_test.go
+++ b/internal/sdkv2/types/nullable/bool_test.go
@@ -87,14 +87,14 @@ func TestValidationBool(t *testing.T) {
 			f:   ValidateTypeStringNullableBool,
 		},
 		{
-			val:             "1",
-			f:               ValidateTypeStringNullableBool,
-			expectedWarning: regexache.MustCompile(`^\w+: the use of values other than "true" and "false" is deprecated and will be removed in a future version of the provider$`),
+			val:         "1",
+			f:           ValidateTypeStringNullableBool,
+			expectedErr: regexache.MustCompile(`^expected \w+ to be one of '', 'true', or 'false', got '.+'$`),
 		},
 		{
 			val:         "A",
 			f:           ValidateTypeStringNullableBool,
-			expectedErr: regexache.MustCompile(`^\w+: cannot parse 'A' as boolean: .+$`),
+			expectedErr: regexache.MustCompile(`^expected \w+ to be one of '', 'true', or 'false', got '.+'$`),
 		},
 		{
 			val:         1,

--- a/internal/sdkv2/types/nullable/testing.go
+++ b/internal/sdkv2/types/nullable/testing.go
@@ -5,17 +5,15 @@ package nullable
 
 import (
 	"regexp"
-	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type testCase struct {
-	val             any
-	f               schema.SchemaValidateFunc
-	expectedErr     *regexp.Regexp
-	expectedWarning *regexp.Regexp
+	val         any
+	f           schema.SchemaValidateFunc
+	expectedErr *regexp.Regexp
 }
 
 func runValidationTestCases(t *testing.T, cases []testCase) {
@@ -32,26 +30,14 @@ func runValidationTestCases(t *testing.T, cases []testCase) {
 		return false
 	}
 
-	matchWarning := func(warnings []string, r *regexp.Regexp) bool {
-		// warning must match one provided
-		return slices.ContainsFunc(warnings, r.MatchString)
-	}
-
 	for i, tc := range cases {
-		warnings, errs := tc.f(tc.val, "test_property")
+		_, errs := tc.f(tc.val, "test_property")
 
 		if tc.expectedErr == nil && len(errs) != 0 {
 			t.Errorf("expected test case %d to produce no errors, got %v", i, errs)
 		}
 		if tc.expectedErr != nil && !matchErr(errs, tc.expectedErr) {
 			t.Errorf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
-		}
-
-		if tc.expectedWarning == nil && len(warnings) != 0 {
-			t.Errorf("expected test case %d to produce no warnings, got %v", i, warnings)
-		}
-		if tc.expectedWarning != nil && !matchWarning(warnings, tc.expectedWarning) {
-			t.Errorf("expected test case %d to produce warning matching \"%s\", got %v", i, tc.expectedWarning, warnings)
 		}
 	}
 }

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -22,6 +22,7 @@ Upgrade topics:
 - [AWS CloudWatch Evidently Deprecation](#aws-cloudwatch-evidently-deprecation)
 - [Amazon Elastic Transcoder Deprecation](#amazon-elastic-transcoder-deprecation)
 - [S3 Global Endpoint Support Deprecation](#s3-global-endpoint-support-deprecation)
+- [Updated TypeNullableBool Validation](#updated-typenullablebool-validation)
 - [data-source/aws_ami](#data-sourceaws_ami)
 - [data-source/aws_batch_compute_environment](#data-sourceaws_batch_compute_environment)
 - [data-source/aws_ecs_task_definition](#data-sourceaws_ecs_task_definition)
@@ -184,6 +185,45 @@ Support for the global S3 endpoint is deprecated, along with the `s3_us_east_1_r
 The ability to use the global S3 endpoint will be removed in `v7.0.0`.
 This change only affects S3 resources in `us-east-1` (excluding directory buckets), where `s3_us_east_1_regional_endpoint` is set to `legacy` in the provider configuration.
 Impacted configurations can remove the `s3_us_east_1_regional_endpoint` provider argument, or switch the value to `regional` to verify connectivity with the regional S3 endpoint in `us-east-1` prior to this option being removed.
+
+## Updated `TypeNullableBool` Validation
+
+`TypeNullableBool` arguments now only accept one of `""` (empty string), `true`, or `false`.
+The ability to provide `0` or `1` to these arguments was previously deprecated and will now result in a plan-time validation error instead.
+
+The following resource arguments are impacted by this change:
+
+- `aws_accessanalyzer_archive_rule`
+    - `filter.exists`
+- `aws_cloudtrail_event_data_store`
+    - `suspend`
+- `aws_ec2_spot_instance_fleet`
+    - `terminate_instances_on_delete`
+- `aws_elasticache_cluster`
+    - `auto_minor_version_upgrade`
+- `aws_elasticache_replication_group`
+    - `at_rest_encryption_enabled`
+    - `auto_minor_version_upgrade`
+- `aws_evidently_feature`
+    - `variations.value.bool_value`
+- `aws_imagebuilder_container_recipe`
+    - `instance_configuration.block_device_mapping.ebs.delete_on_termination`
+    - `instance_configuration.block_device_mapping.ebs.encrypted`
+- `aws_imagebuilder_image_recipe`
+    - `block_device_mapping.ebs.delete_on_termination`
+    - `block_device_mapping.ebs.encrypted`
+- `aws_launch_template`
+    - `block_device_mappings.ebs.delete_on_termination`
+    - `block_device_mappings.ebs.encrypted`
+    - `ebs_optimized`
+    - `network_interfaces.associate_carrier_ip_address`
+    - `network_interfaces.associate_public_ip_address`
+    - `network_interfaces.delete_on_termination`
+    - `network_interfaces.primary_ipv6`
+- `aws_lb_target_group`, `aws_alb_target_group`
+    - `preserve_client_ip`
+- `aws_mq_broker`
+    - `logs.audit`
 
 ## data-source/aws_ami
 


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Arguments of the type `TypeNullableBool` will now only accept one of `""` (empty string), `true`, or `false`. An upgrade guide entry is included enumerating the resources and arguments which are affected by this validation change.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #29379
Relates #32090
Relates #41101

### Output from Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -count=1 ./internal/sdkv2/types/nullable/...
ok      github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable       0.208s
```
