### PR TITLE
resource/aws_backup_region_settings: Fix error in acceptance test

### DIFF
--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -45,7 +45,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_1(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -55,6 +55,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Redshift Serverless", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.S3", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", acctest.CtTrue),
@@ -72,7 +73,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_2(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -94,7 +95,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_3(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -147,6 +148,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true
@@ -172,6 +174,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true
@@ -202,6 +205,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Some time between 29 March and 12 April, AWS added `Redshift Serverless` to `aws_backup_region_settings`. This caused acceptance tests to fail.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=backup TESTS=TestAccBackupRegionSettings_serial

--- PASS: TestAccBackupRegionSettings_serial (26.48s)
    --- PASS: TestAccBackupRegionSettings_serial/basic (26.47s)
```
