### PR TITLE
resource/aws_redshift_cluster: Update default value of `encrypted` to `true` to match AWS default

### DIFF
--- a/.changelog/42631.txt
+++ b/.changelog/42631.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Fixes permanent diff when `encrypted` is not explicitly set to `true`.
+```

--- a/.changelog/42631.txt
+++ b/.changelog/42631.txt
@@ -1,3 +1,7 @@
 ```release-note:bug
 resource/aws_redshift_cluster: Fixes permanent diff when `encrypted` is not explicitly set to `true`.
 ```
+
+```release-note:note
+resource/aws_redshift_cluster: The default value of `encrypted` is now `true` to match the AWS API.
+```

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3641,10 +3641,9 @@ resource "aws_dms_endpoint" "test" {
 }
 
 func testAccEndpointConfig_redshiftBase(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier = %[1]q
-  availability_zone  = data.aws_availability_zones.available.names[0]
   database_name      = "mydb"
   master_username    = "foo"
   master_password    = "Mustbe8characters"
@@ -3698,7 +3697,7 @@ data "aws_iam_policy_document" "test" {
     resources = ["*"]
   }
 }
-`, rName))
+`, rName)
 }
 
 func testAccEndpointConfig_redshift(rName string) string {

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -3181,11 +3181,9 @@ func testAccPipeConfig_basicSQSSourceRedshiftTarget(rName string) string {
 	return acctest.ConfigCompose(
 		testAccPipeConfig_base(rName),
 		testAccPipeConfig_baseSQSSource(rName),
-		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "target" {
   cluster_identifier                  = "%[1]s-target"
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "test"
   master_username                     = "tfacctest"
   master_password                     = "Mustbe8characters"

--- a/internal/service/redshift/cluster.go
+++ b/internal/service/redshift/cluster.go
@@ -581,11 +581,12 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
-	if _, err := waitClusterRelocationStatusResolved(ctx, conn, d.Id()); err != nil {
+	cluster, err := waitClusterRelocationStatusResolved(ctx, conn, d.Id())
+	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Redshift Cluster (%s): waiting for relocation: %s", d.Id(), err)
 	}
 
-	if !isEncrypted {
+	if isEncrypted != aws.ToBool(cluster.Encrypted) {
 		modifyInput := redshift.ModifyClusterInput{
 			ClusterIdentifier: aws.String(d.Id()),
 			Encrypted:         aws.Bool(isEncrypted),

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -100,7 +100,7 @@ func TestAccRedshiftClusterDataSource_logging(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "enable_logging", acctest.CtTrue),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrBucketName, bucketResourceName, names.AttrBucket),
-					resource.TestCheckResourceAttr(dataSourceName, names.AttrS3KeyPrefix, "cluster-logging/"),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrS3KeyPrefix, "aws_redshift_logging.test", names.AttrS3KeyPrefix),
 				),
 			},
 		},
@@ -249,16 +249,18 @@ resource "aws_redshift_cluster" "test" {
   master_username     = "foo"
   node_type           = "dc2.large"
   skip_final_snapshot = true
+}
 
-  logging {
-    bucket_name   = aws_s3_bucket.test.id
-    enable        = true
-    s3_key_prefix = "cluster-logging/"
-  }
+resource "aws_redshift_logging" "test" {
+  cluster_identifier   = aws_redshift_cluster.test.cluster_identifier
+  bucket_name          = aws_s3_bucket.test.bucket
+  s3_key_prefix        = "cluster-logging/"
 }
 
 data "aws_redshift_cluster" "test" {
   cluster_identifier = aws_redshift_cluster.test.cluster_identifier
+
+  depends_on = [aws_redshift_logging.test]
 }
 `, rName)
 }

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -252,9 +252,9 @@ resource "aws_redshift_cluster" "test" {
 }
 
 resource "aws_redshift_logging" "test" {
-  cluster_identifier   = aws_redshift_cluster.test.cluster_identifier
-  bucket_name          = aws_s3_bucket.test.bucket
-  s3_key_prefix        = "cluster-logging/"
+  cluster_identifier = aws_redshift_cluster.test.cluster_identifier
+  bucket_name        = aws_s3_bucket.test.bucket
+  s3_key_prefix      = "cluster-logging/"
 }
 
 data "aws_redshift_cluster" "test" {

--- a/internal/service/redshift/cluster_iam_roles_test.go
+++ b/internal/service/redshift/cluster_iam_roles_test.go
@@ -82,7 +82,7 @@ func TestAccRedshiftClusterIAMRoles_disappears(t *testing.T) {
 }
 
 func testAccClusterIAMRolesConfigBase(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_iam_role" "ec2" {
   name = "%[1]s-ec2"
   path = "/"
@@ -133,7 +133,6 @@ EOF
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -142,7 +141,7 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterIAMRolesConfig_basic(rName string) string {

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -753,6 +753,78 @@ func TestAccRedshiftCluster_changeEncryption_trueToFalse(t *testing.T) {
 	})
 }
 
+func TestAccRedshiftCluster_changeEncryption_falseToTrue(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster1, cluster2 awstypes.Cluster
+	resourceName := "aws_redshift_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_unencrypted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccClusterConfig_encrypted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("true")),
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestAccRedshiftCluster_changeEncryption_falseToUnset(t *testing.T) {
+	ctx := acctest.Context(t)
+	var cluster1, cluster2 awstypes.Cluster
+	resourceName := "aws_redshift_cluster.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RedshiftServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_unencrypted(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &cluster1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccClusterConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &cluster2),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("true")),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccRedshiftCluster_changeEncryption_trueToUnset(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cluster1, cluster2 awstypes.Cluster

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -43,7 +43,7 @@ func TestAccRedshiftCluster_basic(t *testing.T) {
 				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrAvailabilityZone, "data.aws_availability_zones.available", "names.0"),
+					resource.TestCheckResourceAttrSet(resourceName, names.AttrAvailabilityZone),
 					resource.TestCheckResourceAttr(resourceName, "cluster_nodes.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_nodes.0.public_ip_address"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "single-node"),
@@ -1253,7 +1253,6 @@ func TestAccRedshiftCluster_manageMasterPassword(t *testing.T) {
 				Config: testAccClusterConfig_manageMasterPassword(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrAvailabilityZone, "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "manage_master_password", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "master_password_secret_arn"),
 				),
@@ -1441,10 +1440,9 @@ func testAccCheckClusterMasterUsername(c *awstypes.Cluster, value string) resour
 }
 
 func testAccClusterConfig_updateNodeCount(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1455,14 +1453,13 @@ resource "aws_redshift_cluster" "test" {
   number_of_nodes                     = 2
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_updateNodeType(rName, nodeType string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1473,15 +1470,13 @@ resource "aws_redshift_cluster" "test" {
   number_of_nodes                     = 2
   skip_final_snapshot                 = true
 }
-`, rName, nodeType))
+`, rName, nodeType)
 }
 
 func testAccClusterConfig_basic(rName string) string {
-	// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -1490,14 +1485,13 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_aqua(rName, status string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1509,14 +1503,13 @@ resource "aws_redshift_cluster" "test" {
   aqua_configuration_status           = %[2]q
   apply_immediately                   = true
 }
-`, rName, status))
+`, rName, status)
 }
 
 func testAccClusterConfig_encrypted(rName string, encrypted bool) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -1528,14 +1521,13 @@ resource "aws_redshift_cluster" "test" {
 
   encrypted = %[2]t
 }
-`, rName, encrypted))
+`, rName, encrypted)
 }
 
 func testAccClusterConfig_encrypted_default(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -1545,14 +1537,13 @@ resource "aws_redshift_cluster" "test" {
   skip_final_snapshot                 = true
   publicly_accessible                 = false
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_finalSnapshot(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1563,11 +1554,11 @@ resource "aws_redshift_cluster" "test" {
   skip_final_snapshot                 = false
   final_snapshot_identifier           = %[1]q
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_kmsKey(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_kms_key" "test" {
   description             = %[1]q
   deletion_window_in_days = 7
@@ -1594,7 +1585,6 @@ POLICY
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -1605,14 +1595,13 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_enhancedVPCRoutingEnabled(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1623,14 +1612,13 @@ resource "aws_redshift_cluster" "test" {
   enhanced_vpc_routing                = true
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_enhancedVPCRoutingDisabled(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1641,14 +1629,13 @@ resource "aws_redshift_cluster" "test" {
   enhanced_vpc_routing                = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_tags1(rName, tagKey1, tagValue1 string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo"
@@ -1662,14 +1649,13 @@ resource "aws_redshift_cluster" "test" {
     %[2]q = %[3]q
   }
 }
-`, rName, tagKey1, tagValue1))
+`, rName, tagKey1, tagValue1)
 }
 
 func testAccClusterConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagValue2 string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo"
@@ -1684,7 +1670,7 @@ resource "aws_redshift_cluster" "test" {
     %[4]q = %[5]q
   }
 }
-`, rName, tagKey1, tagValue1, tagKey2, tagValue2))
+`, rName, tagKey1, tagValue1, tagKey2, tagValue2)
 }
 
 func testAccClusterConfig_publiclyAccessible(rName string, publiclyAccessible bool) string {
@@ -1693,7 +1679,6 @@ func testAccClusterConfig_publiclyAccessible(rName string, publiclyAccessible bo
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo"
@@ -1751,7 +1736,7 @@ resource "aws_redshift_subnet_group" "test" {
 }
 
 func testAccClusterConfig_iamRoles(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_iam_role" "ec2" {
   name = "%[1]s-ec2"
   path = "/"
@@ -1802,7 +1787,6 @@ EOF
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1813,11 +1797,11 @@ resource "aws_redshift_cluster" "test" {
   iam_roles                           = [aws_iam_role.ec2.arn, aws_iam_role.lambda.arn]
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_updateIAMRoles(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_iam_role" "ec2" {
   name = "%[1]s-ec2"
   path = "/"
@@ -1868,7 +1852,6 @@ EOF
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -1879,12 +1862,12 @@ resource "aws_redshift_cluster" "test" {
   iam_roles                           = [aws_iam_role.ec2.arn]
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_updateAvailabilityZone(rName string, regionIndex int) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1906,7 +1889,7 @@ resource "aws_redshift_cluster" "test" {
 
 func testAccClusterConfig_updateAvailabilityZoneAvailabilityZoneRelocationNotSet(rName string, regionIndex int) string {
 	return acctest.ConfigCompose(
-		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1993,7 +1976,6 @@ resource "aws_redshift_cluster_snapshot" "test" {
 resource "aws_redshift_cluster" "restored" {
   cluster_identifier  = "%[1]s-restored"
   snapshot_identifier = aws_redshift_cluster_snapshot.test.id
-  availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"
   encrypted           = true
   master_username     = "foo_test"
@@ -2016,7 +1998,6 @@ resource "aws_redshift_cluster_snapshot" "test" {
 resource "aws_redshift_cluster" "restored" {
   cluster_identifier  = "%[1]s-restored"
   snapshot_arn        = aws_redshift_cluster_snapshot.test.arn
-  availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"
   encrypted           = true
   master_username     = "foo_test"
@@ -2039,7 +2020,6 @@ resource "aws_redshift_cluster_snapshot" "test" {
 resource "aws_redshift_cluster" "restored" {
   cluster_identifier  = "%[1]s-restored"
   snapshot_identifier = aws_redshift_cluster_snapshot.test.id
-  availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"
   master_username     = "foo_test"
   master_password     = "Mustbe8characters"
@@ -2052,11 +2032,9 @@ resource "aws_redshift_cluster" "restored" {
 }
 
 func testAccClusterConfig_manageMasterPassword(rName string) string {
-	// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -2066,7 +2044,7 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccClusterConfig_multiAZ(rName string, enabled bool) string {
@@ -2118,11 +2096,9 @@ resource "aws_redshift_cluster" "test" {
 }
 
 func testAccClusterConfig_passwordWriteOnly(rName, password string, passwordVersion int) string {
-	// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = "foo_test"
@@ -2134,14 +2110,13 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName, password, passwordVersion))
+`, rName, password, passwordVersion)
 }
 
 func testAccClusterConfig_masterUsername(rName, username string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   encrypted                           = true
   master_username                     = %[2]q
@@ -2152,5 +2127,5 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName, username))
+`, rName, username)
 }

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -928,7 +928,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 func TestAccRedshiftCluster_restoreFromSnapshot_Identifier(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Cluster
-	resourceName := "aws_redshift_cluster.test2"
+	resourceName := "aws_redshift_cluster.restored"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -963,7 +963,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot_Identifier(t *testing.T) {
 func TestAccRedshiftCluster_restoreFromSnapshot_ARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Cluster
-	resourceName := "aws_redshift_cluster.test2"
+	resourceName := "aws_redshift_cluster.restored"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1724,8 +1724,8 @@ resource "aws_redshift_cluster_snapshot" "test" {
   snapshot_identifier = %[1]q
 }
 
-resource "aws_redshift_cluster" "test2" {
-  cluster_identifier  = "%[1]s-2"
+resource "aws_redshift_cluster" "restored" {
+  cluster_identifier  = "%[1]s-restored"
   snapshot_identifier = aws_redshift_cluster_snapshot.test.id
   availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"
@@ -1745,8 +1745,8 @@ resource "aws_redshift_cluster_snapshot" "test" {
   snapshot_identifier = %[1]q
 }
 
-resource "aws_redshift_cluster" "test2" {
-  cluster_identifier  = "%[1]s-2"
+resource "aws_redshift_cluster" "restored" {
+  cluster_identifier  = "%[1]s-restored"
   snapshot_arn        = aws_redshift_cluster_snapshot.test.arn
   availability_zone   = data.aws_availability_zones.available.names[0]
   database_name       = "mydb"

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -41,7 +41,7 @@ func TestAccRedshiftCluster_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrAvailabilityZone, "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_nodes.#", "1"),
@@ -89,7 +89,7 @@ func TestAccRedshiftCluster_aqua(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_aqua(rName, names.AttrEnabled),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
@@ -107,14 +107,14 @@ func TestAccRedshiftCluster_aqua(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_aqua(rName, "disabled"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_aqua(rName, names.AttrEnabled),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "aqua_configuration_status", "auto"),
 				),
@@ -137,7 +137,7 @@ func TestAccRedshiftCluster_disappears(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfredshift.ResourceCluster(), resourceName),
 				),
@@ -161,7 +161,7 @@ func TestAccRedshiftCluster_withFinalSnapshot(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_finalSnapshot(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 				),
 			},
@@ -195,7 +195,7 @@ func TestAccRedshiftCluster_kmsKey(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_kmsKey(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "single-node"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtFalse),
@@ -231,7 +231,7 @@ func TestAccRedshiftCluster_enhancedVPCRoutingEnabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_enhancedVPCRoutingEnabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_vpc_routing", acctest.CtTrue),
 				),
@@ -249,7 +249,7 @@ func TestAccRedshiftCluster_enhancedVPCRoutingEnabled(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_enhancedVPCRoutingDisabled(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "enhanced_vpc_routing", acctest.CtFalse),
 				),
@@ -272,14 +272,14 @@ func TestAccRedshiftCluster_iamRoles(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_iamRoles(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "2"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_updateIAMRoles(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "iam_roles.#", "1"),
 				),
@@ -302,7 +302,7 @@ func TestAccRedshiftCluster_publiclyAccessible(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_publiclyAccessible(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtFalse),
 				),
@@ -310,7 +310,7 @@ func TestAccRedshiftCluster_publiclyAccessible(t *testing.T) {
 
 			{
 				Config: testAccClusterConfig_publiclyAccessible(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtTrue),
 				),
@@ -338,7 +338,7 @@ func TestAccRedshiftCluster_publiclyAccessible_default(t *testing.T) {
 					},
 				},
 				Config: testAccClusterConfig_publiclyAccessible_default(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtTrue),
 				),
@@ -353,7 +353,7 @@ func TestAccRedshiftCluster_publiclyAccessible_default(t *testing.T) {
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccClusterConfig_publiclyAccessible_default(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtFalse),
 				),
@@ -381,14 +381,14 @@ func TestAccRedshiftCluster_updateNodeCount(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "number_of_nodes", "1"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_updateNodeCount(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "number_of_nodes", "2"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "multi-node"),
@@ -413,14 +413,14 @@ func TestAccRedshiftCluster_updateNodeType(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_updateNodeType(rName, "dc2.large"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.large"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_updateNodeType(rName, "dc2.8xlarge"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.8xlarge"),
 				),
@@ -443,7 +443,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -462,7 +462,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -471,7 +471,7 @@ func TestAccRedshiftCluster_tags(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -495,7 +495,7 @@ func TestAccRedshiftCluster_masterUsername(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_masterUsername(rName, "foo_test"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v1),
 					testAccCheckClusterMasterUsername(&v1, "foo_test"),
 					resource.TestCheckResourceAttr(resourceName, "master_username", "foo_test"),
@@ -503,7 +503,7 @@ func TestAccRedshiftCluster_masterUsername(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_masterUsername(rName, "new-username"),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v2),
 					testAccCheckClusterMasterUsername(&v2, "new-username"),
 					resource.TestCheckResourceAttr(resourceName, "master_username", "new-username"),
@@ -661,14 +661,14 @@ func TestAccRedshiftCluster_changeEncryption_unsetToFalse(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
@@ -697,14 +697,14 @@ func TestAccRedshiftCluster_changeEncryption_unsetToTrue(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -732,14 +732,14 @@ func TestAccRedshiftCluster_changeEncryption_trueToFalse(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
@@ -768,14 +768,14 @@ func TestAccRedshiftCluster_changeEncryption_falseToTrue(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
 			},
 			{
 				Config: testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -804,14 +804,14 @@ func TestAccRedshiftCluster_changeEncryption_falseToUnset(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
 			},
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -840,14 +840,14 @@ func TestAccRedshiftCluster_changeEncryption_trueToUnset(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccClusterConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -880,7 +880,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_default(t *testing.T) {
 					},
 				},
 				Config: testAccClusterConfig_encrypted_default(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -899,7 +899,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_default(t *testing.T) {
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccClusterConfig_encrypted_default(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -932,7 +932,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_true(t *testing.T) {
 					},
 				},
 				Config: testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -940,7 +940,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_true(t *testing.T) {
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccClusterConfig_encrypted(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -973,7 +973,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_false(t *testing.T) {
 					},
 				},
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
@@ -998,7 +998,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_false(t *testing.T) {
 					},
 				},
 				Config: testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
@@ -1012,7 +1012,7 @@ func TestAccRedshiftCluster_Migrate_encrypted_false(t *testing.T) {
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccClusterConfig_encrypted(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
@@ -1040,7 +1040,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_availabilityZoneRelocation(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_relocation_enabled", acctest.CtTrue),
 				),
@@ -1058,7 +1058,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_availabilityZoneRelocation(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_relocation_enabled", acctest.CtFalse),
 				),
@@ -1081,7 +1081,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_availabilityZoneRelocationPubliclyAccessible(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_relocation_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPubliclyAccessible, acctest.CtTrue),
@@ -1105,7 +1105,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot_Identifier(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_restoreFromSnapshot_Identifier(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "snapshot_identifier", "aws_redshift_cluster_snapshot.test", names.AttrID),
 				),
@@ -1140,7 +1140,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot_ARN(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_restoreFromSnapshot_ARN(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "snapshot_arn", "aws_redshift_cluster_snapshot.test", names.AttrARN),
 				),
@@ -1251,7 +1251,7 @@ func TestAccRedshiftCluster_manageMasterPassword(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_manageMasterPassword(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrAvailabilityZone, "data.aws_availability_zones.available", "names.0"),
 					resource.TestCheckResourceAttr(resourceName, "manage_master_password", acctest.CtTrue),
@@ -1287,7 +1287,7 @@ func TestAccRedshiftCluster_multiAZ(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_multiAZ(rName, true),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", acctest.CtTrue),
 				),
@@ -1305,7 +1305,7 @@ func TestAccRedshiftCluster_multiAZ(t *testing.T) {
 			},
 			{
 				Config: testAccClusterConfig_multiAZ(rName, false),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", acctest.CtFalse),
 				),
@@ -1331,13 +1331,13 @@ func TestAccRedshiftCluster_passwordWriteOnly(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_passwordWriteOnly(rName, "Mustbe8characters", 1),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 				),
 			},
 			{
 				Config: testAccClusterConfig_passwordWriteOnly(rName, "Mustbe8charactersupdated", 2),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 				),
 			},

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -925,7 +925,7 @@ func TestAccRedshiftCluster_availabilityZoneRelocation_publiclyAccessible(t *tes
 	})
 }
 
-func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
+func TestAccRedshiftCluster_restoreFromSnapshot_Identifier(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Cluster
 	resourceName := "aws_redshift_cluster.test2"
@@ -938,7 +938,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_restoreFromSnapshot(rName),
+				Config: testAccClusterConfig_restoreFromSnapshot_Identifier(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "snapshot_identifier", "aws_redshift_cluster_snapshot.test", names.AttrID),
@@ -960,7 +960,7 @@ func TestAccRedshiftCluster_restoreFromSnapshot(t *testing.T) {
 	})
 }
 
-func TestAccRedshiftCluster_restoreFromSnapshotARN(t *testing.T) {
+func TestAccRedshiftCluster_restoreFromSnapshot_ARN(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Cluster
 	resourceName := "aws_redshift_cluster.test2"
@@ -973,7 +973,7 @@ func TestAccRedshiftCluster_restoreFromSnapshotARN(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterSnapshotDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_restoreFromSnapshotARN(rName),
+				Config: testAccClusterConfig_restoreFromSnapshot_ARN(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "snapshot_arn", "aws_redshift_cluster_snapshot.test", names.AttrARN),
@@ -1717,7 +1717,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName))
 }
 
-func testAccClusterConfig_restoreFromSnapshot(rName string) string {
+func testAccClusterConfig_restoreFromSnapshot_Identifier(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_cluster_snapshot" "test" {
   cluster_identifier  = aws_redshift_cluster.test.cluster_identifier
@@ -1738,7 +1738,7 @@ resource "aws_redshift_cluster" "test2" {
 `, rName))
 }
 
-func testAccClusterConfig_restoreFromSnapshotARN(rName string) string {
+func testAccClusterConfig_restoreFromSnapshot_ARN(rName string) string {
 	return acctest.ConfigCompose(testAccClusterConfig_basic(rName), fmt.Sprintf(`
 resource "aws_redshift_cluster_snapshot" "test" {
   cluster_identifier  = aws_redshift_cluster.test.cluster_identifier

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -674,7 +674,7 @@ func TestAccRedshiftCluster_changeEncryption_unsetToFalse(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("false")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact(acctest.CtFalse)),
 					},
 				},
 			},
@@ -745,7 +745,7 @@ func TestAccRedshiftCluster_changeEncryption_trueToFalse(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("false")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact(acctest.CtFalse)),
 					},
 				},
 			},
@@ -781,7 +781,7 @@ func TestAccRedshiftCluster_changeEncryption_falseToTrue(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("true")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact(acctest.CtTrue)),
 					},
 				},
 			},
@@ -817,7 +817,7 @@ func TestAccRedshiftCluster_changeEncryption_falseToUnset(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact("true")),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrEncrypted), knownvalue.StringExact(acctest.CtTrue)),
 					},
 				},
 			},

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -666,7 +666,7 @@ func TestAccRedshiftCluster_changeEncryption_unsetToFalse(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterConfig_unencrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
@@ -702,7 +702,7 @@ func TestAccRedshiftCluster_changeEncryption_unsetToTrue(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccClusterConfig_encrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
@@ -730,14 +730,14 @@ func TestAccRedshiftCluster_changeEncryption_trueToFalse(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_encrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
 				),
 			},
 			{
-				Config: testAccClusterConfig_unencrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
@@ -766,14 +766,14 @@ func TestAccRedshiftCluster_changeEncryption_falseToTrue(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_unencrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
 				),
 			},
 			{
-				Config: testAccClusterConfig_encrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
@@ -802,7 +802,7 @@ func TestAccRedshiftCluster_changeEncryption_falseToUnset(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_unencrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtFalse),
@@ -838,7 +838,7 @@ func TestAccRedshiftCluster_changeEncryption_trueToUnset(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_encrypted(rName),
+				Config: testAccClusterConfig_encrypted(rName, true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &cluster2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEncrypted, acctest.CtTrue),
@@ -1270,7 +1270,7 @@ resource "aws_redshift_cluster" "test" {
 `, rName, status))
 }
 
-func testAccClusterConfig_encrypted(rName string) string {
+func testAccClusterConfig_encrypted(rName string, encrypted bool) string {
 	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
@@ -1283,27 +1283,9 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 
-  encrypted = true
+  encrypted = %[2]t
 }
-`, rName))
-}
-
-func testAccClusterConfig_unencrypted(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
-resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
-
-  encrypted = false
-}
-`, rName))
+`, rName, encrypted))
 }
 
 func testAccClusterConfig_finalSnapshot(rName string) string {

--- a/internal/service/redshift/consts.go
+++ b/internal/service/redshift/consts.go
@@ -32,6 +32,13 @@ const (
 )
 
 const (
+	clusterRestoreStatusStarting  = "starting"
+	clusterRestoreStatusRestoring = "restoring"
+	clusterRestoreStatusCompleted = "completed"
+	clusterRestoreStatusFailed    = "failed"
+)
+
+const (
 	clusterTypeMultiNode  = "multi-node"
 	clusterTypeSingleNode = "single-node"
 )

--- a/internal/service/redshift/consts.go
+++ b/internal/service/redshift/consts.go
@@ -5,8 +5,6 @@ package redshift
 
 import (
 	"time"
-
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 const (
@@ -44,7 +42,7 @@ const (
 )
 
 const (
-	clusterAvailabilityZoneRelocationStatusEnabled          = names.AttrEnabled
+	clusterAvailabilityZoneRelocationStatusEnabled          = "enabled"
 	clusterAvailabilityZoneRelocationStatusDisabled         = "disabled"
 	clusterAvailabilityZoneRelocationStatusPendingEnabling  = "pending_enabling"
 	clusterAvailabilityZoneRelocationStatusPendingDisabling = "pending_disabling"
@@ -52,7 +50,7 @@ const (
 
 func clusterAvailabilityZoneRelocationStatus_TerminalValues() []string {
 	return []string{
-		names.AttrEnabled,
+		clusterAvailabilityZoneRelocationStatusEnabled,
 		clusterAvailabilityZoneRelocationStatusDisabled,
 	}
 }

--- a/internal/service/redshift/endpoint_access_test.go
+++ b/internal/service/redshift/endpoint_access_test.go
@@ -197,7 +197,6 @@ resource "aws_redshift_subnet_group" "test" {
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zone                    = data.aws_availability_zones.available.names[0]
   database_name                        = "mydb"
   master_username                      = "foo_test"
   master_password                      = "Mustbe8characters"

--- a/internal/service/redshift/endpoint_authorization_test.go
+++ b/internal/service/redshift/endpoint_authorization_test.go
@@ -220,7 +220,6 @@ resource "aws_redshift_subnet_group" "test" {
 
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                   = %[1]q
-  availability_zone                    = data.aws_availability_zones.available.names[0]
   database_name                        = "mydb"
   master_username                      = "foo_test"
   master_password                      = "Mustbe8characters"

--- a/internal/service/redshift/logging.go
+++ b/internal/service/redshift/logging.go
@@ -54,7 +54,7 @@ func (r *loggingResource) Schema(ctx context.Context, req resource.SchemaRequest
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			names.AttrID: framework.IDAttribute(),
+			names.AttrID: framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrClusterIdentifier)),
 			"log_destination_type": schema.StringAttribute{
 				Optional:   true,
 				CustomType: fwtypes.StringEnumType[awstypes.LogDestinationType](),

--- a/internal/service/redshift/logging_test.go
+++ b/internal/service/redshift/logging_test.go
@@ -221,13 +221,9 @@ func testAccCheckLoggingExists(ctx context.Context, name string, log *redshift.D
 }
 
 func testAccLoggingConfigBase(rName string) string {
-	return acctest.ConfigCompose(
-		// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
-		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
-		fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -237,7 +233,7 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccLoggingConfig_basic(rName string) string {
@@ -245,7 +241,7 @@ func testAccLoggingConfig_basic(rName string) string {
 		testAccLoggingConfigBase(rName),
 		`
 resource "aws_redshift_logging" "test" {
-  cluster_identifier   = aws_redshift_cluster.test.id
+  cluster_identifier   = aws_redshift_cluster.test.cluster_identifier
   log_destination_type = "cloudwatch"
   log_exports          = ["connectionlog", "useractivitylog", "userlog"]
 }
@@ -293,8 +289,8 @@ EOF
 resource "aws_redshift_logging" "test" {
   depends_on = [aws_s3_bucket_policy.test]
 
-  cluster_identifier   = aws_redshift_cluster.test.id
-  bucket_name          = aws_s3_bucket.test.id
+  cluster_identifier   = aws_redshift_cluster.test.cluster_identifier
+  bucket_name          = aws_s3_bucket.test.bucket
   s3_key_prefix        = "testprefix/"
   log_destination_type = "s3"
 }

--- a/internal/service/redshift/snapshot_copy_test.go
+++ b/internal/service/redshift/snapshot_copy_test.go
@@ -218,13 +218,9 @@ func testAccCheckSnapshotCopyExists(ctx context.Context, name string, snap *type
 }
 
 func testAccSnapshotCopyConfigBase(rName string) string {
-	return acctest.ConfigCompose(
-		// "InvalidVPCNetworkStateFault: The requested AZ us-west-2a is not a valid AZ."
-		acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"),
-		fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -234,7 +230,7 @@ resource "aws_redshift_cluster" "test" {
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
-`, rName))
+`, rName)
 }
 
 func testAccSnapshotCopyConfig_basic(rName string) string {

--- a/internal/service/redshiftdata/statement_test.go
+++ b/internal/service/redshiftdata/statement_test.go
@@ -104,10 +104,9 @@ func testAccCheckStatementExists(ctx context.Context, n string, v *redshiftdata.
 }
 
 func testAccStatementConfig_basic(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigAvailableAZsNoOptInExclude("usw2-az2"), fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
-  availability_zone                   = data.aws_availability_zones.available.names[0]
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
@@ -123,7 +122,7 @@ resource "aws_redshiftdata_statement" "test" {
   db_user            = aws_redshift_cluster.test.master_username
   sql                = "CREATE GROUP group_name;"
 }
-`, rName))
+`, rName)
 }
 
 func testAccStatementConfig_workgroup(rName string) string {

--- a/website/docs/guides/version-6-upgrade.html.markdown
+++ b/website/docs/guides/version-6-upgrade.html.markdown
@@ -606,6 +606,7 @@ Treat the `key_attributes` and `key_attributes.key_modes_of_use` as lists of nes
 
 ## Resource `aws_redshift_cluster`
 
+* `encrypted` now defaults to `true`.
 * `publicly_accessible` now defaults to `false`.
 * Remove `snapshot_copy`—it is no longer supported. Use the `aws_redshift_snapshot_copy` resource instead.
 * Remove `logging`—it is no longer supported. Use the `aws_redshift_logging` resource instead.

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -98,6 +98,7 @@ This resource supports the following arguments:
 * `number_of_nodes` - (Optional) The number of compute nodes in the cluster. This parameter is required when the ClusterType parameter is specified as multi-node. Default is 1.
 * `publicly_accessible` - (Optional) If true, the cluster can be accessed from a public network. Default is `false`.
 * `encrypted` - (Optional) If true , the data in the cluster is encrypted at rest.
+  Default is `true`.
 * `enhanced_vpc_routing` - (Optional) If true , enhanced VPC routing is enabled.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.

--- a/website/docs/r/redshift_logging.html.markdown
+++ b/website/docs/r/redshift_logging.html.markdown
@@ -49,7 +49,7 @@ The following arguments are optional:
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - Identifier of the source cluster.
+* `id` - (**Deprecated**, use `cluster_identifier` instead) Identifier of the source cluster.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

None

### Description

AWS defaults to encryption at rest, but the default value of `encrypted` is `false`. This PR updates the default value to `true`. It also fixes a bug where encryption cannot be set to `false` on creation.

Additionally removes unneeded availability zone restrictions on acceptance tests.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42598

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
