### PR TITLE
resource/aws_s3_bucket_lifecycle_configuration: Correctly handles switching `rule.filter` attributes

### DIFF
--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int32planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -202,13 +201,15 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 										path.MatchRelative().AtName("tag"),
 									),
 								},
+								PlanModifiers: []planmodifier.Object{
+									emptyFilterPlanModifier(),
+								},
 								Attributes: map[string]schema.Attribute{
 									"object_size_greater_than": schema.Int64Attribute{
 										Optional: true,
 										Computed: true, // Because of Legacy value handling
 										PlanModifiers: []planmodifier.Int64{
 											tfint64planmodifier.NullValue(),
-											int64planmodifier.UseStateForUnknown(),
 										},
 									},
 									"object_size_less_than": schema.Int64Attribute{
@@ -216,15 +217,11 @@ func (r *resourceBucketLifecycleConfiguration) Schema(ctx context.Context, reque
 										Computed: true, // Because of Legacy value handling
 										PlanModifiers: []planmodifier.Int64{
 											tfint64planmodifier.NullValue(),
-											int64planmodifier.UseStateForUnknown(),
 										},
 									},
 									names.AttrPrefix: schema.StringAttribute{
 										Optional: true,
 										Computed: true, // Because of Legacy value handling
-										PlanModifiers: []planmodifier.String{
-											ruleFilterPrefixForUnknown(),
-										},
 									},
 								},
 								Blocks: map[string]schema.Block{
@@ -1102,58 +1099,6 @@ func (m transitionDefaultMinimumObjectSizeDefaultModifier) PlanModifyString(ctx 
 	resp.PlanValue = v
 }
 
-// ruleFilterPrefixForUnknown handles the planned value for `rule.filter.prefix`
-// * If no value is set
-//   - If no other `filter` attributes are set, default to ""
-//   - Otherwise, default to `null`
-func ruleFilterPrefixForUnknown() planmodifier.String {
-	return ruleFilterPrefixUnknownModifier{}
-}
-
-type ruleFilterPrefixUnknownModifier struct{}
-
-func (m ruleFilterPrefixUnknownModifier) Description(_ context.Context) string {
-	return ""
-}
-
-func (m ruleFilterPrefixUnknownModifier) MarkdownDescription(ctx context.Context) string {
-	return m.Description(ctx)
-}
-
-func (m ruleFilterPrefixUnknownModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// Nothing to do if a value is configured
-	if !req.ConfigValue.IsNull() {
-		return
-	}
-
-	// Do nothing if there is a known planned value.
-	if !req.PlanValue.IsUnknown() {
-		return
-	}
-
-	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
-	if req.ConfigValue.IsUnknown() {
-		return
-	}
-
-	var parentConfig lifecycleRuleFilterModel
-	andPrefixPath := req.Path.ParentPath()
-	diags := req.Config.GetAttribute(ctx, andPrefixPath, &parentConfig)
-	resp.Diagnostics.Append(diags...)
-	if diags.HasError() {
-		return
-	}
-
-	if parentConfig.And.IsNull() &&
-		parentConfig.ObjectSizeGreaterThan.IsNull() &&
-		parentConfig.ObjectSizeLessThan.IsNull() &&
-		parentConfig.Tag.IsNull() {
-		resp.PlanValue = types.StringValue("")
-	} else {
-		resp.PlanValue = types.StringNull()
-	}
-}
-
 // ruleTransitionForUnknownDays handles the planned value for `rule.transition.days`
 // * If no value is set
 //   - If `date` isn't set, default to 0
@@ -1264,4 +1209,70 @@ func (av warnExactlyOneOfChildrenValidator) ValidateObject(ctx context.Context, 
 			fmt.Sprintf("No attribute specified when one (and only one) of %s is required", paths),
 		))
 	}
