### PR TITLE
Fix CI deps checks on main

### DIFF
--- a/.github/workflows/pull_request_target.yml
+++ b/.github/workflows/pull_request_target.yml
@@ -1,4 +1,4 @@
-name: Dependency Checks
+name: Pull Request Target Check
 
 permissions:
   contents: read
@@ -12,16 +12,8 @@ on:
     branches:
       - main
       - "release/**"
-    paths-ignore:
-      - .teamcity/**
-      - .release/**
-      - infrastructure/**
-      - .archive/**
-      - .changelog/**
-      - .devcontainer/**
-      - docs/**
-      - examples/**
-      - META.d/**
+    paths:
+      - .github/workflows/**
 
 ## NOTE: !!!
 ## When changing these workflows, ensure that the following is updated:
@@ -31,7 +23,7 @@ on:
 
 jobs:
   checks:
-    name: go mod
+    name: pr-target-check
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,8 +51,7 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-pkg-mod-${{ hashFiles('go.sum') }}
-
-      - name: Run make deps-check
+      - name: Run make pr-target-check
         run: |
-          echo "Using make to check dependencies"
-          make deps-check
+          echo "Using make to check for disallowed uses of PR target"
+          make pr-target-check

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -343,7 +343,7 @@ pr-target-check: ## [CI] Check for pull request target
 		echo "$$disallowed_files"; \
 		exit 1; \
 	fi
-	@echo "make: pull_request_target check passed."
+	@echo "make: pr-target-check check passed."
 
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -343,7 +343,7 @@ pr-target-check: ## [CI] Check for pull request target
 		echo "$$disallowed_files"; \
 		exit 1; \
 	fi
-	@echo "make: pr-target-check check passed."
+	@echo "make: pr-target-check passed."
 
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -337,14 +337,11 @@ modern-fix: prereq-go ## [CI] Fix checks for modern Go code (best run in individ
 
 pr-target-check: ## [CI] Check for pull request target
 	@echo "make: Checking for pull request target..."
-	@files_with_pull_request_target=$$(grep -rl 'pull_request_target' ./.github/workflows/*.yml || true); \
-	if [ -n "$$files_with_pull_request_target" ]; then \
-		for file in $$files_with_pull_request_target; do \
-			if [ "$$file" != "./.github/workflows/maintainer_helpers.yml" ] && [ "$$file" != "./.github/workflows/triage.yml" ]; then \
-				echo "Error: 'pull_request_target' found in disallowed file: $$file"; \
-				exit 1; \
-			fi; \
-		done; \
+	@disallowed_files=$$(grep -rl 'pull_request_target' ./.github/workflows/*.yml | grep -vE './.github/workflows/(maintainer_helpers|triage|closed_items|community_note|readiness_comment).yml' || true); \
+	if [ -n "$$disallowed_files" ]; then \
+		echo "Error: 'pull_request_target' found in disallowed files:"; \
+		echo "$$disallowed_files"; \
+		exit 1; \
 	fi
 	@echo "make: pull_request_target check passed."
 

--- a/docs/continuous-integration.md
+++ b/docs/continuous-integration.md
@@ -258,6 +258,10 @@ GoReleaser CI build-32-bit ensures that GoReleaser can build a 32-bit binary. Th
 
 This check ensures that code uses current idiomatic Go. Currently, the check is only run on a subset of services. To determine which services must have modern Go, check the `.github/workflows/modern_go.yml` file.
 
+### PR Target Check
+
+This check ensures that the `pull_request_target` event is only used in approved workflows. Unlike `pull_request`, which runs workflows against the pull request’s changes, `pull_request_target` runs against the base branch. This can cause issues to go undetected if the workflow is intended to validate the pull request itself. Restricting its use helps ensure that CI checks reflect the actual content of proposed changes.
+
 ### Provider Checks
 
 Provider checks are a suite of tests that ensure Go code functions and markdown is correct.

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -132,7 +132,9 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `lint`<sup>M</sup> | Legacy target, use caution |  | ✔️ |  |
 | `lint-fix`<sup>M</sup> | Fix acceptance test, website, and docs linter findings |  | ✔️ |  |
 | `misspell`<sup>M</sup> | Run all CI misspell checks | ✔️ |  |  |
-| `modern-check` | Check for modern GO | ✔️ |  | `TEST` |
+| `modern-check` | Check for modern Go | ✔️ |  | `TEST` |
+| `modern-fix` | Fix checks for modern Go | ✔️ |  | `TEST` |
+| `pr-target-check` | Pull Request Target Check | ✔️ |  |  |
 | `prereq-go` | Install the project's Go version |  |  | `GO_VER` |
 | `provider-lint` | ProviderLint Checks / providerlint | ✔️ |  | `K`, `PKG`, `SVC_DIR` |
 | `provider-markdown-lint` | Provider Check / markdown-lint | ✔️ |  |  |


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR:

* Fixes the CI workflow in .github/workflows/dependencies.yml so that it checks the actual changes in pull requests, not the base branch. The previous use of pull_request_target caused broken dependencies in PRs to go undetected. Switching to pull_request ensures accurate validation moving forward.
* Adds a CI check for use of pull_request_target except in approved places.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42543
Relates #42634

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make pr-target-check 
make: Checking for pull request target...
make: pr-target-check passed.
```
