### PR TITLE
sweeper/aws_dataexchange_revision: listing revisions requires data set ID

### DIFF
--- a/internal/service/dataexchange/sweep.go
+++ b/internal/service/dataexchange/sweep.go
@@ -19,13 +19,12 @@ import (
 func RegisterSweepers() {
 	awsv2.Register("aws_dataexchange_data_set", sweepDataSets,
 		"aws_dataexchange_event_action",
+		"aws_dataexchange_revision",
 	)
 
 	awsv2.Register("aws_dataexchange_event_action", sweepEventActions)
 
-	awsv2.Register("aws_dataexchange_revision", sweepRevisions,
-		"aws_dataexchange_data_set",
-	)
+	awsv2.Register("aws_dataexchange_revision", sweepRevisions)
 }
 
 func sweepDataSets(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {


### PR DESCRIPTION
Fixes `aws_dataexchange_revision` sweeper to pass data set ID when listing revisions
