### PR TITLE
Correct `v5.98.0` and `v5.99.0` CHANGELOG headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
-## 5.98.0 (Unreleased)
+## 5.99.0 (Unreleased)
 
 BUG FIXES:
 
 * resource/aws_s3_bucket_lifecycle_configuration: No longer returns warning on empty `rule.filter`. ([#42624](https://github.com/hashicorp/terraform-provider-aws/issues/42624))
 
-## 5.98.0 (Unreleased)
+## 5.98.0 (May 15, 2025)
 
 FEATURES:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The **Post Publish** action, which adds a new _Unreleased_ CHANGELOG entry, [failed](https://github.com/hashicorp/terraform-provider-aws/actions/runs/15055797308) after yesterday's `v5.98.0` release (because the `v6.0.0-beta1` release is still the _semver_ latest).
Manually fix up the CHANGELOG.