### PR TITLE
[Enhancement] aws_codepipeline:  support for `Compute` action

### DIFF
--- a/.changelog/42507.txt
+++ b/.changelog/42507.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_codepipeline: Support for `Compute` action
+```

--- a/.changelog/42507.txt
+++ b/.changelog/42507.txt
@@ -1,5 +1,5 @@
 ```release-note:enhancement
-resource/aws_codepipeline: Added new arguments `commands` and 'output_artifacts_for_compute_action' to support 'Compute' action
+resource/aws_codepipeline: Add `stage.action.commands` and `stage.action.output_artifacts_for_compute_action` arguments to support Compute action types
 ```
 
 ```release-note:enhancement

--- a/.changelog/42507.txt
+++ b/.changelog/42507.txt
@@ -3,5 +3,5 @@ resource/aws_codepipeline: Add `stage.action.commands` and `stage.action.output_
 ```
 
 ```release-note:enhancement
-resource/aws_codepipeline: 'output_artifacts_for_compute_action' and 'output_artifacts' now conflict
+resource/aws_codepipeline: `stage.action.output_artifacts_for_compute_action` and `stage.action.output_artifacts` now conflict
 ```

--- a/.changelog/42507.txt
+++ b/.changelog/42507.txt
@@ -1,3 +1,7 @@
 ```release-note:enhancement
-resource/aws_codepipeline: Support for `Compute` action
+resource/aws_codepipeline: Added new arguments `commands` and 'output_artifacts_for_compute_action' to support 'Compute' action
+```
+
+```release-note:enhancement
+resource/aws_codepipeline: 'output_artifacts_for_compute_action' and 'output_artifacts' now conflict
 ```

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -1099,27 +1099,13 @@ func expandActionDeclaration(tfMap map[string]any) *types.ActionDeclaration {
 		apiObject.Namespace = aws.String(v)
 	}
 
-	outputArtifacts := []types.OutputArtifact{}
-	outputArtifactsForComputeAction := []types.OutputArtifact{}
-	if v, ok := tfMap["output_artifacts"].([]any); ok && len(v) > 0 {
-		outputArtifacts = expandOutputArtifacts(v)
-	}
-	if v, ok := tfMap["output_artifacts_for_compute_action"].([]any); ok && len(v) > 0 {
-		outputArtifactsForComputeAction = expandOutputArtifactsForComputeAction(v)
-	}
 	if apiObject.ActionTypeId.Category == types.ActionCategoryCompute {
-		if len(outputArtifactsForComputeAction) > 0 {
-			apiObject.OutputArtifacts = outputArtifactsForComputeAction
-		}
-		if len(outputArtifacts) > 0 {
-			log.Printf("[WARN] CodePipeline Pipeline Action %s: output_artifacts is ignored for compute action", aws.ToString(apiObject.Name))
+		if v, ok := tfMap["output_artifacts_for_compute_action"].([]any); ok && len(v) > 0 {
+			apiObject.OutputArtifacts = expandOutputArtifactsForComputeAction(v)
 		}
 	} else {
-		if len(outputArtifacts) > 0 {
-			apiObject.OutputArtifacts = outputArtifacts
-		}
-		if len(outputArtifactsForComputeAction) > 0 {
-			log.Printf("[WARN] CodePipeline Pipeline Action %s: output_artifacts_for_compute_action is ignored for non-compute action", aws.ToString(apiObject.Name))
+		if v, ok := tfMap["output_artifacts"].([]any); ok && len(v) > 0 {
+			apiObject.OutputArtifacts = expandOutputArtifacts(v)
 		}
 	}
 

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -521,6 +521,15 @@ func resourcePipeline() *schema.Resource {
 												},
 											},
 										},
