### PR TITLE
feat: update max length for bedrock agent instructions to 20k

### DIFF
--- a/.changelog/42596.txt
+++ b/.changelog/42596.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_bedrockagent_agent: Increase `instruction` max length for validation to 20000
+```

--- a/internal/service/bedrockagent/agent.go
+++ b/internal/service/bedrockagent/agent.go
@@ -133,7 +133,7 @@ func (r *agentResource) Schema(ctx context.Context, request resource.SchemaReque
 					stringplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.String{
-					stringvalidator.UTF8LengthBetween(40, 8000),
+					stringvalidator.UTF8LengthBetween(40, 20000),
 				},
 			},
 			"memory_configuration":          framework.ResourceOptionalComputedListOfObjectsAttribute[memoryConfigurationModel](ctx, 1, nil, listplanmodifier.UseStateForUnknown()),

--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -82,7 +82,7 @@ The following arguments are optional:
 * `description` - (Optional) Description of the agent.
 * `guardrail_configuration` - (Optional) Details about the guardrail associated with the agent. See [`guardrail_configuration` Block](#guardrail_configuration-block) for details.
 * `idle_session_ttl_in_seconds` - (Optional) Number of seconds for which Amazon Bedrock keeps information about a user's conversation with the agent. A user interaction remains active for the amount of time specified. If no conversation occurs during this time, the session expires and Amazon Bedrock deletes any data provided before the timeout.
-* `instruction` - (Optional) Instructions that tell the agent what it should do and how it should interact with users. The valid range is 40 - 8000 characters.
+* `instruction` - (Optional) Instructions that tell the agent what it should do and how it should interact with users. The valid range is 40 - 20000 characters.
 * `memory_configuration` (Optional) Configurations for the agent's ability to retain the conversational context.
 * `prepare_agent` (Optional) Whether to prepare the agent after creation or modification. Defaults to `true`.
 * `prompt_override_configuration` (Optional) Configurations to override prompt templates in different parts of an agent sequence. For more information, see [Advanced prompts](https://docs.aws.amazon.com/bedrock/latest/userguide/advanced-prompts.html). See [`prompt_override_configuration` Block](#prompt_override_configuration-block) for details.


### PR DESCRIPTION
### Description
AWS have updated the maximum instruction character count from 8000 to 20000. The current provider version allows 40 - 8000 characters in the `instruction` argument.

The below command can validate this new default service quota.

❯ `aws service-quotas get-service-quota --service-code bedrock --quota-code L-6E3CDA2D --output table`

Output:
```
----------------------------------------------------------------------------------------------
|                                       GetServiceQuota                                      |
+--------------------------------------------------------------------------------------------+
||                                           Quota                                          ||
|+----------------------+-------------------------------------------------------------------+|
||  Adjustable          |  False                                                            ||
||  GlobalQuota         |  False                                                            ||
||  QuotaAppliedAtLevel |  ACCOUNT                                                          ||
||  QuotaArn            |  arn:aws:servicequotas:eu-west-2:<redacted>:bedrock/L-6E3CDA2D    ||
||  QuotaCode           |  L-6E3CDA2D                                                       ||
||  QuotaName           |  Characters in Agent instructions                                 ||
||  ServiceCode         |  bedrock                                                          ||
||  ServiceName         |  Amazon Bedrock                                                   ||
||  Unit                |  None                                                             ||
||  Value               |  20000.0                                                          ||
|+----------------------+-------------------------------------------------------------------+|
```

### Relations
- Relates #40236 
Closed bug relating to the previous increase to 8000 characters.
- Relates #40279 
Previous character count increase completed by @stefanfreitag 

### References
[Bedrock Quotas](https://docs.aws.amazon.com/general/latest/gr/bedrock.html#limits_bedrock)


### Output from Acceptance Testing
```
make testacc ACCTEST_PARALLELISM=3 TESTS=TestAccBedrockAgentAgent_ PKG=bedrockagent 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/bedrockagent/... -v -count 1 -parallel 3 -run='TestAccBedrockAgentAgent_'  -timeout 360m -vet=off
2025/05/13 14:24:58 Initializing Terraform AWS Provider...
=== RUN   TestAccBedrockAgentAgent_basic
=== PAUSE TestAccBedrockAgentAgent_basic
=== RUN   TestAccBedrockAgentAgent_full
=== PAUSE TestAccBedrockAgentAgent_full
=== RUN   TestAccBedrockAgentAgent_singlePrompt
=== PAUSE TestAccBedrockAgentAgent_singlePrompt
=== RUN   TestAccBedrockAgentAgent_singlePromptUpdate
=== PAUSE TestAccBedrockAgentAgent_singlePromptUpdate
=== RUN   TestAccBedrockAgentAgent_addPrompt
=== PAUSE TestAccBedrockAgentAgent_addPrompt
=== RUN   TestAccBedrockAgentAgent_guardrail
=== PAUSE TestAccBedrockAgentAgent_guardrail
=== RUN   TestAccBedrockAgentAgent_update
=== PAUSE TestAccBedrockAgentAgent_update
=== RUN   TestAccBedrockAgentAgent_tags
=== PAUSE TestAccBedrockAgentAgent_tags
=== RUN   TestAccBedrockAgentAgent_kms
=== PAUSE TestAccBedrockAgentAgent_kms
=== RUN   TestAccBedrockAgentAgent_agentCollaboration
=== PAUSE TestAccBedrockAgentAgent_agentCollaboration
=== RUN   TestAccBedrockAgentAgent_memoryConfiguration
=== PAUSE TestAccBedrockAgentAgent_memoryConfiguration
=== CONT  TestAccBedrockAgentAgent_basic
=== CONT  TestAccBedrockAgentAgent_agentCollaboration
=== CONT  TestAccBedrockAgentAgent_guardrail
--- PASS: TestAccBedrockAgentAgent_basic (35.44s)
=== CONT  TestAccBedrockAgentAgent_tags
--- PASS: TestAccBedrockAgentAgent_agentCollaboration (53.14s)
=== CONT  TestAccBedrockAgentAgent_kms
--- PASS: TestAccBedrockAgentAgent_guardrail (102.22s)
=== CONT  TestAccBedrockAgentAgent_singlePromptUpdate
--- PASS: TestAccBedrockAgentAgent_tags (82.34s)
=== CONT  TestAccBedrockAgentAgent_addPrompt
--- PASS: TestAccBedrockAgentAgent_kms (66.68s)
=== CONT  TestAccBedrockAgentAgent_memoryConfiguration
--- PASS: TestAccBedrockAgentAgent_memoryConfiguration (35.35s)
=== CONT  TestAccBedrockAgentAgent_update
--- PASS: TestAccBedrockAgentAgent_singlePromptUpdate (57.65s)
=== CONT  TestAccBedrockAgentAgent_singlePrompt
--- PASS: TestAccBedrockAgentAgent_singlePrompt (34.80s)
=== CONT  TestAccBedrockAgentAgent_full
--- PASS: TestAccBedrockAgentAgent_addPrompt (105.40s)
--- PASS: TestAccBedrockAgentAgent_update (77.94s)
--- PASS: TestAccBedrockAgentAgent_full (38.47s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       240.645s
```
