### PR TITLE
Documentation: Additional `Argument Reference` section byline standardization

### DIFF
--- a/website/docs/d/apigatewayv2_api.html.markdown
+++ b/website/docs/d/apigatewayv2_api.html.markdown
@@ -20,9 +20,6 @@ data "aws_apigatewayv2_api" "example" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available APIs in the current region.
-The given filters must match exactly one API whose data will be exported as attributes.
-
 This data source supports the following arguments:
 
 * `api_id` - (Required) API identifier.

--- a/website/docs/d/connect_contact_flow.html.markdown
+++ b/website/docs/d/connect_contact_flow.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_contact_flow" "test" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_id` is required.
-
 This data source supports the following arguments:
 
 * `contact_flow_id` - (Optional) Returns information on a specific Contact Flow by contact flow id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Contact Flow by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_contact_flow_module.html.markdown
+++ b/website/docs/d/connect_contact_flow_module.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_contact_flow_module" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_module_id` is required.
-
 This data source supports the following arguments:
 
 * `contact_flow_module_id` - (Optional) Returns information on a specific Contact Flow Module by contact flow module id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Contact Flow Module by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `contact_flow_module_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_hours_of_operation.html.markdown
+++ b/website/docs/d/connect_hours_of_operation.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_hours_of_operation" "test" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `hours_of_operation_id` is required.
-
 This data source supports the following arguments:
 
 * `hours_of_operation_id` - (Optional) Returns information on a specific Hours of Operation by hours of operation id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Hours of Operation by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `hours_of_operation_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_instance.html.markdown
