### PR TITLE
add retry to handle `VpcEndpoint modify operation in progress` error

### DIFF
--- a/internal/service/ec2/consts.go
+++ b/internal/service/ec2/consts.go
@@ -4,6 +4,8 @@
 package ec2
 
 import (
+	"time"
+
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -307,4 +309,8 @@ const (
 
 const (
 	supportedRegionServiceStateAvailable = "Available"
+)
+
+const (
+	vpcModifyTimeout = 2 * time.Minute
 )


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
No

### Description
This PR adds retry logic for creating and deleting VPC Endpoint Security Group Associations. Currently, if someone creates multiple associations in parallel, as shown in the example below, the VPC Endpoint will throw a `VpcEndpoint modify operation in progress` error.

```hcl
resource "aws_vpc_endpoint_security_group_association" "vpc_sg_association" {
  for_each = toset([
    aws_security_group.sg1.id,
    aws_security_group.sg2.id,
    aws_security_group.sg3.id
  ])
  security_group_id = each.value
  vpc_endpoint_id   = aws_vpc_endpoint.example.id
}
```

### Relations


### References



### Output from Acceptance Testing

```console
make testacc TESTS=TestAccVPCEndpointSecurityGroupAssociation_ PKG=ec2                                                                                                                                 b-handle-concurrent-vpc-endpoint-security-group-association ✭
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccVPCEndpointSecurityGroupAssociation_'  -timeout 360m -vet=off
2025/05/21 13:21:37 Initializing Terraform AWS Provider...
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_basic
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_basic
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_disappears
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_disappears
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_multiple
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_multiple
=== RUN   TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== PAUSE TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_basic
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_multiple
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation
=== CONT  TestAccVPCEndpointSecurityGroupAssociation_disappears
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_multiple (107.89s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_disappears (111.15s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_replaceDefaultAssociation (117.69s)
--- PASS: TestAccVPCEndpointSecurityGroupAssociation_basic (118.78s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        124.018s
...
```
