### PR TITLE
Fix(aws_verifiedaccess_endpoint) load_balancer_options.port not omitted in TCP load balancer

### DIFF
--- a/.changelog/42694.txt
+++ b/.changelog/42694.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_verifiedaccess_endpoint: No longer set load_balancer_options.port when load_balancer_options.protocol="tcp"
+```

--- a/internal/service/ec2/verifiedaccess_endpoint.go
+++ b/internal/service/ec2/verifiedaccess_endpoint.go
@@ -823,16 +823,21 @@ func expandCreateVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]any)
 		apiObject.LoadBalancerArn = aws.String(v)
 	}
 
-	if v, ok := tfMap[names.AttrPort].(int); ok {
-		apiObject.Port = aws.Int32(int32(v))
+	protocol := ""
+	if v, ok := tfMap[names.AttrProtocol].(string); ok && v != "" {
+		protocol = v
+		apiObject.Protocol = types.VerifiedAccessEndpointProtocol(v)
+	}
+
+	// Fix for issue #42654 - For protocol=TCP, only portRange can be set
+	if protocol != string(types.VerifiedAccessEndpointProtocolTcp) {
+		if v, ok := tfMap[names.AttrPort].(int); ok {
+			apiObject.Port = aws.Int32(int32(v))
+		}
 	}
 
 	if v, ok := tfMap["port_range"].(*schema.Set); ok && v.Len() > 0 {
 		apiObject.PortRanges = expandCreateVerifiedAccessEndpointPortRanges(v.List())
-	}
-
-	if v, ok := tfMap[names.AttrProtocol].(string); ok && v != "" {
-		apiObject.Protocol = types.VerifiedAccessEndpointProtocol(v)
 	}
 
 	if v, ok := tfMap[names.AttrSubnetIDs].(*schema.Set); ok && v.Len() > 0 {
@@ -910,16 +915,21 @@ func expandModifyVerifiedAccessEndpointLoadBalancerOptions(tfMap map[string]any)
 
 	apiObject := &types.ModifyVerifiedAccessEndpointLoadBalancerOptions{}
 
-	if v, ok := tfMap[names.AttrPort].(int); ok {
-		apiObject.Port = aws.Int32(int32(v))
+	protocol := ""
+	if v, ok := tfMap[names.AttrProtocol].(string); ok && v != "" {
+		protocol = v
+		apiObject.Protocol = types.VerifiedAccessEndpointProtocol(v)
+	}
+
+	// Fix for issue #42654 - For protocol=TCP, only portRange can be set
+	if protocol != string(types.VerifiedAccessEndpointProtocolTcp) {
+		if v, ok := tfMap[names.AttrPort].(int); ok {
+			apiObject.Port = aws.Int32(int32(v))
+		}
 	}
 
 	if v, ok := tfMap["port_range"].(*schema.Set); ok {
 		apiObject.PortRanges = expandModifyVerifiedAccessEndpointPortRanges(v.List())
-	}
-
-	if v, ok := tfMap[names.AttrProtocol].(string); ok && v != "" {
-		apiObject.Protocol = types.VerifiedAccessEndpointProtocol(v)
 	}
 
 	if v, ok := tfMap[names.AttrSubnetIDs].(*schema.Set); ok && v.Len() > 0 {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Description

The API request for a VA endpoint does not accept `LoadBalancerOptions.port` when `LoadBalancerOptions.protocol="tcp"`, but it was being set (to `0`), breaking creation. This PR makes the inclusion (in the request) conditional.

### Relations
Closes #42654 

### References

* [Verified Access User Guide - Create a load balancer endpoint](https://docs.aws.amazon.com/verified-access/latest/ug/create-load-balancer-endpoint.html)
  > (HTTP/HTTPS) For Port, enter the port number. (TCP) For Port ranges, enter a port range and choose Add port.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

**TODO - WIP**
seems broken... will fix later this week.

```console
% make testacc TESTS=TestAccVerifiedAccessEndpoint PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVerifiedAccessEndpoint'  -timeout 360m -vet=off
2025/05/20 16:36:24 Initializing Terraform AWS Provider...
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	4.121s [no tests to run]
...
```