+}
+
+func emptyFilterPlanModifier() planmodifier.Object {
+	return emptyFilterPlanModifier_{}
+}
+
+type emptyFilterPlanModifier_ struct{}
+
+func (m emptyFilterPlanModifier_) Description(_ context.Context) string {
+	return ""
+}
+
+func (m emptyFilterPlanModifier_) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m emptyFilterPlanModifier_) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	var config lifecycleRuleFilterModel
+	resp.Diagnostics.Append(req.ConfigValue.As(ctx, &config, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if config.And.IsUnknown() ||
+		config.ObjectSizeGreaterThan.IsUnknown() ||
+		config.ObjectSizeLessThan.IsUnknown() ||
+		config.Prefix.IsUnknown() ||
+		config.Tag.IsUnknown() {
+		return
+	}
+
+	var plan lifecycleRuleFilterModel
+	resp.Diagnostics.Append(req.PlanValue.As(ctx, &plan, basetypes.ObjectAsOptions{})...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !config.And.IsNull() || !config.Tag.IsNull() {
+		plan.Prefix = types.StringNull()
+		p, d := fwtypes.NewObjectValueOf(ctx, &plan)
+		resp.Diagnostics.Append(d...)
+		if d.HasError() {
+			return
+		}
+		resp.PlanValue = p.ObjectValue
+		return
+	}
+
+	// If none are set in config, set Prefix to ""
+	if config.And.IsNull() &&
+		config.ObjectSizeGreaterThan.IsNull() &&
+		config.ObjectSizeLessThan.IsNull() &&
+		config.Prefix.IsNull() &&
+		config.Tag.IsNull() {
+		plan.Prefix = types.StringValue("")
+		p, d := fwtypes.NewObjectValueOf(ctx, &plan)
+		resp.Diagnostics.Append(d...)
+		if d.HasError() {
+			return
+		}
+		resp.PlanValue = p.ObjectValue
+		return
+	}
+
+	resp.PlanValue = req.ConfigValue
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No

### Description

Currently, when the child attribute of `rule.filter` is switched to another attribute, the API request fails with a `MalformedXML` error

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42547

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketLifecycleConfiguration_

--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules (106.30s)
--- PASS: TestAccS3BucketLifecycleConfiguration_multipleRules_noFilterOrPrefix (106.65s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRangeAndPrefix (110.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeRange (196.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionZeroDays_intelligentTiering (196.27s)
--- PASS: TestAccS3BucketLifecycleConfiguration_removeRule (198.38s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_PrefixToAnd (202.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_remove (207.84s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_Tag (207.91s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_expireMarkerOnly (208.06s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionTransition (208.14s)
--- PASS: TestAccS3BucketLifecycleConfiguration_nonCurrentVersionExpiration (208.15s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThanZero (208.87s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RuleExpiration_emptyBlock (210.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeLessThan (210.99s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disableRule (245.86s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionStorageClassOnly_intelligentTiering (250.61s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Update_filterWithAndToFilterWithPrefix (255.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions_WithChange (293.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_intelligentTiering (103.67s)
--- PASS: TestAccS3BucketLifecycleConfiguration_directoryBucket (104.63s)
--- PASS: TestAccS3BucketLifecycleConfiguration_transitionDefaultMinimumObjectSize_update (190.02s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefixToFilter (195.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_RulePrefix (195.13s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_rule_NoFilterOrPrefix (305.56s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionDate_standardIa (180.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_objectSizeLessThanToPrefix (177.91s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_objectSizeGreaterThanToPrefix (177.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithEmptyPrefix (177.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_filterWithPrefix (182.98s)
--- PASS: TestAccS3BucketLifecycleConfiguration_Filter_ObjectSizeGreaterThan (178.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionZeroDays_intelligentTiering (211.46s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_emptyBlock (213.68s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionDate (238.35s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RulePrefix (238.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_disappears (75.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionStorageClassOnly_intelligentTiering (219.33s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RuleExpiration_expireMarkerOnly (214.69s)
--- PASS: TestAccS3BucketLifecycleConfiguration_rule_NoFilterOrPrefix (85.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_ruleAbortIncompleteMultipartUpload (217.73s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_withChange (94.85s)
--- PASS: TestAccS3BucketLifecycleConfiguration_migrateFromBucket_noChange (94.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_nonCurrentVersionExpiration (220.23s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_Tags (233.93s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions (248.78s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_nonCurrentVersionExpiration (253.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_expireMarkerOnly (253.48s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_ruleAbortIncompleteMultipartUpload (254.46s)
--- PASS: TestAccS3BucketLifecycleConfiguration_ruleAbortIncompleteMultipartUpload (168.54s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_Tag (226.83s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_EmptyFilter_NonCurrentVersions_WithChange (307.34s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionStorageClassOnly_intelligentTiering (159.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_RulePrefix (200.15s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_And_ZeroLessThan_ChangeOnUpdate (278.82s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeGreaterThan (219.45s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRangeAndPrefix (223.81s)
--- PASS: TestAccS3BucketLifecycleConfiguration_EmptyFilter_NonCurrentVersions (161.90s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRange (221.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (84.64s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_RuleExpiration_emptyBlock (249.00s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_filterWithEmptyPrefix (248.99s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_FilterWithPrefix (244.20s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_EmptyFilter_NonCurrentVersions (204.01s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeLessThan (215.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeGreaterThan (216.70s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_ObjectSizeRangeAndPrefix (217.97s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_Tag (218.11s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_objectSizeGreaterThanToPrefix (303.08s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_objectSizeLessThanToPrefix (295.45s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_Filter_And_Tags (197.18s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_FilterWithPrefix (189.67s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_TransitionDate (191.29s)
--- PASS: TestAccS3BucketLifecycleConfiguration_TransitionUpdateBetweenDaysAndDate_intelligentTiering (229.79s)
--- PASS: TestAccS3BucketLifecycleConfiguration_upgradeV5_86_0_rule_NoFilterOrPrefix (206.77s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_TransitionZeroDays_intelligentTiering (226.53s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeLessThan (231.03s)
--- PASS: TestAccS3BucketLifecycleConfiguration_frameworkMigrationV0_Filter_ObjectSizeRange (221.51s)
```
