### PR TITLE
chore(amplify): use the webhook.appId field instead of extracting it from the webhookArn

### DIFF
--- a/internal/service/amplify/webhook.go
+++ b/internal/service/amplify/webhook.go
@@ -6,11 +6,9 @@ package amplify
 import (
 	"context"
 	"log"
-	"strings"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/amplify"
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -104,20 +102,8 @@ func resourceWebhookRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	webhookArn := aws.ToString(webhook.WebhookArn)
-	arn, err := arn.Parse(webhookArn)
 
-	if err != nil {
-		return sdkdiag.AppendFromErr(diags, err)
-	}
-
-	// arn:${Partition}:amplify:${Region}:${Account}:apps/${AppId}/webhooks/${WebhookId}
-	parts := strings.Split(arn.Resource, "/")
-
-	if len(parts) != 4 {
-		return sdkdiag.AppendErrorf(diags, "unexpected format for ARN resource (%s)", arn.Resource)
-	}
-
-	d.Set("app_id", parts[1])
+	d.Set("app_id", webhook.AppId)
 	d.Set(names.AttrARN, webhookArn)
 	d.Set("branch_name", webhook.BranchName)
 	d.Set(names.AttrDescription, webhook.Description)


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

The Amplify GetWebhook API returns the `appId` field ([docs](https://docs.aws.amazon.com/amplify/latest/APIReference/API_GetWebhook.html)). This changes the code to simply use the `appId` from the response instead of parsing the `webhookArn` to extract the appId.

There are no changes in functionality. This just simplifies the code to not make unnecessary assumptions on the ARN format. The motivation is to prevent reocurrence of of https://github.com/hashicorp/terraform-provider-aws/issues/39407#issuecomment-2642157988

### Relations

Relates #39407

### References

- https://docs.aws.amazon.com/amplify/latest/APIReference/API_GetWebhook.html

### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAmplify_serial PKG=amplify
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./internal/service/amplify/... -v -count 1 -parallel 20 -run='TestAccAmplify_serial'  -timeout 360m -vet=off
2025/05/08 15:33:55 Initializing Terraform AWS Provider...
=== RUN   TestAccAmplify_serial
=== PAUSE TestAccAmplify_serial
=== CONT  TestAccAmplify_serial
=== RUN   TestAccAmplify_serial/Webhook
=== RUN   TestAccAmplify_serial/Webhook/basic
=== RUN   TestAccAmplify_serial/Webhook/disappears
=== RUN   TestAccAmplify_serial/Webhook/update
--- PASS: TestAccAmplify_serial (48.62s)
    --- PASS: TestAccAmplify_serial/Webhook (48.62s)
        --- PASS: TestAccAmplify_serial/Webhook/basic (15.00s)
        --- PASS: TestAccAmplify_serial/Webhook/disappears (12.98s)
        --- PASS: TestAccAmplify_serial/Webhook/update (20.63s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amplify	53.928s
```

_** Note: I commented out the tests not related to Amplify webhooks in this run. I believe that I cannot target only the Webhook tests with the `TESTS` parm due to how the `TestAccAmplify_serial` is set up https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/amplify/amplify_test.go#L16_ 