### PR TITLE
security/tests: Add `enable_key_rotation` to `aws_kms_key`

### DIFF
--- a/internal/service/amp/workspace_test.go
+++ b/internal/service/amp/workspace_test.go
@@ -325,6 +325,7 @@ resource "aws_prometheus_workspace" "test" {
 resource "aws_kms_key" "test" {
   description             = "Test"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName)
 }

--- a/internal/service/appconfig/configuration_profile_data_source_test.go
+++ b/internal/service/appconfig/configuration_profile_data_source_test.go
@@ -64,6 +64,7 @@ func testAccConfigurationProfileDataSourceConfig_basic(appName, rName string) st
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {

--- a/internal/service/appconfig/configuration_profile_test.go
+++ b/internal/service/appconfig/configuration_profile_test.go
@@ -351,6 +351,7 @@ func testAccConfigurationProfileConfig_kms(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {

--- a/internal/service/appconfig/deployment_test.go
+++ b/internal/service/appconfig/deployment_test.go
@@ -213,6 +213,7 @@ func testAccDeploymentConfig_baseKMS(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_appconfig_application" "test" {

--- a/internal/service/appfabric/app_bundle_test.go
+++ b/internal/service/appfabric/app_bundle_test.go
@@ -165,7 +165,9 @@ resource "aws_appfabric_app_bundle" "test" {}
 func testAccAppBundleConfig_cmk(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_appfabric_app_bundle" "test" {

--- a/internal/service/appintegrations/data_integration_test.go
+++ b/internal/service/appintegrations/data_integration_test.go
@@ -279,6 +279,7 @@ func testAccDataIntegrationBaseConfig() string {
 	return `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/apprunner/service_test.go
+++ b/internal/service/apprunner/service_test.go
@@ -688,6 +688,7 @@ func testAccServiceConfig_ImageRepository_encryptionConfiguration(rName string) 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
   description             = %[1]q
+  enable_key_rotation     = true
 }
 
 resource "aws_apprunner_service" "test" {

--- a/internal/service/athena/database_test.go
+++ b/internal/service/athena/database_test.go
@@ -538,6 +538,7 @@ func testAccDatabaseConfig_kms(rName string, dbName string, forceDestroy bool) s
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 10
   description             = %[1]q
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {

--- a/internal/service/athena/workgroup_test.go
+++ b/internal/service/athena/workgroup_test.go
@@ -953,6 +953,7 @@ func testAccWorkGroupConfig_resultEncryptionEncryptionOptionKMS(rName, encryptio
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
   description             = "Terraform Acceptance Testing"
+  enable_key_rotation     = true
 }
 
 resource "aws_athena_workgroup" "test" {

--- a/internal/service/auditmanager/account_registration_test.go
+++ b/internal/service/auditmanager/account_registration_test.go
@@ -198,7 +198,9 @@ resource "aws_auditmanager_account_registration" "test" {
 
 func testAccAccountRegistrationConfig_KMSKey() string {
 	return `
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  enable_key_rotation = true
+}
 
 resource "aws_auditmanager_account_registration" "test" {
   kms_key = aws_kms_key.test.arn

--- a/internal/service/backup/vault_test.go
+++ b/internal/service/backup/vault_test.go
@@ -355,6 +355,7 @@ func testAccVaultConfig_kmsKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_backup_vault" "test" {

--- a/internal/service/bedrock/custom_model_test.go
+++ b/internal/service/bedrock/custom_model_test.go
@@ -455,6 +455,7 @@ func testAccCustomModelConfig_kmsKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_bedrock_custom_model" "test" {

--- a/internal/service/bedrock/guardrail_test.go
+++ b/internal/service/bedrock/guardrail_test.go
@@ -344,6 +344,7 @@ func testAccGuardrailConfig_kmsKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_bedrock_guardrail" "test" {

--- a/internal/service/chimesdkvoice/voice_profile_domain_test.go
+++ b/internal/service/chimesdkvoice/voice_profile_domain_test.go
@@ -271,6 +271,7 @@ func testAccVoiceProfileDomainConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   description             = "TF Acceptance Test Voice Profile Domain"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_chimesdkvoice_voice_profile_domain" "test" {
@@ -287,6 +288,7 @@ func testAccVoiceProfileDomainConfig_description(rName, description string) stri
 resource "aws_kms_key" "test" {
   description             = "TF Acceptance Test Voice Profile Domain"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_chimesdkvoice_voice_profile_domain" "test" {
@@ -304,6 +306,7 @@ func testAccVoiceProfileDomainConfig_tags1(rName, tagKey1, tagValue1 string) str
 resource "aws_kms_key" "test" {
   description             = "TF Acceptance Test Voice Profile Domain"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_chimesdkvoice_voice_profile_domain" "test" {
@@ -324,6 +327,7 @@ func testAccVoiceProfileDomainConfig_tags2(rName, tagKey1, tagValue1, tagKey2, t
 resource "aws_kms_key" "test" {
   description             = "TF Acceptance Test Voice Profile Domain"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_chimesdkvoice_voice_profile_domain" "test" {

--- a/internal/service/cloudtrail/event_data_store_test.go
+++ b/internal/service/cloudtrail/event_data_store_test.go
@@ -500,7 +500,8 @@ resource "aws_cloudtrail_event_data_store" "test" {
 func testAccEventDataStoreConfig_kmsKeyId(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  multi_region = true
+  multi_region        = true
+  enable_key_rotation = true
   policy = jsonencode({
     Id = %[1]q
     Statement = [{

--- a/internal/service/cloudtrail/trail_test.go
+++ b/internal/service/cloudtrail/trail_test.go
@@ -1221,7 +1221,8 @@ resource "aws_cloudtrail" "test" {
 func testAccCloudTrailConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(testAccCloudTrailConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description         = %[1]q
+  enable_key_rotation = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/codeartifact/authorization_token_data_source_test.go
+++ b/internal/service/codeartifact/authorization_token_data_source_test.go
@@ -85,6 +85,7 @@ func testAccCheckAuthorizationTokenConfig_base(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codeartifact/domain_permissions_policy_test.go
+++ b/internal/service/codeartifact/domain_permissions_policy_test.go
@@ -212,6 +212,7 @@ func testAccDomainPermissionsPolicyConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -243,6 +244,7 @@ func testAccDomainPermissionsPolicyConfig_owner(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -275,6 +277,7 @@ func testAccDomainPermissionsPolicyConfig_updated(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -309,6 +312,7 @@ func testAccDomainPermissionsPolicyConfig_order(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -339,6 +343,7 @@ func testAccDomainPermissionsPolicyConfig_newOrder(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codeartifact/domain_test.go
+++ b/internal/service/codeartifact/domain_test.go
@@ -234,6 +234,7 @@ func testAccDomainConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codeartifact/repository_endpoint_data_source_test.go
+++ b/internal/service/codeartifact/repository_endpoint_data_source_test.go
@@ -81,6 +81,7 @@ func testAccCheckRepositoryEndpointBaseConfig(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codeartifact/repository_permissions_policy_test.go
+++ b/internal/service/codeartifact/repository_permissions_policy_test.go
@@ -211,6 +211,7 @@ func testAccRepositoryPermissionsPolicyConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -248,6 +249,7 @@ func testAccRepositoryPermissionsPolicyConfig_owner(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -286,6 +288,7 @@ func testAccRepositoryPermissionsPolicyConfig_updated(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -326,6 +329,7 @@ func testAccRepositoryPermissionsPolicyConfig_order(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {
@@ -362,6 +366,7 @@ func testAccRepositoryPermissionsPolicyConfig_newOrder(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codeartifact/repository_test.go
+++ b/internal/service/codeartifact/repository_test.go
@@ -327,6 +327,7 @@ func testAccRepositoryConfig_base(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codeartifact_domain" "test" {

--- a/internal/service/codebuild/project_test.go
+++ b/internal/service/codebuild/project_test.go
@@ -3502,6 +3502,7 @@ func testAccProjectConfig_encryptionKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codebuild_project" "test" {

--- a/internal/service/codebuild/report_group_test.go
+++ b/internal/service/codebuild/report_group_test.go
@@ -285,6 +285,7 @@ func testAccReportGroupBasicS3ExportBaseConfig(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/codecommit/repository_test.go
+++ b/internal/service/codecommit/repository_test.go
@@ -413,6 +413,7 @@ resource "aws_kms_key" "test" {
 
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_codecommit_repository" "test" {

--- a/internal/service/codegurureviewer/repository_association_test.go
+++ b/internal/service/codegurureviewer/repository_association_test.go
@@ -358,6 +358,7 @@ func testAccRepositoryAssociation_kms_key() string {
 	return `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `
 }

--- a/internal/service/cognitoidp/user_pool_test.go
+++ b/internal/service/cognitoidp/user_pool_test.go
@@ -2638,6 +2638,7 @@ resource "aws_lambda_function" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/comprehend/document_classifier_test.go
+++ b/internal/service/comprehend/document_classifier_test.go
@@ -1828,10 +1828,12 @@ resource "aws_comprehend_document_classifier" "test" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -1918,10 +1920,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -2006,10 +2010,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -2069,10 +2075,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -2227,6 +2235,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
 resource "aws_kms_key" "output" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -2282,6 +2291,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
 resource "aws_kms_key" "output" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -2342,6 +2352,7 @@ resource "aws_kms_alias" "output" {
 
 resource "aws_kms_key" "output" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -2402,6 +2413,7 @@ resource "aws_kms_alias" "output" {
 
 resource "aws_kms_key" "output" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -2457,6 +2469,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
 resource "aws_kms_key" "output" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {
@@ -2543,6 +2556,7 @@ resource "aws_comprehend_document_classifier" "test" {
 
 resource "aws_kms_key" "output2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role_policy" "kms_keys" {

--- a/internal/service/comprehend/entity_recognizer_test.go
+++ b/internal/service/comprehend/entity_recognizer_test.go
@@ -1503,10 +1503,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -1579,10 +1581,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -1693,10 +1697,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -1769,10 +1775,12 @@ data "aws_iam_policy_document" "kms_keys" {
 
 resource "aws_kms_key" "model2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "volume2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }

--- a/internal/service/configservice/delivery_channel_test.go
+++ b/internal/service/configservice/delivery_channel_test.go
@@ -218,6 +218,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/connect/instance_storage_config_data_source_test.go
+++ b/internal/service/connect/instance_storage_config_data_source_test.go
@@ -289,11 +289,11 @@ data "aws_connect_instance_storage_config" "test" {
 
 func testAccInstanceStorageConfigDataSourceConfig_kinesisVideoStreamConfig(rName string) string {
 	return acctest.ConfigCompose(
-		testAccInstanceStorageConfigDataSourceConfig_base(rName),
-		`
+		testAccInstanceStorageConfigDataSourceConfig_base(rName), `
 resource "aws_kms_key" "test" {
   description             = "KMS Key"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_connect_instance_storage_config" "test" {
@@ -319,7 +319,8 @@ data "aws_connect_instance_storage_config" "test" {
   instance_id    = aws_connect_instance.test.id
   resource_type  = aws_connect_instance_storage_config.test.resource_type
 }
-`)
+`,
+	)
 }
 
 func testAccInstanceStorageConfigDataSourceConfig_S3Config(rName, rName2 string) string {
@@ -329,6 +330,7 @@ func testAccInstanceStorageConfigDataSourceConfig_S3Config(rName, rName2 string)
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {

--- a/internal/service/connect/instance_storage_config_test.go
+++ b/internal/service/connect/instance_storage_config_test.go
@@ -724,6 +724,7 @@ func testAccInstanceStorageConfigConfig_kinesisVideoStreamConfig_prefixRetention
 resource "aws_kms_key" "test" {
   description             = "KMS Key"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_connect_instance_storage_config" "test" {
@@ -757,11 +758,13 @@ locals {
 resource "aws_kms_key" "test" {
   description             = "KMS Key"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   description             = "KMS Key 2"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_connect_instance_storage_config" "test" {
@@ -852,11 +855,13 @@ locals {
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket 1"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   description             = "KMS Key for Bucket 2"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 

--- a/internal/service/customerprofiles/domain_test.go
+++ b/internal/service/customerprofiles/domain_test.go
@@ -321,6 +321,7 @@ resource "aws_sqs_queue" "test" {
 resource "aws_kms_key" "test" {
   description             = "test"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "example" {
@@ -448,6 +449,7 @@ resource "aws_sqs_queue" "test" {
 resource "aws_kms_key" "test" {
   description             = "test"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "example" {

--- a/internal/service/dataexchange/event_action_test.go
+++ b/internal/service/dataexchange/event_action_test.go
@@ -552,6 +552,7 @@ func testAccEventActionConfig_encryption_kmsKey(bucketName, dataSetId string) st
 		s3BucketConfig(bucketName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
+  enable_key_rotation = true
 }
 
 resource "aws_dataexchange_event_action" "test" {

--- a/internal/service/datazone/domain_test.go
+++ b/internal/service/datazone/domain_test.go
@@ -372,6 +372,7 @@ func testAccDomainConfig_kms_key_identifier(rName string) string {
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_datazone_domain" "test" {

--- a/internal/service/devopsguru/service_integration_test.go
+++ b/internal/service/devopsguru/service_integration_test.go
@@ -179,6 +179,7 @@ func testAccServiceIntegrationConfig_kmsCustomerManaged() string {
 	return `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_devopsguru_service_integration" "test" {

--- a/internal/service/dlm/lifecycle_policy_test.go
+++ b/internal/service/dlm/lifecycle_policy_test.go
@@ -1075,8 +1075,9 @@ func testAccLifecyclePolicyConfig_updateCrossRegionCopyRule(rName string) string
 		lifecyclePolicyBaseConfig(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  provider    = "awsalternate"
-  description = %[1]q
+  provider            = "awsalternate"
+  description         = %[1]q
+  enable_key_rotation = true
 
   policy = <<POLICY
 {

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3526,6 +3526,7 @@ func testAccEndpointConfig_postgresKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dms_endpoint" "test" {
@@ -3553,6 +3554,7 @@ func testAccEndpointConfig_sqlserverKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dms_endpoint" "test" {
@@ -3580,6 +3582,7 @@ func testAccEndpointConfig_sybaseKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dms_endpoint" "test" {
@@ -3793,6 +3796,7 @@ resource "aws_dms_endpoint" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -3825,6 +3829,7 @@ resource "aws_dms_endpoint" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -3857,6 +3862,7 @@ resource "aws_dms_endpoint" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }

--- a/internal/service/dms/replication_instance_test.go
+++ b/internal/service/dms/replication_instance_test.go
@@ -582,6 +582,7 @@ data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dms_replication_instance" "test" {

--- a/internal/service/dms/s3_endpoint_test.go
+++ b/internal/service/dms/s3_endpoint_test.go
@@ -508,7 +508,8 @@ func testAccS3EndpointConfig_basic(rName string) string {
 		testAccS3EndpointConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description         = %[1]q
+  enable_key_rotation = true
 
   policy = jsonencode({
     Version = "2012-10-17"
@@ -587,7 +588,8 @@ func testAccS3EndpointConfig_update(rName string) string {
 		testAccS3EndpointConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test2" {
-  description = %[1]q
+  description         = %[1]q
+  enable_key_rotation = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/S3Endpoint/tags/main_gen.tf
+++ b/internal/service/dms/testdata/S3Endpoint/tags/main_gen.tf
@@ -53,7 +53,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/S3Endpoint/tagsComputed1/main_gen.tf
+++ b/internal/service/dms/testdata/S3Endpoint/tagsComputed1/main_gen.tf
@@ -57,7 +57,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/S3Endpoint/tagsComputed2/main_gen.tf
+++ b/internal/service/dms/testdata/S3Endpoint/tagsComputed2/main_gen.tf
@@ -58,7 +58,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/S3Endpoint/tags_defaults/main_gen.tf
+++ b/internal/service/dms/testdata/S3Endpoint/tags_defaults/main_gen.tf
@@ -59,7 +59,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/S3Endpoint/tags_ignore/main_gen.tf
+++ b/internal/service/dms/testdata/S3Endpoint/tags_ignore/main_gen.tf
@@ -62,7 +62,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/dms/testdata/tmpl/s3_endpoint_tags.gtpl
+++ b/internal/service/dms/testdata/tmpl/s3_endpoint_tags.gtpl
@@ -49,7 +49,9 @@ resource "aws_dms_s3_endpoint" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = var.rName
+  description             = var.rName
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/internal/service/docdb/cluster_instance_test.go
+++ b/internal/service/docdb/cluster_instance_test.go
@@ -499,7 +499,9 @@ resource "aws_docdb_cluster_instance" "test" {
 func testAccClusterInstanceConfig_performanceInsights(rName string) string {
 	return acctest.ConfigCompose(testAccClusterInstanceConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -559,7 +561,9 @@ resource "aws_docdb_cluster_instance" "test" {
 func testAccClusterInstanceConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1185,7 +1185,9 @@ resource "aws_docdb_cluster" "test" {
 func testAccClusterConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/dynamodb/table_export_test.go
+++ b/internal/service/dynamodb/table_export_test.go
@@ -331,6 +331,7 @@ func testAccTableExportConfig_kms(tableName string) string {
 	return acctest.ConfigCompose(testAccTableExportConfig_baseConfig(tableName), `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table_export" "test" {

--- a/internal/service/dynamodb/table_replica_test.go
+++ b/internal/service/dynamodb/table_replica_test.go
@@ -465,6 +465,7 @@ func testAccTableReplicaConfig_pitrKMS(rName string, pitr bool) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -493,6 +494,7 @@ resource "aws_kms_key" "alternate" {
   provider                = awsalternate
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table_replica" "test" {
@@ -583,18 +585,21 @@ resource "aws_kms_key" "alternate" {
   description             = "Julie test KMS key A"
   multi_region            = false
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test1" {
   description             = "Julie test KMS key Z"
   multi_region            = false
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   description             = "Julie test KMS key Z"
   multi_region            = false
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {

--- a/internal/service/dynamodb/table_test.go
+++ b/internal/service/dynamodb/table_test.go
@@ -3768,6 +3768,7 @@ data "aws_kms_alias" "dynamodb" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -3793,6 +3794,7 @@ func testAccTableConfig_initialStateEncryptionBYOK(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -4499,12 +4501,14 @@ data "aws_region" "alternate" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "awsalternate" {
   provider                = "awsalternate"
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -4598,30 +4602,35 @@ data "aws_region" "third" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "awsalternate1" {
   provider                = "awsalternate"
   description             = "%[1]s-1"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "awsalternate2" {
   provider                = "awsalternate"
   description             = "%[1]s-2"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "awsthird1" {
   provider                = "awsthird"
   description             = "%[1]s-1"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "awsthird2" {
   provider                = "awsthird"
   description             = "%[1]s-2"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -4716,18 +4725,21 @@ data "aws_region" "third" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "alternate" {
   provider                = awsalternate
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "third" {
   provider                = awsthird
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -5198,6 +5210,7 @@ resource "aws_dynamodb_table" "source" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -5239,6 +5252,7 @@ resource "aws_dynamodb_table" "source" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -5293,6 +5307,7 @@ resource "aws_kms_key" "test" {
 
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test" {
@@ -5323,6 +5338,7 @@ resource "aws_kms_key" "test_restore" {
 
   description             = "%[1]s-restore"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_dynamodb_table" "test_restore" {

--- a/internal/service/ec2/ebs_default_kms_key_data_source_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_data_source_test.go
@@ -29,7 +29,10 @@ func testAccEBSDefaultKMSKeyDataSource_basic(t *testing.T) {
 }
 
 const testAccEBSDefaultKMSKeyDataSourceConfig_basic = `
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_ebs_default_kms_key" "test" {
   key_arn = aws_kms_key.test.arn

--- a/internal/service/ec2/ebs_default_kms_key_test.go
+++ b/internal/service/ec2/ebs_default_kms_key_test.go
@@ -129,7 +129,10 @@ func testAccEBSManagedDefaultKey(ctx context.Context) (*arn.ARN, error) {
 }
 
 const testAccEBSDefaultKMSKeyConfig_basic = `
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_ebs_default_kms_key" "test" {
   key_arn = aws_kms_key.test.arn

--- a/internal/service/ec2/ebs_snapshot_copy_test.go
+++ b/internal/service/ec2/ebs_snapshot_copy_test.go
@@ -358,6 +358,7 @@ func testAccEBSSnapshotCopyConfig_kms(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_ebs_snapshot_copy" "test" {

--- a/internal/service/ec2/ebs_snapshot_test.go
+++ b/internal/service/ec2/ebs_snapshot_test.go
@@ -383,6 +383,7 @@ func testAccEBSSnapshotConfig_kms(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/ebs_volume_test.go
+++ b/internal/service/ec2/ebs_volume_test.go
@@ -1179,8 +1179,10 @@ func testAccEBSVolumeConfig_kmsKey(rName string) string {
 		acctest.ConfigAvailableAZsNoOptIn(),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
-  policy      = <<POLICY
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/ec2/ec2_instance_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_test.go
@@ -952,6 +952,7 @@ func testAccInstanceDataSourceConfig_ebsKMSKeyID(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_instance" "test" {
@@ -985,6 +986,7 @@ func testAccInstanceDataSourceConfig_rootBlockDeviceKMSKeyID(rName string) strin
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_instance" "test" {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -7128,6 +7128,7 @@ func testAccInstanceConfig_ebsKMSKeyARN(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_instance" "test" {
@@ -7163,6 +7164,7 @@ func testAccInstanceConfig_rootBlockDeviceKMSKeyARN(rName string) string {
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_instance" "test" {

--- a/internal/service/ec2/ec2_spot_fleet_request_test.go
+++ b/internal/service/ec2/ec2_spot_fleet_request_test.go
@@ -3114,7 +3114,7 @@ func testAccSpotFleetRequestConfig_launchSpecificationEBSBlockDeviceKMSKeyID(rNa
 	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
-
+  enable_key_rotation     = true
   tags = {
     Name = %[1]q
   }
@@ -3160,7 +3160,7 @@ func testAccSpotFleetRequestConfig_launchSpecificationRootBlockDeviceKMSKeyID(rN
 	return acctest.ConfigCompose(testAccSpotFleetRequestConfig_base(rName, publicKey), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
-
+  enable_key_rotation     = true
   tags = {
     Name = %[1]q
   }

--- a/internal/service/ec2/verifiedaccess_group_test.go
+++ b/internal/service/ec2/verifiedaccess_group_test.go
@@ -474,7 +474,9 @@ resource "aws_verifiedaccess_group" "test" {
 func testAccVerifiedAccessGroupConfig_kms(rName, policyDoc string) string {
 	return acctest.ConfigCompose(testAccVerifiedAccessGroupConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test_key" {
-  description = "KMS key for Verified Access Group test"
+  description             = "KMS key for Verified Access Group test"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_verifiedaccess_group" "test" {

--- a/internal/service/ecr/repository_data_source_test.go
+++ b/internal/service/ecr/repository_data_source_test.go
@@ -111,7 +111,10 @@ data "aws_ecr_repository" "test" {
 
 func testAccRepositoryDataSourceConfig_encryption(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_ecr_repository" "test" {
   name = %q

--- a/internal/service/ecr/repository_test.go
+++ b/internal/service/ecr/repository_test.go
@@ -448,7 +448,10 @@ resource "aws_ecr_repository" "test" {
 
 func testAccRepositoryConfig_encryptionKMSCustomkey(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_ecr_repository" "test" {
   name = %[1]q

--- a/internal/service/ecs/cluster_test.go
+++ b/internal/service/ecs/cluster_test.go
@@ -429,6 +429,7 @@ func testAccClusterConfig_configuration(rName string, enable bool) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_cloudwatch_log_group" "test" {
@@ -460,6 +461,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -5162,6 +5162,7 @@ func testAccServiceConfig_serviceConnectAllAttributes(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.test.json
 }
 
@@ -5342,6 +5343,7 @@ func testAccServiceConfig_serviceConnect_tls_with_empty_timeout_block(rName stri
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.test.json
 }
 

--- a/internal/service/efs/file_system_test.go
+++ b/internal/service/efs/file_system_test.go
@@ -663,7 +663,9 @@ resource "aws_efs_file_system" "test" {
 func testAccFileSystemConfig_kmsKey(rName string, enable bool) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_efs_file_system" "test" {

--- a/internal/service/efs/replication_configuration_test.go
+++ b/internal/service/efs/replication_configuration_test.go
@@ -270,6 +270,7 @@ resource "aws_kms_key" "test" {
 
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_availability_zones" "available" {

--- a/internal/service/eks/cluster_test.go
+++ b/internal/service/eks/cluster_test.go
@@ -1964,6 +1964,7 @@ func testAccClusterConfig_encryption(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_eks_cluster" "test" {
@@ -1992,6 +1993,7 @@ func testAccClusterConfig_encryptionVersion(rName, version string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_eks_cluster" "test" {

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -4242,7 +4242,9 @@ resource "aws_security_group" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = "tf-test-cmk-kms-key-id"
+  description             = "tf-test-cmk-kms-key-id"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName),
 	)

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -733,7 +733,9 @@ resource "aws_elasticache_serverless_cache" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = "tf-test-cmk-kms-key-id"
+  description             = "tf-test-cmk-kms-key-id"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_security_group" "test" {
@@ -781,7 +783,9 @@ resource "aws_elasticache_serverless_cache" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_security_group" "test" {
@@ -869,7 +873,9 @@ resource "aws_elasticache_serverless_cache" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_security_group" "test" {

--- a/internal/service/elasticsearch/domain_test.go
+++ b/internal/service/elasticsearch/domain_test.go
@@ -2449,6 +2449,7 @@ func testAccDomainConfig_encryptAtRestKey(rName, version string, enabled bool) s
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_elasticsearch_domain" "test" {

--- a/internal/service/elastictranscoder/pipeline_test.go
+++ b/internal/service/elastictranscoder/pipeline_test.go
@@ -345,8 +345,10 @@ resource "aws_s3_bucket" "test" {
 func testAccPipelineConfig_kmsKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
-  policy      = <<POLICY
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/emr/cluster_test.go
+++ b/internal/service/emr/cluster_test.go
@@ -3164,6 +3164,7 @@ EOF
 resource "aws_kms_key" "test" {
   description             = "Terraform %[1]s"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -3667,9 +3668,10 @@ resource "aws_s3_bucket" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test %[1]s"
-
-  policy = <<POLICY
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/emr/studio_test.go
+++ b/internal/service/emr/studio_test.go
@@ -377,9 +377,10 @@ data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
-
-  policy = <<POLICY
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+  policy                  = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/events/bus_data_source_test.go
+++ b/internal/service/events/bus_data_source_test.go
@@ -77,6 +77,7 @@ data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_iam_policy_document" "key_policy" {

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -373,10 +373,12 @@ data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test1" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_iam_policy_document" "key_policy" {

--- a/internal/service/finspace/kx_cluster_test.go
+++ b/internal/service/finspace/kx_cluster_test.go
@@ -771,6 +771,7 @@ output "account_id" {
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_finspace_kx_environment" "test" {

--- a/internal/service/finspace/kx_database_test.go
+++ b/internal/service/finspace/kx_database_test.go
@@ -233,6 +233,7 @@ func testAccKxDatabaseConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_finspace_kx_environment" "test" {

--- a/internal/service/finspace/kx_dataview_test.go
+++ b/internal/service/finspace/kx_dataview_test.go
@@ -289,6 +289,7 @@ func testAccKxDataviewConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_finspace_kx_environment" "test" {

--- a/internal/service/finspace/kx_environment_test.go
+++ b/internal/service/finspace/kx_environment_test.go
@@ -425,6 +425,7 @@ func testAccKxEnvironmentConfigBase() string {
 	return `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `
 }

--- a/internal/service/finspace/kx_scaling_group_test.go
+++ b/internal/service/finspace/kx_scaling_group_test.go
@@ -204,6 +204,7 @@ output "account_id" {
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_finspace_kx_environment" "test" {

--- a/internal/service/finspace/kx_user_test.go
+++ b/internal/service/finspace/kx_user_test.go
@@ -235,6 +235,7 @@ func testAccKxUserConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/finspace/kx_volume_test.go
+++ b/internal/service/finspace/kx_volume_test.go
@@ -200,6 +200,7 @@ data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_finspace_kx_environment" "test" {

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -3778,7 +3778,9 @@ func testAccDeliveryStreamConfig_extendedS3KMSKeyARN(rName string) string {
 		testAccDeliveryStreamConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "test" {

--- a/internal/service/fsx/file_cache_test.go
+++ b/internal/service/fsx/file_cache_test.go
@@ -631,6 +631,7 @@ func testAccFileCacheConfig_kmsKeyID1(rName string) string {
 resource "aws_kms_key" "test1" {
   description             = "FSx KMS Testing key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_file_cache" "test" {
@@ -658,6 +659,7 @@ func testAccFileCacheConfig_kmsKeyID2(rName string) string {
 resource "aws_kms_key" "test2" {
   description             = "FSx KMS Testing key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_file_cache" "test" {

--- a/internal/service/fsx/lustre_file_system_test.go
+++ b/internal/service/fsx/lustre_file_system_test.go
@@ -1798,6 +1798,7 @@ func testAccLustreFileSystemConfig_kmsKeyID1(rName string) string {
 resource "aws_kms_key" "test1" {
   description             = "%[1]s-1"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_lustre_file_system" "test" {
@@ -1819,6 +1820,7 @@ func testAccLustreFileSystemConfig_kmsKeyID2(rName string) string {
 resource "aws_kms_key" "test2" {
   description             = "%[1]s-2"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_lustre_file_system" "test" {

--- a/internal/service/fsx/ontap_file_system_test.go
+++ b/internal/service/fsx/ontap_file_system_test.go
@@ -1339,6 +1339,7 @@ func testAccONTAPFileSystemConfig_kmsKeyID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_ontap_file_system" "test" {

--- a/internal/service/fsx/openzfs_file_system_test.go
+++ b/internal/service/fsx/openzfs_file_system_test.go
@@ -1379,6 +1379,7 @@ func testAccOpenZFSFileSystemConfig_kmsKeyID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_openzfs_file_system" "test" {

--- a/internal/service/fsx/windows_file_system_test.go
+++ b/internal/service/fsx/windows_file_system_test.go
@@ -1114,6 +1114,7 @@ func testAccWindowsFileSystemConfig_kmsKeyID1(rName, domain string) string {
 resource "aws_kms_key" "test1" {
   description             = "%[1]s-1"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_windows_file_system" "test" {
@@ -1136,6 +1137,7 @@ func testAccWindowsFileSystemConfig_kmsKeyID2(rName, domain string) string {
 resource "aws_kms_key" "test2" {
   description             = "%[1]s-2"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_fsx_windows_file_system" "test" {

--- a/internal/service/glue/data_catalog_encryption_settings_test.go
+++ b/internal/service/glue/data_catalog_encryption_settings_test.go
@@ -132,8 +132,11 @@ func testAccCheckDataCatalogEncryptionSettingsExists(ctx context.Context, resour
 func testAccDataCatalogEncryptionSettingsConfig_encrypted(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
-  policy      = <<POLICY
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",
@@ -171,8 +174,11 @@ resource "aws_glue_data_catalog_encryption_settings" "test" {
 func testAccDataCatalogEncryptionSettingsConfig_encrypted_with_catalog_encryption_service_role(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
-  policy      = <<POLICY
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/glue/security_configuration_test.go
+++ b/internal/service/glue/security_configuration_test.go
@@ -280,6 +280,7 @@ func testAccSecurityConfigurationConfig_cloudWatchEncryptionModeSSEKMS(rName str
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_glue_security_configuration" "test" {
@@ -307,6 +308,7 @@ func testAccSecurityConfigurationConfig_jobBookmarksEncryptionModeCSEKMS(rName s
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_glue_security_configuration" "test" {
@@ -334,6 +336,7 @@ func testAccSecurityConfigurationConfig_s3EncryptionModeSSEKMS(rName string) str
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_glue_security_configuration" "test" {

--- a/internal/service/guardduty/publishing_destination_test.go
+++ b/internal/service/guardduty/publishing_destination_test.go
@@ -176,6 +176,7 @@ resource "aws_s3_bucket_policy" "gd_bucket_policy" {
 resource "aws_kms_key" "gd_key" {
   description             = "Temporary key for AccTest of TF"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.kms_pol.json
 }
 

--- a/internal/service/imagebuilder/component_test.go
+++ b/internal/service/imagebuilder/component_test.go
@@ -393,6 +393,7 @@ func testAccComponentConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_imagebuilder_component" "test" {

--- a/internal/service/imagebuilder/container_recipe_test.go
+++ b/internal/service/imagebuilder/container_recipe_test.go
@@ -1096,6 +1096,7 @@ func testAccContainerRecipeConfig_instanceConfigurationBlockDeviceMappingEBSKMSK
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_imagebuilder_container_recipe" "test" {
@@ -1409,6 +1410,7 @@ func testAccContainerRecipeConfig_kmsKeyID(rName string) string {
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_imagebuilder_container_recipe" "test" {

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -1340,6 +1340,7 @@ func testAccDistributionConfigurationConfig_amiKMSKeyID1(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_region" "current" {}
@@ -1362,6 +1363,7 @@ func testAccDistributionConfigurationConfig_amiKMSKeyID2(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_region" "current" {}

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -900,6 +900,7 @@ func testAccImageRecipeConfig_blockDeviceMappingEBSKMSKeyID(rName string) string
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_imagebuilder_image_recipe" "test" {

--- a/internal/service/imagebuilder/workflow_test.go
+++ b/internal/service/imagebuilder/workflow_test.go
@@ -402,6 +402,7 @@ func testAccWorkflowConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_imagebuilder_workflow" "test" {

--- a/internal/service/kafka/cluster_test.go
+++ b/internal/service/kafka/cluster_test.go
@@ -1997,7 +1997,9 @@ resource "aws_msk_cluster" "test" {
 func testAccClusterConfig_encryptionInfoEncryptionAtRestKMSKeyARN(rName string) string { // nosemgrep:ci.msk-in-func-name
 	return acctest.ConfigCompose(testAccClusterConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "example_key" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   tags = {
     Name = %[1]q

--- a/internal/service/kafka/scram_secret_association_test.go
+++ b/internal/service/kafka/scram_secret_association_test.go
@@ -214,8 +214,10 @@ resource "aws_msk_cluster" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  count       = %[2]d
-  description = "%[1]s-${count.index + 1}"
+  count                   = %[2]d
+  description             = "%[1]s-${count.index + 1}"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_secretsmanager_secret" "test" {

--- a/internal/service/keyspaces/table_test.go
+++ b/internal/service/keyspaces/table_test.go
@@ -767,7 +767,9 @@ resource "aws_keyspaces_table" "test" {
 func testAccTableConfig_allAttributes(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_keyspaces_keyspace" "test" {
@@ -820,7 +822,9 @@ resource "aws_keyspaces_table" "test" {
 func testAccTableConfig_allAttributesUpdated(rName1, rName2 string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_keyspaces_keyspace" "test" {

--- a/internal/service/kinesis/stream_data_source_test.go
+++ b/internal/service/kinesis/stream_data_source_test.go
@@ -173,6 +173,7 @@ data "aws_kinesis_stream" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/kinesis/stream_test.go
+++ b/internal/service/kinesis/stream_test.go
@@ -735,6 +735,7 @@ resource "aws_kinesis_stream" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -862,6 +863,7 @@ resource "aws_kms_key" "key" {
 
   description             = "%[1]s-${count.index}"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_kinesis_stream" "test" {

--- a/internal/service/kinesisvideo/stream_test.go
+++ b/internal/service/kinesisvideo/stream_test.go
@@ -237,6 +237,7 @@ resource "aws_kinesis_video_stream" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName, deviceName, mediaType)
 }

--- a/internal/service/kms/alias_data_source_test.go
+++ b/internal/service/kms/alias_data_source_test.go
@@ -73,6 +73,7 @@ func testAccAliasDataSourceConfig_cmk(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {

--- a/internal/service/kms/alias_test.go
+++ b/internal/service/kms/alias_test.go
@@ -293,6 +293,7 @@ func testAccAliasConfig_name(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -307,6 +308,7 @@ func testAccAliasConfig_nameGenerated(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -320,6 +322,7 @@ func testAccAliasConfig_namePrefix(rName, namePrefix string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -334,11 +337,13 @@ func testAccAliasConfig_updatedKeyID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   description             = "%[1]s-2"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -353,6 +358,7 @@ func testAccAliasConfig_multiple(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -372,6 +378,7 @@ func testAccAliasConfig_diffSuppress(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {

--- a/internal/service/kms/ciphertext_data_source_test.go
+++ b/internal/service/kms/ciphertext_data_source_test.go
@@ -70,8 +70,10 @@ func TestAccKMSCiphertextDataSource_Validate_withContext(t *testing.T) {
 
 const testAccCiphertextDataSourceConfig_basic = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_kms_ciphertext" "test" {
@@ -83,8 +85,10 @@ data "aws_kms_ciphertext" "test" {
 
 const testAccCiphertextDataSourceConfig_validate = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_kms_ciphertext" "test" {
@@ -96,8 +100,10 @@ data "aws_kms_ciphertext" "test" {
 
 const testAccCiphertextDataSourceConfig_validateContext = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_kms_ciphertext" "test" {

--- a/internal/service/kms/ciphertext_test.go
+++ b/internal/service/kms/ciphertext_test.go
@@ -77,8 +77,10 @@ func TestAccKMSCiphertext_Validate_withContext(t *testing.T) {
 
 const testAccCiphertextConfig_basic = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-basic"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_ciphertext" "test" {
@@ -90,8 +92,10 @@ resource "aws_kms_ciphertext" "test" {
 
 const testAccCiphertextConfig_validate = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-validate"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_ciphertext" "test" {
@@ -110,8 +114,10 @@ data "aws_kms_secrets" "test" {
 
 const testAccCiphertextConfig_validateContext = `
 resource "aws_kms_key" "test" {
-  description = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
-  is_enabled  = true
+  description             = "tf-test-acc-data-source-aws-kms-ciphertext-validate-with-context"
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_ciphertext" "test" {

--- a/internal/service/kms/grant_test.go
+++ b/internal/service/kms/grant_test.go
@@ -368,6 +368,7 @@ func testAccGrantConfig_base(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_iam_policy_document" "test" {
@@ -463,6 +464,7 @@ resource "aws_kms_grant" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "RSA_2048"
@@ -493,6 +495,7 @@ func testAccGrantConfig_crossAccountARN(rName string, operations string) string 
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_iam_policy_document" "test" {

--- a/internal/service/kms/key_data_source_test.go
+++ b/internal/service/kms/key_data_source_test.go
@@ -278,6 +278,7 @@ func testAccKeyDataSourceConfig_byKeyARN(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_kms_key" "test" {
@@ -291,6 +292,7 @@ func testAccKeyDataSourceConfig_byKeyID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_kms_key" "test" {
@@ -304,6 +306,7 @@ func testAccKeyDataSourceConfig_byAliasARN(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -322,6 +325,7 @@ func testAccKeyDataSourceConfig_byAliasID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test" {
@@ -356,6 +360,7 @@ func testAccKeyDataSourceConfig_multiRegionByARN(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   multi_region            = true
 }
 
@@ -370,6 +375,7 @@ func testAccKeyDataSourceConfig_multiRegionByID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   multi_region            = true
 }
 

--- a/internal/service/kms/key_policy_test.go
+++ b/internal/service/kms/key_policy_test.go
@@ -313,7 +313,9 @@ func testAccKeyPolicyConfig_policy(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
+
 resource "aws_kms_key_policy" "test" {
   key_id = aws_kms_key.test.id
   policy = jsonencode({
@@ -340,6 +342,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {
@@ -398,6 +401,7 @@ resource "aws_iam_role" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {
@@ -557,6 +561,7 @@ data "aws_iam_policy_document" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {
@@ -580,6 +585,7 @@ resource "aws_iam_service_linked_role" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {
@@ -629,7 +635,9 @@ data "aws_partition" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
+
 resource "aws_kms_key_policy" "test" {
   key_id = aws_kms_key.test.id
   policy = jsonencode({
@@ -679,6 +687,7 @@ func testAccKeyPolicyConfig_removedPolicy(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName)
 }
@@ -689,8 +698,10 @@ data "aws_caller_identity" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   is_enabled              = %[2]t
 }
+
 resource "aws_kms_key_policy" "test" {
   key_id = aws_kms_key.test.id
   policy = jsonencode({

--- a/internal/service/kms/key_test.go
+++ b/internal/service/kms/key_test.go
@@ -798,7 +798,9 @@ func testAccKeyAddTag(ctx context.Context, t *testing.T, identifier, key, value 
 
 func testAccKeyConfig_basic() string {
 	return `
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  enable_key_rotation = true
+}
 `
 }
 
@@ -806,6 +808,7 @@ func testAccKeyConfig_basicDeletionWindow() string {
 	return `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `
 }
@@ -815,6 +818,7 @@ func testAccKeyConfig_name(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName)
 }
@@ -836,6 +840,7 @@ func testAccKeyConfig_asymmetric(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   key_usage                = "SIGN_VERIFY"
   customer_master_key_spec = "ECC_NIST_P384"
@@ -848,6 +853,7 @@ func testAccKeyConfig_hmac(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   key_usage                = "GENERATE_VERIFY_MAC"
   customer_master_key_spec = "HMAC_256"
@@ -861,6 +867,7 @@ func testAccKeyConfig_policy(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Id = %[1]q
@@ -886,6 +893,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   bypass_policy_lockout_safety_check = %[2]t
 
@@ -941,6 +949,7 @@ resource "aws_iam_role" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Id = %[1]q
@@ -1097,6 +1106,7 @@ data "aws_iam_policy_document" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = data.aws_iam_policy_document.test.json
 }
@@ -1117,6 +1127,7 @@ resource "aws_iam_service_linked_role" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Id = %[1]q
@@ -1163,6 +1174,7 @@ data "aws_partition" "current" {}
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = jsonencode({
     Id = %[1]q
@@ -1211,6 +1223,7 @@ func testAccKeyConfig_removedPolicy(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName)
 }

--- a/internal/service/kms/public_key_data_source_test.go
+++ b/internal/service/kms/public_key_data_source_test.go
@@ -84,6 +84,7 @@ func testAccPublicKeyDataSourceConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   description              = %[1]q
   deletion_window_in_days  = 7
+  enable_key_rotation      = true
   customer_master_key_spec = "RSA_2048"
   key_usage                = "SIGN_VERIFY"
 }
@@ -99,6 +100,7 @@ func testAccPublicKeyDataSourceConfig_encrypt(rName string) string {
 resource "aws_kms_key" "test" {
   description              = %[1]q
   deletion_window_in_days  = 7
+  enable_key_rotation      = true
   customer_master_key_spec = "RSA_2048"
   key_usage                = "ENCRYPT_DECRYPT"
 }

--- a/internal/service/kms/replica_key_test.go
+++ b/internal/service/kms/replica_key_test.go
@@ -225,8 +225,10 @@ func testAccReplicaKeyConfig_basic(rName string) string {
 resource "aws_kms_key" "test" {
   provider = awsalternate
 
-  description  = %[1]q
-  multi_region = true
+  description             = %[1]q
+  multi_region            = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_replica_key" "test" {
@@ -244,6 +246,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_replica_key" "test" {
@@ -265,6 +268,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_replica_key" "test" {
@@ -289,6 +293,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_replica_key" "test1" {

--- a/internal/service/kms/secrets_data_source_test.go
+++ b/internal/service/kms/secrets_data_source_test.go
@@ -168,6 +168,7 @@ func testAccSecretsDataSourceDecryptAsymmetric(ctx context.Context, t *testing.T
 const testAccSecretsDataSourceConfig_key = `
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Testing the Terraform AWS KMS Secrets data_source"
 }
 `
@@ -190,6 +191,7 @@ data "aws_kms_secrets" "test" {
 const testAccSecretsDataSourceConfig_asymmetricKey = `
 resource "aws_kms_key" "test" {
   deletion_window_in_days  = 7
+  enable_key_rotation      = true
   description              = "Testing the Terraform AWS KMS Secrets data_source"
   customer_master_key_spec = "RSA_2048"
 }

--- a/internal/service/kms/secrets_ephemeral_test.go
+++ b/internal/service/kms/secrets_ephemeral_test.go
@@ -49,8 +49,10 @@ func testAccSecretsEphemeralResourceConfig_basic(rName, secretString string) str
 		acctest.ConfigWithEchoProvider("ephemeral.aws_kms_secrets.test"),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
-  is_enabled  = true
+  description             = %[1]q
+  is_enabled              = true
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_ciphertext" "test" {

--- a/internal/service/kms/testdata/ReplicaKey/tags/main_gen.tf
+++ b/internal/service/kms/testdata/ReplicaKey/tags/main_gen.tf
@@ -20,6 +20,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 variable "rName" {

--- a/internal/service/kms/testdata/ReplicaKey/tagsComputed1/main_gen.tf
+++ b/internal/service/kms/testdata/ReplicaKey/tagsComputed1/main_gen.tf
@@ -24,6 +24,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/kms/testdata/ReplicaKey/tagsComputed2/main_gen.tf
+++ b/internal/service/kms/testdata/ReplicaKey/tagsComputed2/main_gen.tf
@@ -25,6 +25,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "null_resource" "test" {}

--- a/internal/service/kms/testdata/ReplicaKey/tags_defaults/main_gen.tf
+++ b/internal/service/kms/testdata/ReplicaKey/tags_defaults/main_gen.tf
@@ -26,6 +26,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 variable "rName" {

--- a/internal/service/kms/testdata/ReplicaKey/tags_ignore/main_gen.tf
+++ b/internal/service/kms/testdata/ReplicaKey/tags_ignore/main_gen.tf
@@ -29,6 +29,7 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 variable "rName" {

--- a/internal/service/kms/testdata/tmpl/replica_key_tags.gtpl
+++ b/internal/service/kms/testdata/tmpl/replica_key_tags.gtpl
@@ -13,4 +13,5 @@ resource "aws_kms_key" "test" {
   multi_region = true
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }

--- a/internal/service/lambda/event_source_mapping_test.go
+++ b/internal/service/lambda/event_source_mapping_test.go
@@ -2134,7 +2134,9 @@ resource "aws_docdb_cluster" "test" {
 func testAccEventSourceMappingConfig_sqsKMSKeyARN(rName, pattern string) string {
 	return acctest.ConfigCompose(testAccEventSourceMappingConfig_sqsBase(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = "%[1]s"
+  description             = "%[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2853,7 +2853,9 @@ func testAccFunctionConfig_encryptedEnvVariablesKey1(rName string) string {
 		acctest.ConfigLambdaBase(rName, rName, rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test1" {
-  description = "%[1]s-1"
+  description             = "%[1]s-1"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -2875,7 +2877,9 @@ POLICY
 }
 
 resource "aws_kms_key" "test2" {
-  description = "%[1]s-2"
+  description             = "%[1]s-2"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -2920,7 +2924,9 @@ func testAccFunctionConfig_encryptedEnvVariablesKey2(rName string) string {
 # Delete aws_kms_key.test1.
 
 resource "aws_kms_key" "test2" {
-  description = "%[1]s-2"
+  description             = "%[1]s-2"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -3428,6 +3434,7 @@ func testAccFunctionConfig_kmsKeyARNNoEnvironmentVariables(rName string) string 
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/lexmodels/bot_alias_test.go
+++ b/internal/service/lexmodels/bot_alias_test.go
@@ -519,7 +519,10 @@ resource "aws_s3_bucket" "test" {
   bucket = "%[1]s"
 }
 
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_iam_role" "test" {
   name               = "%[1]s"
@@ -588,7 +591,10 @@ resource "aws_s3_bucket" "test" {
   bucket = "%[1]s"
 }
 
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_iam_role" "test" {
   name               = "%[1]s"

--- a/internal/service/location/geofence_collection_test.go
+++ b/internal/service/location/geofence_collection_test.go
@@ -258,6 +258,7 @@ func testAccGeofenceCollectionConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_location_geofence_collection" "test" {

--- a/internal/service/location/tracker_test.go
+++ b/internal/service/location/tracker_test.go
@@ -295,6 +295,7 @@ func testAccTrackerConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_location_tracker" "test" {

--- a/internal/service/logs/group_test.go
+++ b/internal/service/logs/group_test.go
@@ -425,6 +425,7 @@ resource "aws_kms_key" "test" {
 
   description             = "%[1]s-${count.index}"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/m2/application_test.go
+++ b/internal/service/m2/application_test.go
@@ -409,7 +409,9 @@ resource "aws_s3_object" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_iam_role" "test" {

--- a/internal/service/m2/environment_test.go
+++ b/internal/service/m2/environment_test.go
@@ -434,7 +434,9 @@ resource "aws_m2_environment" "test" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName))
 }

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -128,6 +128,8 @@ data "aws_region" "current" {}
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
+
   policy = jsonencode({
     "Version" : "2012-10-17",
     "Id" : "allow_macie",

--- a/internal/service/memorydb/cluster_data_source_test.go
+++ b/internal/service/memorydb/cluster_data_source_test.go
@@ -81,7 +81,10 @@ resource "aws_security_group" "test" {
   vpc_id      = aws_vpc.test.id
 }
 
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_memorydb_cluster" "test" {
   acl_name                   = aws_memorydb_acl.test.id

--- a/internal/service/memorydb/cluster_test.go
+++ b/internal/service/memorydb/cluster_test.go
@@ -1419,7 +1419,10 @@ func testAccClusterConfig_kms(rName string) string {
 	return acctest.ConfigCompose(
 		testAccClusterConfig_baseNetwork(rName),
 		fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_memorydb_cluster" "test" {
   acl_name               = "open-access"

--- a/internal/service/memorydb/snapshot_data_source_test.go
+++ b/internal/service/memorydb/snapshot_data_source_test.go
@@ -58,7 +58,10 @@ func testAccSnapshotDataSourceConfig_basic(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_memorydb_snapshot" "test" {
   cluster_name = aws_memorydb_cluster.test.name

--- a/internal/service/memorydb/snapshot_test.go
+++ b/internal/service/memorydb/snapshot_test.go
@@ -329,7 +329,10 @@ func testAccSnapshotConfig_kms(rName string) string {
 	return acctest.ConfigCompose(
 		testAccSnapshotConfigBase(rName),
 		fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_memorydb_snapshot" "test" {
   cluster_name = aws_memorydb_cluster.test.name

--- a/internal/service/mq/broker_test.go
+++ b/internal/service/mq/broker_test.go
@@ -2075,6 +2075,7 @@ func testAccBrokerConfig_encryptionOptionsKMSKeyID(rName, version string) string
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_security_group" "test" {

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -914,8 +914,10 @@ resource "aws_mwaa_environment" "test" {
 data "aws_region" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = "Key for a Terraform ACC test"
-  key_usage   = "ENCRYPT_DECRYPT"
+  description             = "Key for a Terraform ACC test"
+  key_usage               = "ENCRYPT_DECRYPT"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -962,6 +964,8 @@ resource "aws_s3_object" "startup_script" {
   key     = "startup.sh"
   content = "airflow db init"
 }
+
+
 
 
 `, rName))

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -964,10 +964,6 @@ resource "aws_s3_object" "startup_script" {
   key     = "startup.sh"
   content = "airflow db init"
 }
-
-
-
-
 `, rName))
 }
 

--- a/internal/service/neptune/cluster_instance_test.go
+++ b/internal/service/neptune/cluster_instance_test.go
@@ -499,7 +499,9 @@ resource "aws_neptune_cluster" "test" {
 func testAccClusterInstanceConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(testAccClusterInstanceConfig_baseSansCluster(rName), acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -1160,7 +1160,9 @@ resource "aws_iam_role" "kms_admin" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1467,7 +1469,9 @@ resource "aws_iam_role" "kms_admin" {
 }
 
 resource "aws_kms_key" "test1" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1528,7 +1532,9 @@ POLICY
 }
 
 resource "aws_kms_key" "test2" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/neptunegraph/graph_test.go
+++ b/internal/service/neptunegraph/graph_test.go
@@ -450,7 +450,9 @@ resource "aws_iam_role" "kms_admin" {
 }
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -1774,7 +1774,10 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 
 func testAccFirewallPolicyConfig_encryptionConfiguration(rName, statelessDefaultActions string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_networkfirewall_firewall_policy" "test" {
   name = %[1]q
@@ -1799,7 +1802,10 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 // InvalidRequestException: firewall policy has KMS key misconfigured
 func testAccFirewallPolicyConfig_encryptionConfigurationDisabled(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_networkfirewall_firewall_policy" "test" {
   name = %[1]q

--- a/internal/service/networkfirewall/firewall_test.go
+++ b/internal/service/networkfirewall/firewall_test.go
@@ -644,7 +644,10 @@ resource "aws_networkfirewall_firewall" "test" {
 
 func testAccFirewallConfig_encryptionConfiguration(rName, description string) string {
 	return acctest.ConfigCompose(testAccFirewallConfig_base(rName), fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_networkfirewall_firewall" "test" {
   name                = %[1]q

--- a/internal/service/networkfirewall/rule_group_test.go
+++ b/internal/service/networkfirewall/rule_group_test.go
@@ -1732,7 +1732,10 @@ resource "aws_networkfirewall_rule_group" "test" {
 
 func testAccRuleGroupConfig_encryptionConfiguration(rName, generatedRulesType string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_networkfirewall_rule_group" "test" {
   capacity = 100
@@ -1764,7 +1767,10 @@ resource "aws_networkfirewall_rule_group" "test" {
 // InvalidRequestException: rule group has KMS key misconfigured
 func testAccRuleGroupConfig_encryptionConfigurationDisabled(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_networkfirewall_rule_group" "test" {
   capacity = 100

--- a/internal/service/networkfirewall/tls_inspection_configuration_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_test.go
@@ -537,6 +537,7 @@ func testAccTLSInspectionConfigurationConfig_encryptionConfiguration(rName, comm
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_networkfirewall_tls_inspection_configuration" "test" {

--- a/internal/service/opensearch/domain_test.go
+++ b/internal/service/opensearch/domain_test.go
@@ -3098,6 +3098,7 @@ func testAccDomainConfig_encryptAtRestKey(rName, version string, enabled bool) s
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_opensearch_domain" "test" {

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -638,6 +638,7 @@ resource "aws_osis_pipeline" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, rName)
 }

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -2114,8 +2114,15 @@ func testAccPipeConfig_kmsKeyIdentifier(rName, kmsKeyID string) string {
 		testAccPipeConfig_baseSQSSource(rName),
 		testAccPipeConfig_baseSQSTarget(rName),
 		fmt.Sprintf(`
-resource "aws_kms_key" "test_1" {}
-resource "aws_kms_key" "test_2" {}
+resource "aws_kms_key" "test_1" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_key" "test_2" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_pipes_pipe" "test" {
   depends_on = [aws_iam_role_policy.source, aws_iam_role_policy.target]

--- a/internal/service/qldb/ledger_test.go
+++ b/internal/service/qldb/ledger_test.go
@@ -316,6 +316,7 @@ func testAccLedgerConfig_kmsKey(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_qldb_ledger" "test" {
@@ -332,6 +333,7 @@ func testAccLedgerConfig_kmsKeyUpdated(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_qldb_ledger" "test" {

--- a/internal/service/rds/cluster_activity_stream_test.go
+++ b/internal/service/rds/cluster_activity_stream_test.go
@@ -132,6 +132,7 @@ func testAccClusterActivityStreamConfig_base(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster" "test" {

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1399,7 +1399,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1714,6 +1716,7 @@ func testAccClusterInstanceConfig_performanceInsightsKMSKeyIDAuroraMySQL1(rName,
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster" "test" {
@@ -1743,6 +1746,7 @@ func testAccClusterInstanceConfig_performanceInsightsKMSKeyIDAuroraPostgresql(rN
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster" "test" {

--- a/internal/service/rds/cluster_snapshot_copy_test.go
+++ b/internal/service/rds/cluster_snapshot_copy_test.go
@@ -389,7 +389,9 @@ func testAccClusterSnapshotCopyConfig_kms(rName string) string {
 		testAccClusterSnapshotCopyConfig_encryptedBase(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = "test"
+  description             = "test"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster_snapshot_copy" "test" {

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -3763,7 +3763,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "example" {
-  description = "Terraform acc test %[1]s"
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -4490,7 +4492,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "foo" {
-  description = "Terraform acc test %[1]d"
+  description             = "Terraform acc test %[1]d"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -4980,7 +4984,9 @@ resource "aws_rds_cluster_instance" "test" {
 resource "aws_kms_key" "test" {
   provider = "awsalternate"
 
-  description = %[3]q
+  description             = %[3]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -5112,7 +5118,9 @@ resource "aws_rds_cluster_instance" "test" {
 resource "aws_kms_key" "test" {
   provider = "awsalternate"
 
-  description = %[3]q
+  description             = %[3]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -5929,6 +5937,7 @@ func testAccClusterConfig_SnapshotID_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster" "source" {
@@ -6188,7 +6197,10 @@ resource "aws_rds_cluster" "test" {
 
 func testAccClusterConfig_SnapshotID_encryptedRestore(rName string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "test" {}
+resource "aws_kms_key" "test" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_rds_cluster" "source" {
   cluster_identifier  = "%[1]s-source"
@@ -6527,6 +6539,7 @@ func testAccClusterConfig_performanceInsightsKMSKeyID(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_cluster" "test" {

--- a/internal/service/rds/custom_db_engine_version_test.go
+++ b/internal/service/rds/custom_db_engine_version_test.go
@@ -390,7 +390,9 @@ resource "aws_rds_custom_db_engine_version" "test" {
 func testAccCustomDBEngineVersionConfig_oracle(rName, bucket string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "rdscfo_kms_key" {
-  description = "KMS symmetric key for RDS Custom for Oracle"
+  description             = "KMS symmetric key for RDS Custom for Oracle"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_custom_db_engine_version" "test" {
@@ -410,7 +412,9 @@ resource "aws_rds_custom_db_engine_version" "test" {
 func testAccCustomDBEngineVersionConfig_manifestFile(rName, bucket, filename string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "rdscfo_kms_key" {
-  description = "KMS symmetric key for RDS Custom for Oracle"
+  description             = "KMS symmetric key for RDS Custom for Oracle"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_rds_custom_db_engine_version" "test" {

--- a/internal/service/rds/export_task_test.go
+++ b/internal/service/rds/export_task_test.go
@@ -233,6 +233,7 @@ resource "aws_iam_role_policy_attachment" "test-attach" {
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_db_instance" "test" {

--- a/internal/service/rds/instance_automated_backups_replication_test.go
+++ b/internal/service/rds/instance_automated_backups_replication_test.go
@@ -310,7 +310,9 @@ resource "aws_db_instance_automated_backups_replication" "test" {
 func testAccInstanceAutomatedBackupsReplicationConfig_kmsEncrypted(rName string) string {
 	return acctest.ConfigCompose(testAccInstanceAutomatedBackupsReplicationConfig_base(rName, true), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_db_instance_automated_backups_replication" "test" {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -8277,7 +8277,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -9383,7 +9385,9 @@ resource "aws_security_group_rule" "test" {
 }
 
 resource "aws_kms_key" "example" {
-  description = "Terraform acc test %[1]s"
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -10251,7 +10255,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "example" {
-  description = "Terraform acc test %[1]s"
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -12221,7 +12227,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "example" {
-  description = "Terraform acc test %[1]s"
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -13386,6 +13394,7 @@ func testAccInstanceConfig_performanceInsightsKMSKeyIdDisabled(rName string) str
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_rds_engine_version" "default" {
@@ -13423,6 +13432,7 @@ func testAccInstanceConfig_performanceInsightsKMSKeyID(rName string) string {
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_rds_engine_version" "default" {
@@ -13500,7 +13510,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test"
+  description             = "Terraform acc test"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -13567,7 +13579,9 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test"
+  description             = "Terraform acc test"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/rds/integration_test.go
+++ b/internal/service/rds/integration_test.go
@@ -422,6 +422,7 @@ func testAccIntegrationConfig_optional(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
   policy                  = data.aws_iam_policy_document.key_policy.json
 }
 

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -288,7 +288,9 @@ data "aws_redshift_cluster" "test" {
 func testAccClusterDataSourceConfig_multiAZEnabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -1127,7 +1127,9 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_encrypted(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1170,7 +1172,9 @@ func testAccClusterConfig_unencrypted(rName string) string {
 	//Removing the kms key here causes the key to be deleted before the redshift cluster is unencrypted, resulting in an unstable cluster. This is to be kept for the time-being unti we find a better way to handle this.
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1228,7 +1232,9 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_kmsKey(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {
@@ -1698,7 +1704,9 @@ func testAccClusterConfig_multiAZ(rName string, enabled bool) string {
 	return acctest.ConfigCompose(
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/redshift/integration_test.go
+++ b/internal/service/redshift/integration_test.go
@@ -621,6 +621,7 @@ func testAccIntegrationConfig_optional(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key_policy" "test" {

--- a/internal/service/route53/hosted_zone_dnssec_test.go
+++ b/internal/service/route53/hosted_zone_dnssec_test.go
@@ -161,7 +161,9 @@ func testAccHostedZoneDNSSECConfig_base(rName, domainName string) string {
 resource "aws_kms_key" "test" {
   customer_master_key_spec = "ECC_NIST_P256"
   deletion_window_in_days  = 7
+  enable_key_rotation      = true
   key_usage                = "SIGN_VERIFY"
+
   policy = jsonencode({
     Statement = [
       {

--- a/internal/service/route53/key_signing_key_test.go
+++ b/internal/service/route53/key_signing_key_test.go
@@ -175,7 +175,9 @@ func testAccKeySigningKeyConfig_base(rName, domainName string) string {
 resource "aws_kms_key" "test" {
   customer_master_key_spec = "ECC_NIST_P256"
   deletion_window_in_days  = 7
+  enable_key_rotation      = true
   key_usage                = "SIGN_VERIFY"
+
   policy = jsonencode({
     Statement = [
       {

--- a/internal/service/s3/bucket_inventory_test.go
+++ b/internal/service/s3/bucket_inventory_test.go
@@ -282,6 +282,7 @@ func testAccBucketInventoryConfig_encryptSSEKMS(bucketName, inventoryName string
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket_inventory" "test" {

--- a/internal/service/s3/bucket_object_data_source_test.go
+++ b/internal/service/s3/bucket_object_data_source_test.go
@@ -441,6 +441,7 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_kms_key" "example" {
   description             = "TF Acceptance Test KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_object" "object" {
@@ -467,6 +468,7 @@ resource "aws_s3_bucket" "object_bucket" {
 resource "aws_kms_key" "example" {
   description             = "TF Acceptance Test KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_object" "object" {

--- a/internal/service/s3/bucket_object_test.go
+++ b/internal/service/s3/bucket_object_test.go
@@ -1529,7 +1529,10 @@ resource "aws_s3_bucket_object" "test" {
 
 func testAccBucketObjectConfig_kmsID(rName string, source string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "kms_key_1" {}
+resource "aws_kms_key" "kms_key_1" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -1873,6 +1876,7 @@ func testAccBucketObjectConfig_objectKeyEnabled(rName string, content string) st
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -1894,6 +1898,7 @@ func testAccBucketObjectConfig_bucketKeyEnabled(rName string, content string) st
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -1928,6 +1933,7 @@ func testAccBucketObjectConfig_defaultSSE(rName string, content string) string {
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {

--- a/internal/service/s3/bucket_replication_configuration_test.go
+++ b/internal/service/s3/bucket_replication_configuration_test.go
@@ -1743,6 +1743,7 @@ resource "aws_kms_key" "test" {
   provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {
@@ -1844,6 +1845,7 @@ resource "aws_kms_key" "test" {
   provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket_replication_configuration" "test" {

--- a/internal/service/s3/bucket_server_side_encryption_configuration_test.go
+++ b/internal/service/s3/bucket_server_side_encryption_configuration_test.go
@@ -524,6 +524,7 @@ func testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKMSMa
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket %[1]s"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -548,6 +549,7 @@ func testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKMSMa
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket %[1]s"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -611,6 +613,7 @@ func testAccBucketServerSideEncryptionConfigurationConfig_applySSEByDefaultKeyEn
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket %[1]s"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -662,6 +665,7 @@ resource "aws_s3_directory_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "test" {

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2838,6 +2838,7 @@ func testAccBucketConfig_defaultEncryptionKMSMasterKey(bucketName string) string
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket %[1]s"
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -2860,6 +2861,7 @@ func testAccBucketConfig_defaultEncryptionKeyEnabledKMSMasterKey(bucketName stri
 resource "aws_kms_key" "test" {
   description             = "KMS Key for Bucket %[1]s"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -3487,6 +3489,7 @@ resource "aws_kms_key" "replica" {
   provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "source" {
@@ -3531,6 +3534,7 @@ resource "aws_kms_key" "replica" {
   provider                = "awsalternate"
   description             = "TF Acceptance Test S3 repl KMS key"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "source" {

--- a/internal/service/s3/object_copy_test.go
+++ b/internal/service/s3/object_copy_test.go
@@ -822,6 +822,7 @@ func testAccObjectCopyConfig_baseBucketKeyEnabled(sourceBucket, sourceKey, targe
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `, targetBucket))
 }

--- a/internal/service/s3/object_data_source_test.go
+++ b/internal/service/s3/object_data_source_test.go
@@ -657,6 +657,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_object" "test" {
@@ -683,6 +684,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_object" "test" {

--- a/internal/service/s3/object_test.go
+++ b/internal/service/s3/object_test.go
@@ -2531,7 +2531,10 @@ resource "aws_s3_object" "test" {
 
 func testAccObjectConfig_kmsID(rName string, source string) string {
 	return fmt.Sprintf(`
-resource "aws_kms_key" "kms_key_1" {}
+resource "aws_kms_key" "kms_key_1" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -2993,6 +2996,7 @@ func testAccObjectConfig_bucketKeyEnabled(rName string, content string) string {
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -3014,6 +3018,7 @@ func testAccObjectConfig_bucketBucketKeyEnabled(rName string, content string) st
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {
@@ -3048,6 +3053,7 @@ func testAccObjectConfig_defaultBucketSSE(rName string, content string) string {
 resource "aws_kms_key" "test" {
   description             = "Encrypts test objects"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_s3_bucket" "test" {

--- a/internal/service/sagemaker/data_quality_job_definition_test.go
+++ b/internal/service/sagemaker/data_quality_job_definition_test.go
@@ -1129,6 +1129,7 @@ func testAccDataQualityJobDefinitionConfig_outputConfigKMSKeyID(rName string) st
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_data_quality_job_definition" "test" {
@@ -1205,6 +1206,7 @@ func testAccDataQualityJobDefinitionConfig_jobResourcesVolumeKMSKeyID(rName stri
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_data_quality_job_definition" "test" {

--- a/internal/service/sagemaker/domain_test.go
+++ b/internal/service/sagemaker/domain_test.go
@@ -1976,6 +1976,7 @@ func testAccDomainConfig_kms(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_domain" "test" {
@@ -2078,6 +2079,7 @@ func testAccDomainConfig_sharingSettings(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 

--- a/internal/service/sagemaker/endpoint_configuration_test.go
+++ b/internal/service/sagemaker/endpoint_configuration_test.go
@@ -1172,6 +1172,7 @@ resource "aws_sagemaker_endpoint_configuration" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 10
+  enable_key_rotation     = true
 }
 `, rName))
 }
@@ -1414,6 +1415,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
@@ -1479,6 +1481,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
@@ -1521,6 +1524,7 @@ resource "aws_sns_topic" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
@@ -1560,6 +1564,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {
@@ -1597,6 +1602,7 @@ resource "aws_s3_bucket" "test" {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_endpoint_configuration" "test" {

--- a/internal/service/sagemaker/feature_group_test.go
+++ b/internal/service/sagemaker/feature_group_test.go
@@ -803,6 +803,7 @@ func testAccFeatureGroupConfig_onlineSecurity(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_sagemaker_feature_group" "test" {

--- a/internal/service/sagemaker/notebook_instance_test.go
+++ b/internal/service/sagemaker/notebook_instance_test.go
@@ -958,7 +958,9 @@ resource "aws_sagemaker_notebook_instance" "test" {
 func testAccNotebookInstanceConfig_kms(rName string) string {
 	return acctest.ConfigCompose(testAccNotebookInstanceBaseConfig(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/scheduler/schedule_test.go
+++ b/internal/service/scheduler/schedule_test.go
@@ -1807,7 +1807,9 @@ func testAccScheduleConfig_kmsKeyARN(name string, index int) string {
 resource "aws_sqs_queue" "test" {}
 
 resource "aws_kms_key" "test" {
-  count = 2
+  count                   = 2
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_scheduler_schedule" "test" {

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -419,11 +419,13 @@ func testAccSecretConfig_overwriteReplica(rName string, force_overwrite_replica_
 resource "aws_kms_key" "test" {
   provider                = awsalternate
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   provider                = awsthird
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_region" "alternate" {
@@ -447,11 +449,13 @@ func testAccSecretConfig_overwriteReplicaUpdate(rName string, force_overwrite_re
 resource "aws_kms_key" "test" {
   provider                = awsalternate
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   provider                = awsthird
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 data "aws_region" "third" {
@@ -490,10 +494,12 @@ func testAccSecretConfig_kmsKeyID(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test1" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_secretsmanager_secret" "test" {
@@ -507,10 +513,12 @@ func testAccSecretConfig_kmsKeyIDUpdated(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test1" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_key" "test2" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_secretsmanager_secret" "test" {

--- a/internal/service/securitylake/data_lake_test.go
+++ b/internal/service/securitylake/data_lake_test.go
@@ -445,6 +445,7 @@ POLICY
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/sfn/activity_test.go
+++ b/internal/service/sfn/activity_test.go
@@ -228,7 +228,10 @@ func testAccCheckActivityDestroy(ctx context.Context) resource.TestCheckFunc {
 
 func testAccActivityConfig_kmsBase() string {
 	return `
-resource "aws_kms_key" "kms_key_for_sfn" {}
+resource "aws_kms_key" "kms_key_for_sfn" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 `
 }
 

--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -757,8 +757,16 @@ resource "aws_iam_role" "for_sfn" {
 EOF
 }
 
-resource "aws_kms_key" "kms_key_for_sfn_1" {}
-resource "aws_kms_key" "kms_key_for_sfn_2" {}
+resource "aws_kms_key" "kms_key_for_sfn_1" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_key" "kms_key_for_sfn_2" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
 
 `, rName)
 }

--- a/internal/service/ssm/parameter_test.go
+++ b/internal/service/ssm/parameter_test.go
@@ -1541,6 +1541,7 @@ resource "aws_ssm_parameter" "test" {
 resource "aws_kms_key" "test_key" {
   description             = "KMS key 1"
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_kms_alias" "test_alias" {

--- a/internal/service/ssmincidents/replication_set_test.go
+++ b/internal/service/ssmincidents/replication_set_test.go
@@ -523,14 +523,19 @@ resource "aws_ssmincidents_replication_set" "test" {
 
 func testAccReplicationSetConfig_baseKeyDefaultRegion() string {
 	return `
-resource "aws_kms_key" "default" {}
+resource "aws_kms_key" "default" {
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
 `
 }
 
 func testAccReplicationSetConfig_baseKeyAlternateRegion() string {
 	return acctest.ConfigCompose(acctest.ConfigMultipleRegionProvider(2), `
 resource "aws_kms_key" "alternate" {
-  provider = awsalternate
+  provider                = awsalternate
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 `)
 }

--- a/internal/service/storagegateway/cached_iscsi_volume_test.go
+++ b/internal/service/storagegateway/cached_iscsi_volume_test.go
@@ -408,8 +408,11 @@ func testAccCachediSCSIVolumeConfig_kmsEncrypted(rName string) string {
 		testAccCachediSCSIVolumeConfig_base(rName),
 		fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test %[1]s"
-  policy      = <<POLICY
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
  {
    "Version": "2012-10-17",
    "Id": "kms-tf-1",

--- a/internal/service/storagegateway/nfs_file_share_test.go
+++ b/internal/service/storagegateway/nfs_file_share_test.go
@@ -917,6 +917,7 @@ resource "aws_kms_key" "test" {
   count = 2
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Terraform Acceptance Testing"
 }
 
@@ -937,6 +938,7 @@ resource "aws_kms_key" "test" {
   count = 2
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Terraform Acceptance Testing"
 }
 

--- a/internal/service/storagegateway/smb_file_share_test.go
+++ b/internal/service/storagegateway/smb_file_share_test.go
@@ -1157,6 +1157,7 @@ func testAccSMBFileShareConfig_encryptedUpdate(rName string, readOnly bool) stri
 	return acctest.ConfigCompose(testAcc_SMBFileShare_GuestAccessBase(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Terraform Acceptance Testing"
 }
 
@@ -1259,6 +1260,7 @@ resource "aws_kms_key" "test" {
   count = 2
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Terraform Acceptance Testing"
 }
 
@@ -1280,6 +1282,7 @@ resource "aws_kms_key" "test" {
   count = 2
 
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = "Terraform Acceptance Testing"
 }
 

--- a/internal/service/storagegateway/stored_iscsi_volume_test.go
+++ b/internal/service/storagegateway/stored_iscsi_volume_test.go
@@ -320,8 +320,11 @@ resource "aws_storagegateway_stored_iscsi_volume" "test" {
 func testAccStorediSCSIVolumeConfig_kmsEncrypted(rName string) string {
 	return acctest.ConfigCompose(testAccStorediSCSIVolumeConfig_base(rName), fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = "Terraform acc test %[1]s"
-  policy      = <<POLICY
+  description             = "Terraform acc test %[1]s"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Id": "kms-tf-1",

--- a/internal/service/synthetics/canary_test.go
+++ b/internal/service/synthetics/canary_test.go
@@ -1006,6 +1006,7 @@ func testAccCanaryConfig_artifactEncryptionKMS(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 }
 
 resource "aws_synthetics_canary" "test" {

--- a/internal/service/timestreamwrite/database_data_source_test.go
+++ b/internal/service/timestreamwrite/database_data_source_test.go
@@ -126,7 +126,9 @@ data "aws_timestreamwrite_database" "test" {
 func testAccDatabaseDataSourceConfig_kmsKey(rDatabaseName, rKmsKeyName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/timestreamwrite/database_test.go
+++ b/internal/service/timestreamwrite/database_test.go
@@ -289,7 +289,9 @@ resource "aws_timestreamwrite_database" "test" {
 func testAccDatabaseConfig_kmsKey(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
-  description = %[1]q
+  description             = %[1]q
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {

--- a/internal/service/timestreamwrite/table_data_source_test.go
+++ b/internal/service/timestreamwrite/table_data_source_test.go
@@ -345,6 +345,7 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = %[2]q
 }
 

--- a/internal/service/timestreamwrite/table_test.go
+++ b/internal/service/timestreamwrite/table_test.go
@@ -497,6 +497,7 @@ resource "aws_s3_bucket" "test" {
 
 resource "aws_kms_key" "test" {
   deletion_window_in_days = 7
+  enable_key_rotation     = true
   description             = %[1]q
 }
 

--- a/internal/service/xray/encryption_config_test.go
+++ b/internal/service/xray/encryption_config_test.go
@@ -100,6 +100,7 @@ func testAccEncryptionConfigConfig_key(rName string) string {
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
+  enable_key_rotation     = true
 
   policy = <<POLICY
 {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Best practices for security are that key rotation should be enabled. This updates tests, which, strictly speaking, do not need adhere to these standards. However, to avoid additional findings and provide a good example, we are adding them.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
* [Example finding](https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/364)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
