### PR TITLE
[New Data Source] `aws_s3_bucket_replication_configuration`

### DIFF
--- a/internal/service/s3/bucket_replication_configuration_data_source.go
+++ b/internal/service/s3/bucket_replication_configuration_data_source.go
@@ -1,0 +1,402 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_s3_bucket_replication_configuration", name="Bucket Replication Configuration")
+func newDataSourceBucketReplicationConfiguration(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceBucketReplicationConfiguration{}, nil
+}
+
+const (
+	DSNameBucketReplicationConfiguration = "Bucket Replication Configuration Data Source"
+)
+
+type dataSourceBucketReplicationConfiguration struct {
+	framework.DataSourceWithConfigure
+}
+
+func (d *dataSourceBucketReplicationConfiguration) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrBucket: schema.StringAttribute{
+				Required: true,
+			},
+
+			names.AttrRole: schema.StringAttribute{
+				Computed: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			names.AttrRule: schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigRuleModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1000),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrID: schema.StringAttribute{
+							Computed: true,
+						},
+						names.AttrPrefix: schema.StringAttribute{
+							Computed: true,
+						},
+						names.AttrPriority: schema.Int64Attribute{
+							Computed: true,
+						},
+						names.AttrStatus: schema.StringAttribute{
+							Computed: true,
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"delete_marker_replication": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigDeleteMarkerReplicationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"status": schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+						names.AttrDestination: schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigDestinationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"account": schema.StringAttribute{
+										Computed: true,
+									},
+									"bucket": schema.StringAttribute{
+										Computed: true,
+									},
+									names.AttrStorageClass: schema.StringAttribute{
+										Computed: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"access_control_translation": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigAccessControlTranslationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"owner": schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+									names.AttrEncryptionConfiguration: schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigEncryptionConfigurationModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												"replica_kms_key_id": schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+									"metrics": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigMetricsModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrStatus: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"event_threshold": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigEventThresholdModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"minutes": schema.Int64Attribute{
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"replication_time": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigReplicationTimeModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrStatus: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"time": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigTimeModel](ctx),
+													Validators: []validator.List{
+														listvalidator.SizeAtMost(1),
+													},
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															"minutes": schema.Int64Attribute{
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"existing_object_replication": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigExistingObjectReplicationModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrStatus: schema.StringAttribute{
+										Computed: true,
+									},
+								},
+							},
+						},
+						names.AttrFilter: schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigFilterModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									names.AttrPrefix: schema.StringAttribute{
+										Computed: true,
+									},
+								},
+								Blocks: map[string]schema.Block{
+									"and": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigFilterAndModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrPrefix: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+											Blocks: map[string]schema.Block{
+												"tag": schema.ListNestedBlock{
+													CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigFilterTagModel](ctx),
+													NestedObject: schema.NestedBlockObject{
+														Attributes: map[string]schema.Attribute{
+															names.AttrKey: schema.StringAttribute{
+																Computed: true,
+															},
+															names.AttrValue: schema.StringAttribute{
+																Computed: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"tag": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigFilterTagModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrKey: schema.StringAttribute{
+													Computed: true,
+												},
+												names.AttrValue: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"source_selection_criteria": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigSourceSelectionCriteriaModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtMost(1),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Blocks: map[string]schema.Block{
+									"replica_modifications": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigReplicaModificationsModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrStatus: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+									"sse_kms_encrypted_objects": schema.ListNestedBlock{
+										CustomType: fwtypes.NewListNestedObjectTypeOf[dsBucketRepConfigSseKmsEncryptedObjectsModel](ctx),
+										Validators: []validator.List{
+											listvalidator.SizeAtMost(1),
+										},
+										NestedObject: schema.NestedBlockObject{
+											Attributes: map[string]schema.Attribute{
+												names.AttrStatus: schema.StringAttribute{
+													Computed: true,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceBucketReplicationConfiguration) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	conn := d.Meta().S3Client(ctx)
+
+	var data dataSourceBucketReplicationConfigurationModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	out, err := findReplicationConfiguration(ctx, conn, data.Bucket.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			create.ProblemStandardMessage(names.S3, create.ErrActionReading, DSNameBucketReplicationConfiguration, data.Bucket.String(), err),
+			err.Error(),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(flex.Flatten(ctx, out, &data, flex.WithNoIgnoredFieldNames())...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+type dataSourceBucketReplicationConfigurationModel struct {
+	Bucket types.String                                                `tfsdk:"bucket"`
+	Role   types.String                                                `tfsdk:"role"`
+	Rule   fwtypes.ListNestedObjectValueOf[dsBucketRepConfigRuleModel] `tfsdk:"rule"`
+}
+
+type dsBucketRepConfigRuleModel struct {
+	DeleteMarkerReplication   fwtypes.ListNestedObjectValueOf[dsBucketRepConfigDeleteMarkerReplicationModel]   `tfsdk:"delete_marker_replication"`
+	Destination               fwtypes.ListNestedObjectValueOf[dsBucketRepConfigDestinationModel]               `tfsdk:"destination"`
+	ExistingObjectReplication fwtypes.ListNestedObjectValueOf[dsBucketRepConfigExistingObjectReplicationModel] `tfsdk:"existing_object_replication"`
+	Filter                    fwtypes.ListNestedObjectValueOf[dsBucketRepConfigFilterModel]                    `tfsdk:"filter"`
+	ID                        types.String                                                                     `tfsdk:"id"`
+	Prefix                    types.String                                                                     `tfsdk:"prefix"`
+	Priority                  types.Int64                                                                      `tfsdk:"priority"`
+	Status                    types.String                                                                     `tfsdk:"status"`
+	SourceSelectionCriteria   fwtypes.ListNestedObjectValueOf[dsBucketRepConfigSourceSelectionCriteriaModel]   `tfsdk:"source_selection_criteria"`
+}
+
+type dsBucketRepConfigDeleteMarkerReplicationModel struct {
+	Status types.String `tfsdk:"status"`
+}
+type dsBucketRepConfigDestinationModel struct {
+	AccessControlTranslation fwtypes.ListNestedObjectValueOf[dsBucketRepConfigAccessControlTranslationModel] `tfsdk:"access_control_translation"`
+	Account                  types.String                                                                    `tfsdk:"account"`
+	Bucket                   types.String                                                                    `tfsdk:"bucket"`
+	EncryptionConfiguration  fwtypes.ListNestedObjectValueOf[dsBucketRepConfigEncryptionConfigurationModel]  `tfsdk:"encryption_configuration"`
+	Metrics                  fwtypes.ListNestedObjectValueOf[dsBucketRepConfigMetricsModel]                  `tfsdk:"metrics"`
+	ReplicationTime          fwtypes.ListNestedObjectValueOf[dsBucketRepConfigReplicationTimeModel]          `tfsdk:"replication_time"`
+	StorageClass             types.String                                                                    `tfsdk:"storage_class"`
+}
+
+type dsBucketRepConfigAccessControlTranslationModel struct {
+	Owner types.String `tfsdk:"owner"`
+}
+type dsBucketRepConfigEncryptionConfigurationModel struct {
+	ReplicaKmsKeyId types.String `tfsdk:"replica_kms_key_id"`
+}
+type dsBucketRepConfigMetricsModel struct {
+	EventThreshold fwtypes.ListNestedObjectValueOf[dsBucketRepConfigEventThresholdModel] `tfsdk:"event_threshold"`
+	Status         types.String                                                          `tfsdk:"status"`
+}
+
+type dsBucketRepConfigEventThresholdModel struct {
+	Minutes types.Int64 `tfsdk:"minutes"`
+}
+type dsBucketRepConfigReplicationTimeModel struct {
+	Status types.String                                                `tfsdk:"status"`
+	Time   fwtypes.ListNestedObjectValueOf[dsBucketRepConfigTimeModel] `tfsdk:"time"`
+}
+type dsBucketRepConfigTimeModel struct {
+	Minutes types.Int64 `tfsdk:"minutes"`
+}
+
+type dsBucketRepConfigExistingObjectReplicationModel struct {
+	Status types.String `tfsdk:"status"`
+}
+type dsBucketRepConfigFilterModel struct {
+	And    fwtypes.ListNestedObjectValueOf[dsBucketRepConfigFilterAndModel] `tfsdk:"and"`
+	Tag    fwtypes.ListNestedObjectValueOf[dsBucketRepConfigFilterTagModel] `tfsdk:"tag"`
+	Prefix types.String                                                     `tfsdk:"prefix"`
+}
+type dsBucketRepConfigFilterAndModel struct {
+	Prefix types.String                                                     `tfsdk:"prefix"`
+	Tag    fwtypes.ListNestedObjectValueOf[dsBucketRepConfigFilterTagModel] `tfsdk:"tag"`
+}
+type dsBucketRepConfigFilterTagModel struct {
+	Key   types.String `tfsdk:"key"`
+	Value types.String `tfsdk:"value"`
+}
+type dsBucketRepConfigSourceSelectionCriteriaModel struct {
+	ReplicaModifications   fwtypes.ListNestedObjectValueOf[dsBucketRepConfigReplicaModificationsModel]   `tfsdk:"replica_modifications"`
+	SseKmsEncryptedObjects fwtypes.ListNestedObjectValueOf[dsBucketRepConfigSseKmsEncryptedObjectsModel] `tfsdk:"sse_kms_encrypted_objects"`
+}
+type dsBucketRepConfigReplicaModificationsModel struct {
+	Status types.String `tfsdk:"status"`
+}
+type dsBucketRepConfigSseKmsEncryptedObjectsModel struct {
+	Status types.String `tfsdk:"status"`
+}

--- a/internal/service/s3/bucket_replication_configuration_data_source_test.go
+++ b/internal/service/s3/bucket_replication_configuration_data_source_test.go
@@ -1,0 +1,225 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package s3_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccS3BucketReplicationConfigurationDataSource_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	iamRoleResourceName := "aws_iam_role.test"
+	dstBucketResourceName := "aws_s3_bucket.destination"
+	resourceName := "aws_s3_bucket_replication_configuration.test"
+	dataSourceName := "data.aws_s3_bucket_replication_configuration.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	var providers []*schema.Provider
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckMultipleRegion(t, 2)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesPlusProvidersAlternate(ctx, t, &providers),
+		CheckDestroy:             acctest.CheckWithProviders(testAccCheckBucketReplicationConfigurationDestroyWithProvider(ctx), &providers),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketReplicationConfigurationDataSourceConfig_basic(rName, string(types.StorageClassStandard)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketReplicationConfigurationExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrRole, iamRoleResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(dataSourceName, acctest.CtRulePound, "3"),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "rule.*", map[string]string{
+						names.AttrID:                                        "rule1",
+						names.AttrPriority:                                  "1",
+						"filter.#":                                          "1",
+						"filter.0.prefix":                                   "foo",
+						names.AttrStatus:                                    string(types.ReplicationRuleStatusEnabled),
+						"delete_marker_replication.#":                       "1",
+						"delete_marker_replication.0.status":                string(types.DeleteMarkerReplicationStatusEnabled),
+						"destination.#":                                     "1",
+						"destination.0.storage_class":                       string(types.StorageClassStandard),
+						"destination.0.replication_time.#":                  "1",
+						"destination.0.replication_time.0.status":           string(types.ReplicationTimeStatusEnabled),
+						"destination.0.replication_time.0.time.#":           "1",
+						"destination.0.replication_time.0.time.0.minutes":   "15",
+						"destination.0.metrics.#":                           "1",
+						"destination.0.metrics.0.status":                    string(types.MetricsStatusEnabled),
+						"destination.0.metrics.0.event_threshold.#":         "1",
+						"destination.0.metrics.0.event_threshold.0.minutes": "15",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "rule.*", map[string]string{
+						names.AttrID:                                        "rule2",
+						names.AttrPriority:                                  "2",
+						"filter.#":                                          "1",
+						"filter.0.and.#":                                    "1",
+						"filter.0.and.0.prefix":                             "bar",
+						"filter.0.and.0.tag.#":                              "1",
+						"filter.0.and.0.tag.0.key":                          "key1",
+						"filter.0.and.0.tag.0.value":                        "value1",
+						names.AttrStatus:                                    string(types.ReplicationRuleStatusEnabled),
+						"delete_marker_replication.#":                       "1",
+						"delete_marker_replication.0.status":                string(types.DeleteMarkerReplicationStatusDisabled),
+						"destination.#":                                     "1",
+						"destination.0.storage_class":                       string(types.StorageClassStandard),
+						"destination.0.replication_time.#":                  "1",
+						"destination.0.replication_time.0.status":           string(types.ReplicationTimeStatusDisabled),
+						"destination.0.replication_time.0.time.#":           "1",
+						"destination.0.replication_time.0.time.0.minutes":   "15",
+						"destination.0.metrics.#":                           "1",
+						"destination.0.metrics.0.status":                    string(types.MetricsStatusDisabled),
+						"destination.0.metrics.0.event_threshold.#":         "1",
+						"destination.0.metrics.0.event_threshold.0.minutes": "15",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(dataSourceName, "rule.*", map[string]string{
+						names.AttrID:                                        "rule3",
+						names.AttrPriority:                                  "3",
+						"filter.#":                                          "1",
+						"filter.0.tag.#":                                    "1",
+						"filter.0.tag.0.key":                                "Key",
+						"filter.0.tag.0.value":                              "Value",
+						names.AttrStatus:                                    string(types.ReplicationRuleStatusEnabled),
+						"delete_marker_replication.#":                       "1",
+						"delete_marker_replication.0.status":                string(types.DeleteMarkerReplicationStatusDisabled),
+						"destination.#":                                     "1",
+						"destination.0.storage_class":                       string(types.StorageClassStandard),
+						"destination.0.replication_time.#":                  "1",
+						"destination.0.replication_time.0.status":           string(types.ReplicationTimeStatusDisabled),
+						"destination.0.replication_time.0.time.#":           "1",
+						"destination.0.replication_time.0.time.0.minutes":   "15",
+						"destination.0.metrics.#":                           "1",
+						"destination.0.metrics.0.status":                    string(types.MetricsStatusDisabled),
+						"destination.0.metrics.0.event_threshold.#":         "1",
+						"destination.0.metrics.0.event_threshold.0.minutes": "15",
+					}),
+					resource.TestCheckTypeSetElemAttrPair(dataSourceName, "rule.*.destination.0.bucket", dstBucketResourceName, names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
+func testAccBucketReplicationConfigurationDataSourceConfig_basic(rName, storageClass string) string {
+	return acctest.ConfigCompose(testAccBucketReplicationConfigurationConfig_base(rName), fmt.Sprintf(`
+resource "aws_s3_bucket_replication_configuration" "test" {
+  depends_on = [
+    aws_s3_bucket_versioning.source,
+    aws_s3_bucket_versioning.destination
+  ]
+
+  bucket = aws_s3_bucket.source.id
+  role   = aws_iam_role.test.arn
+
+  rule {
+    id = "rule1"
+    priority = 1
+    filter {
+      prefix = "foo"
+    }
+    status = "Enabled"
+    delete_marker_replication {
+      status = "Enabled"
+    }
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+      storage_class = %[1]q
+      replication_time {
+        status = "Enabled"
+        time {
+          minutes = 15
+        }
+      }
+      metrics {
+        status = "Enabled"
+        event_threshold {
+          minutes = 15
+        }
+      }
+    }
+  }
+
+  rule {
+    id = "rule2"
+    priority = 2
+    filter {
+      and {
+        prefix = "bar"
+        tags = {
+          key1 = "value1"
+        }
+      }
+    }
+    status = "Enabled"
+    delete_marker_replication {
+      status = "Disabled"
+    }
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+      storage_class = %[1]q
+      replication_time {
+        status = "Disabled"
+        time {
+          minutes = 15
+        }
+      }
+      metrics {
+        status = "Disabled"
+        event_threshold {
+          minutes = 15
+        }
+      }
+    }
+  }
+  rule {
+    id = "rule3"
+    priority = 3
+    filter {
+      tag {
+        key   = "Key"
+        value = "Value"
+      }
+    }
+    status = "Enabled"
+    delete_marker_replication {
+      status = "Disabled"
+    }
+    destination {
+      bucket = aws_s3_bucket.destination.arn
+      storage_class = %[1]q
+      replication_time {
+        status = "Disabled"
+        time {
+          minutes = 15
+        }
+      }
+      metrics {
+        status = "Disabled"
+        event_threshold {
+          minutes = 15
+        }
+      }
+    }
+  }
+}
+
+data "aws_s3_bucket_replication_configuration" "test" {
+  bucket = aws_s3_bucket.source.id
+
+  depends_on = [
+    aws_s3_bucket_replication_configuration.test,
+  ]
+}
+
+`, storageClass))
+}

--- a/internal/service/s3/service_package_gen.go
+++ b/internal/service/s3/service_package_gen.go
@@ -17,6 +17,11 @@ type servicePackage struct{}
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*types.ServicePackageFrameworkDataSource {
 	return []*types.ServicePackageFrameworkDataSource{
 		{
+			Factory:  newDataSourceBucketReplicationConfiguration,
+			TypeName: "aws_s3_bucket_replication_configuration",
+			Name:     "Bucket Replication Configuration",
+		},
+		{
 			Factory:  newDirectoryBucketsDataSource,
 			TypeName: "aws_s3_directory_buckets",
 			Name:     "Directory Buckets",

--- a/website/docs/d/s3_bucket_replication_configuration.html.markdown
+++ b/website/docs/d/s3_bucket_replication_configuration.html.markdown
@@ -1,0 +1,38 @@
+---
+subcategory: "S3 (Simple Storage)"
+layout: "aws"
+page_title: "AWS: aws_s3_bucket_replication_configuration"
+description: |-
+  Terraform data source for managing an AWS S3 (Simple Storage) Bucket Replication Configuration.
+---
+
+# Data Source: aws_s3_bucket_replication_configuration
+
+Terraform data source for managing an AWS S3 (Simple Storage) Bucket Replication Configuration.
+
+## Example Usage
+
+### Basic Usage
+
+```terraform
+data "aws_s3_bucket_replication_configuration" "example" {
+  bucket = "example-bucket"
+}
+```
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `role` – The ARN of the IAM role that Amazon S3 assumes when replicating objects.
+* `rule` – An unordered list of configuration blocks that define the rules managing replication.
+
+See the [`aws_s3_replication_configuration`](../r/s3_bucket_replication_configuration.html.markdown#rule) resource documentation for details about the `rule` block (excluding the `and` block within the `filter` block).
+
+### `and`
+
+* `prefix` – The object key name prefix that identifies the subset of objects to which the rule applies.
+* `tag` – An unordered list of tags that identify a subset of objects to which the rule applies.
+  
+  * `key` – The key of the tag.
+  * `value` – The value of the tag.


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Added a new data source: `aws_s3_bucket_replication_configuration`, backed by the [[GetBucketReplication API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html)](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html).
* The schema is identical to that of the `aws_s3_bucket_replication_configuration` resource, except for the `and` block within the `filter` block.

  * While this block is defined as a map in the resource, it is implemented as a block with `key` and `value` arguments in the data source, to better align with the API response structure.

### Relations

Closes #42028

### References
[GetBucketReplication API](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html)

### Output from Acceptance Testing

```console

```
