### PR TITLE
fix: add missing attribute `policy_variables` in data source `aws_networkfirewall_firewall_policy`

### DIFF
--- a/.changelog/42473.txt
+++ b/.changelog/42473.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+data-source/aws_networkfirewall_firewall_policy: Add `firewall_policy.policy_variables` configuration block
+```

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -43,6 +43,39 @@ func dataSourceFirewallPolicy() *schema.Resource {
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"policy_variables": {
+								Type:     schema.TypeList,
+								Computed: true,
+								Elem: &schema.Resource{
+									Schema: map[string]*schema.Schema{
+										"rule_variables": {
+											Type:     schema.TypeSet,
+											Computed: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													"ip_set": {
+														Type:     schema.TypeList,
+														Computed: true,
+														Elem: &schema.Resource{
+															Schema: map[string]*schema.Schema{
+																"definition": {
+																	Type:     schema.TypeSet,
+																	Computed: true,
+																	Elem:     &schema.Schema{Type: schema.TypeString},
+																},
+															},
+														},
+													},
+													names.AttrKey: {
+														Type:     schema.TypeString,
+														Computed: true,
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 							"stateful_default_actions": {
 								Type:     schema.TypeSet,
 								Computed: true,


### PR DESCRIPTION
### Description

The data source [`aws_networkfirewall_firewall_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/networkfirewall_firewall_policy)  is missing the attribute `policy_variables` (and contained other attributes).


When a resource [`aws_networkfirewall_firewall_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/networkfirewall_firewall_policy)   containing `policy_variables` is created and its contents read by the data source, an error similar to the one  below is thrown


```shell
Error: setting firewall_policy: Invalid address to set: []string{"firewall_policy", "0", "policy_variables"}
```

Example code demonstrating the issue

```hcl
resource "aws_networkfirewall_firewall_policy" "test" {
  name = "Test"
  firewall_policy {
    stateless_fragment_default_actions = ["aws:drop"]
    stateless_default_actions          = ["aws:pass"]
    policy_variables {
      rule_variables {
        key = "HOME_NET"
        ip_set {
          definition = ["10.0.0.0/16", "10.1.0.0/24"]
        }
      }
    }
  }
}

data "aws_networkfirewall_firewall_policy" "example" {
 name = "Test"
}

output "rule_variables" {
  value = data.aws_networkfirewall_firewall_policy.example.firewall_policy[0].policy_variables[0].rule_variables
}
```

### Relations

Closes #42443 

### References

- [Pull request 32400](https://github.com/hashicorp/terraform-provider-aws/pull/32400) Adding the functionality only to the resource

### Output from Acceptance Testing

```console
❯ make testacc TESTS=TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables PKG=networkfirewall
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables'  -timeout 360m -vet=off
2025/05/04 20:39:08 Initializing Terraform AWS Provider...
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables (168.11s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    168.247s
```
