### PR TITLE
Align `make` between v5 and v6

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -343,7 +343,7 @@ pr-target-check: ## [CI] Check for pull request target
 		echo "$$disallowed_files"; \
 		exit 1; \
 	fi
-	@echo "make: pull_request_target check passed."
+	@echo "make: pr-target-check check passed."
 
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -343,7 +343,7 @@ pr-target-check: ## [CI] Check for pull request target
 		echo "$$disallowed_files"; \
 		exit 1; \
 	fi
-	@echo "make: pr-target-check check passed."
+	@echo "make: pr-target-check passed."
 
 prereq-go: ## If $(GO_VER) is not installed, install it
 	@if ! type "$(GO_VER)" > /dev/null 2>&1 ; then \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -337,14 +337,11 @@ modern-fix: prereq-go ## [CI] Fix checks for modern Go code (best run in individ
 
 pr-target-check: ## [CI] Check for pull request target
 	@echo "make: Checking for pull request target..."
-	@files_with_pull_request_target=$$(grep -rl 'pull_request_target' ./.github/workflows/*.yml || true); \
-	if [ -n "$$files_with_pull_request_target" ]; then \
-		for file in $$files_with_pull_request_target; do \
-			if [ "$$file" != "./.github/workflows/maintainer_helpers.yml" ] && [ "$$file" != "./.github/workflows/triage.yml" ]; then \
-				echo "Error: 'pull_request_target' found in disallowed file: $$file"; \
-				exit 1; \
-			fi; \
-		done; \
+	@disallowed_files=$$(grep -rl 'pull_request_target' ./.github/workflows/*.yml | grep -vE './.github/workflows/(maintainer_helpers|triage|closed_items|community_note|readiness_comment).yml' || true); \
+	if [ -n "$$disallowed_files" ]; then \
+		echo "Error: 'pull_request_target' found in disallowed files:"; \
+		echo "$$disallowed_files"; \
+		exit 1; \
 	fi
 	@echo "make: pull_request_target check passed."
 
@@ -712,7 +709,7 @@ tools: prereq-go ## Install tools
 	cd .ci/providerlint && $(GO_VER) install .
 	cd .ci/tools && $(GO_VER) install github.com/YakDriver/tfproviderdocs
 	cd .ci/tools && $(GO_VER) install github.com/client9/misspell/cmd/misspell
-	cd .ci/tools && $(GO_VER) install github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd .ci/tools && $(GO_VER) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 	cd .ci/tools && $(GO_VER) install github.com/hashicorp/copywrite
 	cd .ci/tools && $(GO_VER) install github.com/hashicorp/go-changelog/cmd/changelog-build
 	cd .ci/tools && $(GO_VER) install github.com/katbyte/terrafmt


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR aligns the make file between v5 and v6.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #42633
Relates #42543

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make pr-target-check 
make: Checking for pull request target...
make: pr-target-check passed.
```
