### PR TITLE
r/aws_docdb_cluster: add support for `manage_master_user_password` argument 

### DIFF
--- a/.changelog/42563.txt
+++ b/.changelog/42563.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_docdb_cluster: Add `manage_master_user_password` argument allowing management of master user password through Secrets Manager
+resource/aws_docdb_cluster: Add `manage_master_user_password` argument and `master_user_secret` attribute
 ```

--- a/.changelog/42563.txt
+++ b/.changelog/42563.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_docdb_cluster: Add `manage_master_user_password` argument allowing management of master user password through Secrets Manager
+```

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -696,9 +696,9 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	if dbc.MasterUserSecret != nil {
 		masterUserSecret := []map[string]interface{}{
 			{
-				"kms_key_id":     aws.ToString(dbc.MasterUserSecret.KmsKeyId),
-				"secret_arn":     aws.ToString(dbc.MasterUserSecret.SecretArn),
-				"secret_status":  aws.ToString(dbc.MasterUserSecret.SecretStatus),
+				"kms_key_id":    aws.ToString(dbc.MasterUserSecret.KmsKeyId),
+				"secret_arn":    aws.ToString(dbc.MasterUserSecret.SecretArn),
+				"secret_status": aws.ToString(dbc.MasterUserSecret.SecretStatus),
 			},
 		}
 		if err := d.Set("master_user_secret", masterUserSecret); err != nil {

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -187,9 +187,27 @@ func resourceCluster() *schema.Resource {
 				ValidateFunc: verify.ValidARN,
 			},
 			"manage_master_user_password": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
+				Type:          schema.TypeBool,
+				Optional:      true,
+				ConflictsWith: []string{"master_password", "master_password_wo"},
+			},
+			"master_password": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Sensitive:     true,
+				ConflictsWith: []string{"manage_master_user_password", "master_password_wo"},
+			},
+			"master_password_wo": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				WriteOnly:     true,
+				ConflictsWith: []string{"manage_master_user_password", "master_password"},
+				RequiredWith:  []string{"master_password_wo_version"},
+			},
+			"master_password_wo_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				RequiredWith: []string{"master_password_wo"},
 			},
 			"master_user_secret": {
 				Type:     schema.TypeList,
@@ -210,24 +228,6 @@ func resourceCluster() *schema.Resource {
 						},
 					},
 				},
