### PR TITLE
feat: Adds 'merge' OpenAPI ability to API Gateway PUT API resource

### DIFF
--- a/internal/service/apigateway/rest_api_put.go
+++ b/internal/service/apigateway/rest_api_put.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -74,6 +75,14 @@ func (r *resourceRestAPIPut) Schema(ctx context.Context, req resource.SchemaRequ
 					mapplanmodifier.RequiresReplace(),
 				},
 			},
+			"put_rest_api_mode": schema.StringAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  stringdefault.StaticString(string(awstypes.PutModeOverwrite)),
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"rest_api_id": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
@@ -107,7 +116,7 @@ func (r *resourceRestAPIPut) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	input := apigateway.PutRestApiInput{
-		Mode: awstypes.PutModeOverwrite,
+		Mode: awstypes.PutMode(plan.PutRestAPIMode.ValueString()),
 	}
 
 	resp.Diagnostics.Append(flex.Expand(ctx, plan, &input)...)
@@ -227,6 +236,7 @@ type resourceRestAPIPutModel struct {
 	Body           types.String        `tfsdk:"body"`
 	FailOnWarnings types.Bool          `tfsdk:"fail_on_warnings"`
 	Parameters     fwtypes.MapOfString `tfsdk:"parameters"`
+	PutRestAPIMode types.String        `tfsdk:"put_rest_api_mode"`
 	RestAPIID      types.String        `tfsdk:"rest_api_id"`
 	Timeouts       timeouts.Value      `tfsdk:"timeouts"`
 	Triggers       fwtypes.MapOfString `tfsdk:"triggers"`

--- a/website/docs/r/api_gateway_rest_api_put.markdown
+++ b/website/docs/r/api_gateway_rest_api_put.markdown
@@ -141,6 +141,7 @@ The following arguments are optional:
 
 * `fail_on_warnings` - (Optional) Whether to rollback the API update when a warning is encountered. The default value is `false`.
 * `parameters` - (Optional) Map of customizations for importing the specification in the `body` argument. For example, to exclude DocumentationParts from an imported API, use `ignore = "documentation"`. Additional documentation, including other parameters such as `basepath`, can be found in the [API Gateway Developer Guide](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-import-api.html).
+* `put_rest_api_mode` - (Optional) Mode of the PutRestApi operation. Valid values are `overwrite` and `merge`. The default value is `overwrite`. When set to `merge`, the API Gateway will not delete existing literal properties if they are not explicitly set in the OpenAPI definition. When set to `overwrite`, all existing literal properties will be deleted if they are not explicitly set in the OpenAPI definition. Additional information in [API Gateway Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-import-api-update.html).
 * `triggers` - (Optional) Map of arbitrary keys and values that, when changed, will trigger a redeployment. To force a redeployment without changing these keys/values, use the [`-replace` option](https://developer.hashicorp.com/terraform/cli/commands/plan#replace-address) with `terraform plan` or `terraform apply`.
 
 ## Attribute Reference


### PR DESCRIPTION
Enable API Spec Merging on REST APIs. Fixes #42497 

### Description

Adds an additional, optional, property to the `aws_api_gateway_rest_api_put` resource, `put_rest_api_mode`. This is the same name of the property with the same intended behaviour in the [api_gateway_rest_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_rest_api#put_rest_api_mode-7)

### Relations

Closes #42497 