+										"output_variables": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 15,
+											Elem: &schema.Schema{
+												Type:         schema.TypeString,
+												ValidateFunc: validation.StringLenBetween(1, 128),
+											},
+										},
 										names.AttrOwner: {
 											Type:             schema.TypeString,
 											Required:         true,
@@ -1111,6 +1120,14 @@ func expandActionDeclaration(tfMap map[string]any) *types.ActionDeclaration {
 		}
 		if len(outputArtifactsForComputeAction) > 0 {
 			log.Printf("[WARN] CodePipeline Pipeline Action %s: output_artifacts_for_compute_action is ignored for non-compute action", aws.ToString(apiObject.Name))
+		}
+	}
+
+	if v, ok := tfMap["output_variables"].([]any); ok && len(v) > 0 {
+		for _, v := range v {
+			if v, ok := v.(string); ok && v != "" {
+				apiObject.OutputVariables = append(apiObject.OutputVariables, v)
+			}
 		}
 	}
 
@@ -2041,6 +2058,14 @@ func flattenActionDeclaration(d *schema.ResourceData, i, j int, apiObject types.
 		} else {
 			tfMap["output_artifacts"] = flattenOutputArtifacts(v)
 		}
+	}
+
+	if v := apiObject.OutputVariables; len(v) > 0 {
+		var tfList []any
+		for _, outputVariable := range v {
+			tfList = append(tfList, outputVariable)
+		}
+		tfMap["output_variables"] = tfList
 	}
 
 	if v := apiObject.Region; v != nil {

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -451,6 +451,15 @@ func resourcePipeline() *schema.Resource {
 											Required:         true,
 											ValidateDiagFunc: enum.Validate[types.ActionCategory](),
 										},
+										"commands": {
+											Type:     schema.TypeList,
+											Optional: true,
+											MaxItems: 50,
+											Elem: &schema.Schema{
+												Type:         schema.TypeString,
+												ValidateFunc: validation.StringLenBetween(1, 1000),
+											},
+										},
 										names.AttrConfiguration: {
 											Type:     schema.TypeMap,
 											Optional: true,
@@ -486,6 +495,31 @@ func resourcePipeline() *schema.Resource {
 											Type:     schema.TypeList,
 											Optional: true,
 											Elem:     &schema.Schema{Type: schema.TypeString},
+										},
+										"output_artifacts_for_compute_action": {
+											Type:     schema.TypeList,
+											Optional: true,
+											Elem: &schema.Resource{
+												Schema: map[string]*schema.Schema{
+													names.AttrName: {
+														Type:     schema.TypeString,
+														Required: true,
+														ValidateFunc: validation.All(
+															validation.StringLenBetween(1, 100),
+															validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9_\-]+$`), ""),
+														),
+													},
+													"files": {
+														Type:     schema.TypeList,
+														Optional: true,
+														MaxItems: 10,
+														Elem: &schema.Schema{
+															Type:         schema.TypeString,
+															ValidateFunc: validation.StringLenBetween(1, 128),
+														},
+													},
+												},
+											},
 										},
 										names.AttrOwner: {
 											Type:             schema.TypeString,
@@ -1032,6 +1066,14 @@ func expandActionDeclaration(tfMap map[string]any) *types.ActionDeclaration {
 		apiObject.ActionTypeId.Category = types.ActionCategory(v)
 	}
 
+	if v, ok := tfMap["commands"].([]any); ok && len(v) > 0 {
+		for _, v := range v {
+			if v, ok := v.(string); ok && v != "" {
+				apiObject.Commands = append(apiObject.Commands, v)
+			}
+		}
+	}
+
 	if v, ok := tfMap[names.AttrConfiguration].(map[string]any); ok && len(v) > 0 {
 		apiObject.Configuration = flex.ExpandStringValueMap(v)
 	}
@@ -1048,8 +1090,28 @@ func expandActionDeclaration(tfMap map[string]any) *types.ActionDeclaration {
 		apiObject.Namespace = aws.String(v)
 	}
 
+	outputArtifacts := []types.OutputArtifact{}
+	outputArtifactsForComputeAction := []types.OutputArtifact{}
 	if v, ok := tfMap["output_artifacts"].([]any); ok && len(v) > 0 {
-		apiObject.OutputArtifacts = expandOutputArtifacts(v)
+		outputArtifacts = expandOutputArtifacts(v)
+	}
+	if v, ok := tfMap["output_artifacts_for_compute_action"].([]any); ok && len(v) > 0 {
+		outputArtifactsForComputeAction = expandOutputArtifactsForComputeAction(v)
+	}
+	if apiObject.ActionTypeId.Category == types.ActionCategoryCompute {
+		if len(outputArtifactsForComputeAction) > 0 {
+			apiObject.OutputArtifacts = outputArtifactsForComputeAction
+		}
+		if len(outputArtifacts) > 0 {
+			log.Printf("[WARN] CodePipeline Pipeline Action %s: output_artifacts is ignored for compute action", aws.ToString(apiObject.Name))
+		}
+	} else {
+		if len(outputArtifacts) > 0 {
+			apiObject.OutputArtifacts = outputArtifacts
+		}
+		if len(outputArtifactsForComputeAction) > 0 {
+			log.Printf("[WARN] CodePipeline Pipeline Action %s: output_artifacts_for_compute_action is ignored for non-compute action", aws.ToString(apiObject.Name))
+		}
 	}
 
 	if v, ok := tfMap[names.AttrOwner].(string); ok && v != "" {
@@ -1149,6 +1211,41 @@ func expandOutputArtifacts(tfList []any) []types.OutputArtifact {
 
 		apiObject := types.OutputArtifact{
 			Name: aws.String(v),
+		}
+
+		apiObjects = append(apiObjects, apiObject)
+	}
+
+	return apiObjects
+}
+
+func expandOutputArtifactsForComputeAction(tfList []any) []types.OutputArtifact {
+	if len(tfList) == 0 {
+		return nil
+	}
+
+	var apiObjects []types.OutputArtifact
+
+	for _, v := range tfList {
+		tfMap, ok := v.(map[string]any)
+
+		if !ok {
+			continue
+		}
+
+		apiObject := types.OutputArtifact{}
+
+		if v, ok := tfMap[names.AttrName].(string); ok && v != "" {
+			apiObject.Name = aws.String(v)
+		}
+		if v, ok := tfMap["files"].([]any); ok && len(v) > 0 {
+			for _, v := range v {
+				if v, ok := v.(string); ok && v != "" {
+					apiObject.Files = append(apiObject.Files, v)
+				}
+			}
+		} else {
+			apiObject.Files = nil
 		}
 
 		apiObjects = append(apiObjects, apiObject)
@@ -1906,6 +2003,14 @@ func flattenActionDeclaration(d *schema.ResourceData, i, j int, apiObject types.
 		}
 	}
 
+	if v := apiObject.Commands; len(v) > 0 {
+		var tfList []any
+		for _, command := range v {
+			tfList = append(tfList, command)
+		}
+		tfMap["commands"] = tfList
+	}
+
 	if v := apiObject.Configuration; v != nil {
 		// The AWS API returns "****" for the OAuthToken value. Copy the value from the configuration.
 		if actionProvider == providerGitHub {
@@ -1931,7 +2036,11 @@ func flattenActionDeclaration(d *schema.ResourceData, i, j int, apiObject types.
 	}
 
 	if v := apiObject.OutputArtifacts; len(v) > 0 {
-		tfMap["output_artifacts"] = flattenOutputArtifacts(v)
+		if apiObject.ActionTypeId.Category == types.ActionCategoryCompute {
+			tfMap["output_artifacts_for_compute_action"] = flattenOutputArtifactsForComputeAction(v)
+		} else {
+			tfMap["output_artifacts"] = flattenOutputArtifacts(v)
+		}
 	}
 
 	if v := apiObject.Region; v != nil {
@@ -1993,6 +2102,29 @@ func flattenOutputArtifacts(apiObjects []types.OutputArtifact) []string {
 	}
 
 	return aws.ToStringSlice(tfList)
+}
+
+func flattenOutputArtifactsForComputeAction(apiObjects []types.OutputArtifact) []map[string]any {
+	if len(apiObjects) == 0 {
+		return nil
+	}
+
+	var tfList []map[string]any
+
+	for _, apiObject := range apiObjects {
+		tfMap := map[string]any{}
+		if v := apiObject.Name; v != nil {
+			tfMap[names.AttrName] = aws.ToString(v)
+		}
+		if v := apiObject.Files; len(v) > 0 {
+			tfMap["files"] = v
+		} else {
+			tfMap["files"] = nil
+		}
+		tfList = append(tfList, tfMap)
+	}
+
+	return tfList
 }
 
 func flattenVariableDeclaration(apiObject types.PipelineVariableDeclaration) map[string]any {

--- a/internal/service/codepipeline/codepipeline.go
+++ b/internal/service/codepipeline/codepipeline.go
@@ -679,6 +679,7 @@ func resourcePipeline() *schema.Resource {
 				},
 			}
 		},
+		CustomizeDiff: outputArtifactsConflictValidate,
 	}
 }
 
@@ -2129,8 +2130,6 @@ func flattenOutputArtifactsForComputeAction(apiObjects []types.OutputArtifact) [
 		}
 		if v := apiObject.Files; len(v) > 0 {
 			tfMap["files"] = v
-		} else {
-			tfMap["files"] = nil
 		}
 		tfList = append(tfList, tfMap)
 	}
@@ -2347,4 +2346,27 @@ func flattenTriggerDeclarations(apiObjects []types.PipelineTriggerDeclaration) [
 	}
 
 	return tfList
+}
+
+func outputArtifactsConflictValidate(_ context.Context, diff *schema.ResourceDiff, _ any) error {
+	stageCount := diff.Get("stage.#").(int)
+	for i := range stageCount {
+		actionCount := diff.Get(fmt.Sprintf("stage.%d.action.#", i)).(int)
+		for j := range actionCount {
+			category := diff.Get(fmt.Sprintf("stage.%d.action.%d.category", i, j)).(string)
+			outputArtifactsCount := diff.Get(fmt.Sprintf("stage.%d.action.%d.output_artifacts.#", i, j)).(int)
+			computeArtifactsCount := diff.Get(fmt.Sprintf("stage.%d.action.%d.output_artifacts_for_compute_action.#", i, j)).(int)
+
+			if outputArtifactsCount > 0 && computeArtifactsCount > 0 {
+				return fmt.Errorf("stage.%d.action.%d: only one of \"output_artifacts\" or \"output_artifacts_for_compute_action\" may be set", i, j)
+			}
+			if category == string(types.ActionCategoryCompute) && outputArtifactsCount > 0 {
+				return fmt.Errorf("stage.%d.action.%d: \"output_artifacts\" cannot be set when category is %q, use \"output_artifacts_for_compute_action\"", i, j, category)
+			}
+			if category != string(types.ActionCategoryCompute) && computeArtifactsCount > 0 {
+				return fmt.Errorf("stage.%d.action.%d: \"output_artifacts_for_compute_action\" can only be set when category is %q", i, j, types.ActionCategoryCompute)
+			}
+		}
+	}
+	return nil
 }

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -56,6 +56,8 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "lifesum-terraform/test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "main"),
@@ -73,6 +75,8 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
@@ -96,6 +100,8 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "test-terraform/test-repo"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "stable"),
@@ -105,6 +111,8 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
 				),
@@ -1211,6 +1219,82 @@ func TestAccCodePipeline_conditions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.5.before_entry.0.condition.0.rule.0.rule_type_id.0.provider", "Commands"),
 					resource.TestCheckResourceAttr(resourceName, "stage.5.before_entry.0.condition.0.rule.0.rule_type_id.0.version", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "stage.5.before_entry.0.condition.0.rule.0.role_arn", "aws_iam_role.codepipeline_role", names.AttrARN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCodePipeline_computeAction(t *testing.T) {
+	ctx := acctest.Context(t)
+	var p types.PipelineDeclaration
+	rName := sdkacctest.RandString(10)
+	resourceName := "aws_codepipeline.test"
+	codestarConnectionResourceName := "aws_codestarconnections_connection.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodePipelineServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCodePipelineConfig_computeAction(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckPipelineExists(ctx, resourceName, &p),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.codepipeline_role", names.AttrARN),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", rName))),
+					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.name", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.category", "Source"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.provider", "CodeStarSourceConnection"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.input_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "lifesum-terraform/test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.BranchName", "main"),
+					resource.TestCheckResourceAttrPair(resourceName, "stage.0.action.0.configuration.ConnectionArn", codestarConnectionResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.region", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.name", "Build"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.category", "Compute"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.owner", "AWS"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.provider", "Commands"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.0", "echo hello1 > hello1.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.1", "echo hello2 > hello2.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.2", "echo hello3 > hello3.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.name", "ComputeArtifact"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.0", "hello1.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.1", "hello2.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.2", "hello3.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
 				),
 			},
 			{
@@ -3560,5 +3644,77 @@ resource "aws_codestarconnections_connection" "test" {
 }
 
 data "aws_region" "current" {}
+`, rName))
+}
+
+func testAccCodePipelineConfig_computeAction(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name          = "test-pipeline-%[1]s"
+  role_arn      = aws_iam_role.codepipeline_role.arn
+  pipeline_type = "V2"
+
+  artifact_store {
+    location = aws_s3_bucket.test.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "lifesum-terraform/test"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Compute"
+      owner           = "AWS"
+      provider        = "Commands"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      commands = [
+        "echo hello1 > hello1.txt",
+        "echo hello2 > hello2.txt",
+        "echo hello3 > hello3.txt",
+      ]
+
+      configuration = {}
+      output_artifacts_for_compute_action {
+        name  = "ComputeArtifact"
+        files = ["hello1.txt", "hello2.txt", "hello3.txt"]
+      }
+
+    }
+  }
+}
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
 `, rName))
 }

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -1241,7 +1241,7 @@ func TestAccCodePipeline_computeAction(t *testing.T) {
 	resourceName := "aws_codepipeline.test"
 	codestarConnectionResourceName := "aws_codestarconnections_connection.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -1366,6 +1366,48 @@ func TestAccCodePipeline_trigger(t *testing.T) {
 	})
 }
 
+func TestAccCodePipeline_computeActionWithOutputAttributes(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandString(t, 10)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodePipelineServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCodePipelineConfig_computeActionWithOutputArtifacts(rName),
+				ExpectError: regexache.MustCompile(`stage.\d+.action.\d+: only one of "output_artifacts" or "output_artifacts_for_compute_action" may be set`),
+			},
+		},
+	})
+}
+
+func TestAccCodePipeline_nonComputeActionWithOutputAttributesForComputeAction(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := acctest.RandString(t, 10)
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodePipelineServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCodePipelineConfig_nonComputeActionWithOutputAttributesForComputeAction(rName),
+				ExpectError: regexache.MustCompile(`stage.\d+.action.\d+: "output_artifacts_for_compute_action" can only be set when category is "Compute"`),
+			},
+		},
+	})
+}
+
 func testAccCheckPipelineExists(ctx context.Context, t *testing.T, n string, v *types.PipelineDeclaration) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -3718,6 +3760,146 @@ resource "aws_codepipeline" "test" {
     }
   }
 }
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_computeActionWithOutputArtifacts(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name          = "test-pipeline-%[1]s"
+  role_arn      = aws_iam_role.codepipeline_role.arn
+  pipeline_type = "V2"
+
+  artifact_store {
+    location = aws_s3_bucket.test.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "lifesum-terraform/test"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Compute"
+      owner           = "AWS"
+      provider        = "Commands"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      commands = [
+        "echo hello1 > hello1.txt",
+        "echo hello2 > hello2.txt",
+        "echo hello3 > hello3.txt",
+      ]
+
+      configuration = {}
+      output_artifacts = ["test"]
+      output_artifacts_for_compute_action {
+        name  = "ComputeArtifact"
+        files = ["hello1.txt", "hello2.txt", "hello3.txt"]
+      }
+      output_variables = ["AWS_DEFAULT_REGION"]
+    }
+  }
+}
+resource "aws_codestarconnections_connection" "test" {
+  name          = %[1]q
+  provider_type = "GitHub"
+}
+`, rName))
+}
+
+func testAccCodePipelineConfig_nonComputeActionWithOutputAttributesForComputeAction(rName string) string { // nosemgrep:ci.codepipeline-in-func-name
+	return acctest.ConfigCompose(
+		testAccS3DefaultBucket(rName),
+		testAccServiceIAMRole(rName),
+		fmt.Sprintf(`
+resource "aws_codepipeline" "test" {
+  name     = "test-pipeline-%[1]s"
+  role_arn = aws_iam_role.codepipeline_role.arn
+
+  artifact_store {
+    location = aws_s3_bucket.test.bucket
+    type     = "S3"
+
+    encryption_key {
+      id   = "1234"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["test"]
+
+      configuration = {
+        ConnectionArn    = aws_codestarconnections_connection.test.arn
+        FullRepositoryId = "lifesum-terraform/test"
+        BranchName       = "main"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name            = "Build"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["test"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = "test"
+      }
+      output_artifacts_for_compute_action {
+        name  = "ComputeArtifact"
+        files = ["hello1.txt", "hello2.txt", "hello3.txt"]
+      }
+    }
+  }
+}
+
 resource "aws_codestarconnections_connection" "test" {
   name          = %[1]q
   provider_type = "GitHub"

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -3823,7 +3823,7 @@ resource "aws_codepipeline" "test" {
         "echo hello3 > hello3.txt",
       ]
 
-      configuration = {}
+      configuration    = {}
       output_artifacts = ["test"]
       output_artifacts_for_compute_action {
         name  = "ComputeArtifact"

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -57,6 +57,7 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_variables.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "lifesum-terraform/test"),
@@ -76,6 +77,7 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "test"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_variables.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
@@ -101,6 +103,7 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts.0", "artifacts"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.output_variables.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.%", "3"),
 					resource.TestCheckResourceAttr(resourceName, "stage.0.action.0.configuration.FullRepositoryId", "test-terraform/test-repo"),
@@ -112,6 +115,7 @@ func TestAccCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.input_artifacts.0", "artifacts"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_variables.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.commands.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.%", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.configuration.ProjectName", "test"),
@@ -1292,6 +1296,8 @@ func TestAccCodePipeline_computeAction(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.0", "hello1.txt"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.1", "hello2.txt"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_artifacts_for_compute_action.0.files.2", "hello3.txt"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_variables.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.output_variables.0", "AWS_DEFAULT_REGION"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.role_arn", ""),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.run_order", "1"),
 					resource.TestCheckResourceAttr(resourceName, "stage.1.action.0.region", ""),
@@ -3708,7 +3714,7 @@ resource "aws_codepipeline" "test" {
         name  = "ComputeArtifact"
         files = ["hello1.txt", "hello2.txt", "hello3.txt"]
       }
-
+      output_variables = ["AWS_DEFAULT_REGION"]
     }
   }
 }

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -1237,7 +1237,7 @@ func TestAccCodePipeline_conditions(t *testing.T) {
 func TestAccCodePipeline_computeAction(t *testing.T) {
 	ctx := acctest.Context(t)
 	var p types.PipelineDeclaration
-	rName := sdkacctest.RandString(10)
+	rName := acctest.RandString(t, 10)
 	resourceName := "aws_codepipeline.test"
 	codestarConnectionResourceName := "aws_codestarconnections_connection.test"
 
@@ -1248,12 +1248,12 @@ func TestAccCodePipeline_computeAction(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodePipelineServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
+		CheckDestroy:             testAccCheckPipelineDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCodePipelineConfig_computeAction(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckPipelineExists(ctx, resourceName, &p),
+					testAccCheckPipelineExists(ctx, t, resourceName, &p),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, "aws_iam_role.codepipeline_role", names.AttrARN),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "codepipeline", regexache.MustCompile(fmt.Sprintf("test-pipeline-%s", rName))),
 					resource.TestCheckResourceAttr(resourceName, "artifact_store.#", "1"),

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -223,9 +223,14 @@ An `action` block supports the following arguments:
 * `name` - (Required) The action declaration's name.
 * `provider` - (Required) The provider of the service being called by the action. Valid providers are determined by the action category. Provider names are listed in the [Action Structure Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference.html) documentation.
 * `version` - (Required) A string that identifies the action type.
+* `commands` - (Optional) A list of shell commands to run with the compute action.
 * `configuration` - (Optional) A map of the action declaration's configuration. Configurations options for action types and providers can be found in the [Pipeline Structure Reference](http://docs.aws.amazon.com/codepipeline/latest/userguide/reference-pipeline-structure.html#action-requirements) and [Action Structure Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference.html) documentation. Note: The `DetectChanges` parameter (optional, default value is true) in the `configuration` section causes CodePipeline to automatically start your pipeline upon new commits. Please refer to AWS Documentation for more details: https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html#action-reference-CodestarConnectionSource-config.
 * `input_artifacts` - (Optional) A list of artifact names to be worked on.
-* `output_artifacts` - (Optional) A list of artifact names to output. Output artifact names must be unique within a pipeline.
+* `output_artifacts` - (Optional) A list of artifact names to output. Output artifact names must be unique within a pipeline. If the action is `Compute`, this argument is ignored.
+* `output_artifacts_for_compute_action` - (Optional) A block of output artifacts for the compute action. If the action is not `Compute`, this argument is ignored.
+    * `name` - (Required) The name of the output artifact.
+    * `files` - (Optional) A list of the files to associate with the output artifact that will be exported from the compute action.
+* `output_variables` - (Optional) A list of variables that are to be exported from the compute action.
 * `role_arn` - (Optional) The ARN of the IAM service role that will perform the declared action. This is assumed through the roleArn for the pipeline.
 * `run_order` - (Optional) The order in which actions are run.
 * `region` - (Optional) The region in which to run the action.

--- a/website/docs/r/codepipeline.html.markdown
+++ b/website/docs/r/codepipeline.html.markdown
@@ -218,7 +218,7 @@ A `stage` block supports the following arguments:
 
 An `action` block supports the following arguments:
 
-* `category` - (Required) A category defines what kind of action can be taken in the stage, and constrains the provider type for the action. Possible values are `Approval`, `Build`, `Deploy`, `Invoke`, `Source` and `Test`.
+* `category` - (Required) A category defines what kind of action can be taken in the stage, and constrains the provider type for the action. Possible values are `Approval`, `Build`, `Deploy`, `Invoke`, `Source`, `Compute` and `Test`.
 * `owner` - (Required) The creator of the action being called. Possible values are `AWS`, `Custom` and `ThirdParty`.
 * `name` - (Required) The action declaration's name.
 * `provider` - (Required) The provider of the service being called by the action. Valid providers are determined by the action category. Provider names are listed in the [Action Structure Reference](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference.html) documentation.


### PR DESCRIPTION
### Description

* Add several arguments to the `action` block to support the `Compute` action:

  * `commands`
  * `output_variables`
  * `output_artifacts_for_compute_action`

    * This argument does not directly correspond to the AWS API objects.
    * In the AWS API, [OutputArtifacts](https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_OutputArtifact.html) is an object with two attributes. However, in Terraform, the existing `output_artifacts` is implemented as a list of artifact names.
    * The `Compute` action uses the `files` attribute in `OutputArtifacts`, which cannot be represented using the current `output_artifacts`.
    * To avoid affecting existing configurations, a new argument, `output_artifacts_for_compute_action`, has been introduced. Its schema matches that of the `OutputArtifacts` object in the AWS API.
    * When the action is `Compute`, `output_artifacts_for_compute_action` is used and `output_artifacts` is ignored.
    * For all other actions, the reverse applies.

* This PR is based on #41034, rebased onto the latest `main` branch, and adds the `output_variables` and `output_artifacts_for_compute_action` arguments.

### Relations

Closes #39743
Relates #41034
Closes #42997

### References
https://docs.aws.amazon.com/codepipeline/latest/APIReference/API_ActionDeclaration.html#CodePipeline-Type-ActionDeclaration-commands
https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Commands.html

### Output from Acceptance Testing
Rerun after rebasing on the latest branch (2025-10-02)

```console
$ make testacc TESTS='TestAccCodePipeline_' PKG=codepipeline
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running acceptance tests on branch: 🌿 f-aws_codepipeline-add_commands 🌿...
TF_ACC=1 go1.24.6 test ./internal/service/codepipeline/... -v -count 1 -parallel 20 -run='TestAccCodePipeline_'  -timeout 360m -vet=off
2025/10/02 23:35:05 Creating Terraform AWS Provider (SDKv2-style)...
2025/10/02 23:35:06 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodePipeline_basic
=== PAUSE TestAccCodePipeline_basic
=== RUN   TestAccCodePipeline_disappears
=== PAUSE TestAccCodePipeline_disappears
=== RUN   TestAccCodePipeline_emptyStageArtifacts
=== PAUSE TestAccCodePipeline_emptyStageArtifacts
=== RUN   TestAccCodePipeline_deployWithServiceRole
=== PAUSE TestAccCodePipeline_deployWithServiceRole
=== RUN   TestAccCodePipeline_tags
=== PAUSE TestAccCodePipeline_tags
=== RUN   TestAccCodePipeline_MultiRegion_basic
=== PAUSE TestAccCodePipeline_MultiRegion_basic
=== RUN   TestAccCodePipeline_MultiRegion_update
=== PAUSE TestAccCodePipeline_MultiRegion_update
=== RUN   TestAccCodePipeline_MultiRegion_convertSingleRegion
=== PAUSE TestAccCodePipeline_MultiRegion_convertSingleRegion
=== RUN   TestAccCodePipeline_withNamespace
=== PAUSE TestAccCodePipeline_withNamespace
=== RUN   TestAccCodePipeline_withGitHubV1SourceAction
    codepipeline_test.go:492: Environment variable GITHUB_TOKEN is not set, skipping test
--- SKIP: TestAccCodePipeline_withGitHubV1SourceAction (0.00s)
=== RUN   TestAccCodePipeline_ecr
=== PAUSE TestAccCodePipeline_ecr
=== RUN   TestAccCodePipeline_pipelineType
=== PAUSE TestAccCodePipeline_pipelineType
=== RUN   TestAccCodePipeline_manualApprovalTimeoutInMinutes
=== PAUSE TestAccCodePipeline_manualApprovalTimeoutInMinutes
=== RUN   TestAccCodePipeline_conditions
=== PAUSE TestAccCodePipeline_conditions
=== RUN   TestAccCodePipeline_computeAction
=== PAUSE TestAccCodePipeline_computeAction
=== RUN   TestAccCodePipeline_trigger
=== PAUSE TestAccCodePipeline_trigger
=== CONT  TestAccCodePipeline_basic
=== CONT  TestAccCodePipeline_withNamespace
=== CONT  TestAccCodePipeline_conditions
=== CONT  TestAccCodePipeline_trigger
=== CONT  TestAccCodePipeline_computeAction
=== CONT  TestAccCodePipeline_pipelineType
=== CONT  TestAccCodePipeline_manualApprovalTimeoutInMinutes
=== CONT  TestAccCodePipeline_tags
=== CONT  TestAccCodePipeline_MultiRegion_convertSingleRegion
=== CONT  TestAccCodePipeline_MultiRegion_update
=== CONT  TestAccCodePipeline_MultiRegion_basic
=== CONT  TestAccCodePipeline_emptyStageArtifacts
=== CONT  TestAccCodePipeline_deployWithServiceRole
=== CONT  TestAccCodePipeline_disappears
=== CONT  TestAccCodePipeline_ecr
--- PASS: TestAccCodePipeline_deployWithServiceRole (52.31s)
--- PASS: TestAccCodePipeline_computeAction (58.95s)
--- PASS: TestAccCodePipeline_disappears (59.18s)
--- PASS: TestAccCodePipeline_emptyStageArtifacts (59.97s)
--- PASS: TestAccCodePipeline_withNamespace (67.88s)
--- PASS: TestAccCodePipeline_ecr (72.42s)
--- PASS: TestAccCodePipeline_trigger (75.23s)
--- PASS: TestAccCodePipeline_MultiRegion_basic (78.39s)
--- PASS: TestAccCodePipeline_conditions (85.66s)
--- PASS: TestAccCodePipeline_basic (87.62s)
--- PASS: TestAccCodePipeline_manualApprovalTimeoutInMinutes (89.55s)
--- PASS: TestAccCodePipeline_tags (102.31s)
--- PASS: TestAccCodePipeline_MultiRegion_update (103.87s)
--- PASS: TestAccCodePipeline_MultiRegion_convertSingleRegion (111.02s)
--- PASS: TestAccCodePipeline_pipelineType (145.75s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codepipeline       150.697s



```
