### PR TITLE
r/aws_instance: Improve retry for `RunInstances`

### DIFF
--- a/internal/retry2/deadline.go
+++ b/internal/retry2/deadline.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package retry2
+
+import (
+	"time"
+)
+
+type deadline time.Time
+
+func NewDeadline(duration time.Duration) deadline {
+	return deadline(time.Now().Add(duration))
+}
+
+func (d deadline) Remaining() time.Duration {
+	if v := time.Until(time.Time(d)); v < 0 {
+		return 0
+	} else {
+		return v
+	}
+}

--- a/internal/retry2/retry.go
+++ b/internal/retry2/retry.go
@@ -5,6 +5,8 @@ package retry2
 
 import (
 	"context"
+	"math"
+	"math/rand"
 	"time"
 )
 
@@ -15,11 +17,99 @@ type Timer interface {
 	After(time.Duration) <-chan time.Time
 }
 
+// DelayFunc returns the duration to wait before the next retry attempt.
+type DelayFunc func(uint) time.Duration
+
+// FixedDelay returns a delay that is the same through all iterations except the firts (when it is 0).
+func FixedDelay(delay time.Duration) DelayFunc {
+	return func(n uint) time.Duration {
+		if n == 0 {
+			return 0
+		}
+
+		return delay
+	}
+}
+
+// Do not use the default RNG since we do not want different provider instances
+// to pick the same deterministic random sequence.
+var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// ExponentialBackoffWithJitterDelay returns a duration of backoffMinDuration * backoffMultiplier**n, with added jitter.
+func ExponentialBackoffWithJitterDelay(backoffMinDuration time.Duration, backoffMultiplier float64) DelayFunc {
+	return func(n uint) time.Duration {
+		if n == 0 {
+			return 0
+		}
+
+		mult := math.Pow(backoffMultiplier, float64(n))
+		d := time.Duration(float64(backoffMinDuration) * mult)
+		const jitter = 0.4
+		mult = 1 - jitter*rng.Float64() // Subtract up to 40%.
+		return time.Duration(float64(d) * mult)
+	}
+}
+
+type sdkv2HelperRetryCompatibleDelay struct {
+	minTimeout   time.Duration
+	pollInterval time.Duration
+	wait         time.Duration
+}
+
+func (d *sdkv2HelperRetryCompatibleDelay) delay() time.Duration {
+	wait := d.wait
+
+	// First round had no wait.
+	if wait == 0 {
+		wait = 100 * time.Millisecond
+	}
+
+	wait *= 2
+
+	// If a poll interval has been specified, choose that interval.
+	// Otherwise bound the default value.
+	if d.pollInterval > 0 && d.pollInterval < 180*time.Second {
+		wait = d.pollInterval
+	} else {
+		if wait < d.minTimeout {
+			wait = d.minTimeout
+		} else if wait > 10*time.Second {
+			wait = 10 * time.Second
+		}
+	}
+
+	d.wait = wait
+
+	return wait
+}
+
+// SDKv2HelperRetryCompatibleDelay returns a Terraform Plugin SDK v2 helper/retry-compatible delay.
+func SDKv2HelperRetryCompatibleDelay(initialDelay, pollInterval, minTimeout time.Duration) DelayFunc {
+	delay := &sdkv2HelperRetryCompatibleDelay{
+		minTimeout:   minTimeout,
+		pollInterval: pollInterval,
+	}
+
+	return func(n uint) time.Duration {
+		if n == 0 {
+			return initialDelay
+		}
+
+		return delay.delay()
+	}
+}
+
+// DefaultSDKv2HelperRetryCompatibleDelay returns a Terraform Plugin SDK v2 helper/retry-compatible delay
+// with default values (from the `RetryContext` function).
+func DefaultSDKv2HelperRetryCompatibleDelay() DelayFunc {
+	return SDKv2HelperRetryCompatibleDelay(0, 0, 500*time.Millisecond)
+}
+
 // Config configures a retry loop.
 type Config struct {
-	delay    time.Duration
-	maxDelay time.Duration
-	timer    Timer
+	delay       DelayFunc
+	gracePeriod time.Duration
+	timer       Timer
 }
 
 // Option represents an option for retry.
@@ -27,17 +117,19 @@ type Option func(*Config)
 
 func emptyOption(c *Config) {}
 
