### PR TITLE
[Enhancement] aws_cloudwatch_log_group: Add support for `log_group_class = "DELIVERY"` with retention policy handling

### DIFF
--- a/website/docs/r/cloudwatch_log_group.html.markdown
+++ b/website/docs/r/cloudwatch_log_group.html.markdown
@@ -30,10 +30,10 @@ This resource supports the following arguments:
 * `name` - (Optional, Forces new resource) The name of the log group. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `skip_destroy` - (Optional) Set to true if you do not wish the log group (and any logs it may contain) to be deleted at destroy time, and instead just remove the log group from the Terraform state.
-* `log_group_class` - (Optional) Specified the log class of the log group. Possible values are: `STANDARD` or `INFREQUENT_ACCESS`.
+* `log_group_class` - (Optional) Specified the log class of the log group. Possible values are: `STANDARD`, `INFREQUENT_ACCESS`, or `DELIVERY`.
 * `retention_in_days` - (Optional) Specifies the number of days
   you want to retain log events in the specified log group.  Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0.
-  If you select 0, the events in the log group are always retained and never expire.
+  If you select 0, the events in the log group are always retained and never expire. If `log_group_class` is set to `DELIVERY`, this argument is ignored and `retention_in_days` is forcibly set to 2.
 * `kms_key_id` - (Optional) The ARN of the KMS Key to use when encrypting log data. Please note, after the AWS KMS CMK is disassociated from the log group,
 AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
 permissions for the CMK whenever the encrypted data is requested.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* To support the `DELIVERY` log group class introduced in the AWS SDK for Go v2, diffs on `retention_in_days` are now suppressed when `log_group_class = "DELIVERY"`, and operations related to the retention policy are skipped even if `retention_in_days` is specified.

  * When `log_group_class = "DELIVERY"`, retention policy operations are rejected by the AWS API, and the retention period is forcibly set to 2 days.
  * Since the AWS API returns this value during the read operation, the Terraform state is refreshed to reflect `retention_in_days = 2`. If `retention_in_days` is not explicitly set in the configuration, Terraform attempts to reset it to 0, resulting in an unnecessary diff.
  * The implementation to suppress the diff is straightforward: when `log_group_class = "DELIVERY"`, any diff on `retention_in_days` is always ignored.
  * Acceptance tests verify that no plan diffs occur, even when the `retention_in_days` value is modified in the configuration.

* See #42657 for details.



### Relations

Closes #42657
Relates #42573 



### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccLogsGroup_ PKG=logs 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsGroup_'  -timeout 360m -vet=off
2025/05/17 19:05:40 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_nameGenerate
=== PAUSE TestAccLogsGroup_nameGenerate
=== RUN   TestAccLogsGroup_namePrefix
=== PAUSE TestAccLogsGroup_namePrefix
=== RUN   TestAccLogsGroup_disappears
=== PAUSE TestAccLogsGroup_disappears
=== RUN   TestAccLogsGroup_kmsKey
=== PAUSE TestAccLogsGroup_kmsKey
=== RUN   TestAccLogsGroup_logGroupClass
=== PAUSE TestAccLogsGroup_logGroupClass
=== RUN   TestAccLogsGroup_retentionPolicy
=== PAUSE TestAccLogsGroup_retentionPolicy
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== RUN   TestAccLogsGroup_skipDestroy
=== PAUSE TestAccLogsGroup_skipDestroy
=== RUN   TestAccLogsGroup_skipDestroyInconsistentPlan
=== PAUSE TestAccLogsGroup_skipDestroyInconsistentPlan
=== RUN   TestAccLogsGroup_logGroupClassDELIVERY1
=== PAUSE TestAccLogsGroup_logGroupClassDELIVERY1
=== RUN   TestAccLogsGroup_logGroupClassDELIVERY2
=== PAUSE TestAccLogsGroup_logGroupClassDELIVERY2
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_skipDestroyInconsistentPlan
=== CONT  TestAccLogsGroup_retentionPolicy
=== CONT  TestAccLogsGroup_skipDestroy
=== CONT  TestAccLogsGroup_logGroupClassDELIVERY2
=== CONT  TestAccLogsGroup_logGroupClassDELIVERY1
=== CONT  TestAccLogsGroup_disappears
=== CONT  TestAccLogsGroup_logGroupClass
=== CONT  TestAccLogsGroup_kmsKey
=== CONT  TestAccLogsGroup_nameGenerate
=== CONT  TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_namePrefix
--- PASS: TestAccLogsGroup_skipDestroy (29.81s)
--- PASS: TestAccLogsGroup_logGroupClassDELIVERY2 (30.12s)
--- PASS: TestAccLogsGroup_logGroupClass (30.62s)
--- PASS: TestAccLogsGroup_disappears (31.30s)
--- PASS: TestAccLogsGroup_multiple (31.35s)
--- PASS: TestAccLogsGroup_namePrefix (32.50s)
--- PASS: TestAccLogsGroup_basic (33.76s)
--- PASS: TestAccLogsGroup_nameGenerate (34.84s)
--- PASS: TestAccLogsGroup_skipDestroyInconsistentPlan (41.51s)
--- PASS: TestAccLogsGroup_logGroupClassDELIVERY1 (41.66s)
--- PASS: TestAccLogsGroup_retentionPolicy (56.31s)
--- PASS: TestAccLogsGroup_kmsKey (63.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       67.685s

```
