### PR TITLE
docs: fix cloudwatch alarm example for anomaly detection

### DIFF
--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
 
   metric_query {
     id          = "m1"
-    return_data = "true"
+    return_data = true
     metric {
       metric_name = "CPUUtilization"
       namespace   = "AWS/EC2"

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -119,9 +119,10 @@ resource "aws_cloudwatch_metric_alarm" "xx_anomaly_detection" {
   insufficient_data_actions = []
 
   metric_query {
-    id         = "e1"
-    expression = "ANOMALY_DETECTION_BAND(m1)"
-    label      = "CPUUtilization (Expected)"
+    id          = "e1"
+    return_data = true
+    expression  = "ANOMALY_DETECTION_BAND(m1)"
+    label       = "CPUUtilization (Expected)"
   }
 
   metric_query {


### PR DESCRIPTION
### Description
For creating a CloudWatch Alarm with Anomaly Detection, the example in the current documentation does not work. (At least did not for me, and as far as I can see, there are a lot of confusion about the usage of `return_data` attribute due to AWS documentation saying "only one metric should set this to `true`", but that's apparently not the case for alarms with anomaly detection)

If only the `metric_query` block with the anomaly detection expression has `return_data` set to `true`, we get;
`Error: creating CloudWatch Metric Alarm (<redacted>): operation error CloudWatch: PutMetricAlarm, https response error StatusCode: 400, RequestID: <redacted>, api error ValidationError: Exactly two elements of the metrics list should return data.`

If only the `metric_query` block with the actual metric has `return_data` set to `true` (this is the example from the current Terraform AWS Provider documenation), we get;
`Error: creating CloudWatch Metric Alarm (<redacted>): operation error CloudWatch: PutMetricAlarm, https response error StatusCode: 400, RequestID: <redacted>, api error ValidationError: Metrics list must contain exactly one metric matching the ThresholdMetricId parameter`

Only when both `metric_query` blocks have the `return_data` attribute set to `true`, everything works as expected.

Even the test code in this repo has both blocks' `return_data` attributes set to `true`
https://github.com/hashicorp/terraform-provider-aws/blob/9ca25c2ab96aad67d660e5e62205153d5658287c/internal/service/cloudwatch/metric_alarm_test.go#L947-L969


### References
https://github.com/aws/aws-cdk/issues/19286
https://github.com/hashicorp/terraform-provider-aws/issues/33515
https://github.com/hashicorp/terraform-provider-aws/issues/10987
