### PR TITLE
r/aws_controltower_control: handle removal of parameters block

### DIFF
--- a/.changelog/42494.txt
+++ b/.changelog/42494.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_controltower_control: Fix handling of `parameters` block removal
+```
+```release-note:bug
+resource/aws_controltower_control: Fix handling `ResourceNotFound` exceptions during delete
+```

--- a/docs/acc-test-environment-variables.md
+++ b/docs/acc-test-environment-variables.md
@@ -94,6 +94,7 @@ Environment variables (beyond standard AWS Go SDK ones) used by acceptance testi
 | `TF_ACC` | Enables Go tests containing `resource.Test()` and `resource.ParallelTest()`. |
 | `TF_ACC_ASSUME_ROLE_ARN` | Amazon Resource Name of existing IAM Role to use for limited permissions acceptance testing. |
 | `TF_AWS_BEDROCK_OSS_COLLECTION_NAME` | Name of the OpenSearch Serverless collection to be used with an Amazon Bedrock Knowledge Base. |
+| `TF_AWS_CONTROLTOWER_CONTROL_OU_NAME` | Organizational unit name to be targeted by the Control Tower control. |
 | `TF_AWS_DATAEXCHANGE_DATA_SET_ID` | ID of DataExchange Data Set to use for testing. |
 | `TF_AWS_LICENSE_MANAGER_GRANT_HOME_REGION` | Region where a License Manager license is imported. |
 | `TF_AWS_LICENSE_MANAGER_GRANT_LICENSE_ARN` | ARN for a License Manager license imported into the current account. |

--- a/internal/service/controltower/control.go
+++ b/internal/service/controltower/control.go
@@ -241,6 +241,9 @@ func resourceControlDelete(ctx context.Context, d *schema.ResourceData, meta any
 		TargetIdentifier:  aws.String(targetIdentifier),
 	}
 	output, err := conn.DisableControl(ctx, &input)
+	if errs.IsA[*types.ResourceNotFoundException](err) {
+		return diags
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "deleting ControlTower Control (%s): %s", d.Id(), err)

--- a/internal/service/controltower/control.go
+++ b/internal/service/controltower/control.go
@@ -258,11 +258,7 @@ const (
 )
 
 func expandControlParameters(input []any) ([]types.EnabledControlParameter, error) {
-	if len(input) == 0 {
-		return nil, nil
-	}
-
-	var output []types.EnabledControlParameter
+	output := []types.EnabledControlParameter{}
 
 	for _, v := range input {
 		val := v.(map[string]any)

--- a/internal/service/controltower/control_test.go
+++ b/internal/service/controltower/control_test.go
@@ -10,6 +10,7 @@ import (
 
 	types "github.com/aws/aws-sdk-go-v2/service/controltower/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -18,42 +19,29 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
-func TestAccControlTowerControl_serial(t *testing.T) {
-	t.Parallel()
-
-	testCases := map[string]map[string]func(t *testing.T){
-		"Control": {
-			acctest.CtBasic:      testAccControl_basic,
-			acctest.CtDisappears: testAccControl_disappears,
-		},
-	}
-
-	acctest.RunSerialTests2Levels(t, testCases, 0)
-}
-
 func testAccControl_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var control types.EnabledControlSummary
 	resourceName := "aws_controltower_control.test"
-	controlName := "AWS-GR_EC2_VOLUME_INUSE_CHECK"
-	ouName := "Security"
-	region := "us-west-2" //lintignore:AWSAT003
+	ouDataSourceName := "data.aws_organizations_organizational_unit.test"
+	ouName := acctest.SkipIfEnvVarNotSet(t, "TF_AWS_CONTROLTOWER_CONTROL_OU_NAME")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckOrganizationManagementAccount(ctx, t)
-			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
 		CheckDestroy:             testAccCheckControlDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccControlConfig_basic(controlName, ouName, region),
+				Config: testAccControlConfig_basic(ouName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckControlExists(ctx, resourceName, &control),
 					resource.TestCheckResourceAttrSet(resourceName, "control_identifier"),
+					resource.TestCheckResourceAttrPair(resourceName, "target_identifier", ouDataSourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "parameters.#", "0"),
 				),
 			},
 		},
@@ -64,27 +52,84 @@ func testAccControl_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var control types.EnabledControlSummary
 	resourceName := "aws_controltower_control.test"
-	controlName := "AWS-GR_EC2_VOLUME_INUSE_CHECK"
-	ouName := "Security"
-	region := "us-west-2" //lintignore:AWSAT003
+	ouName := acctest.SkipIfEnvVarNotSet(t, "TF_AWS_CONTROLTOWER_CONTROL_OU_NAME")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckOrganizationManagementAccount(ctx, t)
-			testAccPreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckControlDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccControlConfig_basic(controlName, ouName, region),
+				Config: testAccControlConfig_basic(ouName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckControlExists(ctx, resourceName, &control),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfcontroltower.ResourceControl(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+func testAccControl_parameters(t *testing.T) {
+	ctx := acctest.Context(t)
+	var control types.EnabledControlSummary
+	resourceName := "aws_controltower_control.test"
+	ouName := acctest.SkipIfEnvVarNotSet(t, "TF_AWS_CONTROLTOWER_CONTROL_OU_NAME")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckOrganizationManagementAccount(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.ControlTowerServiceID),
+		CheckDestroy:             testAccCheckControlDestroy(ctx),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccControlConfig_parameters(ouName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckControlExists(ctx, resourceName, &control),
+					resource.TestCheckResourceAttrSet(resourceName, "control_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.key", "ExemptedPrincipalArns"),
+				),
+			},
+			{
+				Config: testAccControlConfig_basic(ouName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckControlExists(ctx, resourceName, &control),
+					resource.TestCheckResourceAttrSet(resourceName, "control_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.#", "0"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccControlConfig_parameters(ouName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckControlExists(ctx, resourceName, &control),
+					resource.TestCheckResourceAttrSet(resourceName, "control_identifier"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.key", "ExemptedPrincipalArns"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -137,29 +182,49 @@ func testAccCheckControlDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccControlConfig_basic(controlName, ouName, region string) string {
+func testAccControlConfigBase(ouName string) string {
 	return fmt.Sprintf(`
