### PR TITLE
Implement VPC configuration for AWS Kendra data source 

### DIFF
--- a/.changelog/42672.txt
+++ b/.changelog/42672.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+resource/aws_kendra_data_source: Add support for VPC configuration
+``` 

--- a/internal/service/kendra/data_source.go
+++ b/internal/service/kendra/data_source.go
@@ -1793,12 +1793,12 @@ func flattenDocumentAttributeValue(apiObject *types.DocumentAttributeValue) []an
 	return []any{tfMap}
 }
 
-func expandVPCConfiguration(vVpcConfiguration []any) *awstypes.VpcConfiguration {
+func expandVPCConfiguration(vVpcConfiguration []any) *types.DataSourceVpcConfiguration {
 	if len(vVpcConfiguration) == 0 || vVpcConfiguration[0] == nil {
 		return nil
 	}
 
-	vpcConfiguration := &awstypes.VpcConfiguration{}
+	vpcConfiguration := &types.DataSourceVpcConfiguration{}
 
 	mVpcConfiguration := vVpcConfiguration[0].(map[string]any)
 
@@ -1813,7 +1813,7 @@ func expandVPCConfiguration(vVpcConfiguration []any) *awstypes.VpcConfiguration 
 	return vpcConfiguration
 }
 
-func flattenVPCConfiguration(apiObject *types.VpcConfiguration) []any {
+func flattenVPCConfiguration(apiObject *types.DataSourceVpcConfiguration) []any {
 	if apiObject == nil {
 		return nil
 	}


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for specifying security_group_ids and subnet_ids via a vpc_configuration block in the aws_kendra_data_source resource. Updates schema and resource logic to handle create, read, and update operations with VPC settings.

Impact:
Enables Kendra data sources to connect to resources in a VPC. Backward-compatible with existing configurations.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

[Issues #42670](https://github.com/hashicorp/terraform-provider-aws/issues/42670)

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
https://docs.aws.amazon.com/cli/latest/reference/kendra/create-data-source.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
