### PR TITLE
docs: update aws_transfer_tags keys in example

### DIFF
--- a/website/docs/r/transfer_tag.html.markdown
+++ b/website/docs/r/transfer_tag.html.markdown
@@ -23,13 +23,13 @@ resource "aws_transfer_server" "example" {
 
 resource "aws_transfer_tag" "zone_id" {
   resource_arn = aws_transfer_server.example.arn
-  key          = "aws:transfer:route53HostedZoneId"
+  key          = "transfer:route53HostedZoneId"
   value        = "/hostedzone/MyHostedZoneId"
 }
 
 resource "aws_transfer_tag" "hostname" {
   resource_arn = aws_transfer_server.example.arn
-  key          = "aws:transfer:customHostname"
+  key          = "transfer:customHostname"
   value        = "example.com"
 }
 ```


### PR DESCRIPTION
### Description

The example for resource [aws_transfer_tag](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/transfer_tag)  contains outdated values for the used `Key`s

* `key = "aws:transfer:route53HostedZoneId"`
*  `key = "aws:transfer:customHostname"`

In the [current documentation](https://docs.aws.amazon.com/transfer/latest/userguide/requirements-dns.html#tag-custom-hostname-cdk) the values no longer contain the prefix `aws`.


### Relations

Closes #42496 

### References

- [Working with custom hostnames](https://docs.aws.amazon.com/transfer/latest/userguide/requirements-dns.html#tag-custom-hostname-cdk) 
- [Stack Overflow question](https://repost.aws/questions/QU1xsm4q9DRKa5zHcmmcsQpQ/cloudformation-sftp-transfer-service-with-custom-hostname) mentioning the tag value update.

### Output from Acceptance Testing

Not applicable. Only documentation is updated.