-data "aws_region" "current" {}
-
 data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
 
 data "aws_organizations_organization" "test" {}
 
-data "aws_organizations_organizational_units" "test" {
+data "aws_organizations_organizational_unit" "test" {
   parent_id = data.aws_organizations_organization.test.roots[0].id
+  name      = %[1]q
+}
+`, ouName)
 }
 
+func testAccControlConfig_basic(ouName string) string {
+	return acctest.ConfigCompose(
+		testAccControlConfigBase(ouName),
+		`
 resource "aws_controltower_control" "test" {
-  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.name}::control/%[1]s"
-  target_identifier = [
-    for x in data.aws_organizations_organizational_units.test.children :
-    x.arn if x.name == "%[2]s"
-  ][0]
+  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.name}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
+  target_identifier  = data.aws_organizations_organizational_unit.test.arn
+}
+`)
+}
+
+// See the AWS documentation for a list of parameterized controls.
+//
+// Ref:
+// - https://docs.aws.amazon.com/controltower/latest/controlreference/control-parameter-concepts.html
+// - https://docs.aws.amazon.com/controltower/latest/controlreference/elective-preventive-controls.html
+func testAccControlConfig_parameters(ouName string) string {
+	return acctest.ConfigCompose(
+		testAccControlConfigBase(ouName),
+		`
+resource "aws_controltower_control" "test" {
+  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.name}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
+  target_identifier  = data.aws_organizations_organizational_unit.test.arn
 
   parameters {
-    key   = "AllowedRegions"
-    value = jsonencode([%[3]q])
+    key   = "ExemptedPrincipalArns"
+    value = jsonencode(["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/tf-acctest-example"])
   }
 }
-`, controlName, ouName, region)
+`)
 }

--- a/internal/service/controltower/controltower_test.go
+++ b/internal/service/controltower/controltower_test.go
@@ -18,6 +18,11 @@ func TestAccControlTower_serial(t *testing.T) {
 			acctest.CtDisappears: testAccLandingZone_disappears,
 			"tags":               testAccLandingZone_tags,
 		},
+		"Control": {
+			acctest.CtBasic:      testAccControl_basic,
+			acctest.CtDisappears: testAccControl_disappears,
+			"parameters":         testAccControl_parameters,
+		},
 	}
 
 	acctest.RunSerialTests2Levels(t, testCases, 0)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously, removal of a configured `parameters` block would result in an error due to the update request body being serialized with a nil `Parameters` argument rather than an empty array. This change now returns an empty slice from the `parameters` expander when no value is configured.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42485



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% TF_AWS_CONTROLTOWER_CONTROL_OU_NAME=<redacted> make testacc PKG=controltower TESTS=TestAccControlTower_serial/Control/
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/controltower/... -v -count 1 -parallel 20 -run='TestAccControlTower_serial/Control/'  -timeout 360m -vet=off
2025/05/05 16:50:01 Initializing Terraform AWS Provider...
=== RUN   TestAccControlTower_serial
=== PAUSE TestAccControlTower_serial
=== CONT  TestAccControlTower_serial
=== RUN   TestAccControlTower_serial/Control
=== RUN   TestAccControlTower_serial/Control/basic
=== RUN   TestAccControlTower_serial/Control/disappears
=== RUN   TestAccControlTower_serial/Control/parameters
--- PASS: TestAccControlTower_serial (349.28s)
    --- PASS: TestAccControlTower_serial/Control (349.28s)
        --- PASS: TestAccControlTower_serial/Control/basic (85.56s)
        --- PASS: TestAccControlTower_serial/Control/disappears (86.00s)
        --- PASS: TestAccControlTower_serial/Control/parameters (177.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/controltower       354.847s
```
