### PR TITLE
[Enhancement]: add appflow flow Salesforce destination data_transfer_ap…

### DIFF
--- a/.changelog/42479.txt
+++ b/.changelog/42479.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_appflow_flow: Add support for `data_transfer_api` to Salesforce destination properties.
+resource/aws_appflow_flow: Add `destination_flow_config.destination_connector_properties.salesforce.data_transfer_api` argument
 ```

--- a/.changelog/42479.txt
+++ b/.changelog/42479.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_appflow_flow: Add support for `data_transfer_api` to Salesforce destination properties.
+```

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -475,6 +475,11 @@ func resourceFlow() *schema.Resource {
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
 												},
+												"data_transfer_api": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
+												},
 											},
 										},
 									},
@@ -1952,6 +1957,10 @@ func expandSalesforceDestinationProperties(tfMap map[string]any) *types.Salesfor
 		a.WriteOperationType = types.WriteOperationType(v)
 	}
 
+	if v, ok := tfMap["data_transfer_api"].(string); ok && v != "" {
+		a.DataTransferApi = types.SalesforceDataTransferApi(v)
+	}
+
 	return a
 }
 
@@ -3143,6 +3152,7 @@ func flattenSalesforceDestinationProperties(salesforceDestinationProperties *typ
 	}
 
 	m["write_operation_type"] = salesforceDestinationProperties.WriteOperationType
+	m["data_transfer_api"] = salesforceDestinationProperties.DataTransferApi
 
 	return m
 }

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -434,6 +434,11 @@ func resourceFlow() *schema.Resource {
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
+												"data_transfer_api": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
+												},
 												"error_handling_config": {
 													Type:     schema.TypeList,
 													Optional: true,
@@ -474,11 +479,6 @@ func resourceFlow() *schema.Resource {
 													Type:             schema.TypeString,
 													Optional:         true,
 													ValidateDiagFunc: enum.Validate[types.WriteOperationType](),
-												},
-												"data_transfer_api": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
 												},
 											},
 										},
@@ -940,6 +940,11 @@ func resourceFlow() *schema.Resource {
 										MaxItems: 1,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
+												"data_transfer_api": {
+													Type:             schema.TypeString,
+													Optional:         true,
+													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
+												},
 												"enable_dynamic_field_update": {
 													Type:     schema.TypeBool,
 													Optional: true,
@@ -952,11 +957,6 @@ func resourceFlow() *schema.Resource {
 													Type:         schema.TypeString,
 													Required:     true,
 													ValidateFunc: validation.All(validation.StringMatch(regexache.MustCompile(`\S+`), "must not contain any whitespace characters"), validation.StringLenBetween(1, 512)),
-												},
-												"data_transfer_api": {
-													Type:             schema.TypeString,
-													Optional:         true,
-													ValidateDiagFunc: enum.Validate[types.SalesforceDataTransferApi](),
 												},
 											},
 										},
@@ -1941,6 +1941,10 @@ func expandSalesforceDestinationProperties(tfMap map[string]any) *types.Salesfor
 
 	a := &types.SalesforceDestinationProperties{}
 
+	if v, ok := tfMap["data_transfer_api"].(string); ok && v != "" {
+		a.DataTransferApi = types.SalesforceDataTransferApi(v)
+	}
+
 	if v, ok := tfMap["error_handling_config"].([]any); ok && len(v) > 0 && v[0] != nil {
 		a.ErrorHandlingConfig = expandErrorHandlingConfig(v[0].(map[string]any))
 	}
@@ -1955,10 +1959,6 @@ func expandSalesforceDestinationProperties(tfMap map[string]any) *types.Salesfor
 
 	if v, ok := tfMap["write_operation_type"].(string); ok && v != "" {
 		a.WriteOperationType = types.WriteOperationType(v)
-	}
-
-	if v, ok := tfMap["data_transfer_api"].(string); ok && v != "" {
-		a.DataTransferApi = types.SalesforceDataTransferApi(v)
 	}
 
 	return a
@@ -2371,6 +2371,10 @@ func expandSalesforceSourceProperties(tfMap map[string]any) *types.SalesforceSou
 
 	a := &types.SalesforceSourceProperties{}
 
+	if v, ok := tfMap["data_transfer_api"].(string); ok && v != "" {
+		a.DataTransferApi = types.SalesforceDataTransferApi(v)
+	}
+
 	if v, ok := tfMap["enable_dynamic_field_update"].(bool); ok {
 		a.EnableDynamicFieldUpdate = v
 	}