-// WithDelay sets the delay between retries.
-func WithDelay(delay time.Duration) Option {
+func WithGracePeriod(d time.Duration) Option {
 	return func(c *Config) {
-		c.delay = delay
+		c.gracePeriod = d
 	}
 }
 
-// WithMaxDelay sets the maximum delay between retries.
-func WithMaxDelay(maxDelay time.Duration) Option {
+func WithDelay(d DelayFunc) Option {
+	if d == nil {
+		return emptyOption
+	}
+
 	return func(c *Config) {
-		c.maxDelay = maxDelay
+		c.delay = d
 	}
 }
 
@@ -58,31 +150,28 @@ func (t *timerImpl) After(d time.Duration) <-chan time.Time {
 }
 
 // The default Config is backwards compatible with github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.
-func defaultConfig() *Config {
-	return &Config{
-		timer: &timerImpl{},
+func defaultConfig() Config {
+	return Config{
+		delay:       DefaultSDKv2HelperRetryCompatibleDelay(),
+		gracePeriod: 30 * time.Second,
+		timer:       &timerImpl{},
 	}
 }
 
 // RetryWithTimeout holds state for managing retry loops with a timeout.
 type RetryWithTimeout struct {
-	config   *Config
-	attempt  int
+	attempt  uint
+	config   Config
 	deadline deadline
+	timedOut bool
 }
 
 // BeginWithOptions returns a new retry loop configured with the provided options.
 func BeginWithOptions(timeout time.Duration, opts ...Option) *RetryWithTimeout {
 	config := defaultConfig()
 	for _, opt := range opts {
-		opt(config)
+		opt(&config)
 	}
-
-	if timeout <= 0 {
-		timeout = 1<<63 - 1 // time.maxDuration
-	}
-
-	// TODO Backwards compatibel grace period.
 
 	return &RetryWithTimeout{
 		config:   config,
@@ -100,18 +189,40 @@ func Begin(timeout time.Duration) *RetryWithTimeout {
 // The first call does not sleep.
 func (r *RetryWithTimeout) Continue(ctx context.Context) bool {
 	if r.deadline.Remaining() == 0 {
-		return false
+		if r.config.gracePeriod == 0 {
+			r.timedOut = true
+			return false
+		}
+
+		r.deadline = NewDeadline(r.config.gracePeriod)
+		r.config.gracePeriod = 0
 	}
 
-	if r.attempt != 0 {
-		//randomizedSleep(ctx, r.backoffDelay())
-	}
+	r.sleep(ctx, r.config.delay(r.attempt))
 	r.attempt++
 
 	return true
 }
 
-// Reset resets a Retry to its initial state.
+// Reset resets a RetryWithTimeout to its initial state.
 func (r *RetryWithTimeout) Reset() {
 	r.attempt = 0
+}
+
+// TimedOut return whether the retry timed out.
+func (r *RetryWithTimeout) TimedOut() bool {
+	return r.timedOut
+}
+
+// Sleeps for the specified duration or until context is done, whichever occurs first.
+func (r *RetryWithTimeout) sleep(ctx context.Context, d time.Duration) {
+	if d == 0 {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-r.config.timer.After(d):
+	}
 }

--- a/internal/retry2/retry.go
+++ b/internal/retry2/retry.go
@@ -1,0 +1,117 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package retry2
+
+import (
+	"context"
+	"time"
+)
+
+// Inspired by https://github.com/ServiceWeaver/weaver and https://github.com/avast/retry-go.
+
+// Timer represents the timer used to track time for a retry.
+type Timer interface {
+	After(time.Duration) <-chan time.Time
+}
+
+// Config configures a retry loop.
+type Config struct {
+	delay    time.Duration
+	maxDelay time.Duration
+	timer    Timer
+}
+
+// Option represents an option for retry.
+type Option func(*Config)
+
+func emptyOption(c *Config) {}
+
+// WithDelay sets the delay between retries.
+func WithDelay(delay time.Duration) Option {
+	return func(c *Config) {
+		c.delay = delay
+	}
+}
+
+// WithMaxDelay sets the maximum delay between retries.
+func WithMaxDelay(maxDelay time.Duration) Option {
+	return func(c *Config) {
+		c.maxDelay = maxDelay
+	}
+}
+
+// WithTimer provides a way to swap out timer module implementations.
+// This primarily is useful for mocking/testing, where you may not want to explicitly wait for a set duration
+// for retries.
+func WithTimer(t Timer) Option {
+	return func(c *Config) {
+		c.timer = t
+	}
+}
+
+// Default timer is a wrapper around time.After
+type timerImpl struct{}
+
+func (t *timerImpl) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+// The default Config is backwards compatible with github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry.
+func defaultConfig() *Config {
+	return &Config{
+		timer: &timerImpl{},
+	}
+}
+
+// RetryWithTimeout holds state for managing retry loops with a timeout.
+type RetryWithTimeout struct {
+	config   *Config
+	attempt  int
+	deadline deadline
+}
+
+// BeginWithOptions returns a new retry loop configured with the provided options.
+func BeginWithOptions(timeout time.Duration, opts ...Option) *RetryWithTimeout {
+	config := defaultConfig()
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	if timeout <= 0 {
+		timeout = 1<<63 - 1 // time.maxDuration
+	}
+
+	// TODO Backwards compatibel grace period.
+
+	return &RetryWithTimeout{
+		config:   config,
+		deadline: NewDeadline(timeout),
+	}
+}
+
+// Begin returns a new retry loop configured with the default options.
+func Begin(timeout time.Duration) *RetryWithTimeout {
+	return BeginWithOptions(timeout)
+}
+
+// Continue sleeps between retry attempts.
+// It returns false if the timeout has been exceeded.
+// The first call does not sleep.
+func (r *RetryWithTimeout) Continue(ctx context.Context) bool {
+	if r.deadline.Remaining() == 0 {
+		return false
+	}
+
+	if r.attempt != 0 {
+		//randomizedSleep(ctx, r.backoffDelay())
+	}
+	r.attempt++
+
+	return true
+}
+
+// Reset resets a Retry to its initial state.
+func (r *RetryWithTimeout) Reset() {
+	r.attempt = 0
+}

--- a/internal/retry2/retry.go
+++ b/internal/retry2/retry.go
@@ -186,9 +186,9 @@ func Begin(timeout time.Duration) *RetryWithTimeout {
 
 // Continue sleeps between retry attempts.
 // It returns false if the timeout has been exceeded.
-// The first call does not sleep.
+// The deadline is not checked on the first call to Continue.
 func (r *RetryWithTimeout) Continue(ctx context.Context) bool {
-	if r.deadline.Remaining() == 0 {
+	if r.attempt != 0 && r.deadline.Remaining() == 0 {
 		if r.config.gracePeriod == 0 {
 			r.timedOut = true
 			return false

--- a/internal/retry2/retry_test.go
+++ b/internal/retry2/retry_test.go
@@ -1,0 +1,114 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package retry2
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDefaultSDKv2HelperRetryCompatibleDelay(t *testing.T) {
+	t.Parallel()
+
+	delay := DefaultSDKv2HelperRetryCompatibleDelay()
+	want := []time.Duration{
+		0,
+		500 * time.Millisecond,
+		1 * time.Second,
+		2 * time.Second,
+		4 * time.Second,
+		8 * time.Second,
+		10 * time.Second,
+		10 * time.Second,
+		10 * time.Second,
+		10 * time.Second,
+	}
+	var got []time.Duration
+	for i := range len(want) {
+		got = append(got, delay(uint(i)))
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+	}
+}
+
+func TestSDKv2HelperRetryCompatibleDelay(t *testing.T) {
+	t.Parallel()
+
+	delay := SDKv2HelperRetryCompatibleDelay(200*time.Millisecond, 0, 3*time.Second)
+	want := []time.Duration{
+		200 * time.Millisecond,
+		3 * time.Second,
+		6 * time.Second,
+		10 * time.Second,
+		10 * time.Second,
+	}
+	var got []time.Duration
+	for i := range len(want) {
+		got = append(got, delay(uint(i)))
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+	}
+}
+
+func TestSDKv2HelperRetryCompatibleDelayWithPollTimeout(t *testing.T) {
+	t.Parallel()
+
+	delay := SDKv2HelperRetryCompatibleDelay(200*time.Millisecond, 20*time.Second, 3*time.Second)
+	want := []time.Duration{
+		200 * time.Millisecond,
+		20 * time.Second,
+		20 * time.Second,
+		20 * time.Second,
+		20 * time.Second,
+	}
+	var got []time.Duration
+	for i := range len(want) {
+		got = append(got, delay(uint(i)))
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+	}
+}
+
+func TestRetryWithTimeoutDefaultGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var n int
+	for r := BeginWithOptions(1*time.Minute, WithDelay(FixedDelay(1*time.Second))); r.Continue(ctx); {
+		time.Sleep(35 * time.Second)
+		n++
+	}
+
+	// Want = 3 because of default 30s grace period.
+	if got, want := n, 3; got != want {
+		t.Errorf("Iterations = %v, want %v", got, want)
+	}
+}
+
+func TestRetryWithTimeoutNoGracePeriod(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	var n int
+	for r := BeginWithOptions(1*time.Minute, WithDelay(FixedDelay(1*time.Second)), WithGracePeriod(0)); r.Continue(ctx); {
+		time.Sleep(35 * time.Second)
+		n++
+	}
+
+	// Want = 2 because of no grace period.
+	if got, want := n, 2; got != want {
+		t.Errorf("Iterations = %v, want %v", got, want)
+	}
+}

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry2"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
@@ -1049,34 +1050,30 @@ func resourceInstanceCreate(ctx context.Context, d *schema.ResourceData, meta an
 		input.DisableApiStop = instanceOpts.DisableAPIStop
 	}
 
-	log.Printf("[DEBUG] Creating EC2 Instance: %s", d.Id())
-	outputRaw, err := tfresource.RetryWhen(ctx, iamPropagationTimeout,
-		func() (any, error) {
-			return conn.RunInstances(ctx, &input)
-		},
-		func(err error) (bool, error) {
-			// IAM instance profiles can take ~10 seconds to propagate in AWS:
-			// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Invalid IAM Instance Profile") {
-				return true, err
-			}
+	var output *ec2.RunInstancesOutput
+	for r := retry2.Begin(iamPropagationTimeout); r.Continue(ctx); {
+		output, err = conn.RunInstances(ctx, &input)
 
-			// IAM roles can also take time to propagate in AWS:
-			if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, " has no associated IAM Roles") {
-				return true, err
-			}
+		// IAM instance profiles can take ~10 seconds to propagate in AWS:
+		// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
+		if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, "Invalid IAM Instance Profile") {
+			continue
+		}
 
-			return false, err
-		},
-	)
+		// IAM roles can also take time to propagate in AWS:
+		if tfawserr.ErrMessageContains(err, errCodeInvalidParameterValue, " has no associated IAM Roles") {
+			continue
+		}
+
+		break
+	}
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Instance: %s", err)
 	}
 
-	instanceId := outputRaw.(*ec2.RunInstancesOutput).Instances[0].InstanceId
-
-	d.SetId(aws.ToString(instanceId))
+	instanceID := output.Instances[0].InstanceId
+	d.SetId(aws.ToString(instanceID))
 
 	instance, err := waitInstanceCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate))
 

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -4769,7 +4769,7 @@ func TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "credit_specification.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "unlimited"),
+					resource.TestCheckResourceAttr(resourceName, "credit_specification.0.cpu_credits", "standard"),
 				),
 			},
 			{


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Addresses the retry issues with `RunInstances` for the `aws_instance` resource as described in https://github.com/hashicorp/terraform-provider-aws/issues/42554.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Requires https://github.com/hashicorp/terraform-provider-aws/pull/42621.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% ACCTEST_TIMEOUT=720m make testacc TESTARGS='-run=TestAccEC2Instance_' PKG=ec2 ACCTEST_PARALLELISM=8
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/ec2/... -v -count 1 -parallel 8  -run=TestAccEC2Instance_ -timeout 720m -vet=off
2025/05/14 15:27:57 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2Instance_tags
=== PAUSE TestAccEC2Instance_tags
=== RUN   TestAccEC2Instance_tags_null
=== PAUSE TestAccEC2Instance_tags_null
=== RUN   TestAccEC2Instance_tags_EmptyMap
=== PAUSE TestAccEC2Instance_tags_EmptyMap
=== RUN   TestAccEC2Instance_tags_AddOnUpdate
=== PAUSE TestAccEC2Instance_tags_AddOnUpdate
=== RUN   TestAccEC2Instance_tags_EmptyTag_OnCreate
=== PAUSE TestAccEC2Instance_tags_EmptyTag_OnCreate
=== RUN   TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add
=== PAUSE TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add
=== RUN   TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace
=== PAUSE TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace
=== RUN   TestAccEC2Instance_tags_DefaultTags_providerOnly
=== PAUSE TestAccEC2Instance_tags_DefaultTags_providerOnly
=== RUN   TestAccEC2Instance_tags_DefaultTags_nonOverlapping
=== PAUSE TestAccEC2Instance_tags_DefaultTags_nonOverlapping
=== RUN   TestAccEC2Instance_tags_DefaultTags_overlapping
=== PAUSE TestAccEC2Instance_tags_DefaultTags_overlapping
=== RUN   TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly
=== PAUSE TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly
=== RUN   TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly
=== PAUSE TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly
=== RUN   TestAccEC2Instance_tags_DefaultTags_emptyResourceTag
=== PAUSE TestAccEC2Instance_tags_DefaultTags_emptyResourceTag
=== RUN   TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag
=== PAUSE TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag
=== RUN   TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag
=== PAUSE TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag
=== RUN   TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag
=== PAUSE TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag
=== RUN   TestAccEC2Instance_tags_ComputedTag_OnCreate
=== PAUSE TestAccEC2Instance_tags_ComputedTag_OnCreate
=== RUN   TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add
=== PAUSE TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add
=== RUN   TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace
=== PAUSE TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace
=== RUN   TestAccEC2Instance_tags_IgnoreTags_Overlap_DefaultTag
=== PAUSE TestAccEC2Instance_tags_IgnoreTags_Overlap_DefaultTag
=== RUN   TestAccEC2Instance_tags_IgnoreTags_Overlap_ResourceTag
=== PAUSE TestAccEC2Instance_tags_IgnoreTags_Overlap_ResourceTag
=== RUN   TestAccEC2Instance_basic
=== PAUSE TestAccEC2Instance_basic
=== RUN   TestAccEC2Instance_disappears
=== PAUSE TestAccEC2Instance_disappears
=== RUN   TestAccEC2Instance_inDefaultVPCBySgName
=== PAUSE TestAccEC2Instance_inDefaultVPCBySgName
=== RUN   TestAccEC2Instance_inDefaultVPCBySgID
=== PAUSE TestAccEC2Instance_inDefaultVPCBySgID
=== RUN   TestAccEC2Instance_atLeastOneOtherEBSVolume
=== PAUSE TestAccEC2Instance_atLeastOneOtherEBSVolume
=== RUN   TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
=== PAUSE TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
=== RUN   TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== PAUSE TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
=== RUN   TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== PAUSE TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
=== RUN   TestAccEC2Instance_RootBlockDevice_kmsKeyARN
=== PAUSE TestAccEC2Instance_RootBlockDevice_kmsKeyARN
=== RUN   TestAccEC2Instance_userDataBase64
=== PAUSE TestAccEC2Instance_userDataBase64
=== RUN   TestAccEC2Instance_userDataBase64_updateWithBashFile
=== PAUSE TestAccEC2Instance_userDataBase64_updateWithBashFile
=== RUN   TestAccEC2Instance_userDataBase64_updateWithZipFile
=== PAUSE TestAccEC2Instance_userDataBase64_updateWithZipFile
=== RUN   TestAccEC2Instance_userDataBase64_update
=== PAUSE TestAccEC2Instance_userDataBase64_update
=== RUN   TestAccEC2Instance_gp2IopsDevice
=== PAUSE TestAccEC2Instance_gp2IopsDevice
=== RUN   TestAccEC2Instance_gp2WithIopsValue
=== PAUSE TestAccEC2Instance_gp2WithIopsValue
=== RUN   TestAccEC2Instance_blockDevices
=== PAUSE TestAccEC2Instance_blockDevices
=== RUN   TestAccEC2Instance_rootInstanceStore
=== PAUSE TestAccEC2Instance_rootInstanceStore
=== RUN   TestAccEC2Instance_noAMIEphemeralDevices
=== PAUSE TestAccEC2Instance_noAMIEphemeralDevices
=== RUN   TestAccEC2Instance_sourceDestCheck
=== PAUSE TestAccEC2Instance_sourceDestCheck
=== RUN   TestAccEC2Instance_autoRecovery
=== PAUSE TestAccEC2Instance_autoRecovery
=== RUN   TestAccEC2Instance_disableAPIStop
=== PAUSE TestAccEC2Instance_disableAPIStop
=== RUN   TestAccEC2Instance_disableAPITerminationFinalFalse
=== PAUSE TestAccEC2Instance_disableAPITerminationFinalFalse
=== RUN   TestAccEC2Instance_disableAPITerminationFinalTrue
=== PAUSE TestAccEC2Instance_disableAPITerminationFinalTrue
=== RUN   TestAccEC2Instance_dedicatedInstance
=== PAUSE TestAccEC2Instance_dedicatedInstance
=== RUN   TestAccEC2Instance_outpost
=== PAUSE TestAccEC2Instance_outpost
=== RUN   TestAccEC2Instance_placementGroup
=== PAUSE TestAccEC2Instance_placementGroup
=== RUN   TestAccEC2Instance_placementPartitionNumber
=== PAUSE TestAccEC2Instance_placementPartitionNumber
=== RUN   TestAccEC2Instance_IPv6_supportAddressCount
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCount
=== RUN   TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccEC2Instance_IPv6_primaryEnable
=== PAUSE TestAccEC2Instance_IPv6_primaryEnable
=== RUN   TestAccEC2Instance_IPv6_primaryDisable
=== PAUSE TestAccEC2Instance_IPv6_primaryDisable
=== RUN   TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== RUN   TestAccEC2Instance_IPv6AddressCount
=== PAUSE TestAccEC2Instance_IPv6AddressCount
=== RUN   TestAccEC2Instance_networkInstanceSecurityGroups
=== PAUSE TestAccEC2Instance_networkInstanceSecurityGroups
=== RUN   TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
=== PAUSE TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
=== RUN   TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
=== PAUSE TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
=== RUN   TestAccEC2Instance_BlockDeviceTags_volumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_volumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== PAUSE TestAccEC2Instance_BlockDeviceTags_attachedVolume
=== RUN   TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
=== RUN   TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
=== PAUSE TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
=== RUN   TestAccEC2Instance_instanceProfileChange
=== PAUSE TestAccEC2Instance_instanceProfileChange
=== RUN   TestAccEC2Instance_iamInstanceProfile
=== PAUSE TestAccEC2Instance_iamInstanceProfile
=== RUN   TestAccEC2Instance_iamInstanceProfilePath
=== PAUSE TestAccEC2Instance_iamInstanceProfilePath
=== RUN   TestAccEC2Instance_privateIP
=== PAUSE TestAccEC2Instance_privateIP
=== RUN   TestAccEC2Instance_associatePublicIPAndPrivateIP
=== PAUSE TestAccEC2Instance_associatePublicIPAndPrivateIP
=== RUN   TestAccEC2Instance_Empty_privateIP
=== PAUSE TestAccEC2Instance_Empty_privateIP
=== RUN   TestAccEC2Instance_PrivateDNSNameOptions_computed
=== PAUSE TestAccEC2Instance_PrivateDNSNameOptions_computed
=== RUN   TestAccEC2Instance_PrivateDNSNameOptions_configured
=== PAUSE TestAccEC2Instance_PrivateDNSNameOptions_configured
=== RUN   TestAccEC2Instance_keyPairCheck
=== PAUSE TestAccEC2Instance_keyPairCheck
=== RUN   TestAccEC2Instance_forceNewAndTagsDrift
=== PAUSE TestAccEC2Instance_forceNewAndTagsDrift
=== RUN   TestAccEC2Instance_changeInstanceType
=== PAUSE TestAccEC2Instance_changeInstanceType
=== RUN   TestAccEC2Instance_changeInstanceTypeReplace
=== PAUSE TestAccEC2Instance_changeInstanceTypeReplace
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserData
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserData
=== RUN   TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== PAUSE TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
=== RUN   TestAccEC2Instance_EBSRootDevice_basic
=== PAUSE TestAccEC2Instance_EBSRootDevice_basic
=== RUN   TestAccEC2Instance_EBSRootDevice_modifySize
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifySize
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyType
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyType
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
=== RUN   TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
=== PAUSE TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
=== RUN   TestAccEC2Instance_EBSRootDevice_modifyAll
=== PAUSE TestAccEC2Instance_EBSRootDevice_modifyAll
=== RUN   TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
=== PAUSE TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
=== RUN   TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
=== PAUSE TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
=== RUN   TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
=== PAUSE TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
=== RUN   TestAccEC2Instance_gp3RootBlockDevice
=== PAUSE TestAccEC2Instance_gp3RootBlockDevice
=== RUN   TestAccEC2Instance_primaryNetworkInterface
=== PAUSE TestAccEC2Instance_primaryNetworkInterface
=== RUN   TestAccEC2Instance_networkCardIndex
=== PAUSE TestAccEC2Instance_networkCardIndex
=== RUN   TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
=== PAUSE TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
=== RUN   TestAccEC2Instance_addSecondaryInterface
=== PAUSE TestAccEC2Instance_addSecondaryInterface
=== RUN   TestAccEC2Instance_addSecurityGroupNetworkInterface
=== PAUSE TestAccEC2Instance_addSecurityGroupNetworkInterface
=== RUN   TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
=== PAUSE TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
=== RUN   TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
=== PAUSE TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
=== RUN   TestAccEC2Instance_AssociatePublic_defaultPrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_defaultPrivate
=== RUN   TestAccEC2Instance_AssociatePublic_defaultPublic
=== PAUSE TestAccEC2Instance_AssociatePublic_defaultPublic
=== RUN   TestAccEC2Instance_AssociatePublic_explicitPublic
=== PAUSE TestAccEC2Instance_AssociatePublic_explicitPublic
=== RUN   TestAccEC2Instance_AssociatePublic_explicitPrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_explicitPrivate
=== RUN   TestAccEC2Instance_AssociatePublic_overridePublic
=== PAUSE TestAccEC2Instance_AssociatePublic_overridePublic
=== RUN   TestAccEC2Instance_AssociatePublic_overridePrivate
=== PAUSE TestAccEC2Instance_AssociatePublic_overridePrivate
=== RUN   TestAccEC2Instance_LaunchTemplate_basic
=== PAUSE TestAccEC2Instance_LaunchTemplate_basic
=== RUN   TestAccEC2Instance_LaunchTemplate_overrideTemplate
=== PAUSE TestAccEC2Instance_LaunchTemplate_overrideTemplate
=== RUN   TestAccEC2Instance_LaunchTemplate_setSpecificVersion
=== PAUSE TestAccEC2Instance_LaunchTemplate_setSpecificVersion
=== RUN   TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
=== PAUSE TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
=== RUN   TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
=== PAUSE TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
=== RUN   TestAccEC2Instance_LaunchTemplate_swapIDAndName
=== PAUSE TestAccEC2Instance_LaunchTemplate_swapIDAndName
=== RUN   TestAccEC2Instance_LaunchTemplate_iamInstanceProfile
=== PAUSE TestAccEC2Instance_LaunchTemplate_iamInstanceProfile
=== RUN   TestAccEC2Instance_LaunchTemplate_spotAndStop
=== PAUSE TestAccEC2Instance_LaunchTemplate_spotAndStop
=== RUN   TestAccEC2Instance_LaunchTemplate_vpcSecurityGroup
=== PAUSE TestAccEC2Instance_LaunchTemplate_vpcSecurityGroup
=== RUN   TestAccEC2Instance_GetPasswordData_falseToTrue
=== PAUSE TestAccEC2Instance_GetPasswordData_falseToTrue
=== RUN   TestAccEC2Instance_GetPasswordData_trueToFalse
=== PAUSE TestAccEC2Instance_GetPasswordData_trueToFalse
=== RUN   TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToDisabledToEnabledToUnspecified
=== PAUSE TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToDisabledToEnabledToUnspecified
=== RUN   TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToEnabledToDisabledToUnspecified
=== PAUSE TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToEnabledToDisabledToUnspecified
=== RUN   TestAccEC2Instance_cpuOptionsAmdSevSnpEnabledToDisabled
=== PAUSE TestAccEC2Instance_cpuOptionsAmdSevSnpEnabledToDisabled
=== RUN   TestAccEC2Instance_cpuOptionsAmdSevSnpDisabledToEnabled
=== PAUSE TestAccEC2Instance_cpuOptionsAmdSevSnpDisabledToEnabled
=== RUN   TestAccEC2Instance_cpuOptionsAmdSevSnpCoreThreads
=== PAUSE TestAccEC2Instance_cpuOptionsAmdSevSnpCoreThreads
=== RUN   TestAccEC2Instance_cpuOptionsCoreThreads
=== PAUSE TestAccEC2Instance_cpuOptionsCoreThreads
=== RUN   TestAccEC2Instance_cpuOptionsCoreThreadsMigration
=== PAUSE TestAccEC2Instance_cpuOptionsCoreThreadsMigration
=== RUN   TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
=== PAUSE TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
=== RUN   TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
=== RUN   TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
=== RUN   TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
=== PAUSE TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
=== RUN   TestAccEC2Instance_CreditSpecification_standardCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_standardCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a
=== RUN   TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g
=== PAUSE TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g
=== RUN   TestAccEC2Instance_CreditSpecification_updateCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecification_updateCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
=== PAUSE TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
=== RUN   TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
=== RUN   TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
=== PAUSE TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
=== RUN   TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
=== PAUSE TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
=== RUN   TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
=== PAUSE TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
=== RUN   TestAccEC2Instance_UserData
=== PAUSE TestAccEC2Instance_UserData
=== RUN   TestAccEC2Instance_UserData_update
=== PAUSE TestAccEC2Instance_UserData_update
=== RUN   TestAccEC2Instance_UserData_stringToEncodedString
=== PAUSE TestAccEC2Instance_UserData_stringToEncodedString
=== RUN   TestAccEC2Instance_UserData_emptyStringToUnspecified
=== PAUSE TestAccEC2Instance_UserData_emptyStringToUnspecified
=== RUN   TestAccEC2Instance_UserData_unspecifiedToEmptyString
=== PAUSE TestAccEC2Instance_UserData_unspecifiedToEmptyString
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_On
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_On
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_Off
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_Off
=== RUN   TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
=== PAUSE TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
=== RUN   TestAccEC2Instance_hibernation
=== PAUSE TestAccEC2Instance_hibernation
=== RUN   TestAccEC2Instance_metadataOptions
=== PAUSE TestAccEC2Instance_metadataOptions
=== RUN   TestAccEC2Instance_enclaveOptions
=== PAUSE TestAccEC2Instance_enclaveOptions
=== RUN   TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== PAUSE TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
=== RUN   TestAccEC2Instance_CapacityReservationPreference_open
=== PAUSE TestAccEC2Instance_CapacityReservationPreference_open
=== RUN   TestAccEC2Instance_CapacityReservationPreference_none
=== PAUSE TestAccEC2Instance_CapacityReservationPreference_none
=== RUN   TestAccEC2Instance_CapacityReservation_targetID
=== PAUSE TestAccEC2Instance_CapacityReservation_targetID
=== RUN   TestAccEC2Instance_CapacityReservation_modifyPreference
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyPreference
=== RUN   TestAccEC2Instance_CapacityReservation_modifyTarget
=== PAUSE TestAccEC2Instance_CapacityReservation_modifyTarget
=== RUN   TestAccEC2Instance_basicWithSpot
=== PAUSE TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_tags
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyType
=== CONT  TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits
=== CONT  TestAccEC2Instance_cpuOptionsAmdSevSnpCoreThreads
=== CONT  TestAccEC2Instance_AssociatePublic_defaultPublic
=== CONT  TestAccEC2Instance_basicWithSpot
=== CONT  TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint
=== CONT  TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint
=== NAME  TestAccEC2Instance_cpuOptionsAmdSevSnpCoreThreads
    ec2_instance_test.go:4307: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccEC2Instance_cpuOptionsAmdSevSnpCoreThreads (0.61s)
=== CONT  TestAccEC2Instance_cpuOptionsAmdSevSnpDisabledToEnabled
    ec2_instance_test.go:4258: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccEC2Instance_cpuOptionsAmdSevSnpDisabledToEnabled (0.00s)
=== CONT  TestAccEC2Instance_cpuOptionsAmdSevSnpEnabledToDisabled
    ec2_instance_test.go:4214: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccEC2Instance_cpuOptionsAmdSevSnpEnabledToDisabled (0.00s)
=== CONT  TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToEnabledToDisabledToUnspecified
    ec2_instance_test.go:4148: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToEnabledToDisabledToUnspecified (0.00s)
=== CONT  TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToDisabledToEnabledToUnspecified
    ec2_instance_test.go:4081: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-2]
--- SKIP: TestAccEC2Instance_cpuOptionsAmdSevSnpUnspecifiedToDisabledToEnabledToUnspecified (0.00s)
=== CONT  TestAccEC2Instance_GetPasswordData_trueToFalse
--- PASS: TestAccEC2Instance_basicWithSpot (136.33s)
=== CONT  TestAccEC2Instance_GetPasswordData_falseToTrue
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPublic (208.30s)
=== CONT  TestAccEC2Instance_LaunchTemplate_vpcSecurityGroup
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyType (218.36s)
=== CONT  TestAccEC2Instance_LaunchTemplate_spotAndStop
--- PASS: TestAccEC2Instance_CreditSpecificationT3_updateCPUCredits (249.64s)
=== CONT  TestAccEC2Instance_LaunchTemplate_iamInstanceProfile
--- PASS: TestAccEC2Instance_CreditSpecificationStandardCPUCredits_t2Tot3Taint (266.10s)
=== CONT  TestAccEC2Instance_LaunchTemplate_swapIDAndName
--- PASS: TestAccEC2Instance_tags (305.43s)
=== CONT  TestAccEC2Instance_LaunchTemplate_updateTemplateVersion
--- PASS: TestAccEC2Instance_LaunchTemplate_spotAndStop (104.28s)
=== CONT  TestAccEC2Instance_CapacityReservation_modifyTarget
--- PASS: TestAccEC2Instance_CreditSpecificationUnlimitedCPUCredits_t2Tot3Taint (324.69s)
=== CONT  TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion
--- PASS: TestAccEC2Instance_LaunchTemplate_vpcSecurityGroup (123.66s)
=== CONT  TestAccEC2Instance_CapacityReservation_modifyPreference
--- PASS: TestAccEC2Instance_LaunchTemplate_iamInstanceProfile (111.11s)
=== CONT  TestAccEC2Instance_LaunchTemplate_setSpecificVersion
--- PASS: TestAccEC2Instance_GetPasswordData_trueToFalse (363.75s)
=== CONT  TestAccEC2Instance_CapacityReservation_targetID
--- PASS: TestAccEC2Instance_GetPasswordData_falseToTrue (261.19s)
=== CONT  TestAccEC2Instance_LaunchTemplate_overrideTemplate
--- PASS: TestAccEC2Instance_LaunchTemplate_swapIDAndName (166.15s)
=== CONT  TestAccEC2Instance_CapacityReservationPreference_none
--- PASS: TestAccEC2Instance_LaunchTemplateModifyTemplate_defaultVersion (122.17s)
=== CONT  TestAccEC2Instance_CapacityReservationPreference_open
--- PASS: TestAccEC2Instance_CapacityReservation_targetID (112.96s)
=== CONT  TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen
--- PASS: TestAccEC2Instance_LaunchTemplate_setSpecificVersion (141.42s)
=== CONT  TestAccEC2Instance_LaunchTemplate_basic
=== NAME  TestAccEC2Instance_CapacityReservation_modifyTarget
    acctest.go:1552: skipping test for aws/us-west-2: Error running apply: exit status 1
        
        Error: starting EC2 Instance (i-085f7e20219ab9617): operation error EC2: StartInstances, https response error StatusCode: 400, RequestID: 67f216e7-6f48-4978-a750-fd2b3f6ab581, api error ReservationCapacityExceeded: The requested reservation does not have sufficient compatible and available capacity for this request.
        
          with aws_instance.test,
          on terraform_plugin_test.tf line 50, in resource "aws_instance" "test":
          50: resource "aws_instance" "test" {
        
--- SKIP: TestAccEC2Instance_CapacityReservation_modifyTarget (200.31s)
=== CONT  TestAccEC2Instance_enclaveOptions
--- PASS: TestAccEC2Instance_LaunchTemplate_overrideTemplate (126.88s)
=== CONT  TestAccEC2Instance_metadataOptions
--- PASS: TestAccEC2Instance_CapacityReservationPreference_open (92.36s)
=== CONT  TestAccEC2Instance_AssociatePublic_overridePrivate
--- PASS: TestAccEC2Instance_CapacityReservationPreference_none (111.92s)
=== CONT  TestAccEC2Instance_hibernation
--- PASS: TestAccEC2Instance_LaunchTemplate_updateTemplateVersion (297.25s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64
--- PASS: TestAccEC2Instance_LaunchTemplate_basic (119.43s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_Off
--- PASS: TestAccEC2Instance_CapacityReservation_unspecifiedDefaultsToOpen (169.73s)
=== CONT  TestAccEC2Instance_AssociatePublic_overridePublic
--- PASS: TestAccEC2Instance_AssociatePublic_overridePrivate (128.68s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_On_Base64
--- PASS: TestAccEC2Instance_CapacityReservation_modifyPreference (355.78s)
=== CONT  TestAccEC2Instance_UserDataReplaceOnChange_On
--- PASS: TestAccEC2Instance_enclaveOptions (230.11s)
=== CONT  TestAccEC2Instance_AssociatePublic_explicitPrivate
--- PASS: TestAccEC2Instance_hibernation (244.72s)
=== CONT  TestAccEC2Instance_UserData_emptyStringToUnspecified
--- PASS: TestAccEC2Instance_metadataOptions (284.54s)
=== CONT  TestAccEC2Instance_UserData_unspecifiedToEmptyString
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPrivate (125.22s)
=== CONT  TestAccEC2Instance_UserData_stringToEncodedString
--- PASS: TestAccEC2Instance_UserData_emptyStringToUnspecified (120.81s)
=== CONT  TestAccEC2Instance_UserData_update
--- PASS: TestAccEC2Instance_UserData_unspecifiedToEmptyString (168.01s)
=== CONT  TestAccEC2Instance_AssociatePublic_explicitPublic
--- PASS: TestAccEC2Instance_AssociatePublic_overridePublic (338.36s)
=== CONT  TestAccEC2Instance_UserData
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off (389.44s)
=== CONT  TestAccEC2Instance_autoRecovery
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_Off_Base64 (414.16s)
=== CONT  TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On_Base64 (414.87s)
=== CONT  TestAccEC2Instance_primaryNetworkInterface
--- PASS: TestAccEC2Instance_UserDataReplaceOnChange_On (424.32s)
=== CONT  TestAccEC2Instance_networkCardIndex
--- PASS: TestAccEC2Instance_autoRecovery (144.22s)
=== CONT  TestAccEC2Instance_AssociatePublic_defaultPrivate
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifySize (181.26s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccEC2Instance_networkCardIndex (125.16s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPs (83.35s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate
--- PASS: TestAccEC2Instance_AssociatePublic_explicitPublic (367.87s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_UserData_update (436.66s)
=== CONT  TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs
--- PASS: TestAccEC2Instance_UserData (368.19s)
=== CONT  TestAccEC2Instance_addSecurityGroupNetworkInterface
--- PASS: TestAccEC2Instance_UserData_stringToEncodedString (495.61s)
=== CONT  TestAccEC2Instance_addSecondaryInterface
--- PASS: TestAccEC2Instance_NewNetworkInterface_privateIPAndSecondaryPrivateIPsUpdate (187.04s)
=== CONT  TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccEC2Instance_primaryNetworkInterface (339.06s)
=== CONT  TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPs (124.60s)
=== CONT  TestAccEC2Instance_gp3RootBlockDevice
--- PASS: TestAccEC2Instance_AssociatePublic_defaultPrivate (316.62s)
=== CONT  TestAccEC2Instance_basic
--- PASS: TestAccEC2Instance_NewNetworkInterface_emptyPrivateIPAndSecondaryPrivateIPsUpdate (173.05s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccEC2Instance_EBSRootDeviceMultipleBlockDevices_modifyDeleteOnTermination (151.26s)
=== CONT  TestAccEC2Instance_sourceDestCheck
--- PASS: TestAccEC2Instance_gp3RootBlockDevice (107.14s)
=== CONT  TestAccEC2Instance_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccEC2Instance_NewNetworkInterface_publicIPAndSecondaryPrivateIPs (249.26s)
=== CONT  TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices
--- PASS: TestAccEC2Instance_basic (136.68s)
=== CONT  TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly (163.39s)
=== CONT  TestAccEC2Instance_noAMIEphemeralDevices
--- PASS: TestAccEC2Instance_EBSRootDevice_multipleDynamicEBSBlockDevices (74.10s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags
--- PASS: TestAccEC2Instance_addSecurityGroupNetworkInterface (318.68s)
=== CONT  TestAccEC2Instance_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccEC2Instance_addSecondaryInterface (320.35s)
=== CONT  TestAccEC2Instance_EBSRootDevice_basic
--- PASS: TestAccEC2Instance_primaryNetworkInterfaceSourceDestCheck (328.68s)
=== CONT  TestAccEC2Instance_rootInstanceStore
--- PASS: TestAccEC2Instance_tags_IgnoreTags_Overlap_ResourceTag (163.51s)
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserDataBase64
--- PASS: TestAccEC2Instance_sourceDestCheck (176.87s)
=== CONT  TestAccEC2Instance_blockDevices
--- PASS: TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace (141.81s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifySize
--- PASS: TestAccEC2Instance_noAMIEphemeralDevices (116.47s)
=== CONT  TestAccEC2Instance_gp2WithIopsValue
--- PASS: TestAccEC2Instance_gp2WithIopsValue (11.14s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_ebsAndRoot
--- PASS: TestAccEC2Instance_EBSRootDevice_basic (107.24s)
=== CONT  TestAccEC2Instance_gp2IopsDevice
--- PASS: TestAccEC2Instance_tags_IgnoreTags_Overlap_DefaultTag (177.78s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_attachedVolume
--- PASS: TestAccEC2Instance_blockDevices (128.71s)
=== CONT  TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccEC2Instance_EBSRootDevice_modifySize (144.03s)
=== CONT  TestAccEC2Instance_tags_ComputedTag_OnCreate
--- PASS: TestAccEC2Instance_BlockDeviceTags_ebsAndRoot (138.95s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_volumeTags
--- PASS: TestAccEC2Instance_gp2IopsDevice (127.09s)
=== CONT  TestAccEC2Instance_userDataBase64_update
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTags (267.70s)
=== CONT  TestAccEC2Instance_userDataBase64_updateWithZipFile
--- PASS: TestAccEC2Instance_rootInstanceStore (269.86s)
=== CONT  TestAccEC2Instance_userDataBase64_updateWithBashFile
--- PASS: TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add (168.68s)
=== CONT  TestAccEC2Instance_userDataBase64
--- PASS: TestAccEC2Instance_tags_ComputedTag_OnCreate (163.86s)
=== CONT  TestAccEC2Instance_RootBlockDevice_kmsKeyARN
--- PASS: TestAccEC2Instance_BlockDeviceTags_attachedVolume (229.81s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed
--- PASS: TestAccEC2Instance_userDataBase64_update (197.97s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType
--- PASS: TestAccEC2Instance_BlockDeviceTags_volumeTags (206.97s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidThroughputForVolumeType (11.66s)
=== CONT  TestAccEC2Instance_EBSBlockDevice_kmsKeyARN
--- PASS: TestAccEC2Instance_EBSBlockDevice_invalidIopsForVolumeType (11.30s)
=== CONT  TestAccEC2Instance_atLeastOneOtherEBSVolume
--- PASS: TestAccEC2Instance_userDataBase64 (126.18s)
=== CONT  TestAccEC2Instance_inDefaultVPCBySgID
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserDataBase64 (453.44s)
=== CONT  TestAccEC2Instance_inDefaultVPCBySgName
--- PASS: TestAccEC2Instance_RootBlockDevice_kmsKeyARN (166.15s)
=== CONT  TestAccEC2Instance_disappears
--- PASS: TestAccEC2Instance_EBSBlockDevice_kmsKeyARN (106.99s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCount
--- PASS: TestAccEC2Instance_EBSBlockDevice_RootBlockDevice_removed (181.34s)
=== CONT  TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups
--- PASS: TestAccEC2Instance_userDataBase64_updateWithZipFile (433.20s)
=== CONT  TestAccEC2Instance_networkInstanceSecurityGroups
--- PASS: TestAccEC2Instance_networkInstanceRemovingAllSecurityGroups (116.53s)
=== CONT  TestAccEC2Instance_IPv6AddressCount
--- PASS: TestAccEC2Instance_userDataBase64_updateWithBashFile (471.32s)
=== CONT  TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccEC2Instance_inDefaultVPCBySgID (324.47s)
=== CONT  TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs
--- PASS: TestAccEC2Instance_atLeastOneOtherEBSVolume (387.77s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccEC2Instance_IPv6AddressCount (167.66s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccEC2Instance_inDefaultVPCBySgName (365.52s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_overlapping
--- PASS: TestAccEC2Instance_disappears (350.15s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace (142.21s)
=== CONT  TestAccEC2Instance_placementPartitionNumber
--- PASS: TestAccEC2Instance_networkInstanceVPCSecurityGroupIDs (117.78s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_nonOverlapping
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (388.48s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_providerOnly
--- PASS: TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag (109.99s)
=== CONT  TestAccEC2Instance_IPv6_primaryEnable
--- PASS: TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly (114.09s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2
--- PASS: TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag (158.57s)
=== CONT  TestAccEC2Instance_IPv6_primaryDisable
--- PASS: TestAccEC2Instance_networkInstanceSecurityGroups (108.73s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits
--- PASS: TestAccEC2Instance_placementPartitionNumber (119.04s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits
--- PASS: TestAccEC2Instance_tags_DefaultTags_overlapping (189.47s)
=== CONT  TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t2 (119.80s)
=== CONT  TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable
--- PASS: TestAccEC2Instance_IPv6_primaryEnable (177.12s)
=== CONT  TestAccEC2Instance_CreditSpecification_updateCPUCredits
--- PASS: TestAccEC2Instance_tags_DefaultTags_nonOverlapping (210.29s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unlimitedCPUCredits (123.89s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a
--- PASS: TestAccEC2Instance_CreditSpecificationT3_standardCPUCredits (120.95s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3
--- PASS: TestAccEC2Instance_CreditSpecificationT3_unspecifiedDefaultsToUnlimited (90.72s)
=== CONT  TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3a (79.19s)
=== CONT  TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError
--- PASS: TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError (0.85s)
=== CONT  TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits
--- PASS: TestAccEC2Instance_tags_DefaultTags_providerOnly (276.19s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccEC2Instance_CreditSpecification_isNotAppliedToNonBurstable (110.21s)
=== CONT  TestAccEC2Instance_CreditSpecification_standardCPUCredits
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t3 (111.51s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3
--- PASS: TestAccEC2Instance_CreditSpecification_updateCPUCredits (145.92s)
=== CONT  TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard
--- PASS: TestAccEC2Instance_CreditSpecificationUnspecifiedToEmpty_nonBurstable (160.69s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyAll
--- PASS: TestAccEC2Instance_tags_DefaultTags_emptyResourceTag (138.79s)
=== CONT  TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination
--- PASS: TestAccEC2Instance_CreditSpecification_standardCPUCredits (152.02s)
=== CONT  TestAccEC2Instance_keyPairCheck
--- PASS: TestAccEC2Instance_CreditSpecification_unlimitedCPUCredits (179.03s)
=== CONT  TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyThroughput_gp3 (173.45s)
=== CONT  TestAccEC2Instance_changeInstanceTypeAndUserData
--- PASS: TestAccEC2Instance_CreditSpecificationUnknownCPUCredits_t4g (153.93s)
=== CONT  TestAccEC2Instance_privateIP
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyAll (171.63s)
=== CONT  TestAccEC2Instance_iamInstanceProfilePath
--- PASS: TestAccEC2Instance_EBSRootDevice_modifyDeleteOnTermination (144.14s)
=== CONT  TestAccEC2Instance_iamInstanceProfile
--- PASS: TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag (109.91s)
=== CONT  TestAccEC2Instance_instanceProfileChange
--- PASS: TestAccEC2Instance_CreditSpecification_unspecifiedDefaultsToStandard (336.37s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap
--- PASS: TestAccEC2Instance_IPv6_primaryDisable (686.82s)
=== CONT  TestAccEC2Instance_associatePublicIPAndPrivateIP
--- PASS: TestAccEC2Instance_keyPairCheck (352.94s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps
--- PASS: TestAccEC2Instance_instanceProfileChange (266.57s)
=== CONT  TestAccEC2Instance_Empty_privateIP
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsVolumeTagsOverlap (165.00s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap
--- PASS: TestAccEC2Instance_privateIP (324.78s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2
--- PASS: TestAccEC2Instance_associatePublicIPAndPrivateIP (112.15s)
=== CONT  TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot
--- PASS: TestAccEC2Instance_iamInstanceProfilePath (350.19s)
=== CONT  TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1
--- PASS: TestAccEC2Instance_iamInstanceProfile (338.82s)
=== CONT  TestAccEC2Instance_disableAPITerminationFinalTrue
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsRBDOverlap (124.39s)
=== CONT  TestAccEC2Instance_outpost
    ec2_instance_test.go:1122: skipping since no Outposts found
--- SKIP: TestAccEC2Instance_outpost (0.56s)
=== CONT  TestAccEC2Instance_disableAPITerminationFinalFalse
--- PASS: TestAccEC2Instance_changeInstanceTypeAndUserData (495.87s)
=== CONT  TestAccEC2Instance_dedicatedInstance
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io2 (163.63s)
=== CONT  TestAccEC2Instance_tags_AddOnUpdate
--- PASS: TestAccEC2Instance_EBSRootDeviceModifyIOPS_io1 (153.45s)
=== CONT  TestAccEC2Instance_placementGroup
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsEBSRoot (193.64s)
=== CONT  TestAccEC2Instance_tags_EmptyTag_OnCreate
--- PASS: TestAccEC2Instance_BlockDeviceTags_defaultTagsEBDOverlaps (300.96s)
=== CONT  TestAccEC2Instance_disableAPIStop
--- PASS: TestAccEC2Instance_dedicatedInstance (142.79s)
=== CONT  TestAccEC2Instance_tags_EmptyMap
--- PASS: TestAccEC2Instance_disableAPITerminationFinalFalse (173.21s)
=== CONT  TestAccEC2Instance_tags_null
--- PASS: TestAccEC2Instance_Empty_privateIP (314.22s)
=== CONT  TestAccEC2Instance_changeInstanceTypeReplace
--- PASS: TestAccEC2Instance_placementGroup (111.15s)
=== CONT  TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified
--- PASS: TestAccEC2Instance_tags_AddOnUpdate (160.46s)
=== CONT  TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable
--- PASS: TestAccEC2Instance_tags_EmptyTag_OnCreate (150.29s)
=== CONT  TestAccEC2Instance_cpuOptionsCoreThreadsMigration
--- PASS: TestAccEC2Instance_tags_null (124.36s)
=== CONT  TestAccEC2Instance_cpuOptionsCoreThreads
--- PASS: TestAccEC2Instance_disableAPITerminationFinalTrue (367.23s)
=== CONT  TestAccEC2Instance_PrivateDNSNameOptions_configured
--- PASS: TestAccEC2Instance_CreditSpecificationEmpty_nonBurstable (89.36s)
=== CONT  TestAccEC2Instance_PrivateDNSNameOptions_computed
--- PASS: TestAccEC2Instance_disableAPIStop (183.06s)
=== CONT  TestAccEC2Instance_changeInstanceType
--- PASS: TestAccEC2Instance_cpuOptionsCoreThreadsUnspecifiedToSpecified (140.45s)
=== CONT  TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccEC2Instance_tags_EmptyMap (166.62s)
=== CONT  TestAccEC2Instance_forceNewAndTagsDrift
--- PASS: TestAccEC2Instance_changeInstanceTypeReplace (174.36s)
=== CONT  TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
--- PASS: TestAccEC2Instance_cpuOptionsCoreThreadsMigration (172.34s)
--- PASS: TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add (191.70s)
--- PASS: TestAccEC2Instance_cpuOptionsCoreThreads (246.48s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_configured (268.80s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (356.11s)
--- PASS: TestAccEC2Instance_PrivateDNSNameOptions_computed (420.70s)
--- PASS: TestAccEC2Instance_changeInstanceType (448.32s)
--- PASS: TestAccEC2Instance_forceNewAndTagsDrift (454.19s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	4386.445s
```
