### PR TITLE
Make Glue Table Iceberg table type check case-insensitive

### DIFF
--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -1161,7 +1161,8 @@ func flattenTableTargetTable(apiObject *awstypes.TableIdentifier) map[string]any
 
 func flattenNonManagedParameters(table *awstypes.Table) map[string]string {
 	allParameters := table.Parameters
-	if allParameters["table_type"] == "ICEBERG" {
+	tableTypeUpperCase := strings.ToUpper(allParameters["table_type"])
+	if tableTypeUpperCase == "ICEBERG" {
 		delete(allParameters, "table_type")
 		delete(allParameters, "metadata_location")
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR makes the check for the `"ICEBERG"` value in `"table_type"` parameter of the `aws_glue_catalog_table` case insensitive, or rather, converts to upper case first.

This is needed due to glue actually being inconsistent in its own capitalization of this parameter.
While during table creation, Glue will use the upper case version of this string, it uses the lower case when writing to the table when used as an Iceberg REST catalog.

This fix will at least prevent from terraform breaking the table after an apply when this parameter is lower case but, honestly, the story doesn't end here and I will still work with

```terraform
  lifecycle {
    ignore_changes = [
      parameters
    ]
  }
```
when working with Iceberg tables, as there are plenty more parameters being written that will get removed even with this change. For example, these are the parameters I jave on my table after a write transaction through the Glue REST catalog:

```text
        metadata_location        <metadata-s3-path>
        metadata_hashcode     <metadata-hash>
        iceberg.table.uuid        <table-uuid>
        iceberg.table.lastUpdatedMs <update-timestamp>
        write.parquet.compression-codec zstd
        table_type iceberg
```
As you can see, there are some parameters in there that are expected to mutate and really shouldn't be touched by terraform at all.

At least this little fix should prevent complete table breakage.

Sorry this isn't tested yet as I don't have a Go environment on my current machine.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #33370 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
