### PR TITLE
add support for volume_initialization_rate for EBS volumes. Fixes #42518

### DIFF
--- a/internal/service/autoscaling/launch_configuration.go
+++ b/internal/service/autoscaling/launch_configuration.go
@@ -101,6 +101,12 @@ func resourceLaunchConfiguration() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+						names.AttrVolumeInitializationRate: {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 						names.AttrVolumeSize: {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -260,6 +266,12 @@ func resourceLaunchConfiguration() *schema.Resource {
 							Computed: true,
 							ForceNew: true,
 						},
+						names.AttrVolumeInitializationRate: {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+						},
 						names.AttrVolumeSize: {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -366,7 +378,6 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 
 	// We'll use this to detect if we're declaring it incorrectly as an ebs_block_device.
 	rootDeviceName, err := findImageRootDeviceName(ctx, ec2conn, d.Get("image_id").(string))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Auto Scaling Launch Configuration (%s): %s", lcName, err)
 	}
@@ -416,7 +427,6 @@ func resourceLaunchConfigurationCreate(ctx context.Context, d *schema.ResourceDa
 
 			return false, err
 		})
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating Auto Scaling Launch Configuration (%s): %s", lcName, err)
 	}
@@ -785,7 +795,6 @@ func userDataHashSum(userData string) string {
 
 func findLaunchConfiguration(ctx context.Context, conn *autoscaling.Client, input *autoscaling.DescribeLaunchConfigurationsInput) (*awstypes.LaunchConfiguration, error) {
 	output, err := findLaunchConfigurations(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -800,7 +809,6 @@ func findLaunchConfigurations(ctx context.Context, conn *autoscaling.Client, inp
 
 	for pages.HasMorePages() {
 		page, err := pages.NextPage(ctx)
-
 		if err != nil {
 			return nil, err
 		}
@@ -817,7 +825,6 @@ func findLaunchConfigurationByName(ctx context.Context, conn *autoscaling.Client
 	}
 
 	output, err := findLaunchConfiguration(ctx, conn, input)
-
 	if err != nil {
 		return nil, err
 	}
@@ -834,7 +841,6 @@ func findLaunchConfigurationByName(ctx context.Context, conn *autoscaling.Client
 
 func findImageRootDeviceName(ctx context.Context, conn *ec2.Client, imageID string) (string, error) {
 	image, err := tfec2.FindImageByID(ctx, conn, imageID)
-
 	if err != nil {
 		return "", err
 	}

--- a/internal/service/autoscaling/launch_configuration_data_source.go
+++ b/internal/service/autoscaling/launch_configuration_data_source.go
@@ -60,6 +60,10 @@ func dataSourceLaunchConfiguration() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						names.AttrVolumeInitializationRate: {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
 						names.AttrVolumeSize: {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -195,7 +199,6 @@ func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceDa
 
 	name := d.Get(names.AttrName).(string)
 	lc, err := findLaunchConfigurationByName(ctx, autoscalingconn, name)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Auto Scaling Launch Configuration (%s): %s", name, err)
 	}
@@ -228,7 +231,6 @@ func dataSourceLaunchConfigurationRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("user_data", lc.UserData)
 
 	rootDeviceName, err := findImageRootDeviceName(ctx, ec2conn, d.Get("image_id").(string))
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading Auto Scaling Launch Configuration (%s): %s", name, err)
 	}

--- a/internal/service/ec2/ec2_ami_data_source.go
+++ b/internal/service/ec2/ec2_ami_data_source.go
@@ -260,7 +260,6 @@ func dataSourceAMIRead(ctx context.Context, d *schema.ResourceData, meta any) di
 	diags = checkMostRecentAndMissingFilters(diags, &describeImagesInput, d.Get(names.AttrMostRecent).(bool))
 
 	images, err := findImages(ctx, conn, &describeImagesInput)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 AMIs: %s", err)
 	}
@@ -375,13 +374,14 @@ func flattenAMIBlockDeviceMappings(apiObjects []awstypes.BlockDeviceMapping) []a
 
 		if apiObject := apiObject.Ebs; apiObject != nil {
 			ebs := map[string]any{
-				names.AttrDeleteOnTermination: flex.BoolToStringValue(apiObject.DeleteOnTermination),
-				names.AttrEncrypted:           flex.BoolToStringValue(apiObject.Encrypted),
-				names.AttrIOPS:                flex.Int32ToStringValue(apiObject.Iops),
-				names.AttrSnapshotID:          aws.ToString(apiObject.SnapshotId),
-				names.AttrThroughput:          flex.Int32ToStringValue(apiObject.Throughput),
-				names.AttrVolumeSize:          flex.Int32ToStringValue(apiObject.VolumeSize),
-				names.AttrVolumeType:          apiObject.VolumeType,
+				names.AttrDeleteOnTermination:      flex.BoolToStringValue(apiObject.DeleteOnTermination),
+				names.AttrEncrypted:                flex.BoolToStringValue(apiObject.Encrypted),
+				names.AttrIOPS:                     flex.Int32ToStringValue(apiObject.Iops),
+				names.AttrSnapshotID:               aws.ToString(apiObject.SnapshotId),
+				names.AttrThroughput:               flex.Int32ToStringValue(apiObject.Throughput),
+				names.AttrVolumeSize:               flex.Int32ToStringValue(apiObject.VolumeSize),
+				names.AttrVolumeInitializationRate: flex.Int32ToStringValue(apiObject.VolumeInitializationRate),
+				names.AttrVolumeType:               apiObject.VolumeType,
 			}
 
 			tfMap["ebs"] = ebs

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -103,6 +103,12 @@ func resourceLaunchTemplate() *schema.Resource {
 										Optional: true,
 										Computed: true,
 									},
+									names.AttrVolumeInitializationRate: {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Computed:     true,
+										ValidateFunc: validation.IntBetween(100, 300),
+									},
 									names.AttrVolumeType: {
 										Type:             schema.TypeString,
 										Optional:         true,
@@ -1065,7 +1071,6 @@ func resourceLaunchTemplateCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	output, err := conn.CreateLaunchTemplate(ctx, &input)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating EC2 Launch Template (%s): %s", name, err)
 	}
@@ -1097,7 +1102,6 @@ func resourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, met
 
 	version := flex.Int64ToStringValue(lt.LatestVersionNumber)
 	ltv, err := findLaunchTemplateVersionByTwoPartKey(ctx, conn, d.Id(), version)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Launch Template (%s) Version (%s): %s", d.Id(), version, err)
 	}
@@ -1181,7 +1185,6 @@ func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		output, err := conn.CreateLaunchTemplateVersion(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "creating EC2 Launch Template (%s) Version: %s", d.Id(), err)
 		}
@@ -1201,7 +1204,6 @@ func resourceLaunchTemplateUpdate(ctx context.Context, d *schema.ResourceData, m
 		}
 
 		_, err := conn.ModifyLaunchTemplate(ctx, &input)
-
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "updating EC2 Launch Template (%s): %s", d.Id(), err)
 		}
@@ -1306,7 +1308,6 @@ func expandRequestLaunchTemplateData(ctx context.Context, conn *ec2.Client, d *s
 	if v, ok := d.GetOk("credit_specification"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		if instanceType != "" {
 			instanceTypeInfo, err := findInstanceTypeByName(ctx, conn, instanceType)
-
 			if err != nil {
 				return nil, fmt.Errorf("reading EC2 Instance Type (%s): %w", instanceType, err)
 			}
@@ -1507,6 +1508,10 @@ func expandLaunchTemplateEBSBlockDeviceRequest(tfMap map[string]any) *awstypes.L
 
 	if v, ok := tfMap[names.AttrVolumeSize].(int); ok && v != 0 {
 		apiObject.VolumeSize = aws.Int32(int32(v))
+	}
+
+	if v, ok := tfMap[names.AttrVolumeInitializationRate].(int); ok && v != 0 {
+		apiObject.VolumeInitializationRate = aws.Int32(int32(v))
 	}
 
 	if v, ok := tfMap[names.AttrVolumeType].(string); ok && v != "" {
@@ -2289,7 +2294,6 @@ func flattenResponseLaunchTemplateData(ctx context.Context, conn *ec2.Client, d 
 	}
 	if apiObject.CreditSpecification != nil && instanceType != "" {
 		instanceTypeInfo, err := findInstanceTypeByName(ctx, conn, instanceType)
-
 		if err != nil {
 			return fmt.Errorf("reading EC2 Instance Type (%s): %w", instanceType, err)
 		}
@@ -2486,6 +2490,10 @@ func flattenLaunchTemplateEBSBlockDevice(apiObject *awstypes.LaunchTemplateEbsBl
 
 	if v := apiObject.VolumeSize; v != nil {
 		tfMap[names.AttrVolumeSize] = aws.ToInt32(v)
+	}
+
+	if v := apiObject.VolumeInitializationRate; v != nil {
+		tfMap[names.AttrVolumeInitializationRate] = aws.ToInt32(v)
 	}
 
 	if v := apiObject.VolumeType; v != "" {

--- a/internal/service/ec2/ec2_launch_template_data_source.go
+++ b/internal/service/ec2/ec2_launch_template_data_source.go
@@ -79,6 +79,10 @@ func dataSourceLaunchTemplate() *schema.Resource {
 										Type:     schema.TypeInt,
 										Computed: true,
 									},
+									names.AttrVolumeInitializationRate: {
+										Type:     schema.TypeInt,
+										Computed: true,
+									},
 									names.AttrVolumeType: {
 										Type:     schema.TypeString,
 										Computed: true,
@@ -838,7 +842,6 @@ func dataSourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	lt, err := findLaunchTemplate(ctx, conn, &input)
-
 	if err != nil {
 		return sdkdiag.AppendFromErr(diags, tfresource.SingularDataSourceFindError("EC2 Launch Template", err))
 	}
@@ -847,7 +850,6 @@ func dataSourceLaunchTemplateRead(ctx context.Context, d *schema.ResourceData, m
 
 	version := flex.Int64ToStringValue(lt.LatestVersionNumber)
 	ltv, err := findLaunchTemplateVersionByTwoPartKey(ctx, conn, d.Id(), version)
-
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "reading EC2 Launch Template (%s) Version (%s): %s", d.Id(), version, err)
 	}

--- a/names/attr_consts_gen.go
+++ b/names/attr_consts_gen.go
@@ -232,6 +232,7 @@ const (
 	AttrVersion                    = "version"
 	AttrVirtualName                = "virtual_name"
 	AttrVolumeSize                 = "volume_size"
+	AttrVolumeInitializationRate   = "volume_initialization_rate"
 	AttrVolumeType                 = "volume_type"
 	AttrWeight                     = "weight"
 )

--- a/names/generate/const_or_quote_gen.go
+++ b/names/generate/const_or_quote_gen.go
@@ -239,6 +239,7 @@ func ConstOrQuote(constant string) string {
 		"values":                        "AttrValues",
 		"version":                       "AttrVersion",
 		"virtual_name":                  "AttrVirtualName",
+		"volume_initialization_rate":    "AttrVolumeInitializationRate",
 		"volume_size":                   "AttrVolumeSize",
 		"volume_type":                   "AttrVolumeType",
 		"weight":                        "AttrWeight",

--- a/website/docs/cdktf/python/d/ami.html.markdown
+++ b/website/docs/cdktf/python/d/ami.html.markdown
@@ -87,6 +87,7 @@ This data source exports the following attributes in addition to the arguments a
         * `snapshot_id` - The ID of the snapshot.
         * `volume_size` - The size of the volume, in GiB.
         * `throughput` - The throughput that the EBS volume supports, in MiB/s.
+        * `volume_initialization_rate` - The volume initialization rate, in MiB/s.
         * `volume_type` - The volume type.
     * `no_device` - Suppresses the specified device included in the block device mapping of the AMI.
     * `virtual_name` - Virtual device name (for instance stores).

--- a/website/docs/cdktf/python/r/launch_template.html.markdown
+++ b/website/docs/cdktf/python/r/launch_template.html.markdown
@@ -180,6 +180,7 @@ The `ebs` block supports the following:
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
 * `throughput` - (Optional) The throughput to provision for a `gp3` volume in MiB/s (specified as an integer, e.g., 500), with a maximum of 1,000 MiB/s.
 * `volume_size` - (Optional) The size of the volume in gigabytes.
+* `volume_initialization_rate` - (Optional) The volume initialization rate in MiB/s (specified as an integer, e.g. 100), with a minimum of 100 MiB/s and maximum of 300 MiB/s.
 * `volume_type` - (Optional) The volume type.
   Can be one of `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1`.
 

--- a/website/docs/d/ami.html.markdown
+++ b/website/docs/d/ami.html.markdown
@@ -79,6 +79,7 @@ This data source exports the following attributes in addition to the arguments a
         * `volume_size` - The size of the volume, in GiB.
         * `throughput` - The throughput that the EBS volume supports, in MiB/s.
         * `volume_type` - The volume type.
+        * `volume_initialization_rate` - The volume initialization rate, in MiB/s.
     * `no_device` - Suppresses the specified device included in the block device mapping of the AMI.
     * `virtual_name` - Virtual device name (for instance stores).
 * `creation_date` - Date and time the image was created.

--- a/website/docs/r/launch_template.html.markdown
+++ b/website/docs/r/launch_template.html.markdown
@@ -188,6 +188,7 @@ The `ebs` block supports the following:
 * `snapshot_id` - (Optional) The Snapshot ID to mount.
 * `throughput` - (Optional) The throughput to provision for a `gp3` volume in MiB/s (specified as an integer, e.g., 500), with a maximum of 1,000 MiB/s.
 * `volume_size` - (Optional) The size of the volume in gigabytes.
+* `volume_initialization_rate` - (Optional) The volume initialization rate in MiB/s (specified as an integer, e.g. 100), with a minimum of 100 MiB/s and maximum of 300 MiB/s.
 * `volume_type` - (Optional) The volume type.
   Can be one of `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1`.
 


### PR DESCRIPTION
## Rollback Plan

Rolling back should cause no issues

## Changes to Security Controls

No

### Description
Adds support for [VolumeInitializationRate](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-ebs.html) on EBS volumes.


### Relations
Closes #42518

### References
[Amazon EBS announces Provisioned Rate for Volume Initialization](https://aws.amazon.com/about-aws/whats-new/2025/05/ebs-provisioned-rate-volume-initialization/)


### Output from Acceptance Testing


```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
