### PR TITLE
[document typo fix] aws_lambda_event_source_mapping: `maximum_poller` and `mimimum_poller` in the example to be plural

### DIFF
--- a/website/docs/r/lambda_event_source_mapping.html.markdown
+++ b/website/docs/r/lambda_event_source_mapping.html.markdown
@@ -59,8 +59,8 @@ resource "aws_lambda_event_source_mapping" "example" {
   starting_position = "TRIM_HORIZON"
 
   provisioned_poller_config {
-    maximum_poller = 80
-    minimum_poller = 10
+    maximum_pollers = 80
+    minimum_pollers = 10
   }
 
   self_managed_event_source {


### PR DESCRIPTION
### Description
* fix typos in the documentation of `aws_lambda_event_source_mapping`
  * `maximum_poller` and `mimimum_poller` in the example should be plural
  * I confirmed by reviewing implementation and document that they should be plural.

### Relations

Closes #42570 

### References
Implementation in the source codes:
https://github.com/hashicorp/terraform-provider-aws/blob/d45a5fde7cafea5cf8549f15bcdc3128ff3f36a3/internal/service/lambda/event_source_mapping.go#L264-L284


