### PR TITLE
Glue Partition Documentation Typo Fix

### DIFF
--- a/website/docs/r/glue_partition.html.markdown
+++ b/website/docs/r/glue_partition.html.markdown
@@ -14,9 +14,9 @@ Provides a Glue Partition Resource.
 
 ```terraform
 resource "aws_glue_partition" "example" {
-  database_name = "some-database"
-  table_name    = "some-table"
-  values        = ["some-value"]
+  database_name    = "some-database"
+  table_name       = "some-table"
+  partition_values = ["some-value"]
 }
 ```
 


### PR DESCRIPTION
See line 28 - should be `partition_values` not `values`

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This fixes a small typo in the website docs.  The correct parameter is `partition_values` but the example currently uses `values`


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.


--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
