### PR TITLE
F aws cognito user pool update name in place

### DIFF
--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -395,7 +395,6 @@ func resourceUserPool() *schema.Resource {
 			names.AttrName: {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 				ValidateFunc: validation.Any(
 					validation.StringLenBetween(1, 128),
 					validation.StringMatch(regexache.MustCompile(`[\w\s+=,.@-]+`),
@@ -1069,6 +1068,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		"email_verification_message",
 		"email_verification_subject",
 		"lambda_config",
+		names.AttrName,
 		"password_policy",
 		"sign_in_policy",
 		"sms_authentication_message",
@@ -1146,6 +1146,10 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 
 				input.LambdaConfig = expandLambdaConfigType(v)
 			}
+		}
+
+		if v, ok := d.GetOk(names.AttrName); ok {
+			input.PoolName = aws.String(v.(string))
 		}
 
 		if v, ok := d.GetOk("mfa_configuration"); ok {


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* With this modification, the `name` attribute of the `aws_cognito_user_pool` resource can now be updated in-place. Previously, changing this attribute required replacing the resource.
* Added an acceptance test to verify that the `name` attribute is updated in-place — i.e., the resource ID does not change during the update.

### Relations

Closes #42627 

### References
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider#UpdateUserPoolInput
`name` attribute is included in type `UpdateUserPoolInput`

### Output from Acceptance Testing

```console


```
