### PR TITLE
fix: mark aws_route53profiles_resource_association resource_properties as Computed

### DIFF
--- a/.changelog/42562.txt
+++ b/.changelog/42562.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_route53profiles_resource_association: Change `resource_properties` to Computed to enable `vpc_endpoint` associations
+```

--- a/internal/service/route53profiles/resource_association.go
+++ b/internal/service/route53profiles/resource_association.go
@@ -78,6 +78,7 @@ func (r *resourceResourceAssociation) Schema(ctx context.Context, req resource.S
 				},
 			},
 			"resource_properties": schema.StringAttribute{
+				Computed:   true,
 				CustomType: jsontypes.NormalizedType{},
 				Optional:   true,
 			},

--- a/internal/service/route53profiles/resource_association_test.go
+++ b/internal/service/route53profiles/resource_association_test.go
@@ -130,6 +130,40 @@ func TestAccRoute53ProfilesResourceAssociation_resolverRule(t *testing.T) {
 	})
 }
 
+func TestAccRoute53ProfilesResourceAssociation_vpcEndpoint(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var resourceAssociation awstypes.ProfileResourceAssociation
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_route53profiles_resource_association.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.Route53ProfilesServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceAssociationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceAssociationConfig_vpcEndpoint(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceAssociationExists(ctx, resourceName, &resourceAssociation),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
 func TestAccRoute53ProfilesResourceAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -243,7 +277,6 @@ resource "aws_route53_resolver_firewall_rule_group" "test" {
   name = %[1]q
 }
 
-
 resource "aws_route53profiles_resource_association" "test" {
   name                = %[1]q
   profile_id          = aws_route53profiles_profile.test.id
@@ -270,4 +303,49 @@ resource "aws_route53profiles_resource_association" "test" {
   resource_arn = aws_route53_resolver_rule.test.arn
 }
 `, rName)
+}
+
+func testAccResourceAssociationConfig_vpcEndpoint(rName string) string {
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsEnableDNSHostnames(rName, 3), fmt.Sprintf(`
+resource "aws_route53profiles_profile" "test" {
+  name = %[1]q
+}
+
+data "aws_region" "current" {}
+
+resource "aws_security_group" "test" {
+  vpc_id = aws_vpc.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpc_endpoint" "test" {
+  vpc_id              = aws_vpc.test.id
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  subnet_ids = [
+    aws_subnet.test[2].id,
+    aws_subnet.test[1].id,
+    aws_subnet.test[0].id,
+  ]
+
+  security_group_ids = [
+    aws_security_group.test.id,
+  ]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_route53profiles_resource_association" "test" {
+  name         = %[1]q
+  profile_id   = aws_route53profiles_profile.test.id
+  resource_arn = aws_vpc_endpoint.test.arn
+}
+`, rName))
 }


### PR DESCRIPTION
### Description
Mark `aws_route53profiles_resource_association` `resource_properties` attribute as Computed to enable `aws_vpc_endpoint` association.


### Relations
Closes #42558
Closes #42489

### References

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccRoute53ProfilesResourceAssociation_vpcEndpoint PKG=route53profiles 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/route53profiles/... -v -count 1 -parallel 20 -run='TestAccRoute53ProfilesResourceAssociation_vpcEndpoint'  -timeout 360m -vet=off
2025/05/10 11:38:58 Initializing Terraform AWS Provider...
=== RUN   TestAccRoute53ProfilesResourceAssociation_vpcEndpoint
=== PAUSE TestAccRoute53ProfilesResourceAssociation_vpcEndpoint
=== CONT  TestAccRoute53ProfilesResourceAssociation_vpcEndpoint
--- PASS: TestAccRoute53ProfilesResourceAssociation_vpcEndpoint (1305.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/route53profiles    1308.362s
```
