### PR TITLE
[Enhancement] aws_securityhub_finding_aggregator: add `NO_REGIONS` linking mode

### DIFF
--- a/internal/service/securityhub/finding_aggregator.go
+++ b/internal/service/securityhub/finding_aggregator.go
@@ -24,6 +24,7 @@ const (
 	linkingModeAllRegions                = "ALL_REGIONS"
 	linkingModeAllRegionsExceptSpecified = "ALL_REGIONS_EXCEPT_SPECIFIED"
 	linkingModeSpecifiedRegions          = "SPECIFIED_REGIONS"
+	linkingModeNoRegions                 = "NO_REGIONS"
 )
 
 func linkingMode_Values() []string {
@@ -31,6 +32,7 @@ func linkingMode_Values() []string {
 		linkingModeAllRegions,
 		linkingModeAllRegionsExceptSpecified,
 		linkingModeSpecifiedRegions,
+		linkingModeNoRegions,
 	}
 }
 

--- a/internal/service/securityhub/finding_aggregator_test.go
+++ b/internal/service/securityhub/finding_aggregator_test.go
@@ -57,6 +57,13 @@ func testAccFindingAggregator_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "specified_regions.#", "2"),
 				),
 			},
+			{
+				Config: testAccFindingAggregatorConfig_NoRegions(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFindingAggregatorExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "linking_mode", "NO_REGIONS"),
+				),
+			},
 		},
 	})
 }
@@ -160,4 +167,16 @@ resource "aws_securityhub_finding_aggregator" "test_aggregator" {
   depends_on = [aws_securityhub_account.example]
 }
 `, endpoints.EuWest1RegionID, endpoints.EuWest2RegionID)
+}
+
+func testAccFindingAggregatorConfig_NoRegions() string {
+	return `
+resource "aws_securityhub_account" "example" {}
+
+resource "aws_securityhub_finding_aggregator" "test_aggregator" {
+  linking_mode      = "NO_REGIONS"
+
+  depends_on = [aws_securityhub_account.example]
+}
+`
 }

--- a/website/docs/r/securityhub_finding_aggregator.html.markdown
+++ b/website/docs/r/securityhub_finding_aggregator.html.markdown
@@ -56,11 +56,25 @@ resource "aws_securityhub_finding_aggregator" "example" {
 }
 ```
 
+### No Regions Usage
+
+The following example will enable the aggregator but not link any AWS Regions to the home Region.
+
+```terraform
+resource "aws_securityhub_account" "example" {}
+
+resource "aws_securityhub_finding_aggregator" "example" {
+  linking_mode      = "NO_REGIONS"
+
+  depends_on = [aws_securityhub_account.example]
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
-- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
+- `linking_mode` - (Required) Indicates whether to aggregate findings from all of the available Regions or from a specified list. The options are `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED`, `SPECIFIED_REGIONS` or `NO_REGIONS`. When `ALL_REGIONS` or `ALL_REGIONS_EXCEPT_SPECIFIED` are used, Security Hub will automatically aggregate findings from new Regions as Security Hub supports them and you opt into them.
 - `specified_regions` - (Optional) List of regions to include or exclude (required if `linking_mode` is set to `ALL_REGIONS_EXCEPT_SPECIFIED` or `SPECIFIED_REGIONS`)
 
 ## Attribute Reference


### PR DESCRIPTION
### Description
* Added `NO_REGIONS` to the enum values for the linking mode of `aws_securityhub_finding_aggregator`

### Relations

Closes #42567

### References
https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_CreateFindingAggregator.html#API_CreateFindingAggregator_RequestSyntax

### Output from Acceptance Testing

```console


```