@@ -2381,10 +2385,6 @@ func expandSalesforceSourceProperties(tfMap map[string]any) *types.SalesforceSou
 
 	if v, ok := tfMap["object"].(string); ok && v != "" {
 		a.Object = aws.String(v)
-	}
-
-	if v, ok := tfMap["data_transfer_api"].(string); ok && v != "" {
-		a.DataTransferApi = types.SalesforceDataTransferApi(v)
 	}
 
 	return a
@@ -3139,6 +3139,8 @@ func flattenSalesforceDestinationProperties(salesforceDestinationProperties *typ
 
 	m := map[string]any{}
 
+	m["data_transfer_api"] = salesforceDestinationProperties.DataTransferApi
+
 	if v := salesforceDestinationProperties.ErrorHandlingConfig; v != nil {
 		m["error_handling_config"] = []any{flattenErrorHandlingConfig(v)}
 	}
@@ -3152,7 +3154,6 @@ func flattenSalesforceDestinationProperties(salesforceDestinationProperties *typ
 	}
 
 	m["write_operation_type"] = salesforceDestinationProperties.WriteOperationType
-	m["data_transfer_api"] = salesforceDestinationProperties.DataTransferApi
 
 	return m
 }
@@ -3554,9 +3555,9 @@ func flattenSalesforceSourceProperties(salesforceSourceProperties *types.Salesfo
 
 	m := map[string]any{}
 
+	m["data_transfer_api"] = salesforceSourceProperties.DataTransferApi
 	m["enable_dynamic_field_update"] = salesforceSourceProperties.EnableDynamicFieldUpdate
 	m["include_deleted_records"] = salesforceSourceProperties.IncludeDeletedRecords
-	m["data_transfer_api"] = salesforceSourceProperties.DataTransferApi
 
 	if v := salesforceSourceProperties.Object; v != nil {
 		m["object"] = aws.ToString(v)

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -211,6 +211,7 @@ EventBridge, Honeycode, and Marketo destination properties all support the follo
 * `error_handling_config` - (Optional) Settings that determine how Amazon AppFlow handles an error when placing data in the destination. See [Error Handling Config](#error-handling-config) for more details.
 * `id_field_names` - (Optional) Name of the field that Amazon AppFlow uses as an ID when performing a write operation such as update or delete.
 * `write_operation_type` - (Optional) This specifies the type of write operation to be performed in Salesforce. When the value is `UPSERT`, then `id_field_names` is required. Valid values are `INSERT`, `UPSERT`, `UPDATE`, and `DELETE`.
+* `data_transfer_api` - (Optional) Specifies which Salesforce API is used by Amazon AppFlow when your flow transfers data to Salesforce.
 
 ##### SAPOData Destination Properties
 


### PR DESCRIPTION
### Description
This PR implements new Salesforce destination property `data_transfer_api` in aws_appflow_flow resource. 

### Relations
Closes #41759  

### References
- [SDK](https://docs.aws.amazon.com/appflow/1.0/APIReference/API_SalesforceDestinationProperties.html)


### Output from Acceptance Testing
No acceptance tests updated as tests does not cover external connectors. 

```console
❯ make testacc "TESTS=TestAccAppflow" PKG=appflow
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/appflow/... -v -count 1 -parallel 20 -run='TestAccAppflow'  -timeout 360m -vet=off
2025/05/05 15:02:02 Initializing Terraform AWS Provider...
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appflow    4.590s [no tests to run]
❯ make testacc "TESTS=TestAccAppFlow" PKG=appflow
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/appflow/... -v -count 1 -parallel 20 -run='TestAccAppFlow'  -timeout 360m -vet=off
2025/05/05 15:04:30 Initializing Terraform AWS Provider...
=== RUN   TestAccAppFlowConnectorProfile_basic
=== PAUSE TestAccAppFlowConnectorProfile_basic
=== RUN   TestAccAppFlowConnectorProfile_update
=== PAUSE TestAccAppFlowConnectorProfile_update
=== RUN   TestAccAppFlowConnectorProfile_disappears
=== PAUSE TestAccAppFlowConnectorProfile_disappears
=== RUN   TestAccAppFlowFlow_tags
=== PAUSE TestAccAppFlowFlow_tags
=== RUN   TestAccAppFlowFlow_tags_null
=== PAUSE TestAccAppFlowFlow_tags_null
=== RUN   TestAccAppFlowFlow_tags_EmptyMap
=== PAUSE TestAccAppFlowFlow_tags_EmptyMap
=== RUN   TestAccAppFlowFlow_tags_AddOnUpdate
=== PAUSE TestAccAppFlowFlow_tags_AddOnUpdate
=== RUN   TestAccAppFlowFlow_tags_EmptyTag_OnCreate
=== PAUSE TestAccAppFlowFlow_tags_EmptyTag_OnCreate
=== RUN   TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_providerOnly
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_providerOnly
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_overlapping
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_overlapping
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccAppFlowFlow_tags_ComputedTag_OnCreate
=== PAUSE TestAccAppFlowFlow_tags_ComputedTag_OnCreate
=== RUN   TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccAppFlowFlow_basic
=== PAUSE TestAccAppFlowFlow_basic
=== RUN   TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType
=== PAUSE TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType
=== RUN   TestAccAppFlowFlow_update
=== PAUSE TestAccAppFlowFlow_update
=== RUN   TestAccAppFlowFlow_taskProperties
=== PAUSE TestAccAppFlowFlow_taskProperties
=== RUN   TestAccAppFlowFlow_taskUpdate
=== PAUSE TestAccAppFlowFlow_taskUpdate
=== RUN   TestAccAppFlowFlow_task_mapAll
=== PAUSE TestAccAppFlowFlow_task_mapAll
=== RUN   TestAccAppFlowFlow_disappears
=== PAUSE TestAccAppFlowFlow_disappears
=== RUN   TestAccAppFlowFlow_metadataCatalog
=== PAUSE TestAccAppFlowFlow_metadataCatalog
=== CONT  TestAccAppFlowConnectorProfile_basic
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag
=== CONT  TestAccAppFlowFlow_taskUpdate
=== CONT  TestAccAppFlowFlow_basic
=== CONT  TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_overlapping
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_providerOnly
=== CONT  TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace
=== CONT  TestAccAppFlowFlow_disappears
=== CONT  TestAccAppFlowFlow_metadataCatalog
=== CONT  TestAccAppFlowFlow_task_mapAll
=== CONT  TestAccAppFlowFlow_tags_null
=== CONT  TestAccAppFlowFlow_tags_EmptyTag_OnCreate
=== CONT  TestAccAppFlowFlow_tags_AddOnUpdate
=== CONT  TestAccAppFlowFlow_tags_EmptyMap
=== CONT  TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccAppFlowFlow_disappears (44.48s)
=== CONT  TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccAppFlowFlow_basic (55.38s)
=== CONT  TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag (63.31s)
=== CONT  TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag (66.04s)
=== CONT  TestAccAppFlowFlow_update
--- PASS: TestAccAppFlowFlow_metadataCatalog (67.41s)
=== CONT  TestAccAppFlowFlow_taskProperties
--- PASS: TestAccAppFlowFlow_task_mapAll (68.05s)
=== CONT  TestAccAppFlowConnectorProfile_disappears
--- PASS: TestAccAppFlowFlow_tags_null (76.80s)
=== CONT  TestAccAppFlowFlow_tags
--- PASS: TestAccAppFlowFlow_taskUpdate (77.68s)
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccAppFlowFlow_tags_EmptyMap (80.19s)
=== CONT  TestAccAppFlowFlow_tags_ComputedTag_OnCreate
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace (97.39s)
=== CONT  TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly (98.83s)
=== CONT  TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccAppFlowFlow_tags_AddOnUpdate (99.79s)
=== CONT  TestAccAppFlowConnectorProfile_update
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnCreate (105.97s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly (106.06s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add (107.72s)
--- PASS: TestAccAppFlowFlow_taskProperties (44.11s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag (52.19s)
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add (134.09s)
--- PASS: TestAccAppFlowFlow_update (68.12s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnCreate (55.08s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_overlapping (142.95s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping (142.95s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag (44.21s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace (79.95s)
--- PASS: TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType (51.53s)
--- PASS: TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag (94.32s)
--- PASS: TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag (106.54s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_providerOnly (160.05s)
--- PASS: TestAccAppFlowFlow_tags (102.00s)
--- PASS: TestAccAppFlowConnectorProfile_basic (203.46s)
--- PASS: TestAccAppFlowConnectorProfile_disappears (176.61s)
--- PASS: TestAccAppFlowConnectorProfile_update (198.18s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/appflow    303.726s

```
