### PR TITLE
[New Data Source] aws_cloudfront_key_value_store

### DIFF
--- a/internal/service/cloudfront/key_value_store_data_source.go
+++ b/internal/service/cloudfront/key_value_store_data_source.go
@@ -1,0 +1,101 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront
+
+import (
+	"context"
+	"github.com/YakDriver/regexache"
+	"github.com/hashicorp/terraform-plugin-framework-timetypes/timetypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_cloudfront_key_value_store", name="Key Value Store")
+func newDataSourceKeyValueStore(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceKeyValueStore{}, nil
+}
+
+const (
+	DSNameKeyValueStore = "Key Value Store Data Source"
+)
+
+type dataSourceKeyValueStore struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceKeyValueStore) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrARN: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrComment: schema.StringAttribute{
+				Computed: true,
+			},
+			names.AttrID: schema.StringAttribute{
+				Computed: true,
+			},
+			"last_modified_time": schema.StringAttribute{
+				CustomType: timetypes.RFC3339Type{},
+				Computed:   true,
+			},
+			names.AttrName: schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.LengthBetween(1, 64),
+					stringvalidator.RegexMatches(
+						regexache.MustCompile(`^[a-zA-Z0-9-_]{1,64}$`),
+						"must contain only alphanumeric characters, hyphens, and underscores",
+					),
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceKeyValueStore) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().CloudFrontClient(ctx)
+
+	var data dataSourceKeyValueStoreModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findKeyValueStoreByName(ctx, conn, data.Name.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.CloudFront, create.ErrActionReading, DSNameKeyValueStore, data.Name.String(), err),
+			err.Error(),
+		)
+		return
+	}
+	resp.Diagnostics.Append(flex.Flatten(ctx, out.KeyValueStore, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.setID() // API response has a field named 'Id' which isn't the resource's ID.
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceKeyValueStoreModel struct {
+	ARN              types.String      `tfsdk:"arn"`
+	Comment          types.String      `tfsdk:"comment"`
+	ID               types.String      `tfsdk:"id"`
+	LastModifiedTime timetypes.RFC3339 `tfsdk:"last_modified_time"`
+	Name             types.String      `tfsdk:"name"`
+}
+
+func (data *dataSourceKeyValueStoreModel) setID() {
+	data.ID = data.Name
+}

--- a/internal/service/cloudfront/key_value_store_data_source_test.go
+++ b/internal/service/cloudfront/key_value_store_data_source_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package cloudfront_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccCloudFrontKeyValueStoreDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	dataSourceName := "data.aws_cloudfront_key_value_store.test"
+	resourceName := "aws_cloudfront_key_value_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID)
+			testAccPreCheck(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeyValueStoreDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeyValueStoreDataSourceConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrComment, resourceName, names.AttrComment),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_modified_time", resourceName, "last_modified_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, resourceName, names.AttrName),
+				),
+			},
+		},
+	})
+}
+
+func testAccKeyValueStoreDataSourceConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_key_value_store" "test" {
+  name    = %[1]q
+  comment = "Terraform Acceptance Test"
+}
+
+data "aws_cloudfront_key_value_store" "test" {
+  name = %[1]q
+
+  depends_on = [aws_cloudfront_key_value_store.test]
+}
+`, rName)
+}

--- a/internal/service/cloudfront/service_package_gen.go
+++ b/internal/service/cloudfront/service_package_gen.go
@@ -17,6 +17,11 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
 	return []*types.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newDataSourceKeyValueStore,
+			TypeName: "aws_cloudfront_key_value_store",
+			Name:     "Key Value Store",
+		},
+		{
 			Factory:  newDataSourceOriginAccessControl,
 			TypeName: "aws_cloudfront_origin_access_control",
 			Name:     "Origin Access Control",

--- a/website/docs/d/cloudfront_key_value_store.html.markdown
+++ b/website/docs/d/cloudfront_key_value_store.html.markdown
@@ -1,0 +1,39 @@
+---
+subcategory: "CloudFront"
+layout: "aws"
+page_title: "AWS: aws_cloudfront_key_value_store"
+description: |-
+  Terraform data source for managing an AWS CloudFront Key Value Store.
+---
+# Data Source: aws_cloudfront_key_value_store
+
+Terraform data source for managing an AWS CloudFront Key Value Store.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_cloudfront_key_value_store" "example" {
+  name = "example_key_value_store"
+}
+
+output "key_value_store_arn" {
+  value = data.aws_cloudfront_key_value_store.example.arn
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `name` - (Required) Unique name for your CloudFront KeyValueStore.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `arn` - Amazon Resource Name (ARN) identifying your CloudFront KeyValueStore.
+* `comment` - Comment.
+* `id` - A unique identifier for the KeyValueStore. Same as `name`.
+* `last_modified_time` - The last modified time of the KeyValueStore.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Added a new data source, `aws_cloudfront_key_value_store`, to retrieve attributes of a CloudFront Key Value Store, such as its ARN.

  * When using `aws_cloudfrontkeyvaluestore_key`, the ARN of the Key Value Store must be specified. This new data source makes it easier to work with an existing Key Value Store.

### Relations

Closes #42530 

### References
https://docs.aws.amazon.com/ja_jp/cloudfront/latest/APIReference/API_DescribeKeyValueStore.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccCloudFrontKeyValueStoreDataSource_ PKG=cloudfront               
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.8 test ./internal/service/cloudfront/... -v -count 1 -parallel 20 -run='TestAccCloudFrontKeyValueStoreDataSource_'  -timeout 360m -vet=off
2025/05/16 01:32:49 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFrontKeyValueStoreDataSource_basic
=== PAUSE TestAccCloudFrontKeyValueStoreDataSource_basic
=== CONT  TestAccCloudFrontKeyValueStoreDataSource_basic
--- PASS: TestAccCloudFrontKeyValueStoreDataSource_basic (36.97s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront 40.557s

```
