### PR TITLE
r/aws_sagemaker_image_version: read correct `version` after create

### DIFF
--- a/.changelog/42536.txt
+++ b/.changelog/42536.txt
@@ -1,0 +1,6 @@
+```release-note:bug
+resource/aws_sagemaker_image_version: Read the correct image version after creation rather than always fetching the latest
+```
+```release-note:breaking-change
+resource/aws_sagemaker_image_version: `id` is now a comma-delimited string concatenating `image_name` and `version`
+```

--- a/internal/service/sagemaker/exports_test.go
+++ b/internal/service/sagemaker/exports_test.go
@@ -49,7 +49,7 @@ var (
 	FindHubByName                             = findHubByName
 	FindHumanTaskUIByName                     = findHumanTaskUIByName
 	FindImageByName                           = findImageByName
-	FindImageVersionByName                    = findImageVersionByName
+	FindImageVersionByTwoPartKey              = findImageVersionByTwoPartKey
 	FindMlflowTrackingServerByName            = findMlflowTrackingServerByName
 	FindModelByName                           = findModelByName
 	FindModelPackageGroupByName               = findModelPackageGroupByName

--- a/internal/service/sagemaker/image_version.go
+++ b/internal/service/sagemaker/image_version.go
@@ -6,6 +6,7 @@ package sagemaker
 import (
 	"context"
 	"log"
+	"strconv"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,9 +21,12 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+const imageVersionResourcePartCount = 2
 
 // @SDKResource("aws_sagemaker_image_version", name="Image Version")
 func resourceImageVersion() *schema.Resource {
@@ -31,10 +35,20 @@ func resourceImageVersion() *schema.Resource {
 		ReadWithoutTimeout:   resourceImageVersionRead,
 		UpdateWithoutTimeout: resourceImageVersionUpdate,
 		DeleteWithoutTimeout: resourceImageVersionDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceImageVersionV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: imageVersionStateUpgradeV0,
+				Version: 0,
+			},
+		},
+
+		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
 				Type:     schema.TypeString,
@@ -105,7 +119,7 @@ func resourceImageVersionCreate(ctx context.Context, d *schema.ResourceData, met
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
 	name := d.Get("image_name").(string)
-	input := &sagemaker.CreateImageVersionInput{
+	input := sagemaker.CreateImageVersionInput{
 		ImageName:   aws.String(name),
 		BaseImage:   aws.String(d.Get("base_image").(string)),
 		ClientToken: aws.String(id.UniqueId()),
@@ -139,16 +153,22 @@ func resourceImageVersionCreate(ctx context.Context, d *schema.ResourceData, met
 		input.ProgrammingLang = aws.String(v.(string))
 	}
 
-	_, err := conn.CreateImageVersion(ctx, input)
+	if _, err := conn.CreateImageVersion(ctx, &input); err != nil {
+		return sdkdiag.AppendErrorf(diags, "creating SageMaker AI Image Version %s: %s", name, err)
+	}
+
+	out, err := waitImageVersionCreated(ctx, conn, name)
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI Image Version (%s) to be created: %s", d.Id(), err)
+	}
+
+	parts := []string{name, strconv.Itoa(int(aws.ToInt32(out.Version)))}
+	id, err := flex.FlattenResourceId(parts, imageVersionResourcePartCount, false)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating SageMaker AI Image Version %s: %s", name, err)
 	}
 
-	d.SetId(name)
-
-	if _, err := waitImageVersionCreated(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI Image Version (%s) to be created: %s", d.Id(), err)
-	}
+	d.SetId(id)
 
 	return append(diags, resourceImageVersionRead(ctx, d, meta)...)
 }
@@ -157,7 +177,13 @@ func resourceImageVersionRead(ctx context.Context, d *schema.ResourceData, meta 
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
-	image, err := findImageVersionByName(ctx, conn, d.Id())
+	name, version, err := expandImageVersionResourceID(d.Id())
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading SageMaker AI Image Version (%s): %s", d.Id(), err)
+	}
+	d.Set("image_name", name) // to support import
+
+	image, err := findImageVersionByTwoPartKey(ctx, conn, name, version)
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		d.SetId("")
@@ -174,7 +200,6 @@ func resourceImageVersionRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("image_arn", image.ImageArn)
 	d.Set("container_image", image.ContainerImage)
 	d.Set(names.AttrVersion, image.Version)
-	d.Set("image_name", d.Id())
 	d.Set("horovod", image.Horovod)
 	d.Set("job_type", image.JobType)
 	d.Set("processor", image.Processor)
@@ -190,9 +215,12 @@ func resourceImageVersionUpdate(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
-	input := &sagemaker.UpdateImageVersionInput{
-		ImageName: aws.String(d.Id()),
-		Version:   aws.Int32(int32(d.Get(names.AttrVersion).(int))),
+	name := d.Get("image_name").(string)
+	version := d.Get(names.AttrVersion).(int)
+
+	input := sagemaker.UpdateImageVersionInput{
+		ImageName: aws.String(name),
+		Version:   aws.Int32(int32(version)),
 	}
 
 	if d.HasChange("horovod") {
@@ -223,7 +251,7 @@ func resourceImageVersionUpdate(ctx context.Context, d *schema.ResourceData, met
 		input.ProgrammingLang = aws.String(d.Get("programming_lang").(string))
 	}
 
-	if _, err := conn.UpdateImageVersion(ctx, input); err != nil {
+	if _, err := conn.UpdateImageVersion(ctx, &input); err != nil {
 		return sdkdiag.AppendErrorf(diags, "updating SageMaker AI Image Version (%s): %s", d.Id(), err)
 	}
 
@@ -234,9 +262,12 @@ func resourceImageVersionDelete(ctx context.Context, d *schema.ResourceData, met
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).SageMakerClient(ctx)
 
+	name := d.Get("image_name").(string)
+	version := d.Get(names.AttrVersion).(int)
+
 	input := &sagemaker.DeleteImageVersionInput{
-		ImageName: aws.String(d.Id()),
-		Version:   aws.Int32(int32(d.Get(names.AttrVersion).(int))),
+		ImageName: aws.String(name),
+		Version:   aws.Int32(int32(version)),
 	}
 
 	if _, err := conn.DeleteImageVersion(ctx, input); err != nil {
@@ -246,19 +277,24 @@ func resourceImageVersionDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting SageMaker AI Image Version (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitImageVersionDeleted(ctx, conn, d.Id()); err != nil {
-		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI Image Version (%s) to delete: %s", d.Id(), err)
+	if _, err := waitImageVersionDeleted(ctx, conn, name, version); err != nil {
+		return sdkdiag.AppendErrorf(diags, "waiting for SageMaker AI Image Version (%s) deletion: %s", d.Id(), err)
 	}
 
 	return diags
 }
 
+// findImageVersionByName is used immediately after creation to poll for status of
+// the most recently created image version
+//
+// findImageVersionByTwoPartKey should be used for all subsequent operations once the
+// version number is assigned.
 func findImageVersionByName(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageVersionOutput, error) {
-	input := &sagemaker.DescribeImageVersionInput{
+	input := sagemaker.DescribeImageVersionInput{
 		ImageName: aws.String(name),
 	}
 
-	output, err := conn.DescribeImageVersion(ctx, input)
+	output, err := conn.DescribeImageVersion(ctx, &input)
 
 	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFound](err, "does not exist") {
 		return nil, &retry.NotFoundError{
@@ -276,4 +312,49 @@ func findImageVersionByName(ctx context.Context, conn *sagemaker.Client, name st
 	}
 
 	return output, nil
+}
+
+// findImageVersionByTwoPartKey is used to fetch a specific version once a version number
+// is assigned
+func findImageVersionByTwoPartKey(ctx context.Context, conn *sagemaker.Client, name string, version int) (*sagemaker.DescribeImageVersionOutput, error) {
+	input := sagemaker.DescribeImageVersionInput{
+		ImageName: aws.String(name),
+		Version:   aws.Int32(int32(version)),
+	}
+
+	output, err := conn.DescribeImageVersion(ctx, &input)
+
+	if errs.IsAErrorMessageContains[*awstypes.ResourceNotFound](err, "does not exist") {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output, nil
+}
+
+// expandImageVersionResourceID wraps flex.ExpandResourceId and handles conversion
+// of the version portion to an integer
+func expandImageVersionResourceID(id string) (string, int, error) {
+	parts, err := flex.ExpandResourceId(id, imageVersionResourcePartCount, false)
+	if err != nil {
+		return "", 0, err
+	}
+
+	name := parts[0]
+	version, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return name, version, err
+	}
+
+	return name, version, nil
 }

--- a/internal/service/sagemaker/image_version_migrate.go
+++ b/internal/service/sagemaker/image_version_migrate.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sagemaker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/YakDriver/regexache"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func resourceImageVersionV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			names.AttrARN: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"base_image": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"container_image": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"horovod": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"image_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"job_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.JobType](),
+			},
+			"ml_framework": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z]+ ?\d+\.\d+(\.\d+)?$`), ""),
+			},
+			"processor": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.Processor](),
+			},
+			"programming_lang": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringMatch(regexache.MustCompile(`^[a-zA-Z]+ ?\d+\.\d+(\.\d+)?$`), ""),
+			},
+			"release_notes": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 255),
+			},
+			"vendor_guidance": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.VendorGuidance](),
+			},
+			names.AttrVersion: {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func imageVersionStateUpgradeV0(_ context.Context, rawState map[string]any, meta any) (map[string]any, error) {
+	if rawState == nil {
+		rawState = map[string]any{}
+	}
+
+	// The version attribute must be asserted into an int, otherwise fmt will assume
+	// a float64 when a numerical any value is detected.
+	version, ok := rawState[names.AttrVersion].(int)
+	if !ok {
+		version = 1
+	}
+
+	rawState[names.AttrID] = fmt.Sprintf("%s,%d", rawState["image_name"], version)
+
+	return rawState, nil
+}

--- a/internal/service/sagemaker/image_version_test.go
+++ b/internal/service/sagemaker/image_version_test.go
@@ -6,12 +6,13 @@ package sagemaker_test
 import (
 	"context"
 	"fmt"
-	"os"
+	"strconv"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/sagemaker"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -20,16 +21,21 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
+// imageVersionBaseImageEnvVar is the environment variable which must be
+// set to an ECR image URI for certain acceptance tests to run
+//
+// Follow this guide to set up a private ECR repository and push a simple
+// "hello world" image to it:
+// https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html
+const imageVersionBaseImageEnvVar = "SAGEMAKER_IMAGE_VERSION_BASE_IMAGE"
+
 func TestAccSageMakerImageVersion_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
-	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -39,7 +45,7 @@ func TestAccSageMakerImageVersion_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImageVersionConfig_basic(rName, baseImage),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckImageVersionExists(ctx, resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
@@ -59,17 +65,14 @@ func TestAccSageMakerImageVersion_basic(t *testing.T) {
 	})
 }
 
-func TestAccSageMakerImageVersion_full(t *testing.T) {
+func TestAccSageMakerImageVersion_update(t *testing.T) {
 	ctx := acctest.Context(t)
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
-	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	rNameUpdate := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -79,7 +82,7 @@ func TestAccSageMakerImageVersion_full(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImageVersionConfig_full(rName, baseImage, rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckImageVersionExists(ctx, resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
@@ -103,7 +106,7 @@ func TestAccSageMakerImageVersion_full(t *testing.T) {
 			},
 			{
 				Config: testAccImageVersionConfig_full(rName, baseImage, rNameUpdate),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckImageVersionExists(ctx, resourceName, &image),
 					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
@@ -119,6 +122,11 @@ func TestAccSageMakerImageVersion_full(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ml_framework", "TensorFlow 1.1"),
 					resource.TestCheckResourceAttr(resourceName, "programming_lang", "Python 3.8"),
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -126,14 +134,11 @@ func TestAccSageMakerImageVersion_full(t *testing.T) {
 
 func TestAccSageMakerImageVersion_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
-	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -143,11 +148,16 @@ func TestAccSageMakerImageVersion_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImageVersionConfig_basic(rName, baseImage),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckImageVersionExists(ctx, resourceName, &image),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfsagemaker.ResourceImageVersion(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
 			},
 		},
 	})
@@ -155,14 +165,12 @@ func TestAccSageMakerImageVersion_disappears(t *testing.T) {
 
 func TestAccSageMakerImageVersion_Disappears_image(t *testing.T) {
 	ctx := acctest.Context(t)
-	if os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE") == "" {
-		t.Skip("Environment variable SAGEMAKER_IMAGE_VERSION_BASE_IMAGE is not set")
-	}
 
 	var image sagemaker.DescribeImageVersionOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_sagemaker_image_version.test"
-	baseImage := os.Getenv("SAGEMAKER_IMAGE_VERSION_BASE_IMAGE")
+	imageResourceName := "aws_sagemaker_image.test"
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
@@ -172,11 +180,106 @@ func TestAccSageMakerImageVersion_Disappears_image(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccImageVersionConfig_basic(rName, baseImage),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckImageVersionExists(ctx, resourceName, &image),
-					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfsagemaker.ResourceImage(), "aws_sagemaker_image.test"),
+					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfsagemaker.ResourceImage(), imageResourceName),
 				),
 				ExpectNonEmptyPlan: true,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+						plancheck.ExpectResourceAction(imageResourceName, plancheck.ResourceActionCreate),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccSageMakerImageVersion_multiple verifies multiple image versions by the
+// same name can co-exist in the same configuration without overwriting one another
+//
+// Ref: https://github.com/hashicorp/terraform-provider-aws/issues/40597
+func TestAccSageMakerImageVersion_multiple(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var image, imageV2 sagemaker.DescribeImageVersionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_image_version.test"
+	resourceNameV2 := "aws_sagemaker_image_version.test_v2"
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.SageMakerServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckImageVersionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImageVersionConfig_multiple(rName, baseImage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckImageVersionExists(ctx, resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
+					testAccCheckImageVersionExists(ctx, resourceNameV2, &imageV2),
+					resource.TestCheckResourceAttr(resourceNameV2, "image_name", rName),
+					resource.TestCheckResourceAttr(resourceNameV2, "base_image", baseImage),
+					resource.TestCheckResourceAttr(resourceNameV2, names.AttrVersion, "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccSageMakerImageVersion_upgrade_V5_98_0(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	var image sagemaker.DescribeImageVersionOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_sagemaker_image_version.test"
+	baseImage := acctest.SkipIfEnvVarNotSet(t, imageVersionBaseImageEnvVar)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:   acctest.ErrorCheck(t, names.SageMakerServiceID),
+		CheckDestroy: testAccCheckImageVersionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				// After v5.97.0, id was change to a multi-part key
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.97.0",
+					},
+				},
+				Config: testAccImageVersionConfig_basic(rName, baseImage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckImageVersionExists(ctx, resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
+				),
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccImageVersionConfig_basic(rName, baseImage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckImageVersionExists(ctx, resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "image_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "base_image", baseImage),
+					resource.TestCheckResourceAttr(resourceName, names.AttrVersion, "1"),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 		},
 	})
@@ -191,7 +294,13 @@ func testAccCheckImageVersionDestroy(ctx context.Context) resource.TestCheckFunc
 				continue
 			}
 
-			_, err := tfsagemaker.FindImageVersionByName(ctx, conn, rs.Primary.ID)
+			name := rs.Primary.Attributes["image_name"]
+			version, err := strconv.Atoi(rs.Primary.Attributes[names.AttrVersion])
+			if err != nil {
+				return fmt.Errorf("reading SageMaker AI Image Version (%s): %w", rs.Primary.ID, err)
+			}
+
+			_, err = tfsagemaker.FindImageVersionByTwoPartKey(ctx, conn, name, version)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -215,12 +324,18 @@ func testAccCheckImageVersionExists(ctx context.Context, n string, image *sagema
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No sagmaker Image ID is set")
+		name := rs.Primary.Attributes["image_name"]
+		version, err := strconv.Atoi(rs.Primary.Attributes[names.AttrVersion])
+		if err != nil {
+			return fmt.Errorf("reading SageMaker AI Image Version (%s): %w", rs.Primary.ID, err)
+		}
+
+		if name == "" || version == 0 {
+			return fmt.Errorf("image_name or version not set")
 		}
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).SageMakerClient(ctx)
-		resp, err := tfsagemaker.FindImageVersionByName(ctx, conn, rs.Primary.ID)
+		resp, err := tfsagemaker.FindImageVersionByTwoPartKey(ctx, conn, name, version)
 		if err != nil {
 			return err
 		}
@@ -266,16 +381,20 @@ resource "aws_sagemaker_image" "test" {
 }
 
 func testAccImageVersionConfig_basic(rName, baseImage string) string {
-	return testAccImageVersionConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccImageVersionConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_image_version" "test" {
   image_name = aws_sagemaker_image.test.id
   base_image = %[1]q
 }
-`, baseImage)
+`, baseImage))
 }
 
 func testAccImageVersionConfig_full(rName, baseImage, notes string) string {
-	return testAccImageVersionConfigBase(rName) + fmt.Sprintf(`
+	return acctest.ConfigCompose(
+		testAccImageVersionConfigBase(rName),
+		fmt.Sprintf(`
 resource "aws_sagemaker_image_version" "test" {
   image_name       = aws_sagemaker_image.test.id
   base_image       = %[1]q
@@ -286,5 +405,21 @@ resource "aws_sagemaker_image_version" "test" {
   ml_framework     = "TensorFlow 1.1"
   programming_lang = "Python 3.8"
 }
-`, baseImage, notes)
+`, baseImage, notes))
+}
+
+func testAccImageVersionConfig_multiple(rName, baseImage string) string {
+	return acctest.ConfigCompose(
+		testAccImageVersionConfigBase(rName),
+		fmt.Sprintf(`
+resource "aws_sagemaker_image_version" "test" {
+  image_name = aws_sagemaker_image.test.id
+  base_image = %[1]q
+}
+
+resource "aws_sagemaker_image_version" "test_v2" {
+  image_name = aws_sagemaker_image_version.test.image_name
+  base_image = %[1]q
+}
+`, baseImage))
 }

--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -60,9 +60,25 @@ func statusImage(ctx context.Context, conn *sagemaker.Client, name string) retry
 	}
 }
 
-func statusImageVersion(ctx context.Context, conn *sagemaker.Client, name string) retry.StateRefreshFunc {
+func statusImageVersionByName(ctx context.Context, conn *sagemaker.Client, name string) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		output, err := findImageVersionByName(ctx, conn, name)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.ImageVersionStatus), nil
+	}
+}
+
+func statusImageVersionByID(ctx context.Context, conn *sagemaker.Client, name string, version int) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		output, err := findImageVersionByTwoPartKey(ctx, conn, name, version)
 
 		if tfresource.NotFound(err) {
 			return nil, "", nil

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -217,7 +217,7 @@ func waitImageVersionCreated(ctx context.Context, conn *sagemaker.Client, name s
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageVersionStatusCreating),
 		Target:  enum.Slice(awstypes.ImageVersionStatusCreated),
-		Refresh: statusImageVersion(ctx, conn, name),
+		Refresh: statusImageVersionByName(ctx, conn, name),
 		Timeout: imageVersionCreatedTimeout,
 	}
 
@@ -234,11 +234,11 @@ func waitImageVersionCreated(ctx context.Context, conn *sagemaker.Client, name s
 	return nil, err
 }
 
-func waitImageVersionDeleted(ctx context.Context, conn *sagemaker.Client, name string) (*sagemaker.DescribeImageVersionOutput, error) {
+func waitImageVersionDeleted(ctx context.Context, conn *sagemaker.Client, name string, version int) (*sagemaker.DescribeImageVersionOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageVersionStatusDeleting),
 		Target:  []string{},
-		Refresh: statusImageVersion(ctx, conn, name),
+		Refresh: statusImageVersionByID(ctx, conn, name, version),
 		Timeout: imageVersionDeletedTimeout,
 	}
 

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -92,6 +92,7 @@ Upgrade topics:
 - [Resource `aws_rekognition_stream_processor`](#resource-aws_rekognition_stream_processor)
 - [Resource `aws_resiliencehub_resiliency_policy`](#resource-aws_resiliencehub_resiliency_policy)
 - [Resource `aws_s3_bucket`](#resource-aws_s3_bucket)
+- [Resource `aws_sagemaker_image_version`](#resource-aws_sagemaker_image_version)
 - [Resource `aws_sagemaker_notebook_instance`](#resource-aws_sagemaker_notebook_instance)
 - [Resource `aws_servicequotas_template`](#resource-aws_servicequotas_template)
 - [Resource `aws_spot_instance_request`](#resource-aws_spot_instance_request)
@@ -633,6 +634,11 @@ The resource configuration itself does not change. However, now, include an inde
 ## Resource `aws_s3_bucket`
 
 `bucket_region` has been added and should be used instead of `region`, which is now used for [Enhanced Region Support](enhanced-region-support.html).
+
+## Resource `aws_sagemaker_image_version`
+
+For the `id`, use a comma-delimited string concatenating `image_name` and `version`. For example, in an import command, use comma-delimiting for the composite `id`.
+Use `image_name` to reference the image name.
 
 ## Resource `aws_sagemaker_notebook_instance`
 

--- a/website/docs/r/sagemaker_image_version.html.markdown
+++ b/website/docs/r/sagemaker_image_version.html.markdown
@@ -15,7 +15,7 @@ Provides a SageMaker AI Image Version resource.
 ### Basic usage
 
 ```terraform
-resource "aws_sagemaker_image_version" "test" {
+resource "aws_sagemaker_image_version" "example" {
   image_name = aws_sagemaker_image.test.id
   base_image = "012345678912.dkr.ecr.us-west-2.amazonaws.com/image:latest"
 }
@@ -39,24 +39,23 @@ This resource supports the following arguments:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - The name of the Image.
 * `arn` - The Amazon Resource Name (ARN) assigned by AWS to this Image Version.
 * `version`- The version of the image. If not specified, the latest version is described.
 * `container_image` - The registry path of the container image that contains this image version.
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SageMaker AI Image Versions using the `name`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import SageMaker AI Image Versions using a comma-delimited string concatenating `image_name` and `version`. For example:
 
 ```terraform
 import {
-  to = aws_sagemaker_image_version.test_image
-  id = "my-code-repo"
+  to = aws_sagemaker_image_version.example
+  id = "example-name,1"
 }
 ```
 
-Using `terraform import`, import SageMaker AI Image Versions using the `name`. For example:
+Using `terraform import`, import SageMaker AI Image Versions using a comma-delimited string concatenating `image_name` and `version`. For example:
 
 ```console
-% terraform import aws_sagemaker_image_version.test_image my-code-repo
+% terraform import aws_sagemaker_image_version.example example-name,1
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously the read operation would always retrieve the latest image version matching the `image_name` argument, rather than tracking the version created by a given resource instance. This change updates the `id` attribute to a comma-delimited string concatenating `image_name` and `version`, enabling subsequent read operations to correctly match the version created by this resource, and supporting import of existing versions which are not the most recently created. It also fixes issues observed when managing multiple image versions of the same name in a single workspace.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #40597
Relates #41101


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SAGEMAKER_IMAGE_VERSION_BASE_IMAGE="<redacted>" make testacc PKG=sagemaker TESTS=TestAccSageMakerImageVersion_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/sagemaker/... -v -count 1 -parallel 20 -run='TestAccSageMakerImageVersion_'  -timeout 360m -vet=off
2025/05/08 10:39:43 Initializing Terraform AWS Provider...

--- PASS: TestAccSageMakerImageVersion_Disappears_image (80.09s)
--- PASS: TestAccSageMakerImageVersion_basic (82.82s)
--- PASS: TestAccSageMakerImageVersion_disappears (84.49s)
--- PASS: TestAccSageMakerImageVersion_multiple (88.17s)
--- PASS: TestAccSageMakerImageVersion_update (91.47s)
--- PASS: TestAccSageMakerImageVersion_upgrade_V5_98_0 (102.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker  108.081s
```
