### PR TITLE
Enhanced Regions import: allow setting region directly from ARN or region name used as Import ID

### DIFF
--- a/internal/acctest/state_id.go
+++ b/internal/acctest/state_id.go
@@ -21,3 +21,21 @@ func AttrImportStateIdFunc(resourceName, attrName string) resource.ImportStateId
 		return rs.Primary.Attributes[attrName], nil
 	}
 }
+
+// CrossRegionImportStateIdFunc is a resource.ImportStateIdFunc that appends the region
+func CrossRegionImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := rs.Primary.ID
+		region, ok := rs.Primary.Attributes["region"]
+		if !ok {
+			return "", fmt.Errorf("Attribute \"region\" not found in %s", resourceName)
+		}
+
+		return id + "@" + region, nil
+	}
+}

--- a/internal/generate/servicepackage/file.gtpl
+++ b/internal/generate/servicepackage/file.gtpl
@@ -155,6 +155,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				IsValidateOverrideInPartition: {{ $value.ValidateRegionOverrideInPartition }},
 	{{- end }}
 			}),
+			{{- if $value.SingletonIdentity }}
+				Identity: inttypes.RegionalSingletonIdentity(),
+			{{- end }}
 		},
 {{- end }}
 	}

--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -124,6 +124,7 @@ type ResourceDatum struct {
 	TagsIdentifierAttribute           string
 	TagsResourceType                  string
 	ValidateRegionOverrideInPartition bool
+	SingletonIdentity                 bool
 }
 
 type ServiceDatum struct {
@@ -246,6 +247,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				if attr, ok := args.Keyword["resourceType"]; ok {
 					d.TagsResourceType = attr
 				}
+
+			case "SingletonIdentity":
+				d.SingletonIdentity = true
 			}
 		}
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -418,15 +418,15 @@ func initialize(ctx context.Context, provider *schema.Provider) (map[string]conn
 			provider.DataSourcesMap[typeName] = r
 		}
 