+++ b/website/docs/d/connect_instance.html.markdown
@@ -30,13 +30,12 @@ data "aws_connect_instance" "foo" {
 
 ## Argument Reference
 
-~> **NOTE:** One of either `instance_id` or `instance_alias` is required.
-
 This data source supports the following arguments:
 
 * `instance_id` - (Optional) Returns information on a specific connect instance by id
-
 * `instance_alias` - (Optional) Returns information on a specific connect instance by alias
+
+~> **NOTE:** One of either `instance_id` or `instance_alias` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_queue.html.markdown
+++ b/website/docs/d/connect_queue.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_queue" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `queue_id` is required.
-
 This data source supports the following arguments:
 
 * `queue_id` - (Optional) Returns information on a specific Queue by Queue id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Queue by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `queue_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_quick_connect.html.markdown
+++ b/website/docs/d/connect_quick_connect.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_quick_connect" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `quick_connect_id` is required.
-
 This data source supports the following arguments:
 
 * `quick_connect_id` - (Optional) Returns information on a specific Quick Connect by Quick Connect id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Quick Connect by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `quick_connect_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_routing_profile.html.markdown
+++ b/website/docs/d/connect_routing_profile.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_routing_profile" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `routing_profile_id` is required.
-
 This data source supports the following arguments:
 
 * `instance_id` - Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Routing Profile by name
 * `routing_profile_id` - (Optional) Returns information on a specific Routing Profile by Routing Profile id
+
+~> **NOTE:** `instance_id` and one of either `name` or `routing_profile_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_security_profile.html.markdown
+++ b/website/docs/d/connect_security_profile.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_security_profile" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `security_profile_id` is required.
-
 This data source supports the following arguments:
 
 * `security_profile_id` - (Optional) Returns information on a specific Security Profile by Security Profile id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Security Profile by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `security_profile_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_user.html.markdown
+++ b/website/docs/d/connect_user.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_user" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `user_id` is required.
-
 This data source supports the following arguments:
 
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific User by name
 * `user_id` - (Optional) Returns information on a specific User by User id
+
+~> **NOTE:** `instance_id` and one of either `name` or `user_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_user_hierarchy_group.html.markdown
+++ b/website/docs/d/connect_user_hierarchy_group.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_user_hierarchy_group" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `hierarchy_group_id` is required.
-
 This data source supports the following arguments:
 
 * `hierarchy_group_id` - (Optional) Returns information on a specific hierarchy group by hierarchy group id
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific hierarchy group by name
+
+~> **NOTE:** `instance_id` and one of either `name` or `hierarchy_group_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/connect_vocabulary.html.markdown
+++ b/website/docs/d/connect_vocabulary.html.markdown
@@ -32,13 +32,13 @@ data "aws_connect_vocabulary" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** `instance_id` and one of either `name` or `vocabulary_id` is required.
-
 This data source supports the following arguments:
 
 * `instance_id` - (Required) Reference to the hosting Amazon Connect Instance
 * `name` - (Optional) Returns information on a specific Vocabulary by name
 * `vocabulary_id` - (Optional) Returns information on a specific Vocabulary by Vocabulary id
+
+~> **NOTE:** `instance_id` and one of either `name` or `vocabulary_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/db_snapshot.html.markdown
+++ b/website/docs/d/db_snapshot.html.markdown
@@ -47,8 +47,6 @@ resource "aws_db_instance" "dev" {
 
 ## Argument Reference
 
-~> **NOTE:** One of either `db_instance_identifier` or `db_snapshot_identifier` is required.
-
 This data source supports the following arguments:
 
 * `most_recent` - (Optional) If more than one result is returned, use the most
@@ -65,6 +63,8 @@ The default is `false`.
 copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
 * `tags` - (Optional) Mapping of tags, each pair of which must exactly match
   a pair on the desired DB snapshot.
+
+~> **NOTE:** One of either `db_instance_identifier` or `db_snapshot_identifier` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/ec2_coip_pool.html.markdown
+++ b/website/docs/d/ec2_coip_pool.html.markdown
@@ -28,14 +28,10 @@ data "aws_ec2_coip_pool" "selected" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-COIP Pools in the current region. The given filters must match exactly one
-COIP Pool whose data will be exported as attributes.
+This data source supports the following arguments:
 
 * `local_gateway_route_table_id` - (Optional) Local Gateway Route Table Id assigned to desired COIP Pool
-
 * `pool_id` - (Optional) ID of the specific COIP Pool to retrieve.
-
 * `tags` - (Optional) Mapping of tags, each pair of which must exactly match
   a pair on the desired COIP Pool.
 
@@ -44,7 +40,6 @@ which take the following arguments:
 
 * `name` - (Required) Name of the field to filter by, as defined by
   [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeCoipPools.html).
-
 * `values` - (Required) Set of values that are accepted for the given field.
   A COIP Pool will be selected if any one of the given values matches.
 

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -30,17 +30,15 @@ data "aws_instance" "foo" {
 
 ## Argument Reference
 
-* `instance_id` - (Optional) Specify the exact Instance ID with which to populate the data source.
+This data source supports the following arguments:
 
+* `instance_id` - (Optional) Specify the exact Instance ID with which to populate the data source.
 * `instance_tags` - (Optional) Map of tags, each pair of which must
 exactly match a pair on the desired Instance.
-
 * `filter` - (Optional) One or more name/value pairs to use as filters. There are
 several valid keys, for a full reference, check out
 [describe-instances in the AWS CLI reference][1].
-
 * `get_password_data` - (Optional) If true, wait for password data to become available and retrieve it. Useful for getting the administrator password for instances running Microsoft Windows. The password data is exported to the `password_data` attribute. See [GetPasswordData](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetPasswordData.html) for more information.
-
 * `get_user_data` - (Optional) Retrieve Base64 encoded User Data contents into the `user_data_base64` attribute. A SHA-1 hash of the User Data contents will always be present in the `user_data` attribute. Defaults to `false`.
 
 ~> **NOTE:** At least one of `filter`, `instance_tags`, or `instance_id` must be specified.

--- a/website/docs/d/internet_gateway.html.markdown
+++ b/website/docs/d/internet_gateway.html.markdown
@@ -25,15 +25,11 @@ data "aws_internet_gateway" "default" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-Internet Gateway in the current region. The given filters must match exactly one
-Internet Gateway whose data will be exported as attributes.
+This data source supports the following arguments:
 
 * `internet_gateway_id` - (Optional) ID of the specific Internet Gateway to retrieve.
-
 * `tags` - (Optional) Map of tags, each pair of which must exactly match
   a pair on the desired Internet Gateway.
-
 * `filter` - (Optional) Custom filter block as described below.
 
 More complex filters can be expressed using one or more `filter` sub-blocks,
@@ -41,7 +37,6 @@ which take the following arguments:
 
 * `name` - (Required) Name of the field to filter by, as defined by
   [the underlying AWS API](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html).
-
 * `values` - (Required) Set of values that are accepted for the given field.
   An Internet Gateway will be selected if any one of the given values matches.
 

--- a/website/docs/d/route_table.html.markdown
+++ b/website/docs/d/route_table.html.markdown
@@ -32,9 +32,7 @@ resource "aws_route" "route" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available Route Table in the current region. The given filters must match exactly one Route Table whose data will be exported as attributes.
-
-The following arguments are optional:
+This data source supports the following arguments:
 
 * `filter` - (Optional) Configuration block. Detailed below.
 * `gateway_id` - (Optional) ID of an Internet Gateway or Virtual Private Gateway which is connected to the Route Table (not exported if not passed as a parameter).

--- a/website/docs/d/security_group.html.markdown
+++ b/website/docs/d/security_group.html.markdown
@@ -34,19 +34,13 @@ resource "aws_subnet" "subnet" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-security group in the current region. The given filters must match exactly one
-security group whose data will be exported as attributes.
+This data source supports the following arguments:
 
 * `filter` - (Optional) Custom filter block as described below.
-
 * `id` - (Optional) Id of the specific security group to retrieve.
-
 * `name` - (Optional) Name that the desired security group must have.
-
 * `tags` - (Optional) Map of tags, each pair of which must exactly match
   a pair on the desired security group.
-
 * `vpc_id` - (Optional) Id of the VPC that the desired security group belongs to.
 
 More complex filters can be expressed using one or more `filter` sub-blocks,
@@ -54,7 +48,6 @@ which take the following arguments:
 
 * `name` - (Required) Name of the field to filter by, as defined by
   [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html).
-
 * `values` - (Required) Set of values that are accepted for the given field.
   A Security Group will be selected if any one of the given values matches.
 

--- a/website/docs/d/shield_protection.html.markdown
+++ b/website/docs/d/shield_protection.html.markdown
@@ -30,12 +30,12 @@ data "aws_shield_protection" "example" {
 
 ## Argument Reference
 
-~> Exactly one of `protection_id` or `resource_arn` is required.
-
-The following arguments are optional:
+This data source supports the following arguments:
 
 * `protection_id` - (Optional) Unique identifier for the protection.
 * `resource_arn` - (Optional) ARN (Amazon Resource Name) of the resource being protected.
+
+~> Exactly one of `protection_id` or `resource_arn` is required.
 
 ## Attribute Reference
 

--- a/website/docs/d/subnet.html.markdown
+++ b/website/docs/d/subnet.html.markdown
@@ -50,9 +50,7 @@ data "aws_subnet" "selected" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available subnets in the current region. The given filters must match exactly one subnet whose data will be exported as attributes.
-
-The following arguments are optional:
+This data source supports the following arguments:
 
 * `availability_zone` - (Optional) Availability zone where the subnet must reside.
 * `availability_zone_id` - (Optional) ID of the Availability Zone for the subnet. This argument is not supported in all regions or partitions. If necessary, use `availability_zone` instead.

--- a/website/docs/d/vpc.html.markdown
+++ b/website/docs/d/vpc.html.markdown
@@ -36,24 +36,16 @@ resource "aws_subnet" "example" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available
-VPCs in the current region. The given filters must match exactly one
-VPC whose data will be exported as attributes.
+This data source supports the following arguments:
 
 * `cidr_block` - (Optional) Cidr block of the desired VPC.
-
 * `dhcp_options_id` - (Optional) DHCP options id of the desired VPC.
-
 * `default` - (Optional) Boolean constraint on whether the desired VPC is
   the default VPC for the region.
-
 * `filter` - (Optional) Custom filter block as described below.
-
 * `id` - (Optional) ID of the specific VPC to retrieve.
-
 * `state` - (Optional) Current state of the desired VPC.
   Can be either `"pending"` or `"available"`.
-
 * `tags` - (Optional) Map of tags, each pair of which must exactly match
   a pair on the desired VPC.
 
@@ -62,7 +54,6 @@ which take the following arguments:
 
 * `name` - (Required) Name of the field to filter by, as defined by
   [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html).
-
 * `values` - (Required) Set of values that are accepted for the given field.
   A VPC will be selected if any one of the given values matches.
 

--- a/website/docs/d/vpc_endpoint_service.html.markdown
+++ b/website/docs/d/vpc_endpoint_service.html.markdown
@@ -55,8 +55,7 @@ data "aws_vpc_endpoint_service" "test" {
 
 ## Argument Reference
 
-The arguments of this data source act as filters for querying the available VPC endpoint services.
-The given filters must match exactly one VPC endpoint service whose data will be exported as attributes.
+This data source supports the following arguments:
 
 * `filter` - (Optional) Configuration block(s) for filtering. Detailed below.
 * `service` - (Optional) Common name of an AWS service (e.g., `s3`).

--- a/website/docs/r/autoscaling_policy.html.markdown
+++ b/website/docs/r/autoscaling_policy.html.markdown
@@ -176,6 +176,8 @@ resource "aws_autoscaling_policy" "example" {
 
 ## Argument Reference
 
+This resource supports the following arguments:
+
 * `name` - (Required) Name of the policy.
 * `autoscaling_group_name` - (Required) Name of the autoscaling group.
 * `adjustment_type` - (Optional) Whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity`, and `PercentChangeInCapacity`.

--- a/website/docs/r/budgets_budget.html.markdown
+++ b/website/docs/r/budgets_budget.html.markdown
@@ -175,9 +175,6 @@ resource "aws_budgets_budget" "cost" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to the [AWS official
-documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-budget.html).
-
 The following arguments are required:
 
 * `budget_type` - (Required) Whether this budget tracks monetary cost or usage.
@@ -198,6 +195,9 @@ The following arguments are optional:
 * `tags` - (Optional) Map of tags assigned to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `time_period_end` - (Optional) The end of the time period covered by the budget. There are no restrictions on the end date. Format: `2017-01-01_12:00`.
 * `time_period_start` - (Optional) The start of the time period covered by the budget. If you don't specify a start date, AWS defaults to the start of your chosen time period. The start date must come before the end date. Format: `2017-01-01_12:00`.
+
+For more detailed documentation about each argument, refer to the [AWS official
+documentation](http://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/data-type-budget.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/cloudwatch_event_target.html.markdown
+++ b/website/docs/r/cloudwatch_event_target.html.markdown
@@ -12,6 +12,12 @@ Provides an EventBridge Target resource.
 
 ~> **Note:** EventBridge was formerly known as CloudWatch Events. The functionality is identical.
 
+-> **Note:** In order to be able to have your AWS Lambda function or
+   SNS topic invoked by an EventBridge rule, you must set up the right permissions
+   using [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)
+   or [`aws_sns_topic_policy`](/docs/providers/aws/r/sns_topic_policy.html).
+   More info [here](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html).
+
 ## Example Usage
 
 ### Kinesis Usage
@@ -544,12 +550,6 @@ resource "aws_appsync_graphql_api" "graphql-api" {
 ```
 
 ## Argument Reference
-
--> **Note:** In order to be able to have your AWS Lambda function or
-   SNS topic invoked by an EventBridge rule, you must set up the right permissions
-   using [`aws_lambda_permission`](/docs/providers/aws/r/lambda_permission.html)
-   or [`aws_sns_topic_policy`](/docs/providers/aws/r/sns_topic_policy.html).
-   More info [here](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-use-resource-based.html).
 
 The following arguments are required:
 

--- a/website/docs/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/docs/r/cloudwatch_metric_alarm.html.markdown
@@ -171,9 +171,6 @@ You must choose one or the other
 
 ## Argument Reference
 
-See [related part of AWS Docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html)
-for details about valid values.
-
 This resource supports the following arguments:
 
 * `alarm_name` - (Required) The descriptive name for the alarm. This name must be unique within the user's AWS account
@@ -205,6 +202,9 @@ This resource supports the following arguments:
 The following values are supported: `ignore`, and `evaluate`.
 * `metric_query` (Optional) Enables you to create an alarm based on a metric math expression. You may specify at most 20.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+See [related part of AWS Docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html)
+for details about valid values.
 
 ~> **NOTE:**  If you specify at least one `metric_query`, you may not specify a `metric_name`, `namespace`, `period` or `statistic`. If you do not specify a `metric_query`, you must specify each of these (although you may use `extended_statistic` instead of `statistic`).
 

--- a/website/docs/r/cognito_user_pool.html.markdown
+++ b/website/docs/r/cognito_user_pool.html.markdown
@@ -63,12 +63,9 @@ resource "aws_cognito_user_pool" "test" {
 
 ## Argument Reference
 
-The following argument is required:
+This resource supports the following arguments:
 
 * `name` - (Required) Name of the user pool.
-
-The following arguments are optional:
-
 * `account_recovery_setting` - (Optional) Configuration block to define which verified available method a user can use to recover their forgotten password. [Detailed below](#account_recovery_setting).
 * `admin_create_user_config` - (Optional) Configuration block for creating a new user profile. [Detailed below](#admin_create_user_config).
 * `alias_attributes` - (Optional) Attributes supported as an alias for this user pool. Valid values: `phone_number`, `email`, or `preferred_username`. Conflicts with `username_attributes`.

--- a/website/docs/r/config_conformance_pack.html.markdown
+++ b/website/docs/r/config_conformance_pack.html.markdown
@@ -80,8 +80,6 @@ EOT
 
 ## Argument Reference
 
-~> **Note:** If both `template_body` and `template_s3_uri` are specified, AWS Config uses the `template_s3_uri` and ignores the `template_body`.
-
 This resource supports the following arguments:
 
 * `name` - (Required, Forces new resource) The name of the conformance pack. Must begin with a letter and contain from 1 to 256 alphanumeric characters and hyphens.
@@ -90,6 +88,8 @@ This resource supports the following arguments:
 * `input_parameter` - (Optional) Set of configuration blocks describing input parameters passed to the conformance pack template. Documented below. When configured, the parameters must also be included in the `template_body` or in the template stored in Amazon S3 if using `template_s3_uri`.
 * `template_body` - (Optional, required if `template_s3_uri` is not provided) A string containing full conformance pack template body. Maximum length of 51200. Drift detection is not possible with this argument.
 * `template_s3_uri` - (Optional, required if `template_body` is not provided) Location of file, e.g., `s3://bucketname/prefix`, containing the template body. The uri must point to the conformance pack template that is located in an Amazon S3 bucket in the same region as the conformance pack. Maximum length of 1024. Drift detection is not possible with this argument.
+
+~> **Note:** If both `template_body` and `template_s3_uri` are specified, AWS Config uses the `template_s3_uri` and ignores the `template_body`.
 
 ### input_parameter Argument Reference
 

--- a/website/docs/r/controltower_control.html.markdown
+++ b/website/docs/r/controltower_control.html.markdown
@@ -38,7 +38,7 @@ resource "aws_controltower_control" "example" {
 
 ## Argument Reference
 
-This following arguments are required:
+The following arguments are required:
 
 * `control_identifier` - (Required) The ARN of the control. Only Strongly recommended and Elective controls are permitted, with the exception of the Region deny guardrail.
 * `target_identifier` - (Required) The ARN of the organizational unit.

--- a/website/docs/r/db_instance.html.markdown
+++ b/website/docs/r/db_instance.html.markdown
@@ -276,9 +276,6 @@ resource "aws_db_instance" "default" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to the [AWS official
-documentation](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
-
 This resource supports the following arguments:
 
 * `allocated_storage` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The allocated storage in gibibytes. If `max_allocated_storage` is configured, this argument represents the initial storage allocation and differences from the configuration will be ignored automatically when Storage Autoscaling occurs. If `replicate_source_db` is set, the value is ignored during the creation of the instance.
@@ -426,6 +423,9 @@ is provided) Username for the master DB user. Cannot be specified for a replica.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to
 associate.
 * `customer_owned_ip_enabled` - (Optional) Indicates whether to enable a customer-owned IP address (CoIP) for an RDS on Outposts DB instance. See [CoIP for RDS on Outposts](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-on-outposts.html#rds-on-outposts.coip) for more information.
+
+For more detailed documentation about each argument, refer to the [AWS official
+documentation](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully

--- a/website/docs/r/default_subnet.html.markdown
+++ b/website/docs/r/default_subnet.html.markdown
@@ -31,6 +31,8 @@ resource "aws_default_subnet" "default_az1" {
 
 ## Argument Reference
 
+This resource supports the following arguments:
+
 The arguments of an `aws_default_subnet` differ slightly from those of [`aws_subnet`](subnet.html):
 
 * `availability_zone` is required

--- a/website/docs/r/default_vpc.html.markdown
+++ b/website/docs/r/default_vpc.html.markdown
@@ -34,6 +34,8 @@ resource "aws_default_vpc" "default" {
 
 ## Argument Reference
 
+This resource supports the following arguments:
+
 The arguments of an `aws_default_vpc` differ slightly from those of [`aws_vpc`](vpc.html):
 
 * The `cidr_block` and `instance_tenancy` arguments become computed attributes

--- a/website/docs/r/docdb_cluster.html.markdown
+++ b/website/docs/r/docdb_cluster.html.markdown
@@ -39,9 +39,6 @@ resource "aws_docdb_cluster" "docdb" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-cluster.html).
-
 This resource supports the following arguments:
 
 * `allow_major_version_upgrade` - (Optional) A value that indicates whether major version upgrades are allowed. Constraints: You must allow major version upgrades when specifying a value for the EngineVersion parameter that is a different major version than the DB cluster's current version.
@@ -84,6 +81,9 @@ Default: A 30-minute window selected at random from an 8-hour block of time per 
 * `tags` - (Optional) A map of tags to assign to the DB cluster. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate
   with the Cluster
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-cluster.html).
 
 ### Restore To Point In Time
 

--- a/website/docs/r/docdb_cluster_instance.html.markdown
+++ b/website/docs/r/docdb_cluster_instance.html.markdown
@@ -37,9 +37,6 @@ resource "aws_docdb_cluster" "default" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-instance.html).
-
 This resource supports the following arguments:
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications
@@ -98,6 +95,9 @@ This resource exports the following attributes in addition to the arguments abov
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `writer` – Boolean indicating if this instance is writable. `False` indicates this instance is a read replica.
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb/create-db-instance.html).
 
 [1]: /docs/providers/aws/r/docdb_cluster.html
 [2]: https://docs.aws.amazon.com/documentdb/latest/developerguide/db-cluster-manage-performance.html#db-cluster-manage-scaling-instance

--- a/website/docs/r/docdbelastic_cluster.html.markdown
+++ b/website/docs/r/docdbelastic_cluster.html.markdown
@@ -27,9 +27,6 @@ resource "aws_docdbelastic_cluster" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb-elastic/create-cluster.html).
-
 The following arguments are required:
 
 * `admin_user_name` - (Required) Name of the Elastic DocumentDB cluster administrator
@@ -48,6 +45,9 @@ The following arguments are optional:
 * `subnet_ids` - (Optional) IDs of subnets in which the Elastic DocumentDB Cluster operates.
 * `tags` - (Optional) A map of tags to assign to the collection. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate with the Elastic DocumentDB Cluster
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/docdb-elastic/create-cluster.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -91,10 +91,6 @@ A full example of how to create a VPN Gateway in one AWS account, create a Direc
 
 ## Argument Reference
 
-~> **NOTE:** `dx_gateway_id` and `associated_gateway_id` must be specified for single account Direct Connect gateway associations.
-
-~> **NOTE:** If the `associated_gateway_id` is in another region, an [alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) in a new provider block for that region should be specified.
-
 This resource supports the following arguments:
 
 * `dx_gateway_id` - (Required) The ID of the Direct Connect gateway.
@@ -105,6 +101,10 @@ Used for cross-account Direct Connect gateway associations.
 * `proposal_id` - (Optional) The ID of the Direct Connect gateway association proposal.
 Used for cross-account Direct Connect gateway associations.
 * `allowed_prefixes` - (Optional) VPC prefixes (CIDRs) to advertise to the Direct Connect gateway. Defaults to the CIDR block of the VPC associated with the Virtual Gateway. To enable drift detection, must be configured.
+
+~> **NOTE:** `dx_gateway_id` and `associated_gateway_id` must be specified for single account Direct Connect gateway associations.
+
+~> **NOTE:** If the `associated_gateway_id` is in another region, an [alias](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) in a new provider block for that region should be specified.
 
 ## Attribute Reference
 

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -167,13 +167,13 @@ resource "aws_dynamodb_tag" "example" {
 
 ## Argument Reference
 
-Required arguments:
+The following arguments are required:
 
 * `attribute` - (Required) Set of nested attribute definitions. Only required for `hash_key` and `range_key` attributes. See below.
 * `hash_key` - (Required, Forces new resource) Attribute to use as the hash (partition) key. Must also be defined as an `attribute`. See below.
 * `name` - (Required) Unique within a region name of the table.
 
-Optional arguments:
+The following arguments are optional:
 
 * `billing_mode` - (Optional) Controls how you are charged for read and write throughput and how you manage capacity. The valid values are `PROVISIONED` and `PAY_PER_REQUEST`. Defaults to `PROVISIONED`.
 * `deletion_protection_enabled` - (Optional) Enables deletion protection for table. Defaults to `false`.

--- a/website/docs/r/dynamodb_table_item.html.markdown
+++ b/website/docs/r/dynamodb_table_item.html.markdown
@@ -46,14 +46,14 @@ resource "aws_dynamodb_table" "example" {
 
 ## Argument Reference
 
-~> **Note:** Names included in `item` are represented internally with everything but letters removed. There is the possibility of collisions if two names, once filtered, are the same. For example, the names `your-name-here` and `yournamehere` will overlap and cause an error.
-
 This resource supports the following arguments:
 
 * `hash_key` - (Required) Hash key to use for lookups and identification of the item
 * `item` - (Required) JSON representation of a map of attribute name/value pairs, one for each attribute. Only the primary key attributes are required; you can optionally provide other attribute name-value pairs for the item.
 * `range_key` - (Optional) Range key to use for lookups and identification of the item. Required if there is range key defined in the table.
 * `table_name` - (Required) Name of the table to contain the item.
+
+~> **Note:** Names included in `item` are represented internally with everything but letters removed. There is the possibility of collisions if two names, once filtered, are the same. For example, the names `your-name-here` and `yournamehere` will overlap and cause an error.
 
 ## Attribute Reference
 

--- a/website/docs/r/dynamodb_table_replica.html.markdown
+++ b/website/docs/r/dynamodb_table_replica.html.markdown
@@ -60,11 +60,11 @@ resource "aws_dynamodb_table_replica" "example" {
 
 ## Argument Reference
 
-Required arguments:
+The following arguments are required:
 
 * `global_table_arn` - (Required) ARN of the _main_ or global table which this resource will replicate.
 
-Optional arguments:
+The following arguments are optional:
 
 * `kms_key_arn` - (Optional, Forces new resource) ARN of the CMK that should be used for the AWS KMS encryption. This argument should only be used if the key is different from the default KMS-managed DynamoDB key, `alias/aws/dynamodb`. **Note:** This attribute will _not_ be populated with the ARN of _default_ keys.
 * `deletion_protection_enabled` - (Optional) Whether deletion protection is enabled (true) or disabled (false) on the table replica.

--- a/website/docs/r/ebs_volume.html.markdown
+++ b/website/docs/r/ebs_volume.html.markdown
@@ -25,8 +25,6 @@ resource "aws_ebs_volume" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** At least one of `size` or `snapshot_id` is required.
-
 This resource supports the following arguments:
 
 * `availability_zone` - (Required) Availability zone where the EBS volume will exist.
@@ -41,6 +39,8 @@ This resource supports the following arguments:
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `throughput` - (Optional) Throughput that the volume supports, in MiB/s. Only valid for `type` of `gp3`.
 * `type` - (Optional) Type of EBS volume. Can be `standard`, `gp2`, `gp3`, `io1`, `io2`, `sc1` or `st1` (Default: `gp2`).
+
+~> **NOTE:** At least one of `size` or `snapshot_id` is required.
 
 ~> **NOTE:** When changing the `size`, `iops` or `type` of an instance, there are [considerations](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/considerations.html) to be aware of.
 

--- a/website/docs/r/ecs_task_definition.html.markdown
+++ b/website/docs/r/ecs_task_definition.html.markdown
@@ -227,8 +227,6 @@ TASK_DEFINITION
 
 ## Argument Reference
 
-~> **NOTE:** Proper escaping is required for JSON field values containing quotes (`"`) such as `environment` values. If directly setting the JSON, they should be escaped as `\"` in the JSON,  e.g., `"value": "I \"love\" escaped quotes"`. If using a Terraform variable value, they should be escaped as `\\\"` in the variable, e.g., `value = "I \\\"love\\\" escaped quotes"` in the variable and `"value": "${var.myvariable}"` in the JSON.
-
 The following arguments are required:
 
 * `container_definitions` - (Required) A list of valid [container definitions](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerDefinition.html) provided as a single valid JSON document. Please note that you should only provide values that are part of the container definition document. For a detailed description of what parameters are available, see the [Task Definition Parameters](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html) section from the official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide).
@@ -256,6 +254,8 @@ The following arguments are optional:
 * `task_role_arn` - (Optional) ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `track_latest` - (Optional) Whether should track latest `ACTIVE` task definition on AWS or the one created with the resource stored in state. Default is `false`. Useful in the event the task definition is modified outside of this resource.
 * `volume` - (Optional) Configuration block for [volumes](#volume) that containers in your task may use. Detailed below.
+
+~> **NOTE:** Proper escaping is required for JSON field values containing quotes (`"`) such as `environment` values. If directly setting the JSON, they should be escaped as `\"` in the JSON,  e.g., `"value": "I \"love\" escaped quotes"`. If using a Terraform variable value, they should be escaped as `\\\"` in the variable, e.g., `value = "I \\\"love\\\" escaped quotes"` in the variable and `"value": "${var.myvariable}"` in the JSON.
 
 ### volume
 

--- a/website/docs/r/elastictranscoder_pipeline.html.markdown
+++ b/website/docs/r/elastictranscoder_pipeline.html.markdown
@@ -32,8 +32,6 @@ resource "aws_elastictranscoder_pipeline" "bar" {
 
 ## Argument Reference
 
-See ["Create Pipeline"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-pipeline.html) in the AWS docs for reference.
-
 This resource supports the following arguments:
 
 * `aws_kms_key_arn` - (Optional) The AWS Key Management Service (AWS KMS) key that you want to use with this pipeline.
@@ -46,6 +44,8 @@ This resource supports the following arguments:
 * `role` - (Required) The IAM Amazon Resource Name (ARN) for the role that you want Elastic Transcoder to use to transcode jobs for this pipeline.
 * `thumbnail_config` - (Optional) The ThumbnailConfig object specifies information about the Amazon S3 bucket in which you want Elastic Transcoder to save thumbnail files. (documented below)
 * `thumbnail_config_permissions` - (Optional) The permissions for the `thumbnail_config` object. (documented below)
+
+See ["Create Pipeline"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-pipeline.html) in the AWS docs for reference.
 
 The `content_config` object specifies information about the Amazon S3 bucket in
 which you want Elastic Transcoder to save transcoded files and playlists: which

--- a/website/docs/r/elastictranscoder_preset.html.markdown
+++ b/website/docs/r/elastictranscoder_preset.html.markdown
@@ -78,8 +78,6 @@ resource "aws_elastictranscoder_preset" "bar" {
 
 ## Argument Reference
 
-See ["Create Preset"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-preset.html) in the AWS docs for reference.
-
 This resource supports the following arguments:
 
 * `audio` - (Optional, Forces new resource) Audio parameters object (documented below).
@@ -91,6 +89,8 @@ This resource supports the following arguments:
 * `video` - (Optional, Forces new resource) Video parameters object (documented below)
 * `video_watermarks` - (Optional, Forces new resource) Watermark parameters for the video parameters (documented below)
 * `video_codec_options` (Optional, Forces new resource) Codec options for the video parameters
+
+See ["Create Preset"](http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-preset.html) in the AWS docs for reference.
 
 The `audio` object supports the following:
 

--- a/website/docs/r/flow_log.html.markdown
+++ b/website/docs/r/flow_log.html.markdown
@@ -176,8 +176,6 @@ resource "aws_s3_bucket" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** One of `eni_id`, `subnet_id`, `transit_gateway_id`, `transit_gateway_attachment_id`, or `vpc_id` must be specified.
-
 This resource supports the following arguments:
 
 * `traffic_type` - (Required) The type of traffic to capture. Valid values: `ACCEPT`,`REJECT`, `ALL`.
@@ -198,6 +196,8 @@ This resource supports the following arguments:
   minutes). Default: `600`. When `transit_gateway_id` or `transit_gateway_attachment_id` is specified, `max_aggregation_interval` *must* be 60 seconds (1 minute).
 * `destination_options` - (Optional) Describes the destination options for a flow log. More details below.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+~> **NOTE:** One of `eni_id`, `subnet_id`, `transit_gateway_id`, `transit_gateway_attachment_id`, or `vpc_id` must be specified.
 
 ### destination_options
 

--- a/website/docs/r/glue_crawler.html.markdown
+++ b/website/docs/r/glue_crawler.html.markdown
@@ -128,8 +128,6 @@ resource "aws_glue_crawler" "events_crawler" {
 
 ## Argument Reference
 
-~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target`, `mongodb_target` or `catalog_target`.
-
 This resource supports the following arguments:
 
 * `database_name` (Required) Glue database where results are written.
@@ -154,6 +152,8 @@ This resource supports the following arguments:
 * `security_configuration` (Optional) The name of Security Configuration to be used by the crawler
 * `table_prefix` (Optional) The table prefix used for catalog tables that are created.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+~> **NOTE:** Must specify at least one of `dynamodb_target`, `jdbc_target`, `s3_target`, `mongodb_target` or `catalog_target`.
 
 ### Dynamodb Target
 

--- a/website/docs/r/guardduty_organization_configuration.html.markdown
+++ b/website/docs/r/guardduty_organization_configuration.html.markdown
@@ -46,14 +46,14 @@ resource "aws_guardduty_organization_configuration" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** One of `auto_enable` or `auto_enable_organization_members` must be specified.
-
 This resource supports the following arguments:
 
 * `auto_enable` - (Optional) *Deprecated:* Use `auto_enable_organization_members` instead. When this setting is enabled, all new accounts that are created in, or added to, the organization are added as a member accounts of the organization’s GuardDuty delegated administrator and GuardDuty is enabled in that AWS Region.
 * `auto_enable_organization_members` - (Optional) Indicates the auto-enablement configuration of GuardDuty for the member accounts in the organization. Valid values are `ALL`, `NEW`, `NONE`.
 * `detector_id` - (Required) The detector ID of the GuardDuty account.
 * `datasources` - (Optional) Configuration for the collected datasources. [Deprecated](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-feature-object-api-changes-march2023.html) in favor of [`aws_guardduty_organization_configuration_feature` resources](guardduty_organization_configuration_feature.html).
+
+~> **NOTE:** One of `auto_enable` or `auto_enable_organization_members` must be specified.
 
 `datasources` supports the following:
 

--- a/website/docs/r/iam_role.html.markdown
+++ b/website/docs/r/iam_role.html.markdown
@@ -182,7 +182,7 @@ resource "aws_iam_role" "example" {
 
 ## Argument Reference
 
-The following argument is required:
+The following arguments are required:
 
 * `assume_role_policy` - (Required) Policy that grants an entity permission to assume the role.
 

--- a/website/docs/r/identitystore_user.html.markdown
+++ b/website/docs/r/identitystore_user.html.markdown
@@ -39,8 +39,6 @@ resource "aws_identitystore_user" "example" {
 
 ## Argument Reference
 
--> Unless specified otherwise, all fields can contain up to 1024 characters of free-form text.
-
 The following arguments are required:
 
 * `display_name` - (Required) The name that is typically displayed when the user is referenced.
@@ -60,6 +58,8 @@ The following arguments are optional:
 * `timezone` - (Optional) The user's time zone.
 * `title` - (Optional) The user's title.
 * `user_type` - (Optional) The user type.
+
+-> Unless specified otherwise, all fields can contain up to 1024 characters of free-form text.
 
 ### addresses Configuration Block
 

--- a/website/docs/r/kendra_experience.html.markdown
+++ b/website/docs/r/kendra_experience.html.markdown
@@ -35,8 +35,6 @@ resource "aws_kendra_experience" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** By default of the AWS Kendra API, updates to an existing `aws_kendra_experience` resource (e.g. updating the `name`) will also update the `configuration.content_source_configuration.direct_put_content` parameter to `false` if not already provided.
-
 The following arguments are required:
 
 * `index_id` - (Required, Forces new resource) The identifier of the index for your Amazon Kendra experience.
@@ -47,6 +45,8 @@ The following arguments are optional:
 
 * `description` - (Optional, Forces new resource if removed) A description for your Amazon Kendra experience.
 * `configuration` - (Optional) Configuration information for your Amazon Kendra experience. Terraform will only perform drift detection of its value when present in a configuration. [Detailed below](#configuration).
+
+~> **NOTE:** By default of the AWS Kendra API, updates to an existing `aws_kendra_experience` resource (e.g. updating the `name`) will also update the `configuration.content_source_configuration.direct_put_content` parameter to `false` if not already provided.
 
 ### `configuration`
 

--- a/website/docs/r/lambda_code_signing_config.html.markdown
+++ b/website/docs/r/lambda_code_signing_config.html.markdown
@@ -37,6 +37,8 @@ resource "aws_lambda_code_signing_config" "new_csc" {
 
 ## Argument Reference
 
+This resource supports the following arguments:
+
 * `allowed_publishers` (Required) A configuration block of allowed publishers as signing profiles for this code signing configuration. Detailed below.
 * `policies` (Optional) A configuration block of code signing policies that define the actions to take if the validation checks fail. Detailed below.
 * `description` - (Optional) Descriptive name for this code signing configuration.

--- a/website/docs/r/lb.html.markdown
+++ b/website/docs/r/lb.html.markdown
@@ -95,10 +95,6 @@ resource "aws_lb" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** Please note that internal LBs can only use `ipv4` as the `ip_address_type`. You can only change to `dualstack` `ip_address_type` if the selected subnets are IPv6 enabled.
-
-~> **NOTE:** Please note that one of either `subnets` or `subnet_mapping` is required.
-
 This resource supports the following arguments:
 
 * `access_logs` - (Optional) Access Logs block. See below.
@@ -129,6 +125,10 @@ This resource supports the following arguments:
 * `subnets` - (Optional) List of subnet IDs to attach to the LB. For Load Balancers of type `network` subnets can only be added (see [Availability Zones](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/network-load-balancers.html#availability-zones)), deleting a subnet for load balancers of type `network` will force a recreation of the resource.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `xff_header_processing_mode` - (Optional) Determines how the load balancer modifies the `X-Forwarded-For` header in the HTTP request before sending the request to the target. The possible values are `append`, `preserve`, and `remove`. Only valid for Load Balancers of type `application`. The default is `append`.
+
+~> **NOTE:** Please note that internal LBs can only use `ipv4` as the `ip_address_type`. You can only change to `dualstack` `ip_address_type` if the selected subnets are IPv6 enabled.
+
+~> **NOTE:** Please note that one of either `subnets` or `subnet_mapping` is required.
 
 ### access_logs
 

--- a/website/docs/r/lightsail_container_service.html.markdown
+++ b/website/docs/r/lightsail_container_service.html.markdown
@@ -15,6 +15,9 @@ and manage containers. For more information, see
 ~> **Note:** For more information about the AWS Regions in which you can create Amazon Lightsail container services,
 see ["Regions and Availability Zones in Amazon Lightsail"](https://lightsail.aws.amazon.com/ls/docs/overview/article/understanding-regions-and-availability-zones-in-amazon-lightsail).
 
+~> **NOTE:** You must create and validate an SSL/TLS certificate before you can use `public_domain_names` with your container service. For more information, see
+[Enabling and managing custom domains for your Amazon Lightsail container services](https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-creating-container-services-certificates).
+
 ## Example Usage
 
 ### Basic Usage
@@ -91,10 +94,6 @@ resource "aws_ecr_repository_policy" "default" {
 ```
 
 ## Argument Reference
-
-~> **NOTE:** You must create and validate an SSL/TLS certificate before you can use `public_domain_names` with your
-container service. For more information, see
-[Enabling and managing custom domains for your Amazon Lightsail container services](https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-creating-container-services-certificates).
 
 This resource supports the following arguments:
 

--- a/website/docs/r/rds_cluster.html.markdown
+++ b/website/docs/r/rds_cluster.html.markdown
@@ -196,12 +196,6 @@ resource "aws_rds_global_cluster" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the AWS official documentation :
-
-* [create-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html)
-* [modify-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-cluster.html)
-
 This resource supports the following arguments:
 
 * `allocated_storage` - (Optional, Required for Multi-AZ DB cluster) The amount of storage in gibibytes (GiB) to allocate to each DB instance in the Multi-AZ DB cluster.
@@ -272,6 +266,12 @@ This resource supports the following arguments:
 * `storage_type` - (Optional, Required for Multi-AZ DB cluster) (Forces new for Multi-AZ DB clusters) Specifies the storage type to be associated with the DB cluster. For Aurora DB clusters, `storage_type` modifications can be done in-place. For Multi-AZ DB Clusters, the `iops` argument must also be set. Valid values are: `""`, `aurora-iopt1` (Aurora DB Clusters); `io1`, `io2` (Multi-AZ DB Clusters). Default: `""` (Aurora DB Clusters); `io1` (Multi-AZ DB Clusters).
 * `tags` - (Optional) A map of tags to assign to the DB cluster. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `vpc_security_group_ids` - (Optional) List of VPC security groups to associate with the Cluster
+
+For more detailed documentation about each argument, refer to
+the AWS official documentation:
+
+* [create-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster.html)
+* [modify-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/modify-db-cluster.html)
 
 ### S3 Import Options
 

--- a/website/docs/r/rds_cluster_activity_stream.html.markdown
+++ b/website/docs/r/rds_cluster_activity_stream.html.markdown
@@ -53,15 +53,15 @@ resource "aws_rds_cluster_activity_stream" "default" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation][3].
-
 This resource supports the following arguments:
 
 * `resource_arn` - (Required, Forces new resources) The Amazon Resource Name (ARN) of the DB cluster.
 * `mode` - (Required, Forces new resources) Specifies the mode of the database activity stream. Database events such as a change or access generate an activity stream event. The database session can handle these events either synchronously or asynchronously. One of: `sync`, `async`.
 * `kms_key_id` - (Required, Forces new resources) The AWS KMS key identifier for encrypting messages in the database activity stream. The AWS KMS key identifier is the key ARN, key ID, alias ARN, or alias name for the KMS key.
 * `engine_native_audit_fields_included` - (Optional, Forces new resources) Specifies whether the database activity stream includes engine-native audit fields. This option only applies to an Oracle DB instance. By default, no engine-native audit fields are included. Defaults `false`.
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation][3].
 
 ## Attribute Reference
 

--- a/website/docs/r/rds_cluster_endpoint.html.markdown
+++ b/website/docs/r/rds_cluster_endpoint.html.markdown
@@ -76,9 +76,6 @@ resource "aws_rds_cluster_endpoint" "static" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster-endpoint.html).
-
 This resource supports the following arguments:
 
 * `cluster_identifier` - (Required, Forces new resources) The cluster identifier.
@@ -87,6 +84,9 @@ This resource supports the following arguments:
 * `static_members` - (Optional) List of DB instance identifiers that are part of the custom endpoint group. Conflicts with `excluded_members`.
 * `excluded_members` - (Optional) List of DB instance identifiers that aren't part of the custom endpoint group. All other eligible instances are reachable through the custom endpoint. Only relevant if the list of static members is empty. Conflicts with `static_members`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-cluster-endpoint.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/rds_cluster_instance.html.markdown
+++ b/website/docs/r/rds_cluster_instance.html.markdown
@@ -48,9 +48,6 @@ resource "aws_rds_cluster" "default" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html).
-
 This resource supports the following arguments:
 
 * `apply_immediately` - (Optional) Specifies whether any database modifications are applied immediately, or during the next maintenance window. Default is`false`.
@@ -79,6 +76,9 @@ This resource supports the following arguments:
 * `promotion_tier` - (Optional) Default 0. Failover Priority setting on instance level. The reader who has lower tier has higher priority to get promoted to writer.
 * `publicly_accessible` - (Optional) Bool to control if instance is publicly accessible. Default `false`. See the documentation on [Creating DB Instances][6] for more details on controlling this property.
 * `tags` - (Optional) Map of tags to assign to the instance. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/rds_integration.html.markdown
+++ b/website/docs/r/rds_integration.html.markdown
@@ -90,8 +90,6 @@ resource "aws_rds_integration" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-integration.html).
-
 The following arguments are required:
 
 * `integration_name` - (Required, Forces new resources) Name of the integration.
@@ -112,6 +110,8 @@ See the [Amazon RDS data filtering guide](https://docs.aws.amazon.com/AmazonRDS/
 If you don't specify an encryption key, RDS uses a default AWS owned key.
 If you use the default AWS owned key, you should ignore `kms_key_id` parameter by using [`lifecycle` parameter](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) to avoid unintended change after the first creation.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-integration.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/rds_shard_group.html.markdown
+++ b/website/docs/r/rds_shard_group.html.markdown
@@ -40,8 +40,6 @@ resource "aws_rds_shard_group" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-integration.html).
-
 This resource supports the following arguments:
 
 * `compute_redundancy` - (Optional) Specifies whether to create standby DB shard groups for the DB shard group. Valid values are:
@@ -54,6 +52,8 @@ This resource supports the following arguments:
 * `min_acu` - (Optional) The minimum capacity of the DB shard group in Aurora capacity units (ACUs).
 * `publicly_accessible` - (Optional) Indicates whether the DB shard group is publicly accessible.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/rds/create-shard-group.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/redshift_cluster.html.markdown
+++ b/website/docs/r/redshift_cluster.html.markdown
@@ -48,9 +48,6 @@ resource "aws_redshift_cluster" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to
-the [AWS official documentation](http://docs.aws.amazon.com/cli/latest/reference/redshift/index.html#cli-aws-redshift).
-
 This resource supports the following arguments:
 
 * `cluster_identifier` - (Required) The Cluster Identifier. Must be a lower case string.
@@ -113,6 +110,9 @@ This resource supports the following arguments:
 * `manual_snapshot_retention_period` - (Optional)  The default number of days to retain a manual snapshot. If the value is -1, the snapshot is retained indefinitely. This setting doesn't change the retention period of existing snapshots. Valid values are between `-1` and `3653`. Default value is `-1`.
 * `snapshot_copy` - (Optional, **Deprecated**) Configuration of automatic copy of snapshots from one region to another. Documented below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to
+the [AWS official documentation](http://docs.aws.amazon.com/cli/latest/reference/redshift/index.html#cli-aws-redshift).
 
 ### Nested Blocks
 

--- a/website/docs/r/redshift_integration.html.markdown
+++ b/website/docs/r/redshift_integration.html.markdown
@@ -117,8 +117,6 @@ resource "aws_redshift_integration" "example" {
 
 ## Argument Reference
 
-For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/redshift/create-integration.html).
-
 The following arguments are required:
 
 * `integration_name` - (Required) Name of the integration.
@@ -135,6 +133,8 @@ You can only include this parameter if you specify the `kms_key_id` parameter.
 If you don't specify an encryption key, Redshift uses a default AWS owned key.
 You can only include this parameter if `source_arn` references a DynamoDB table.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For more detailed documentation about each argument, refer to the [AWS official documentation](https://docs.aws.amazon.com/cli/latest/reference/redshift/create-integration.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/route53domains_domain.html.markdown
+++ b/website/docs/r/route53domains_domain.html.markdown
@@ -70,8 +70,6 @@ resource "aws_route53domains_domain" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** You must specify the same privacy setting for `admin_privacy`, `registrant_privacy` and `tech_privacy`.
-
 This resource supports the following arguments:
 
 * `admin_contact` - (Required) Details about the domain administrative contact. See [Contact Blocks](#contact-blocks) for more details.
@@ -88,6 +86,8 @@ This resource supports the following arguments:
 * `tech_contact` - (Required) Details about the domain technical contact. See [Contact Blocks](#contact-blocks) for more details.
 * `tech_privacy` - (Optional) Whether domain technical contact information is concealed from WHOIS queries. Default: `true`.
 * `transfer_lock` - (Optional) Whether the domain is locked for transfer. Default: `true`.
+
+~> **NOTE:** You must specify the same privacy setting for `admin_privacy`, `registrant_privacy` and `tech_privacy`.
 
 ### Contact Blocks
 

--- a/website/docs/r/route53domains_registered_domain.html.markdown
+++ b/website/docs/r/route53domains_registered_domain.html.markdown
@@ -36,8 +36,6 @@ resource "aws_route53domains_registered_domain" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** You must specify the same privacy setting for `admin_privacy`, `registrant_privacy` and `tech_privacy`.
-
 This resource supports the following arguments:
 
 * `admin_contact` - (Optional) Details about the domain administrative contact. See [Contact Blocks](#contact-blocks) for more details.
@@ -53,6 +51,8 @@ This resource supports the following arguments:
 * `tech_contact` - (Optional) Details about the domain technical contact. See [Contact Blocks](#contact-blocks) for more details.
 * `tech_privacy` - (Optional) Whether domain technical contact information is concealed from WHOIS queries. Default: `true`.
 * `transfer_lock` - (Optional) Whether the domain is locked for transfer. Default: `true`.
+
+~> **NOTE:** You must specify the same privacy setting for `admin_privacy`, `registrant_privacy` and `tech_privacy`.
 
 ### Contact Blocks
 

--- a/website/docs/r/route_table_association.html.markdown
+++ b/website/docs/r/route_table_association.html.markdown
@@ -29,13 +29,13 @@ resource "aws_route_table_association" "b" {
 
 ## Argument Reference
 
-~> **NOTE:** Please note that one of either `subnet_id` or `gateway_id` is required.
-
 This resource supports the following arguments:
 
 * `subnet_id` - (Optional) The subnet ID to create an association. Conflicts with `gateway_id`.
 * `gateway_id` - (Optional) The gateway ID to create an association. Conflicts with `subnet_id`.
 * `route_table_id` - (Required) The ID of the routing table to associate with.
+
+~> **NOTE:** Please note that one of either `subnet_id` or `gateway_id` is required.
 
 ## Attribute Reference
 

--- a/website/docs/r/s3_bucket_object.html.markdown
+++ b/website/docs/r/s3_bucket_object.html.markdown
@@ -133,8 +133,6 @@ resource "aws_s3_bucket_object" "example" {
 
 ## Argument Reference
 
--> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
-
 The following arguments are required:
 
 * `bucket` - (Required) Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
@@ -166,6 +164,8 @@ The following arguments are optional:
 * `website_redirect` - (Optional) Target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 
 If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.
+
+-> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
 
 -> **Note:** Terraform ignores all leading `/`s in the object's `key` and treats multiple `/`s in the rest of the object's `key` as a single `/`, so values of `/index.html` and `index.html` correspond to the same S3 object as do `first//second///third//` and `first/second/third/`.
 

--- a/website/docs/r/s3_object.html.markdown
+++ b/website/docs/r/s3_object.html.markdown
@@ -160,8 +160,6 @@ resource "aws_s3_object" "examplebucket_object" {
 
 ## Argument Reference
 
--> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
-
 The following arguments are required:
 
 * `bucket` - (Required) Name of the bucket to put the file in. Alternatively, an [S3 access point](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-access-points.html) ARN can be specified.
@@ -195,6 +193,8 @@ The following arguments are optional:
 * `website_redirect` - (Optional) Target URL for [website redirect](http://docs.aws.amazon.com/AmazonS3/latest/dev/how-to-page-redirect.html).
 
 If no content is provided through `source`, `content` or `content_base64`, then the object will be empty.
+
+-> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately. `source`, `content`, and `content_base64` all expect already encoded/compressed bytes.
 
 -> **Note:** Terraform ignores all leading `/`s in the object's `key` and treats multiple `/`s in the rest of the object's `key` as a single `/`, so values of `/index.html` and `index.html` correspond to the same S3 object as do `first//second///third//` and `first/second/third/`.
 

--- a/website/docs/r/s3tables_table_bucket.html.markdown
+++ b/website/docs/r/s3tables_table_bucket.html.markdown
@@ -22,7 +22,7 @@ resource "aws_s3tables_table_bucket" "example" {
 
 ## Argument Reference
 
-The following argument is required:
+The following arguments are required:
 
 * `name` - (Required, Forces new resource) Name of the table bucket.
   Must be between 3 and 63 characters in length.

--- a/website/docs/r/ses_configuration_set.html.markdown
+++ b/website/docs/r/ses_configuration_set.html.markdown
@@ -46,11 +46,11 @@ resource "aws_ses_configuration_set" "test" {
 
 ## Argument Reference
 
-The following argument is required:
+The following arguments are required:
 
 * `name` - (Required) Name of the configuration set.
 
-The following argument is optional:
+The following arguments are optional:
 
 * `delivery_options` - (Optional) Whether messages that use the configuration set are required to use TLS. See below.
 * `reputation_metrics_enabled` - (Optional) Whether or not Amazon SES publishes reputation metrics for the configuration set, such as bounce and complaint rates, to Amazon CloudWatch. The default value is `false`.

--- a/website/docs/r/ssmcontacts_contact.html.markdown
+++ b/website/docs/r/ssmcontacts_contact.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing an AWS SSM Contact.
 
+~> **NOTE:** A contact implicitly depends on a replication set. If you configured your replication set in Terraform, we recommend you add it to the `depends_on` argument for the Terraform Contact Resource.
+
 ## Example Usage
 
 ### Basic Usage
@@ -41,19 +43,15 @@ resource "aws_ssmcontacts_contact" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** A contact implicitly depends on a replication set. If you configured your replication set in Terraform, we recommend you add it to the `depends_on` argument for the Terraform Contact Resource.
-
 The following arguments are required:
 
 - `alias` - (Required) A unique and identifiable alias for the contact or escalation plan. Must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), and hyphens (`-`).
-
 - `type` - (Required) The type of contact engaged. A single contact is type PERSONAL and an escalation
   plan is type ESCALATION.
 
 The following arguments are optional:
 
 - `display_name` - (Optional) Full friendly name of the contact or escalation plan. If set, must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), hyphens (`-`), periods (`.`), and spaces.
-
 - `tags` - (Optional) Map of tags to assign to the resource.
 
 ## Attribute Reference
@@ -61,7 +59,6 @@ The following arguments are optional:
 This resource exports the following attributes in addition to the arguments above:
 
 - `arn` - The Amazon Resource Name (ARN) of the contact or escalation plan.
-
 - `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Import

--- a/website/docs/r/ssmcontacts_contact_channel.html.markdown
+++ b/website/docs/r/ssmcontacts_contact_channel.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Terraform resource for managing an AWS SSM Contacts Contact Channel.
 
+~> **NOTE:** The contact channel needs to be activated in the AWS Systems Manager console, otherwise it can't be used to engage the contact. See the [Contacts section of the Incident Manager User Guide](https://docs.aws.amazon.com/incident-manager/latest/userguide/contacts.html) for more information.
+
 ## Example Usage
 
 ### Basic Usage
@@ -49,16 +51,11 @@ resource "aws_ssmcontacts_contact_channel" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** The contact channel needs to be activated in the AWS Systems Manager console, otherwise it can't be used to engage the contact. See the [Contacts section of the Incident Manager User Guide](https://docs.aws.amazon.com/incident-manager/latest/userguide/contacts.html) for more information.
-
 The following arguments are required:
 
 - `contact_id` - (Required) Amazon Resource Name (ARN) of the AWS SSM Contact that the contact channel belongs to.
-
 - `delivery_address` - (Required) Block that contains contact engagement details. See details below.
-
 - `name` - (Required) Name of the contact channel. Must be between 1 and 255 characters, and may contain alphanumerics, underscores (`_`), hyphens (`-`), periods (`.`), and spaces.
-
 - `type` - (Required) Type of the contact channel. One of `SMS`, `VOICE` or `EMAIL`.
 
 ### delivery_address
@@ -70,7 +67,6 @@ The following arguments are required:
 This resource exports the following attributes in addition to the arguments above:
 
 - `activation_status` - Whether the contact channel is activated. The contact channel must be activated to use it to engage the contact. One of `ACTIVATED` or `NOT_ACTIVATED`.
-
 - `arn` - Amazon Resource Name (ARN) of the contact channel.
 
 ## Import

--- a/website/docs/r/ssmcontacts_rotation.html.markdown
+++ b/website/docs/r/ssmcontacts_rotation.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Terraform resource for managing a Contacts Rotation in AWS Systems Manager Incident Manager.
 
+~> **NOTE:** A rotation implicitly depends on a replication set. If you configured your replication set in Terraform, we recommend you add it to the `depends_on` argument for the Terraform Contact Resource.
+
 ## Example Usage
 
 ### Basic Usage
@@ -130,8 +132,6 @@ resource "aws_ssmcontacts_rotation" "example" {
 ```
 
 ## Argument Reference
-
-~> **NOTE:** A rotation implicitly depends on a replication set. If you configured your replication set in Terraform, we recommend you add it to the `depends_on` argument for the Terraform Contact Resource.
 
 The following arguments are required:
 

--- a/website/docs/r/ssmincidents_replication_set.html.markdown
+++ b/website/docs/r/ssmincidents_replication_set.html.markdown
@@ -76,6 +76,13 @@ resource "aws_ssmincidents_replication_set" "replicationSetName" {
 
 ## Argument Reference
 
+This resource supports the following arguments:
+
+* `region` - (Required) The Regions that Incident Manager replicates your data to. You can have up to three Regions in your replication set.
+* `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+For information about the maximum allowed number of Regions and tag value constraints, see [CreateReplicationSet in the *AWS Systems Manager Incident Manager API Reference*](https://docs.aws.amazon.com/incident-manager/latest/APIReference/API_CreateReplicationSet.html).
+
 ~> **NOTE:** The Region specified by a Terraform provider must always be one of the Regions specified for the replication set. This is especially important when you perform complex update operations.
 
 ~> **NOTE:** After a replication set is created, you can add or delete only one Region at a time.
@@ -86,16 +93,10 @@ resource "aws_ssmincidents_replication_set" "replicationSetName" {
 
 ~> **NOTE:** If possible, create all the customer managed keys you need (using the `terraform apply` command) before you create the replication set, or create the keys and replication set in the same `terraform apply` command. Otherwise, to delete a replication set, you must run one `terraform apply` command to delete the replication set and another to delete the AWS KMS keys used by the replication set. Deleting the AWS KMS keys before deleting the replication set results in an error. In that case, you must manually reenable the deleted key using the AWS Management Console before you can delete the replication set.
 
-The `region` configuration block is required and supports the following arguments:
+The `region` configuration block supports the following arguments:
 
 * `name` - (Required) The name of the Region, such as `ap-southeast-2`.
 * `kms_key_arn` - (Optional) The Amazon Resource name (ARN) of the customer managed key. If omitted, AWS manages the AWS KMS keys for you, using an AWS owned key, as indicated by a default value of `DefaultKey`.
-
-The following arguments are optional:
-
-* `tags` - Tags applied to the replication set.
-
-For information about the maximum allowed number of Regions and tag value constraints, see [CreateReplicationSet in the *AWS Systems Manager Incident Manager API Reference*](https://docs.aws.amazon.com/incident-manager/latest/APIReference/API_CreateReplicationSet.html).
 
 ## Attribute Reference
 

--- a/website/docs/r/ssmincidents_response_plan.html.markdown
+++ b/website/docs/r/ssmincidents_response_plan.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides a Terraform resource to manage response plans in AWS Systems Manager Incident Manager.
 
+~> NOTE: A response plan implicitly depends on a replication set. If you configured your replication set in Terraform, we recommend you add it to the `depends_on` argument for the Terraform ResponsePlan Resource.
+
 ## Example Usage
 
 ### Basic Usage
@@ -100,9 +102,6 @@ resource "aws_ssmincidents_response_plan" "example" {
 ```
 
 ## Argument Reference
-
-~> NOTE: A response plan implicitly depends on a replication set. If you configured your replication set in Terraform,
-we recommend you add it to the `depends_on` argument for the Terraform ResponsePlan Resource.
 
 The following arguments are required:
 

--- a/website/docs/r/storagegateway_gateway.html.markdown
+++ b/website/docs/r/storagegateway_gateway.html.markdown
@@ -98,8 +98,6 @@ resource "aws_storagegateway_gateway" "example" {
 
 ## Argument Reference
 
-~> **NOTE:** One of `activation_key` or `gateway_ip_address` must be provided for resource creation (gateway activation). Neither is required for resource import. If using `gateway_ip_address`, Terraform must be able to make an HTTP (port 80) GET request to the specified IP address from where it is running.
-
 This resource supports the following arguments:
 
 * `gateway_name` - (Required) Name of the gateway.
@@ -119,6 +117,8 @@ This resource supports the following arguments:
 * `smb_file_share_visibility` - (Optional) Specifies whether the shares on this gateway appear when listing shares.
 * `tape_drive_type` - (Optional) Type of tape drive to use for tape gateway. Terraform cannot detect drift of this argument. Valid values: `IBM-ULT3580-TD5`.
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+
+~> **NOTE:** One of `activation_key` or `gateway_ip_address` must be provided for resource creation (gateway activation). Neither is required for resource import. If using `gateway_ip_address`, Terraform must be able to make an HTTP (port 80) GET request to the specified IP address from where it is running.
 
 ### maintenance_start_time
 

--- a/website/docs/r/vpc_peering_connection.html.markdown
+++ b/website/docs/r/vpc_peering_connection.html.markdown
@@ -10,6 +10,11 @@ description: |-
 
 Provides a resource to manage a VPC peering connection.
 
+-> **Note:** Modifying the VPC Peering Connection options requires peering to be active. An automatic activation
+can be done using the [`auto_accept`](vpc_peering_connection.html#auto_accept) attribute. Alternatively, the VPC Peering
+Connection has to be made active manually using other means. See [notes](vpc_peering_connection.html#notes) below for
+more information.
+
 ~> **NOTE on VPC Peering Connections and VPC Peering Connection Options:** Terraform provides
 both a standalone [VPC Peering Connection Options](vpc_peering_connection_options.html) and a VPC Peering Connection
 resource with `accepter` and `requester` attributes. Do not manage options for the same VPC peering
@@ -97,11 +102,6 @@ resource "aws_vpc" "bar" {
 ```
 
 ## Argument Reference
-
--> **Note:** Modifying the VPC Peering Connection options requires peering to be active. An automatic activation
-can be done using the [`auto_accept`](vpc_peering_connection.html#auto_accept) attribute. Alternatively, the VPC Peering
-Connection has to be made active manually using other means. See [notes](vpc_peering_connection.html#notes) below for
-more information.
 
 This resource supports the following arguments:
 

--- a/website/docs/r/vpc_security_group_egress_rule.html.markdown
+++ b/website/docs/r/vpc_security_group_egress_rule.html.markdown
@@ -31,8 +31,6 @@ resource "aws_vpc_security_group_egress_rule" "example" {
 
 ## Argument Reference
 
-~> **Note** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic. The `from_port` and `to_port` arguments are required unless `ip_protocol` is set to `-1` or `icmpv6`.
-
 This resource supports the following arguments:
 
 * `cidr_ipv4` - (Optional) The destination IPv4 CIDR range.
@@ -45,6 +43,8 @@ This resource supports the following arguments:
 * `security_group_id` - (Required) The ID of the security group.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `to_port` - (Optional) The end of port range for the TCP and UDP protocols, or an ICMP/ICMPv6 code.
+
+~> **Note** Although `cidr_ipv4`, `cidr_ipv6`, `prefix_list_id`, and `referenced_security_group_id` are all marked as optional, you *must* provide one of them in order to configure the destination of the traffic. The `from_port` and `to_port` arguments are required unless `ip_protocol` is set to `-1` or `icmpv6`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Standardizes documentation `Argument Reference` section bylines for data sources and resources when there is more than one paragraph in the section.
An upcoming `tfproviderdocs` release will check these.
Will merge to `release/v6.0.0-beta` subsequently.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/pull/42505.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/42486.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
