### PR TITLE
docs: update environment and compute type details for codebuild project

### DIFF
--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -358,9 +358,8 @@ The following arguments are optional:
 * `certificate` - (Optional) ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
 * `compute_type` - (Required) Information about the compute resources the build project will use. Valid values:
   `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_XLARGE`, `BUILD_GENERAL1_2XLARGE`, `BUILD_LAMBDA_1GB`,
-  `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be
-  `BUILD_GENERAL1_SMALL` or`BUILD_GENERAL1_LARGE`. When `type` is set to `LINUX_LAMBDA_CONTAINER` or `ARM_LAMBDA_CONTAINER`, `compute_type` must
-  be `BUILD_LAMBDA_XGB`.
+  `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. For additional information, see
+  the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
 * `fleet` - (Optional) Configuration block. Detailed below.
 * `environment_variable` - (Optional) Configuration block. Detailed below.
 * `image_pull_credentials_type` - (Optional) Type of credentials AWS CodeBuild uses to pull images in your build. Valid
@@ -375,7 +374,7 @@ The following arguments are optional:
   `false`.
 * `registry_credential` - (Optional) Configuration block. Detailed below.
 * `type` - (Required) Type of build environment to use for related builds. Valid values: `WINDOWS_CONTAINER` (deprecated), `LINUX_CONTAINER`,
-  `LINUX_GPU_CONTAINER`, `ARM_CONTAINER`, `WINDOWS_SERVER_2019_CONTAINER`, `WINDOWS_SERVER_2022_CONTAINER`, 
+  `LINUX_GPU_CONTAINER`, `ARM_CONTAINER`, `WINDOWS_SERVER_2019_CONTAINER`, `WINDOWS_SERVER_2022_CONTAINER`,
   `LINUX_LAMBDA_CONTAINER`, `ARM_LAMBDA_CONTAINER`, `LINUX_EC2`, `ARM_EC2`, `WINDOWS_EC2`, `MAC_ARM`. For additional information, see
   the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
 

--- a/website/docs/r/codebuild_project.html.markdown
+++ b/website/docs/r/codebuild_project.html.markdown
@@ -357,11 +357,10 @@ The following arguments are optional:
 
 * `certificate` - (Optional) ARN of the S3 bucket, path prefix and object key that contains the PEM-encoded certificate.
 * `compute_type` - (Required) Information about the compute resources the build project will use. Valid values:
-  `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_2XLARGE`, `BUILD_LAMBDA_1GB`,
-  `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. `BUILD_GENERAL1_SMALL` is only valid
-  if `type` is set to `LINUX_CONTAINER`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be
-  `BUILD_GENERAL1_LARGE`. When `type` is set to `LINUX_LAMBDA_CONTAINER` or `ARM_LAMBDA_CONTAINER`, `compute_type` must
-  be `BUILD_LAMBDA_XGB`.`
+  `BUILD_GENERAL1_SMALL`, `BUILD_GENERAL1_MEDIUM`, `BUILD_GENERAL1_LARGE`, `BUILD_GENERAL1_XLARGE`, `BUILD_GENERAL1_2XLARGE`, `BUILD_LAMBDA_1GB`,
+  `BUILD_LAMBDA_2GB`, `BUILD_LAMBDA_4GB`, `BUILD_LAMBDA_8GB`, `BUILD_LAMBDA_10GB`. When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be
+  `BUILD_GENERAL1_SMALL` or`BUILD_GENERAL1_LARGE`. When `type` is set to `LINUX_LAMBDA_CONTAINER` or `ARM_LAMBDA_CONTAINER`, `compute_type` must
+  be `BUILD_LAMBDA_XGB`.
 * `fleet` - (Optional) Configuration block. Detailed below.
 * `environment_variable` - (Optional) Configuration block. Detailed below.
 * `image_pull_credentials_type` - (Optional) Type of credentials AWS CodeBuild uses to pull images in your build. Valid
@@ -375,9 +374,9 @@ The following arguments are optional:
 * `privileged_mode` - (Optional) Whether to enable running the Docker daemon inside a Docker container. Defaults to
   `false`.
 * `registry_credential` - (Optional) Configuration block. Detailed below.
-* `type` - (Required) Type of build environment to use for related builds. Valid values: `LINUX_CONTAINER`,
-  `LINUX_GPU_CONTAINER`, `WINDOWS_CONTAINER` (deprecated), `WINDOWS_SERVER_2019_CONTAINER`, `ARM_CONTAINER`,
-  `LINUX_LAMBDA_CONTAINER`, `ARM_LAMBDA_CONTAINER`. For additional information, see
+* `type` - (Required) Type of build environment to use for related builds. Valid values: `WINDOWS_CONTAINER` (deprecated), `LINUX_CONTAINER`,
+  `LINUX_GPU_CONTAINER`, `ARM_CONTAINER`, `WINDOWS_SERVER_2019_CONTAINER`, `WINDOWS_SERVER_2022_CONTAINER`, 
+  `LINUX_LAMBDA_CONTAINER`, `ARM_LAMBDA_CONTAINER`, `LINUX_EC2`, `ARM_EC2`, `WINDOWS_EC2`, `MAC_ARM`. For additional information, see
   the [CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html).
 
 #### environment: fleet


### PR DESCRIPTION
### Description

As mentioned in #42488 the documentation for resource [`aws_codebuild_project`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/codebuild_project) misses a valid value for `environment.compute_type`.

This pull request 

- adds the missing value `BUILD_GENERAL1_XLARGE`
- removes no longer valid information:
  > `BUILD_GENERAL1_SMALL` is only valid   if `type` is set to `LINUX_CONTAINER`.

  `BUILD_GENERAL1_SMALL`  works also with `ARM_CONTAINER`, `ARM_EC2`, `LINUX_EC2`, and `LINUX_GPU_CONTAINER`.

   >When `type` is set to `LINUX_GPU_CONTAINER`, `compute_type` must be  `BUILD_GENERAL1_LARGE`

   `LINUX_GPU_CONTAINER` works also with `BUILD_GENERAL1_SMALL`

- adds under `environment.compute_type` a link to the AWS documentation on combinations/ restrictions for compute and environment types. 

- adds missing  environment types under `environment.type` and orders them as they are found in the AWS SDK Go V2 code (see References section for a link to the source code)
 
### Relations

Closes #42488 

### References

- [AWS SDK Go V2 - Valid compute types](https://github.com/aws/aws-sdk-go-v2/blame/8355f81262526630367d0e6cadaf250c65872056/service/codebuild/types/enums.go#L261) The provider uses these types in the `ValidateDiagFunc` 
- [AWS SDK Go V2 - Valid environment types](https://github.com/aws/aws-sdk-go-v2/blame/8355f81262526630367d0e6cadaf250c65872056/service/codebuild/types/enums.go#L314) The provider uses these types in the `ValidateDiagFunc`
- [AWS Docs - Details on supported compute and environment types](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.