### PR TITLE
`appflow`: Use `name` instead of `arn` as `id`, since API calls take `name`

### DIFF
--- a/internal/service/appflow/connector_profile.go
+++ b/internal/service/appflow/connector_profile.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
 	"github.com/aws/aws-sdk-go-v2/service/appflow/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -1457,13 +1456,13 @@ func resourceConnectorProfileCreate(ctx context.Context, d *schema.ResourceData,
 		input.KmsArn = aws.String(v)
 	}
 
-	output, err := conn.CreateConnectorProfile(ctx, input)
+	_, err := conn.CreateConnectorProfile(ctx, input)
 
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating AppFlow Connector Profile (%s): %s", name, err)
 	}
 
-	d.SetId(aws.ToString(output.ConnectorProfileArn))
+	d.SetId(name)
 
 	return append(diags, resourceConnectorProfileRead(ctx, d, meta)...)
 }
@@ -1473,7 +1472,7 @@ func resourceConnectorProfileRead(ctx context.Context, d *schema.ResourceData, m
 
 	conn := meta.(*conns.AWSClient).AppFlowClient(ctx)
 
-	connectorProfile, err := findConnectorProfileByARN(ctx, conn, d.Id())
+	connectorProfile, err := findConnectorProfileByName(ctx, conn, d.Id())
 
 	if !d.IsNewResource() && tfresource.NotFound(err) {
 		log.Printf("[WARN] AppFlow Connector Profile (%s) not found, removing from state", d.Id())
@@ -1549,32 +1548,21 @@ func resourceConnectorProfileDelete(ctx context.Context, d *schema.ResourceData,
 	return diags
 }
 
-func findConnectorProfileByARN(ctx context.Context, conn *appflow.Client, arn string) (*types.ConnectorProfile, error) {
-	input := &appflow.DescribeConnectorProfilesInput{}
-
-	pages := appflow.NewDescribeConnectorProfilesPaginator(conn, input)
-	for pages.HasMorePages() {
-		page, err := pages.NextPage(ctx)
-
-		if errs.IsA[*types.ResourceNotFoundException](err) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
-			}
-		}
-
-		if err != nil {
-			return nil, err
-		}
-
-		for _, v := range page.ConnectorProfileDetails {
-			if aws.ToString(v.ConnectorProfileArn) == arn {
-				return &v, nil
-			}
-		}
+func findConnectorProfileByName(ctx context.Context, conn *appflow.Client, name string) (*types.ConnectorProfile, error) {
+	input := appflow.DescribeConnectorProfilesInput{
+		ConnectorProfileNames: []string{name},
 	}
 
-	return nil, tfresource.NewEmptyResultError(input)
+	output, err := conn.DescribeConnectorProfiles(ctx, &input)
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || len(output.ConnectorProfileDetails) == 0 {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return tfresource.AssertSingleValueResult(output.ConnectorProfileDetails)
 }
 
 func expandConnectorProfileConfig(m map[string]any) *types.ConnectorProfileConfig {

--- a/internal/service/appflow/connector_profile_test.go
+++ b/internal/service/appflow/connector_profile_test.go
@@ -118,7 +118,7 @@ func testAccCheckConnectorProfileDestroy(ctx context.Context) resource.TestCheck
 				continue
 			}
 
-			_, err := tfappflow.FindConnectorProfileByARN(ctx, conn, rs.Primary.ID)
+			_, err := tfappflow.FindConnectorProfileByName(ctx, conn, rs.Primary.ID)
 
 			if tfresource.NotFound(err) {
 				continue
@@ -144,7 +144,7 @@ func testAccCheckConnectorProfileExists(ctx context.Context, n string, v *types.
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AppFlowClient(ctx)
 
-		output, err := tfappflow.FindConnectorProfileByARN(ctx, conn, rs.Primary.ID)
+		output, err := tfappflow.FindConnectorProfileByName(ctx, conn, rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/internal/service/appflow/exports_test.go
+++ b/internal/service/appflow/exports_test.go
@@ -8,6 +8,6 @@ var (
 	ResourceConnectorProfile = resourceConnectorProfile
 	ResourceFlow             = resourceFlow
 
-	FindConnectorProfileByARN = findConnectorProfileByARN
-	FindFlowByName            = findFlowByName
+	FindConnectorProfileByName = findConnectorProfileByName
+	FindFlowByName             = findFlowByName
 )

--- a/internal/service/appflow/flow.go
+++ b/internal/service/appflow/flow.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"log"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
 	"github.com/aws/aws-sdk-go-v2/service/appflow/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -43,12 +41,7 @@ func resourceFlow() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
-				p, err := arn.Parse(d.Id())
-				if err != nil {
-					return nil, err
-				}
-				name := strings.TrimPrefix(p.Resource, "flow/")
-				d.Set(names.AttrName, name)
+				d.Set(names.AttrName, d.Id())
 
 				return []*schema.ResourceData{d}, nil
 			},
@@ -1378,13 +1371,12 @@ func resourceFlowCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 		input.KmsArn = aws.String(v.(string))
 	}
 
-	output, err := conn.CreateFlow(ctx, input)
-
+	_, err := conn.CreateFlow(ctx, input)
 	if err != nil {
 		return sdkdiag.AppendErrorf(diags, "creating AppFlow Flow (%s): %s", name, err)
 	}
 
-	d.SetId(aws.ToString(output.FlowArn))
+	d.SetId(name)
 
 	return append(diags, resourceFlowRead(ctx, d, meta)...)
 }

--- a/internal/service/appflow/flow_test.go
+++ b/internal/service/appflow/flow_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -38,7 +37,7 @@ func TestAccAppFlowFlow_basic(t *testing.T) {
 				Config: testAccFlowConfig_basic(rName, scheduleStartTime),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckFlowExists(ctx, resourceName, &flowOutput),
-					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "appflow", regexache.MustCompile(`flow/.+`)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "appflow", "flow/{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_flow_config.#"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination_flow_config.0.connector_type"),

--- a/website/docs/r/appflow_connector_profile.html.markdown
+++ b/website/docs/r/appflow_connector_profile.html.markdown
@@ -323,19 +323,19 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow Connector Profile using the connector profile `arn`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow Connector Profile using the connector profile `name`. For example:
 
 ```terraform
 import {
-  to = aws_appflow_connector_profile.profile
-  id = "arn:aws:appflow:us-west-2:123456789012:connectorprofile/example-profile"
+  to = aws_appflow_connector_profile.example
+  id = "example-profile"
 }
 ```
 
-Using `terraform import`, import AppFlow Connector Profile using the connector profile `arn`. For example:
+Using `terraform import`, import AppFlow Connector Profile using the connector profile `name`. For example:
 
 ```console
-% terraform import aws_appflow_connector_profile.profile arn:aws:appflow:us-west-2:123456789012:connectorprofile/example-profile
+% terraform import aws_appflow_connector_profile.example example-profile
 ```
 
 [1]: https://docs.aws.amazon.com/appflow/1.0/APIReference/Welcome.html

--- a/website/docs/r/appflow_flow.html.markdown
+++ b/website/docs/r/appflow_flow.html.markdown
@@ -417,17 +417,17 @@ This resource exports the following attributes in addition to the arguments abov
 
 ## Import
 
-In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow flows using the `arn`. For example:
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import AppFlow flows using the `name`. For example:
 
 ```terraform
 import {
   to = aws_appflow_flow.example
-  id = "arn:aws:appflow:us-west-2:123456789012:flow/example-flow"
+  id = "example-flow"
 }
 ```
 
-Using `terraform import`, import AppFlow flows using the `arn`. For example:
+Using `terraform import`, import AppFlow flows using the `name`. For example:
 
 ```console
-% terraform import aws_appflow_flow.example arn:aws:appflow:us-west-2:123456789012:flow/example-flow
+% terraform import example-flow
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

No

### Description

Updates `aws_appflow_connector_profile` and `aws_appflow_flow` to use the `name` attribute as the `id` instead of the `arn`. API calls for these resource types take the `name`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=appflow

--- PASS: TestAccAppFlowFlow_taskProperties (34.74s)
--- PASS: TestAccAppFlowFlow_basic (48.61s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag (52.18s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag (56.81s)
--- PASS: TestAccAppFlowFlow_taskUpdate (64.84s)
--- PASS: TestAccAppFlowFlow_S3_outputFormatConfig_ParquetFileType (64.86s)
--- PASS: TestAccAppFlowFlow_tags_null (65.67s)
--- PASS: TestAccAppFlowFlow_update (66.89s)
--- PASS: TestAccAppFlowFlow_tags_EmptyMap (68.07s)
--- PASS: TestAccAppFlowFlow_tags_AddOnUpdate (85.90s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly (87.08s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly (90.38s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add (91.06s)
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnCreate (92.36s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag (51.55s)
--- PASS: TestAccAppFlowFlow_disappears (37.59s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnCreate (51.01s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag (47.95s)
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add (122.27s)
--- PASS: TestAccAppFlowFlow_metadataCatalog (42.62s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_overlapping (129.63s)
--- PASS: TestAccAppFlowFlow_task_mapAll (42.66s)
--- PASS: TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag (96.79s)
--- PASS: TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace (71.37s)
--- PASS: TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag (94.57s)
--- PASS: TestAccAppFlowFlow_tags (144.87s)
--- PASS: TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace (54.51s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping (89.57s)
--- PASS: TestAccAppFlowFlow_tags_DefaultTags_providerOnly (106.09s)
--- PASS: TestAccAppFlowConnectorProfile_disappears (193.60s)
--- PASS: TestAccAppFlowConnectorProfile_basic (194.86s)
--- PASS: TestAccAppFlowConnectorProfile_update (210.87s)
```
