### PR TITLE
resource/aws_s3_bucket_lifecycle_configuration: Fixes `filter` validation to allow empty block

### DIFF
--- a/.changelog/42624.txt
+++ b/.changelog/42624.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_s3_bucket_lifecycle_configuration: No longer returns warning on empty `rule.filter`.
+```

--- a/internal/framework/validators/objectvalidator/at_most_one_of_children.go
+++ b/internal/framework/validators/objectvalidator/at_most_one_of_children.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectvalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/validators/internal"
+)
+
+// AtMostOneOfChildren checks that of a set of path.Expression,
+// at most one has a non-null value.
+func AtMostOneOfChildren(expressions ...path.Expression) validator.Object {
+	return atMostOneOfChildrenValidator{
+		pathExpressions: expressions,
+	}
+}
+
+type atMostOneOfChildrenValidator struct {
+	pathExpressions path.Expressions
+}
+
+func (av atMostOneOfChildrenValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av atMostOneOfChildrenValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that one and only one attribute from this collection is set: %q", av.pathExpressions)
+}
+
+func (av atMostOneOfChildrenValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := internal.ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	var validateResp internal.ExactlyOneOfValidatorResponse
+
+	av.validate(ctx, validateReq, &validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av atMostOneOfChildrenValidator) validate(ctx context.Context, req internal.ExactlyOneOfValidatorRequest, res *internal.ExactlyOneOfValidatorResponse) {
+	count := 0
+	expressions := req.PathExpression.MergeExpressions(av.pathExpressions...)
+
+	// If current attribute is unknown, delay validation
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			// TODO: Technically,this would be a misconfguration, so we should probably return an internal error
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				count++
+			}
+		}
+	}
+
+	if count > 1 {
+		res.Diagnostics.Append(validatordiag.InvalidAttributeCombinationDiagnostic(
+			req.Path,
+			fmt.Sprintf("%d attributes specified when at most one of %s may be set", count, expressions),
+		))
+	}
+}

--- a/internal/framework/validators/objectvalidator/warn_at_most_one_of_children.go
+++ b/internal/framework/validators/objectvalidator/warn_at_most_one_of_children.go
@@ -1,0 +1,103 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package objectvalidator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/validators/internal"
+)
+
+// WarnAtMostOneOfChildren is equivalent to AtMostOneOfChildren, but returns a Warning instead of an error
+func WarnAtMostOneOfChildren(expressions ...path.Expression) validator.Object {
+	return warnAtMostOneOfChildrenValidator{
+		pathExpressions: expressions,
+	}
+}
+
+type warnAtMostOneOfChildrenValidator struct {
+	pathExpressions path.Expressions
+}
+
+func (av warnAtMostOneOfChildrenValidator) Description(ctx context.Context) string {
+	return av.MarkdownDescription(ctx)
+}
+
+func (av warnAtMostOneOfChildrenValidator) MarkdownDescription(_ context.Context) string {
+	return fmt.Sprintf("Ensure that one and only one attribute from this collection is set: %q", av.pathExpressions)
+}
+
+func (av warnAtMostOneOfChildrenValidator) ValidateObject(ctx context.Context, req validator.ObjectRequest, resp *validator.ObjectResponse) {
+	validateReq := internal.ExactlyOneOfValidatorRequest{
+		Config:         req.Config,
+		ConfigValue:    req.ConfigValue,
+		Path:           req.Path,
+		PathExpression: req.PathExpression,
+	}
+	var validateResp internal.ExactlyOneOfValidatorResponse
+
+	av.validate(ctx, validateReq, &validateResp)
+
+	resp.Diagnostics.Append(validateResp.Diagnostics...)
+}
+
+func (av warnAtMostOneOfChildrenValidator) validate(ctx context.Context, req internal.ExactlyOneOfValidatorRequest, res *internal.ExactlyOneOfValidatorResponse) {
+	count := 0
+	expressions := req.PathExpression.MergeExpressions(av.pathExpressions...)
+
+	// If current attribute is unknown, delay validation
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	for _, expression := range expressions {
+		matchedPaths, diags := req.Config.PathMatches(ctx, expression)
+
+		res.Diagnostics.Append(diags...)
+
+		// Collect all errors
+		if diags.HasError() {
+			continue
+		}
+
+		for _, mp := range matchedPaths {
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			// TODO: Technically,this would be a misconfguration, so we should probably return an internal error
+			if mp.Equal(req.Path) {
+				continue
+			}
+
+			var mpVal attr.Value
+			diags := req.Config.GetAttribute(ctx, mp, &mpVal)
+			res.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			// Delay validation until all involved attribute have a known value
+			if mpVal.IsUnknown() {
+				return
+			}
+
+			if !mpVal.IsNull() {
+				count++
+			}
+		}
+	}
+
+	if count > 1 {
+		res.Diagnostics.Append(fwdiag.WarningInvalidAttributeCombinationDiagnostic(
+			req.Path,
+			fmt.Sprintf("%d attributes specified when at most one of %s may be set", count, expressions),
+		))
+	}
+}

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -45,7 +45,6 @@ import (
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	fwvalidators "github.com/hashicorp/terraform-provider-aws/internal/framework/validators"
 	tfobjectvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/objectvalidator"
-	tfstringvalidator "github.com/hashicorp/terraform-provider-aws/internal/framework/validators/stringvalidator"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -194,6 +193,15 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 								listvalidator.SizeAtMost(1),
 							},
 							NestedObject: schema.NestedBlockObject{
+								Validators: []validator.Object{
+									tfobjectvalidator.WarnAtMostOneOfChildren(
+										path.MatchRelative().AtName("object_size_greater_than"),
+										path.MatchRelative().AtName("object_size_less_than"),
+										path.MatchRelative().AtName(names.AttrPrefix),
+										path.MatchRelative().AtName("and"),
+										path.MatchRelative().AtName("tag"),
+									),
+								},
 								Attributes: map[string]schema.Attribute{
 									"object_size_greater_than": schema.Int64Attribute{
 										Optional: true,
@@ -216,14 +224,6 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 										Computed: true, // Because of Legacy value handling
 										PlanModifiers: []planmodifier.String{
 											ruleFilterPrefixForUnknown(),
-										},
-										Validators: []validator.String{
-											tfstringvalidator.WarnExactlyOneOf(
-												path.MatchRelative().AtParent().AtName("object_size_greater_than"),
-												path.MatchRelative().AtParent().AtName("object_size_less_than"),
-												path.MatchRelative().AtParent().AtName("and"),
-												path.MatchRelative().AtParent().AtName("tag"),
-											),
 										},
 									},
 								},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No

### Description

Fixes `filter` validation to allow empty block

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42515
Closes #42274
Closes #42112

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_

--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (87.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (88.12s)
--- PASS: TestAccS3BucketLifecycleConfiguration_removeRule (161.72s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (162.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (163.40s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter (163.71s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (163.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (212.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (214.41s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (231.39s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (239.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (256.59s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_rule_NoFilterOrPrefix (256.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (256.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (257.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (260.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (280.04s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (280.04s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (280.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (204.53s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (205.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_rule_NoFilterOrPrefix (334.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (81.41s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (211.51s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (212.28s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (212.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (213.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (169.56s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (170.28s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (223.82s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (222.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (276.49s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (230.22s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (223.23s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (211.31s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (235.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (227.17s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (232.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (223.55s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (236.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (76.12s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (214.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (213.95s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (305.89s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd (200.57s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (204.43s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (110.88s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (183.19s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_noChange (106.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (285.94s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (296.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (296.95s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (197.10s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (267.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (266.24s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (257.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (242.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (206.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (206.60s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (205.84s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_withChange (122.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (208.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate (351.68s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (79.16s)
--- PASS: TestAccS3BucketLifecycleConfiguration_rule_NoFilterOrPrefix (86.99s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (182.91s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (79.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (161.55s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (162.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (158.74s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (155.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (155.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (154.49s)
```
