### PR TITLE
[Enhancement ]aws_redshiftserverless_workgroup:  add `track_name` argument

### DIFF
--- a/internal/service/redshiftserverless/workgroup_data_source.go
+++ b/internal/service/redshiftserverless/workgroup_data_source.go
@@ -105,6 +105,10 @@ func dataSourceWorkgroup() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"track_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"workgroup_id": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -139,6 +143,7 @@ func dataSourceWorkgroupRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set(names.AttrPubliclyAccessible, resource.PubliclyAccessible)
 	d.Set(names.AttrSecurityGroupIDs, resource.SecurityGroupIds)
 	d.Set(names.AttrSubnetIDs, resource.SubnetIds)
+	d.Set("track_name", resource.TrackName)
 	d.Set("workgroup_id", resource.WorkgroupId)
 
 	return diags

--- a/internal/service/redshiftserverless/workgroup_data_source_test.go
+++ b/internal/service/redshiftserverless/workgroup_data_source_test.go
@@ -47,6 +47,7 @@ func TestAccRedshiftServerlessWorkgroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrPubliclyAccessible, resourceName, names.AttrPubliclyAccessible),
 					resource.TestCheckResourceAttrPair(dataSourceName, "security_group_ids.#", resourceName, "security_group_ids.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "subnet_ids.#", resourceName, "subnet_ids.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "track_name", resourceName, "track_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "workgroup_id", resourceName, "workgroup_id"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "workgroup_name", resourceName, "workgroup_name"),
 				),

--- a/website/docs/d/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/d/redshiftserverless_workgroup.html.markdown
@@ -37,6 +37,7 @@ This data source exports the following attributes in addition to the arguments a
 * `publicly_accessible` - A value that specifies whether the workgroup can be accessed from a public network.
 * `security_group_ids` - An array of security group IDs to associate with the workgroup.
 * `subnet_ids` - An array of VPC subnet IDs to associate with the workgroup. When set, must contain at least three subnets spanning three Availability Zones. A minimum number of IP addresses is required and scales with the Base Capacity. For more information, see the following [AWS document](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-known-issues.html).
+* `track_name` - The name of the track for the workgroup.
 * `workgroup_id` - The Redshift Workgroup ID.
 
 ### Endpoint

--- a/website/docs/r/redshiftserverless_workgroup.html.markdown
+++ b/website/docs/r/redshiftserverless_workgroup.html.markdown
@@ -37,6 +37,7 @@ The following arguments are optional:
 * `publicly_accessible` - (Optional) A value that specifies whether the workgroup can be accessed from a public network.
 * `security_group_ids` - (Optional) An array of security group IDs to associate with the workgroup.
 * `subnet_ids` - (Optional) An array of VPC subnet IDs to associate with the workgroup. When set, must contain at least three subnets spanning three Availability Zones. A minimum number of IP addresses is required and scales with the Base Capacity. For more information, see the following [AWS document](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-known-issues.html).
+* `track_name` - (Optional) The name of the track for the workgroup. If it is `current`, you get the most up-to-date certified release version with the latest features, security updates, and performance enhancements. If it is `trailing`, you will be on the previous certified release. For more information, see the following [AWS document](https://docs.aws.amazon.com/redshift/latest/mgmt/tracks.html).
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### Price Performance Target


### PR DESCRIPTION
### Description
* Introduce `track_name` argument/attribute to `aws_redshiftserverless_workgroup` resource and data source.

### Relations

Closes #42442

### References

https://docs.aws.amazon.com/redshift/latest/mgmt/tracks.html
https://docs.aws.amazon.com/ja_jp/redshift-serverless/latest/APIReference/API_CreateWorkgroup.html#redshiftserverless-CreateWorkgroup-request-trackName


### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccRedshiftServerlessWorkgroup_ PKG=redshiftserverless
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessWorkgroup_'  -timeout 360m -vet=off
2025/05/02 22:04:12 Initializing Terraform AWS Provider...
=== RUN   TestAccRedshiftServerlessWorkgroup_basic
=== PAUSE TestAccRedshiftServerlessWorkgroup_basic
=== RUN   TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
=== PAUSE TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
=== RUN   TestAccRedshiftServerlessWorkgroup_pricePerformanceTarget
=== PAUSE TestAccRedshiftServerlessWorkgroup_pricePerformanceTarget
=== RUN   TestAccRedshiftServerlessWorkgroup_configParameters
=== PAUSE TestAccRedshiftServerlessWorkgroup_configParameters
=== RUN   TestAccRedshiftServerlessWorkgroup_tags
=== PAUSE TestAccRedshiftServerlessWorkgroup_tags
=== RUN   TestAccRedshiftServerlessWorkgroup_disappears
=== PAUSE TestAccRedshiftServerlessWorkgroup_disappears
=== RUN   TestAccRedshiftServerlessWorkgroup_port
=== PAUSE TestAccRedshiftServerlessWorkgroup_port
=== RUN   TestAccRedshiftServerlessWorkgroup_trackName
=== PAUSE TestAccRedshiftServerlessWorkgroup_trackName
=== CONT  TestAccRedshiftServerlessWorkgroup_basic
=== CONT  TestAccRedshiftServerlessWorkgroup_tags
=== CONT  TestAccRedshiftServerlessWorkgroup_port
=== CONT  TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible
=== CONT  TestAccRedshiftServerlessWorkgroup_trackName
=== CONT  TestAccRedshiftServerlessWorkgroup_disappears
=== CONT  TestAccRedshiftServerlessWorkgroup_pricePerformanceTarget
=== CONT  TestAccRedshiftServerlessWorkgroup_configParameters
--- PASS: TestAccRedshiftServerlessWorkgroup_tags (298.57s)
--- PASS: TestAccRedshiftServerlessWorkgroup_basic (532.54s)
--- PASS: TestAccRedshiftServerlessWorkgroup_port (572.98s)
--- PASS: TestAccRedshiftServerlessWorkgroup_trackName (584.99s)
--- PASS: TestAccRedshiftServerlessWorkgroup_disappears (611.41s)
--- PASS: TestAccRedshiftServerlessWorkgroup_configParameters (672.69s)
--- PASS: TestAccRedshiftServerlessWorkgroup_pricePerformanceTarget (760.95s)
--- PASS: TestAccRedshiftServerlessWorkgroup_baseAndMaxCapacityAndPubliclyAccessible (2684.70s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 2688.883s


```

```console
$ make testacc TESTS=TestAccRedshiftServerlessWorkgroupDataSource_basic PKG=redshiftserverless
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/redshiftserverless/... -v -count 1 -parallel 20 -run='TestAccRedshiftServerlessWorkgroupDataSource_basic'  -timeout 360m -vet=off
2025/05/02 18:18:54 Initializing Terraform AWS Provider...
=== RUN   TestAccRedshiftServerlessWorkgroupDataSource_basic
=== PAUSE TestAccRedshiftServerlessWorkgroupDataSource_basic
=== CONT  TestAccRedshiftServerlessWorkgroupDataSource_basic
--- PASS: TestAccRedshiftServerlessWorkgroupDataSource_basic (332.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/redshiftserverless 335.771s
```
