### PR TITLE
make aws_dynamodb_table.stream_arn a computed attribute when stream_v…

### DIFF
--- a/internal/service/dynamodb/table.go
+++ b/internal/service/dynamodb/table.go
@@ -92,7 +92,7 @@ func resourceTable() *schema.Resource {
 				return nil
 			},
 			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
-				if diff.Id() != "" && diff.HasChange("stream_enabled") {
+				if diff.Id() != "" && (diff.HasChange("stream_enabled") || diff.HasChange("stream_view_type")) {
 					if err := diff.SetNewComputed(names.AttrStreamARN); err != nil {
 						return fmt.Errorf("setting stream_arn to computed: %s", err)
 					}


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR resolves a bug where updating a dynamodb table's `stream_view_type` can break references to that table's `stream_arn`. See #42560

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42560

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
I'm not sure if a change this small warrants Acceptance Testing. Reading the contributing guidlines, it seems like a bit much. But if so, please provide guidance.