-		for _, v := range sp.SDKResources(ctx) {
-			typeName := v.TypeName
+		for _, resource := range sp.SDKResources(ctx) {
+			typeName := resource.TypeName
 
 			if _, ok := provider.ResourcesMap[typeName]; ok {
 				errs = append(errs, fmt.Errorf("duplicate resource: %s", typeName))
 				continue
 			}
 
-			r := v.Factory()
+			r := resource.Factory()
 
 			// Ensure that the correct CRUD handler variants are used.
 			if r.Create != nil || r.CreateContext != nil {
@@ -447,14 +447,14 @@ func initialize(ctx context.Context, provider *schema.Provider) (map[string]conn
 			}
 
 			var isRegionOverrideEnabled bool
-			if v := v.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
+			if v := resource.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
 				isRegionOverrideEnabled = true
 			}
 
 			var interceptors interceptorInvocations
 
 			if isRegionOverrideEnabled {
-				v := v.Region.Value()
+				v := resource.Region.Value()
 				s := r.SchemaMap()
 
 				if _, ok := s[names.AttrRegion]; !ok {
@@ -506,18 +506,26 @@ func initialize(ctx context.Context, provider *schema.Provider) (map[string]conn
 					why:         CustomizeDiff,
 					interceptor: forceNewIfRegionChanges(),
 				})
-				interceptors = append(interceptors, interceptorInvocation{
-					when:        Before,
-					why:         Import,
-					interceptor: importRegion(),
-				})
+				if resource.Identity.Singleton {
+					interceptors = append(interceptors, interceptorInvocation{
+						when:        Before,
+						why:         Import,
+						interceptor: importRegionNoDefault(),
+					})
+				} else {
+					interceptors = append(interceptors, interceptorInvocation{
+						when:        Before,
+						why:         Import,
+						interceptor: importRegion(),
+					})
+				}
 			}
 
-			if !tfunique.IsHandleNil(v.Tags) {
+			if !tfunique.IsHandleNil(resource.Tags) {
 				interceptors = append(interceptors, interceptorInvocation{
 					when:        Before | After | Finally,
 					why:         Create | Read | Update,
-					interceptor: resourceTransparentTagging(v.Tags),
+					interceptor: resourceTransparentTagging(resource.Tags),
 				})
 				interceptors = append(interceptors, interceptorInvocation{
 					when:        Before,
@@ -537,7 +545,7 @@ func initialize(ctx context.Context, provider *schema.Provider) (map[string]conn
 						}
 					}
 
-					ctx = conns.NewResourceContext(ctx, servicePackageName, v.Name, overrideRegion)
+					ctx = conns.NewResourceContext(ctx, servicePackageName, resource.Name, overrideRegion)
 					if c, ok := meta.(*conns.AWSClient); ok {
 						ctx = tftags.NewContext(ctx, c.DefaultTagsConfig(ctx), c.IgnoreTagsConfig(ctx))
 						ctx = c.RegisterLogger(ctx)

--- a/internal/provider/region.go
+++ b/internal/provider/region.go
@@ -156,3 +156,24 @@ func importRegion() importInterceptor {
 		return []*schema.ResourceData{d}, nil
 	})
 }
+
+// importRegionNoDefault does not provide a default value for `region`. This should be used when the import ID is or contains a region.
+func importRegionNoDefault() importInterceptor {
+	return interceptorFunc2[*schema.ResourceData, []*schema.ResourceData, error](func(ctx context.Context, opts importInterceptorOptions) ([]*schema.ResourceData, error) {
+		d := opts.d
+
+		switch when, why := opts.when, opts.why; when {
+		case Before:
+			switch why {
+			case Import:
+				// Import ID optionally ends with "@<region>".
+				if matches := regexache.MustCompile(`^(.+)@([a-z]{2}(?:-[a-z]+)+-\d{1,2})$`).FindStringSubmatch(d.Id()); len(matches) == 3 {
+					d.SetId(matches[1])
+					d.Set(names.AttrRegion, matches[2])
+				}
+			}
+		}
+
+		return []*schema.ResourceData{d}, nil
+	})
+}

--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -17,6 +17,7 @@ import (
 )
 
 // @SDKResource("aws_backup_region_settings", name="Region Settings")
+// @SingletonIdentity
 func resourceRegionSettings() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceRegionSettingsUpdate,

--- a/internal/service/backup/region_settings.go
+++ b/internal/service/backup/region_settings.go
@@ -5,6 +5,7 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go-v2/service/backup"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @SDKResource("aws_backup_region_settings", name="Region Settings")
@@ -26,7 +28,16 @@ func resourceRegionSettings() *schema.Resource {
 		DeleteWithoutTimeout: schema.NoopContext,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, rd *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+				if region, ok := rd.GetOk(names.AttrRegion); ok {
+					if region != rd.Id() {
+						return nil, fmt.Errorf("the region passed for import %q does not match the region in the ID %q", region, rd.Id())
+					}
+				} else {
+					rd.Set(names.AttrRegion, rd.Id())
+				}
+				return []*schema.ResourceData{rd}, nil
+			},
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/internal/service/backup/region_settings_test.go
+++ b/internal/service/backup/region_settings_test.go
@@ -45,7 +45,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_1(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -55,6 +55,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.FSx", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Neptune", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.RDS", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Redshift Serverless", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.S3", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Storage Gateway", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.VirtualMachine", acctest.CtTrue),
@@ -72,7 +73,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_2(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -94,7 +95,7 @@ func testAccRegionSettings_basic(t *testing.T) {
 				Config: testAccRegionSettingsConfig_3(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckRegionSettingsExists(ctx, &settings),
-					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "16"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.%", "17"),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.Aurora", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DocumentDB", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "resource_type_opt_in_preference.DynamoDB", acctest.CtTrue),
@@ -147,6 +148,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true
@@ -172,6 +174,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true
@@ -202,6 +205,7 @@ resource "aws_backup_region_settings" "test" {
     "Neptune"                = true
     "RDS"                    = true
     "Redshift"               = true
+    "Redshift Serverless"    = true
     "S3"                     = true
     "SAP HANA on Amazon EC2" = true
     "Storage Gateway"        = true

--- a/internal/service/backup/service_package_gen.go
+++ b/internal/service/backup/service_package_gen.go
@@ -162,6 +162,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				IsOverrideEnabled:             true,
 				IsValidateOverrideInPartition: true,
 			}),
+			Identity: inttypes.RegionalSingletonIdentity(),
 		},
 		{
 			Factory:  resourceReportPlan,

--- a/internal/types/service_package.go
+++ b/internal/types/service_package.go
@@ -72,4 +72,17 @@ type ServicePackageSDKResource struct {
 	Name     string
 	Tags     unique.Handle[ServicePackageResourceTags]
 	Region   unique.Handle[ServicePackageResourceRegion]
+	Identity Identity
+}
+
+type Identity struct {
+	Global    bool
+	Singleton bool
+}
+
+func RegionalSingletonIdentity() Identity {
+	return Identity{
+		Global:    false,
+		Singleton: true,
+	}
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

Some resource types use an ARN or a region name as their Import ID. When using Enhanced Region, this makes specifying the region by appending `@<region>` redundant.

If no additional region is specified, use the region from the Import ID. If an additional region is specified, it should match.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42527

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
