### PR TITLE
fix(aws_elasticache_user): ignore noop changes with no-password auth

### DIFF
--- a/.changelog/42712.txt
+++ b/.changelog/42712.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_user: Ignore no-op changes from authentication mode `no-password` to `no-password-required`
+```

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -85,6 +85,14 @@ func resourceUser() *schema.Resource {
 								Type:             schema.TypeString,
 								Required:         true,
 								ValidateDiagFunc: enum.Validate[awstypes.InputAuthenticationType](),
+								DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+									// AWS uses different values for input and output of the auth type, ignore equivalent values
+									if old == string(awstypes.AuthenticationTypeNoPassword) &&
+										new == string(awstypes.InputAuthenticationTypeNoPassword) {
+										return true
+									}
+									return false
+								},
 							},
 						},
 					},

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -128,6 +128,40 @@ func TestAccElastiCacheUser_iamAuthMode(t *testing.T) {
 	})
 }
 
+func TestAccElastiCacheUser_noPasswordAuthMode(t *testing.T) {
+	ctx := acctest.Context(t)
+	var user awstypes.User
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
+	resourceName := "aws_elasticache_user.test"
+
+	acctest.ParallelTest(ctx, t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserConfigWithNoPasswordAuthMode_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists(ctx, t, resourceName, &user),
+					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.type", "no-password"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"no_password_required",
+				},
+			},
+		},
+	})
+}
+
 func TestAccElastiCacheUser_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
@@ -533,6 +567,21 @@ resource "aws_elasticache_user" "test" {
 
   authentication_mode {
     type = "iam"
+  }
+}
+`, rName)
+}
+
+func testAccUserConfigWithNoPasswordAuthMode_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_elasticache_user" "test" {
+  user_id       = %[1]q
+  user_name     = %[1]q
+  access_string = "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+  engine        = "redis"
+
+  authentication_mode {
+    type = "no-password-required"
   }
 }
 `, rName)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

<!-- Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain. -->

There are no changes to security controls.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This is my first PR in this repo, I read the contribution guidelines but please let me know if I forgot something :) .

As reported in #33877 this provider always reports a difference when using ElastiCache Users with the authentication type `no-password-required`.
AWS accepts this input value but returns `no-password` as output type which causes a diff that is always reconciled but effectively a no-op.
Some users ignore the `authentication_mode` field as a workaround as described in the referenced issue.

I checked the docs and related resources where I also found the option to use the `CustomizeDiff` function but decided to use `DiffSuppressFunc` as it is used for similar changes - let me know if you prefer something else.

Thanks for having a look!


### Relations

Closes #33877

### References

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I added a new test for the no password authentication mode with the following output **before** I added my fix:
```console
❯ make testacc TESTS=TestAccElastiCacheUser_noPasswordAuthMode PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser_noPasswordAuthMode'  -timeout 360m -vet=off
2025/05/21 18:56:55 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheUser_noPasswordAuthMode
=== PAUSE TestAccElastiCacheUser_noPasswordAuthMode
=== CONT  TestAccElastiCacheUser_noPasswordAuthMode
    user_test.go:138: Step 1/2 error: After applying this test step, the non-refresh plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # aws_elasticache_user.test will be updated in-place
          ~ resource "aws_elasticache_user" "test" {
                id                   = "tf-acc-7220037518642091563"
                # (7 unchanged attributes hidden)

              ~ authentication_mode {
                  + passwords      = (sensitive value)
                  ~ type           = "no-password" -> "no-password-required"
                    # (1 unchanged attribute hidden)
                }
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccElastiCacheUser_noPasswordAuthMode (47.56s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        51.697s
FAIL
make: *** [testacc] Error 1
``` 

After adding my fix all tests finished successfully:

```console
❯ make testacc TESTS=TestAccElastiCacheUser PKG=elasticache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser'  -timeout 360m -vet=off
2025/05/21 19:59:41 Initializing Terraform AWS Provider...
=== RUN   TestAccElastiCacheUserDataSource_basic
=== PAUSE TestAccElastiCacheUserDataSource_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_basic
=== PAUSE TestAccElastiCacheUserGroupAssociation_basic
=== RUN   TestAccElastiCacheUserGroupAssociation_update
=== PAUSE TestAccElastiCacheUserGroupAssociation_update
=== RUN   TestAccElastiCacheUserGroupAssociation_disappears
=== PAUSE TestAccElastiCacheUserGroupAssociation_disappears
=== RUN   TestAccElastiCacheUserGroupAssociation_multiple
=== PAUSE TestAccElastiCacheUserGroupAssociation_multiple
=== RUN   TestAccElastiCacheUserGroup_basic
=== PAUSE TestAccElastiCacheUserGroup_basic
=== RUN   TestAccElastiCacheUserGroup_update
=== PAUSE TestAccElastiCacheUserGroup_update
=== RUN   TestAccElastiCacheUserGroup_tags
=== PAUSE TestAccElastiCacheUserGroup_tags
=== RUN   TestAccElastiCacheUserGroup_disappears
=== PAUSE TestAccElastiCacheUserGroup_disappears
=== RUN   TestAccElastiCacheUser_basic
=== PAUSE TestAccElastiCacheUser_basic
=== RUN   TestAccElastiCacheUser_passwordAuthMode
=== PAUSE TestAccElastiCacheUser_passwordAuthMode
=== RUN   TestAccElastiCacheUser_iamAuthMode
=== PAUSE TestAccElastiCacheUser_iamAuthMode
=== RUN   TestAccElastiCacheUser_noPasswordAuthMode
=== PAUSE TestAccElastiCacheUser_noPasswordAuthMode
=== RUN   TestAccElastiCacheUser_update
=== PAUSE TestAccElastiCacheUser_update
=== RUN   TestAccElastiCacheUser_updateEngine
=== PAUSE TestAccElastiCacheUser_updateEngine
=== RUN   TestAccElastiCacheUser_updatePasswordAuthMode
=== PAUSE TestAccElastiCacheUser_updatePasswordAuthMode
=== RUN   TestAccElastiCacheUser_tags
=== PAUSE TestAccElastiCacheUser_tags
=== RUN   TestAccElastiCacheUser_disappears
=== PAUSE TestAccElastiCacheUser_disappears
=== RUN   TestAccElastiCacheUser_oobModify
=== PAUSE TestAccElastiCacheUser_oobModify
=== CONT  TestAccElastiCacheUserDataSource_basic
=== CONT  TestAccElastiCacheUser_passwordAuthMode
=== CONT  TestAccElastiCacheUser_updatePasswordAuthMode
=== CONT  TestAccElastiCacheUserGroup_basic
=== CONT  TestAccElastiCacheUserGroupAssociation_basic
=== CONT  TestAccElastiCacheUser_update
=== CONT  TestAccElastiCacheUser_updateEngine
=== CONT  TestAccElastiCacheUser_basic
=== CONT  TestAccElastiCacheUserGroupAssociation_disappears
=== CONT  TestAccElastiCacheUserGroupAssociation_multiple
=== CONT  TestAccElastiCacheUserGroupAssociation_update
=== CONT  TestAccElastiCacheUser_noPasswordAuthMode
=== CONT  TestAccElastiCacheUserGroup_tags
=== CONT  TestAccElastiCacheUserGroup_update
=== CONT  TestAccElastiCacheUser_disappears
=== CONT  TestAccElastiCacheUser_oobModify
=== CONT  TestAccElastiCacheUser_iamAuthMode
=== CONT  TestAccElastiCacheUser_tags
=== CONT  TestAccElastiCacheUserGroup_disappears
--- PASS: TestAccElastiCacheUser_basic (55.14s)
--- PASS: TestAccElastiCacheUser_passwordAuthMode (56.74s)
--- PASS: TestAccElastiCacheUserDataSource_basic (56.95s)
--- PASS: TestAccElastiCacheUser_noPasswordAuthMode (57.83s)
--- PASS: TestAccElastiCacheUser_iamAuthMode (61.93s)
--- PASS: TestAccElastiCacheUser_tags (121.41s)
--- PASS: TestAccElastiCacheUser_updateEngine (124.46s)
--- PASS: TestAccElastiCacheUser_update (124.76s)
--- PASS: TestAccElastiCacheUser_oobModify (177.50s)
--- PASS: TestAccElastiCacheUserGroup_disappears (178.95s)
--- PASS: TestAccElastiCacheUserGroup_basic (182.77s)
--- PASS: TestAccElastiCacheUser_disappears (234.71s)
--- PASS: TestAccElastiCacheUserGroup_tags (239.78s)
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (241.16s)
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (301.15s)
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (306.05s)
--- PASS: TestAccElastiCacheUserGroup_update (423.93s)
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (424.03s)
--- PASS: TestAccElastiCacheUserGroupAssociation_update (432.33s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        436.523s
```