-			},
-			"master_password": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Sensitive:     true,
-				ConflictsWith: []string{"master_password_wo"},
-			},
-			"master_password_wo": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				WriteOnly:     true,
-				ConflictsWith: []string{"master_password"},
-				RequiredWith:  []string{"master_password_wo_version"},
-			},
-			"master_password_wo_version": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				RequiredWith: []string{"master_password_wo"},
 			},
 			"master_username": {
 				Type:     schema.TypeString,
@@ -365,7 +365,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	// ModifyDBInstance afterwadocdb to prevent Terraform operators from API
 	// errors or needing to double apply.
 	var requiresModifyDbCluster bool
-	inputM := &docdb.ModifyDBClusterInput{
+	inputMDBC := docdb.ModifyDBClusterInput{
 		ApplyImmediately: aws.Bool(true),
 	}
 
@@ -377,7 +377,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if _, ok := d.GetOk("snapshot_identifier"); ok {
-		input := &docdb.RestoreDBClusterFromSnapshotInput{
+		input := docdb.RestoreDBClusterFromSnapshotInput{
 			DBClusterIdentifier: aws.String(identifier),
 			DeletionProtection:  aws.Bool(d.Get(names.AttrDeletionProtection).(bool)),
 			Engine:              aws.String(d.Get(names.AttrEngine).(string)),
@@ -390,12 +390,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if v, ok := d.GetOk("backup_retention_period"); ok {
-			inputM.BackupRetentionPeriod = aws.Int32(int32(v.(int)))
+			inputMDBC.BackupRetentionPeriod = aws.Int32(int32(v.(int)))
 			requiresModifyDbCluster = true
 		}
 
 		if v, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
-			inputM.DBClusterParameterGroupName = aws.String(v.(string))
+			inputMDBC.DBClusterParameterGroupName = aws.String(v.(string))
 			requiresModifyDbCluster = true
 		}
 
@@ -415,13 +415,18 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			input.KmsKeyId = aws.String(v.(string))
 		}
 
+		if v, ok := d.GetOk("manage_master_user_password"); ok {
+			inputMDBC.ManageMasterUserPassword = aws.Bool(v.(bool))
+			requiresModifyDbCluster = true
+		}
+
 		if v, ok := d.GetOk("master_password"); ok {
-			inputM.MasterUserPassword = aws.String(v.(string))
+			inputMDBC.MasterUserPassword = aws.String(v.(string))
 			requiresModifyDbCluster = true
 		}
 
 		if masterPasswordWO != "" {
-			inputM.MasterUserPassword = aws.String(masterPasswordWO)
+			inputMDBC.MasterUserPassword = aws.String(masterPasswordWO)
 			requiresModifyDbCluster = true
 		}
 
@@ -430,12 +435,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		if v, ok := d.GetOk("preferred_backup_window"); ok {
-			inputM.PreferredBackupWindow = aws.String(v.(string))
+			inputMDBC.PreferredBackupWindow = aws.String(v.(string))
 			requiresModifyDbCluster = true
 		}
 
 		if v, ok := d.GetOk(names.AttrPreferredMaintenanceWindow); ok {
-			inputM.PreferredMaintenanceWindow = aws.String(v.(string))
+			inputMDBC.PreferredMaintenanceWindow = aws.String(v.(string))
 			requiresModifyDbCluster = true
 		}
 
@@ -448,7 +453,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
-			return conn.RestoreDBClusterFromSnapshot(ctx, input)
+			return conn.RestoreDBClusterFromSnapshot(ctx, &input)
 		}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 
 		if err != nil {
@@ -456,7 +461,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	} else if v, ok := d.GetOk("restore_to_point_in_time"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		tfMap := v.([]any)[0].(map[string]any)
-		input := &docdb.RestoreDBClusterToPointInTimeInput{
+		input := docdb.RestoreDBClusterToPointInTimeInput{
 			DBClusterIdentifier:       aws.String(identifier),
 			SourceDBClusterIdentifier: aws.String(tfMap["source_cluster_identifier"].(string)),
 			DeletionProtection:        aws.Bool(d.Get(names.AttrDeletionProtection).(bool)),
@@ -505,7 +510,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
-			return conn.RestoreDBClusterToPointInTime(ctx, input)
+			return conn.RestoreDBClusterToPointInTime(ctx, &input)
 		}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating DocumentDB Cluster (restore to point-in-time) (%s): %s", identifier, err)
@@ -514,7 +519,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		// Secondary DocDB clusters part of a global cluster will not supply the master_password
 		if _, ok := d.GetOk("global_cluster_identifier"); !ok {
 			// If manage_master_user_password is true, we don't need master_password
-			if manageMasterPassword, ok := d.GetOk("manage_master_user_password"); !ok || !manageMasterPassword.(bool) {
+			if v, ok := d.GetOk("manage_master_user_password"); !ok || !v.(bool) {
 				if _, ok := d.GetOk("master_password"); !ok && masterPasswordWO == "" {
 					return sdkdiag.AppendErrorf(diags, `provider.aws: aws_docdb_cluster: %s: "master_password", "master_password_wo": required field is not set`, identifier)
 				}
@@ -528,7 +533,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			}
 		}
 
-		input := &docdb.CreateDBClusterInput{
+		input := docdb.CreateDBClusterInput{
 			DBClusterIdentifier: aws.String(identifier),
 			DeletionProtection:  aws.Bool(d.Get(names.AttrDeletionProtection).(bool)),
 			Engine:              aws.String(d.Get(names.AttrEngine).(string)),
@@ -605,7 +610,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		_, err := tfresource.RetryWhenAWSErrMessageContains(ctx, propagationTimeout, func() (any, error) {
-			return conn.CreateDBCluster(ctx, input)
+			return conn.CreateDBCluster(ctx, &input)
 		}, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions")
 
 		if err != nil {
@@ -620,9 +625,9 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	if requiresModifyDbCluster {
-		inputM.DBClusterIdentifier = aws.String(d.Id())
+		inputMDBC.DBClusterIdentifier = aws.String(d.Id())
 
-		_, err := conn.ModifyDBCluster(ctx, inputM)
+		_, err := conn.ModifyDBCluster(ctx, &inputMDBC)
 
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "modifying DocumentDB Cluster (%s): %s", d.Id(), err)
@@ -682,6 +687,18 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrEngine, dbc.Engine)
 	d.Set(names.AttrHostedZoneID, dbc.HostedZoneId)
 	d.Set(names.AttrKMSKeyID, dbc.KmsKeyId)
+	if v := dbc.MasterUserSecret; v != nil {
+		tfList := []any{map[string]any{
+			"kms_key_id":    aws.ToString(v.KmsKeyId),
+			"secret_arn":    aws.ToString(v.SecretArn),
+			"secret_status": aws.ToString(v.SecretStatus),
+		}}
+		if err := d.Set("master_user_secret", tfList); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
+		}
+	} else {
+		d.Set("master_user_secret", nil)
+	}
 	d.Set("master_username", dbc.MasterUsername)
 	d.Set(names.AttrPort, dbc.Port)
 	d.Set("preferred_backup_window", dbc.PreferredBackupWindow)
@@ -689,25 +706,9 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set("reader_endpoint", dbc.ReaderEndpoint)
 	d.Set(names.AttrStorageEncrypted, dbc.StorageEncrypted)
 	d.Set(names.AttrStorageType, dbc.StorageType)
-	var securityGroupIDs []string
-	for _, v := range dbc.VpcSecurityGroups {
-		securityGroupIDs = append(securityGroupIDs, aws.ToString(v.VpcSecurityGroupId))
-	}
-	d.Set(names.AttrVPCSecurityGroupIDs, securityGroupIDs)
-
-	// Set master_user_secret if exists
-	if dbc.MasterUserSecret != nil {
-		masterUserSecret := []map[string]interface{}{
-			{
-				"kms_key_id":    aws.ToString(dbc.MasterUserSecret.KmsKeyId),
-				"secret_arn":    aws.ToString(dbc.MasterUserSecret.SecretArn),
-				"secret_status": aws.ToString(dbc.MasterUserSecret.SecretStatus),
-			},
-		}
-		if err := d.Set("master_user_secret", masterUserSecret); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)
-		}
-	}
+	d.Set(names.AttrVPCSecurityGroupIDs, tfslices.ApplyToAll(dbc.VpcSecurityGroups, func(v awstypes.VpcSecurityGroupMembership) string {
+		return aws.ToString(v.VpcSecurityGroupId)
+	}))
 
 	return diags
 }
@@ -717,7 +718,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 	conn := meta.(*conns.AWSClient).DocDBClient(ctx)
 
 	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll, "global_cluster_identifier", "skip_final_snapshot") {
-		input := &docdb.ModifyDBClusterInput{
+		input := docdb.ModifyDBClusterInput{
 			ApplyImmediately:    aws.Bool(d.Get(names.AttrApplyImmediately).(bool)),
 			DBClusterIdentifier: aws.String(d.Id()),
 		}
@@ -786,9 +787,12 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			}
 		}
 
-		_, err := tfresource.RetryWhen(ctx, 5*time.Minute,
+		const (
+			timeout = 5 * time.Minute
+		)
+		_, err := tfresource.RetryWhen(ctx, timeout,
 			func() (any, error) {
-				return conn.ModifyDBCluster(ctx, input)
+				return conn.ModifyDBCluster(ctx, &input)
 			},
 			func(err error) (bool, error) {
 				if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "IAM role ARN value is invalid or does not include the required permissions") {
@@ -841,7 +845,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 	conn := meta.(*conns.AWSClient).DocDBClient(ctx)
 
 	skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
-	input := &docdb.DeleteDBClusterInput{
+	input := docdb.DeleteDBClusterInput{
 		DBClusterIdentifier: aws.String(d.Id()),
 		SkipFinalSnapshot:   aws.Bool(skipFinalSnapshot),
 	}
@@ -863,7 +867,7 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 	log.Printf("[DEBUG] Deleting DocumentDB Cluster: %s", d.Id())
 	_, err := tfresource.RetryWhen(ctx, d.Timeout(schema.TimeoutDelete),
 		func() (any, error) {
-			return conn.DeleteDBCluster(ctx, input)
+			return conn.DeleteDBCluster(ctx, &input)
 		},
 		func(err error) (bool, error) {
 			if errs.IsAErrorMessageContains[*awstypes.InvalidDBClusterStateFault](err, "is not currently in the available state") {
@@ -926,12 +930,12 @@ func diffCloudWatchLogsExportConfiguration(old, new []any) ([]any, []any) {
 }
 
 func removeClusterFromGlobalCluster(ctx context.Context, conn *docdb.Client, clusterARN, globalClusterID string, timeout time.Duration) error {
-	input := &docdb.RemoveFromGlobalClusterInput{
+	input := docdb.RemoveFromGlobalClusterInput{
 		DbClusterIdentifier:     aws.String(clusterARN),
 		GlobalClusterIdentifier: aws.String(globalClusterID),
 	}
 
-	_, err := conn.RemoveFromGlobalCluster(ctx, input)
+	_, err := conn.RemoveFromGlobalCluster(ctx, &input)
 
 	if errs.IsA[*awstypes.DBClusterNotFoundFault](err) || errs.IsA[*awstypes.GlobalClusterNotFoundFault](err) ||
 		tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "is not found in global cluster") {
@@ -954,10 +958,10 @@ func removeClusterFromGlobalCluster(ctx context.Context, conn *docdb.Client, clu
 }
 
 func findDBClusterByID(ctx context.Context, conn *docdb.Client, id string) (*awstypes.DBCluster, error) {
-	input := &docdb.DescribeDBClustersInput{
+	input := docdb.DescribeDBClustersInput{
 		DBClusterIdentifier: aws.String(id),
 	}
-	output, err := findDBCluster(ctx, conn, input, tfslices.PredicateTrue[*awstypes.DBCluster]())
+	output, err := findDBCluster(ctx, conn, &input, tfslices.PredicateTrue[*awstypes.DBCluster]())
 
 	if err != nil {
 		return nil, err
@@ -974,9 +978,9 @@ func findDBClusterByID(ctx context.Context, conn *docdb.Client, id string) (*aws
 }
 
 func findClusterByARN(ctx context.Context, conn *docdb.Client, arn string) (*awstypes.DBCluster, error) {
-	input := &docdb.DescribeDBClustersInput{}
+	input := docdb.DescribeDBClustersInput{}
 
-	return findDBCluster(ctx, conn, input, func(v *awstypes.DBCluster) bool {
+	return findDBCluster(ctx, conn, &input, func(v *awstypes.DBCluster) bool {
 		return aws.ToString(v.DBClusterArn) == arn
 	})
 }

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -689,9 +689,9 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrKMSKeyID, dbc.KmsKeyId)
 	if v := dbc.MasterUserSecret; v != nil {
 		tfList := []any{map[string]any{
-			names.AttrKMSKeyID:    aws.ToString(v.KmsKeyId),
-			"secret_arn":    aws.ToString(v.SecretArn),
-			"secret_status": aws.ToString(v.SecretStatus),
+			names.AttrKMSKeyID: aws.ToString(v.KmsKeyId),
+			"secret_arn":       aws.ToString(v.SecretArn),
+			"secret_status":    aws.ToString(v.SecretStatus),
 		}}
 		if err := d.Set("master_user_secret", tfList); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting master_user_secret: %s", err)

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -573,7 +573,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 			input.KmsKeyId = aws.String(v.(string))
 		}
 
-		if v, ok := d.GetOk("manage_master_user_password"); ok && v.(bool) {
+		if v, ok := d.GetOk("manage_master_user_password"); ok {
 			input.ManageMasterUserPassword = aws.Bool(v.(bool))
 		} else {
 			if v, ok := d.GetOk("master_password"); ok {

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -214,7 +214,7 @@ func resourceCluster() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"kms_key_id": {
+						names.AttrKMSKeyID: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
@@ -689,7 +689,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrKMSKeyID, dbc.KmsKeyId)
 	if v := dbc.MasterUserSecret; v != nil {
 		tfList := []any{map[string]any{
-			"kms_key_id":    aws.ToString(v.KmsKeyId),
+			names.AttrKMSKeyID:    aws.ToString(v.KmsKeyId),
 			"secret_arn":    aws.ToString(v.SecretArn),
 			"secret_status": aws.ToString(v.SecretStatus),
 		}}

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1628,11 +1628,10 @@ resource "aws_docdb_cluster" "test" {
   ]
 
   master_username             = "tfacctest"
-  manage_master_user_password = %[2]t
 
-  %[3]s
+  %[2]s
 
   skip_final_snapshot = true
 }
-`, rName, manageMasterUserPassword, passwordConfig))
+`, rName, passwordConfig))
 }

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1623,10 +1623,10 @@ resource "aws_docdb_cluster" "test" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username            = "tfacctest"
+  master_username             = "tfacctest"
   manage_master_user_password = %[2]t
   %[3]s
-  skip_final_snapshot        = true
+  skip_final_snapshot         = true
 }
 `, rName, manageMasterUserPassword, passwordConfig))
 }

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1581,7 +1581,7 @@ resource "aws_docdb_cluster" "test" {
 `, rName, storageType))
 }
 
-func testAccClusterConfig_passwordWriteOnly(rName, password string, passworVersion int) string {
+func testAccClusterConfig_passwordWriteOnly(rName, password string, passwordVersion int) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`
 resource "aws_docdb_cluster" "test" {
   cluster_identifier = %[1]q
@@ -1602,7 +1602,7 @@ resource "aws_docdb_cluster" "test" {
     "profiler",
   ]
 }
-`, rName, password, passworVersion))
+`, rName, password, passwordVersion))
 }
 
 func testAccClusterConfig_manageMasterUserPassword(rName string, manageMasterUserPassword bool) string {

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -974,7 +974,7 @@ func TestAccDocDBCluster_manageMasterUserPassword(t *testing.T) {
 				Config: testAccClusterConfig_manageMasterUserPassword(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", "true"),
+					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "master_user_secret.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "master_user_secret.0.secret_status"),
@@ -997,7 +997,7 @@ func TestAccDocDBCluster_manageMasterUserPassword(t *testing.T) {
 				Config: testAccClusterConfig_manageMasterUserPassword(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &dbCluster),
-					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", "false"),
+					resource.TestCheckResourceAttr(resourceName, "manage_master_user_password", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "master_password", "avoid-plaintext-passwords"),
 				),
 			},
@@ -1608,9 +1608,13 @@ resource "aws_docdb_cluster" "test" {
 func testAccClusterConfig_manageMasterUserPassword(rName string, manageMasterUserPassword bool) string {
 	var passwordConfig string
 	if manageMasterUserPassword {
-		passwordConfig = ""
+		passwordConfig = `
+		manage_master_user_password = true
+		`
 	} else {
-		passwordConfig = "master_password = \"avoid-plaintext-passwords\""
+		passwordConfig = `
+		master_password = "avoid-plaintext-passwords"
+		`
 	}
 
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptIn(), fmt.Sprintf(`

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1625,8 +1625,10 @@ resource "aws_docdb_cluster" "test" {
 
   master_username             = "tfacctest"
   manage_master_user_password = %[2]t
+
   %[3]s
-  skip_final_snapshot         = true
+
+  skip_final_snapshot = true
 }
 `, rName, manageMasterUserPassword, passwordConfig))
 }

--- a/internal/service/docdb/cluster_test.go
+++ b/internal/service/docdb/cluster_test.go
@@ -1627,7 +1627,7 @@ resource "aws_docdb_cluster" "test" {
     data.aws_availability_zones.available.names[2]
   ]
 
-  master_username             = "tfacctest"
+  master_username = "tfacctest"
 
   %[2]s
 

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -65,10 +65,11 @@ This resource supports the following arguments:
     made.
 * `global_cluster_identifier` - (Optional) The global cluster identifier specified on [`aws_docdb_global_cluster`](/docs/providers/aws/r/docdb_global_cluster.html).
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `storage_encrypted` needs to be set to true.
+* `manage_master_user_password` - (Optional) Set to `true` to allow Amazon DocumentDB to manage the master user password in AWS Secrets Manager. Cannot be set if `master_password` or `master_password_wo` is provided.
 * `master_password` - (Optional, required unless a `snapshot_identifier` or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may
-    show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints. Conflicts with `master_password_wo`.
+    show up in logs, and it will be stored in the state file. Please refer to the DocumentDB Naming Constraints. Conflicts with `master_password_wo` and `manage_master_user_password`.
 * `master_password_wo` - (Optional, Write-Only, required unless a `snapshot_identifier` or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Password for the master DB user. Note that this may
-  show up in logs. Please refer to the DocumentDB Naming Constraints. Conflicts with `master_password`.
+  show up in logs. Please refer to the DocumentDB Naming Constraints. Conflicts with `master_password` and `manage_master_user_password`.
 * `master_password_wo_version` - (Optional) Used together with `master_password_wo` to trigger an update. Increment this value when an update to the `master_password_wo` is required.
 * `master_username` - (Required unless a `snapshot_identifier` or unless a `global_cluster_identifier` is provided when the cluster is the "secondary" cluster of a global database) Username for the master DB user.
 * `port` - (Optional) The port on which the DB accepts connections


### PR DESCRIPTION
### Description

This PR adds support for the `manage_master_user_password` argument to the `aws_docdb_cluster` resource, allowing users to manage their DocumentDB master user password through AWS Secrets Manager rather than storing it as plaintext in Terraform state.

- Added the `manage_master_user_password` boolean parameter to the resource schema (defaults to false)
- Added a computed `master_user_secret` attribute that returns information about the secret in Secrets Manager when enabled
- Updated validation logic to make `master_password` optional when `manage_master_user_password` is set to true

### Relations

Closes #41115

### References

- Definition of `ManageMasterUserPassword` in `CreateDBClusterInput`: https://github.com/aws/aws-sdk-go-v2/blob/main/service/docdb/api_op_CreateDBCluster.go#L127
- Definition of `MasterUserSecret` in `DescribeDBClustersOutput`: https://github.com/aws/aws-sdk-go-v2/blob/main/service/docdb/types/types.go#L90


### Output from Acceptance Testing

```console
make testacc TESTS=TestAccDocDBCluster_manageMasterUserPassword PKG=docdb
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/docdb/... -v -count 1 -parallel 20 -run='TestAccDocDBCluster_manageMasterUserPassword'  -timeout 360m -vet=off
2025/05/10 22:58:35 Initializing Terraform AWS Provider...
=== RUN   TestAccDocDBCluster_manageMasterUserPassword
=== PAUSE TestAccDocDBCluster_manageMasterUserPassword
=== CONT  TestAccDocDBCluster_manageMasterUserPassword
--- PASS: TestAccDocDBCluster_manageMasterUserPassword (176.32s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/docdb  183.811s
```
