### PR TITLE
[Enhancement] aws_events_bus:  add `dead_letter_config`

### DIFF
--- a/internal/service/events/bus_data_source.go
+++ b/internal/service/events/bus_data_source.go
@@ -23,6 +23,18 @@ func dataSourceBus() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"dead_letter_config": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			names.AttrDescription: {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -52,6 +64,7 @@ func dataSourceBusRead(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	d.SetId(eventBusName)
 	d.Set(names.AttrARN, output.Arn)
+	d.Set("dead_letter_config", flattenDeadLetterConfig(output.DeadLetterConfig))
 	d.Set(names.AttrDescription, output.Description)
 	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.Name)

--- a/internal/service/events/bus_test.go
+++ b/internal/service/events/bus_test.go
@@ -41,6 +41,7 @@ func TestAccEventsBus_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBusExists(ctx, resourceName, &v1),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "events", fmt.Sprintf("event-bus/%s", busName)),
+					resource.TestCheckResourceAttr(resourceName, "dead_letter_config.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckNoResourceAttr(resourceName, "event_source_name"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, busName),
@@ -243,6 +244,43 @@ func TestAccEventsBus_partnerEventSource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "event_source_name", busName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, busName),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEventsBus_deadLetterConfig(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1, v2 eventbridge.DescribeEventBusOutput
+	busName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_bus.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBusDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBusConfig_deadLetterConfig1(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBusExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, "dead_letter_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "dead_letter_config.0.arn", "aws_sqs_queue.test1", names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBusConfig_deadLetterConfig2(busName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBusExists(ctx, resourceName, &v2),
+					resource.TestCheckResourceAttr(resourceName, "dead_letter_config.#", "1"),
+					resource.TestCheckResourceAttrPair(resourceName, "dead_letter_config.0.arn", "aws_sqs_queue.test2", names.AttrARN),
 				),
 			},
 		},
@@ -452,4 +490,34 @@ resource "aws_cloudwatch_event_bus" "test" {
   kms_key_identifier = aws_kms_key.test2.arn
 }
 `, name))
+}
+
+func testAccBusConfig_deadLetterConfig1(name string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test1" {
+  name = "%[1]s-test1"
+}
+
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+  dead_letter_config {
+    arn = aws_sqs_queue.test1.arn
+  }
+}
+`, name)
+}
+
+func testAccBusConfig_deadLetterConfig2(name string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "test2" {
+  name = "%[1]s-test2"
+}
+
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+  dead_letter_config {
+    arn = aws_sqs_queue.test2.arn
+  }
+}
+`, name)
 }

--- a/website/docs/d/cloudwatch_event_bus.html.markdown
+++ b/website/docs/d/cloudwatch_event_bus.html.markdown
@@ -29,6 +29,8 @@ data "aws_cloudwatch_event_bus" "example" {
 This data source exports the following attributes in addition to the arguments above:
 
 * `arn` - ARN of the event bus.
+* `dead_letter_config` - Configuration details of the Amazon SQS queue for EventBridge to use as a dead-letter queue (DLQ). This block has the following arguments:
+  * `arn` - The ARN of the SQS queue specified as the target for the dead-letter queue.
 * `description` - Event bus description.
 * `id` - Name of the event bus.
 * `kms_key_identifier` - Identifier of the AWS KMS customer managed key for EventBridge to use to encrypt events on this event bus, if one has been specified.

--- a/website/docs/r/cloudwatch_event_bus.html.markdown
+++ b/website/docs/r/cloudwatch_event_bus.html.markdown
@@ -42,6 +42,8 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `dead_letter_config` - (Optional) Configuration details of the Amazon SQS queue for EventBridge to use as a dead-letter queue (DLQ). This block supports the following arguments:
+  * `arn` - (Optional) The ARN of the SQS queue specified as the target for the dead-letter queue.
 * `description` - (Optional) Event bus description.
 * `event_source_name` - (Optional) Partner event source that the new event bus will be matched with. Must match `name`.
 * `kms_key_identifier` - (Optional) Identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt events on this event bus. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN.


### PR DESCRIPTION
### Description


### Relations

Closes #41563

### References
https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateEventBus.html#eventbridge-CreateEventBus-request-DeadLetterConfig

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
