### PR TITLE
Split initialization check into a distinct workflow

### DIFF
--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -50,6 +50,7 @@ jobs:
           jira_github_url_field_id: 'cf[10089]'
           github_release_name: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
   on-failure:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
@@ -59,6 +60,7 @@ jobs:
   start-registry-check:
     name: Start Registry Check
     runs-on: ubuntu-latest
+    needs: [on-success-or-workflow-dispatch]
     permissions:
       actions: write
     steps:
@@ -66,9 +68,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}
         run: |
           gh workflow run \
             --repo ${{ github.repository }} \
             --ref main \
-            --field version=${{ github.event.client_payload.payload.version }} \
+            --field version=${VERSION:1} \
             registry-check.yml

--- a/.github/workflows/post_publish.yml
+++ b/.github/workflows/post_publish.yml
@@ -1,4 +1,5 @@
 name: Post Publish
+
 on:
   workflow_dispatch:
     inputs:
@@ -6,10 +7,12 @@ on:
         type: string
         description: 'Semver release tag e.g. v1.1.0'
         required: true
+
   workflow_run:
     workflows: [Release]
     types:
       - completed
+
 jobs:
   on-success-or-workflow-dispatch:
     runs-on: ubuntu-latest
@@ -32,6 +35,7 @@ jobs:
             value=`cat release-tag.data`
             echo "tag=$value" >> "$GITHUB_OUTPUT"
           fi
+
   tidy-jira:
     needs: [on-success-or-workflow-dispatch]
     runs-on: ubuntu-latest
@@ -52,81 +56,19 @@ jobs:
     steps:
       - run: echo 'The triggering workflow failed'
 
-  registry-check:
+  start-registry-check:
+    name: Start Registry Check
     runs-on: ubuntu-latest
-    needs: [on-success-or-workflow-dispatch]
-    outputs:
-      latest-version: ${{ steps.registry_latest_ver.outputs.current }}
+    permissions:
+      actions: write
     steps:
-      - name: Registry Version Check
-        id: registry_latest_ver
+      - name: Initiate Workflow
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          for i in 1 2
-          do
-            LATEST_VERSION=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions/latest" | jq -r '.data.attributes.version')
-            if [[ "${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}" != "v${LATEST_VERSION}" ]]; then
-              sleep 1h
-            else
-              echo "Registry and Github Version matches"
-              echo "current=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          done
-
-          echo "Registry does not contain ${{ needs.on-success-or-workflow-dispatch.outputs.release-tag }}"
-          exit 1
-
-  os-version-init:
-    name: Run terraform init On Supported Platforms
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    needs: [registry-check]
-    steps:
-      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
-        with:
-          terraform_wrapper: false
-      - name: Specify Provider Version in TF Configuration
-        run: |
-          cat <<EOF > main.tf
-          terraform {
-            required_providers {
-              aws = {
-                source  = "hashicorp/aws"
-                version = "${{ needs.registry-check.outputs.latest-version }}"
-              }
-            }
-          }
-
-          provider "aws" {
-            region = "us-east-1"
-          }
-          EOF
-
-      - name: Initialize the AWS Provider
-        run: terraform init -upgrade
-
-      - name: Send Slack Notification Upon Failure
-        if: ${{ failure() }}
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          method: chat.postMessage
-          token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel" : "${{ secrets.SLACK_CHANNEL }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "ERROR: Registry Provder Initiation Failure on ${{ matrix.os }}"
-                  }
-                }
-              ]
-            }
+          gh workflow run \
+            --repo ${{ github.repository }} \
+            --ref main \
+            --field version=${{ github.event.client_payload.payload.version }} \
+            registry-check.yml

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -212,7 +212,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04-arm, ubuntu-22.04-arm64, windows-latest, macOS-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Add Status Update Message in Thread

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -1,0 +1,358 @@
+name: Registry Initialization Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout:
+        description: The number of minutes to wait for Registry ingest
+        required: true
+        default: 120
+      version:
+        description: |
+          The version of the provider to test initialization for (without the preceding 'v'). If unset, will use the version pulled from the latest GitHub release
+        required: false
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  registry-check:
+    name: Check Terraform Registry for Latest Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.registry-ingest.outputs.version }}
+      ts: ${{ steps.message.outputs.ts }}
+    steps:
+      - name: Get Latest GitHub Release
+        if: inputs.version == ''
+        id: github-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "tag=$(gh release list --repo ${{ github.repository }} --json name,isLatest --jq '.[] | select(.isLatest).name')" >> "$GITHUB_OUTPUT"
+
+      - name: Set Up Initial Slack Message Blocks
+        id: parent
+        env:
+          VERSION: ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}
+        run: |
+          BASE_MESSAGE_BLOCKS=$(jq -nc --arg version $VERSION '[
+            {
+              "type": "header",
+              "text": {
+                "type": "plain_text",
+                "text": ("Initialization Check for aws Version " + $version)
+              }
+            },
+            {
+              "type": "divider"
+            },
+            {
+              "type": "rich_text",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "text",
+                      "text": "\n\nView the "
+                    },
+                    {
+                      "type": "link",
+                      "text": "Run Logs",
+                      "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    },
+                    {
+                      "type": "text",
+                      "text": " for additional information.\n\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]')
+
+          INITIAL_MESSAGE_ADDITION=$(jq -nc --arg version $VERSION '[
+            {
+              "type": "rich_text",
+              "elements": [
+                {
+                  "type": "rich_text_section",
+                  "elements": [
+                    {
+                      "type": "emoji",
+                      "name": "waiting-spin"
+                    },
+                    {
+                      "type": "text",
+                      "text": (" Waiting on Terraform Registry to ingest version " + $version + "...")
+                    }
+                  ]
+                }
+              ]
+            }
+          ]')
+
+          echo "base-message-blocks=$(echo $BASE_MESSAGE_BLOCKS | jq '. | @json')" >> "$GITHUB_OUTPUT"
+
+          echo "initial-message-blocks=$(echo $BASE_MESSAGE_BLOCKS | jq --argjson addition "$INITIAL_MESSAGE_ADDITION" '. += $addition | @json')" >> "$GITHUB_OUTPUT"
+
+      - name: Post Initial Slack Message
+        id: message
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL }}",
+              "text": "Testing Provider Initialization",
+              "blocks": ${{ fromJSON(steps.parent.outputs.initial-message-blocks) }}
+            }
+
+      - name: Await Ingest
+        id: registry-ingest
+        env:
+          VERSION: ${{ steps.github-release.outputs.tag || format('v{0}', inputs.version) }}
+        run: |
+          SECONDS=0
+
+          while :
+          do
+
+            if [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "Timeout has been reached, exiting."
+              TIMED_OUT="true"
+
+              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]')
+
+              break
+            fi
+
+            REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions" | jq --arg version $VERSION '.data[] | select(.attributes.tag == $version)')
+
+            if [[ -z "$REGISTRY_DATA" ]]; then
+              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
+              sleep 300
+            else
+              echo "Registry has ingested version $VERSION"
+              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
+
+              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "bufo-check"
+                        },
+                        {
+                          "type": "text",
+                          "text": (" Terraform Registry has ingested version " + $version + ". Initialization testing details will be threaded below.")
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]')
+
+              break
+            fi
+          done
+
+          echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --argjson update "$UPDATED_BLOCKS" '. += $update | @json')" >> "$GITHUB_OUTPUT"
+
+          if [[ "$TIMED_OUT" == "true" ]]; then
+            exit 1
+          fi
+
+      - name: Update Initial Slack Message
+        if: ${{ success() || failure() }}
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ steps.message.outputs.channel_id }}",
+              "ts": "${{ steps.message.outputs.ts }}",
+              "as_user": true,
+              "blocks": ${{ fromJSON(steps.registry-ingest.outputs.slack-payload-blocks) }}
+            }
+
+  init-check:
+    name: Initialize Provider
+    needs: [registry-check]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, ubuntu-22.04-arm, ubuntu-22.04-arm64, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Add Status Update Message in Thread
+        id: thread-message
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ secrets.SLACK_CHANNEL }}",
+              "text": "Initialization details for ${{ matrix.os }}",
+              "thread_ts": "${{ needs.registry-check.outputs.ts }}",
+              "blocks": [
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "waiting-spin"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization check on ${{ matrix.os }} is running..."
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_wrapper: false
+
+      - name: Set Provider Version in Terraform Configuration
+        run: |
+          cat <<EOF > main.tf
+          terraform {
+            required_providers {
+              aws = {
+                source  = "hashicorp/aws"
+                version = "${{ needs.registry-check.outputs.version }}"
+              }
+            }
+          }
+
+          provider "aws" {
+            region = "us-east-1"
+          }
+          EOF
+
+      # Explicitly setting '+o pipefail' here, as GitHub uses 'set -eo pipefail' for the bash shell
+      # and we need to capture error messages rather than outright fail
+      # Reference:
+      # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunshell
+      - name: Initialize
+        id: init
+        run: |
+          set +o pipefail
+          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
+
+          if [[ "$ERROR" == "" ]]; then
+            echo "payload=$(jq -nc '[
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "emoji",
+                        "name": "bufo-check"
+                      },
+                      {
+                        "type": "text",
+                        "text": " Initialization on ${{ matrix.os }} succeeded"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ] | @json')" >> "$GITHUB_OUTPUT"
+          else
+            echo "payload=$(echo $ERROR | jq -c '[
+              {
+                "type": "rich_text",
+                "elements": [
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "emoji",
+                        "name": "failure"
+                      },
+                      {
+                        "type": "text",
+                        "text": " Initialization on ${{ matrix.os }} failed."
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_section",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": "\n\n The error produced during initialization was:"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "rich_text_preformatted",
+                    "elements": [
+                      {
+                        "type": "text",
+                        "text": (.["@message"] + "\n\n" + .diagnostic.detail)
+                      }
+                    ]
+                  }
+                ]
+              }
+            ] | @json')" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+      - name: Update Threaded Message with Results
+        if: ${{ success() || failure() }}
+        id: thread-message-update
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.update
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ steps.thread-message.outputs.channel_id }}",
+              "as_user": true,
+              "ts": "${{ steps.thread-message.outputs.ts }}",
+              "blocks": ${{ fromJSON(steps.init.outputs.payload) }}
+            }

--- a/.github/workflows/registry-check.yml
+++ b/.github/workflows/registry-check.yml
@@ -24,8 +24,9 @@ jobs:
     name: Check Terraform Registry for Latest Version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.registry-ingest.outputs.version }}
+      elapsed-time: ${{ steps.registry-ingest.outputs.elapsed-time }}
       ts: ${{ steps.message.outputs.ts }}
+      version: ${{ steps.registry-ingest.outputs.version }}
     steps:
       - name: Get Latest GitHub Release
         if: inputs.version == ''
@@ -124,44 +125,10 @@ jobs:
           while :
           do
 
-            if [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
-              echo "Timeout has been reached, exiting."
-              TIMED_OUT="true"
-
-              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
-                {
-                  "type": "rich_text",
-                  "elements": [
-                    {
-                      "type": "rich_text_section",
-                      "elements": [
-                        {
-                          "type": "emoji",
-                          "name": "failure"
-                        },
-                        {
-                          "type": "text",
-                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]')
-
-              break
-            fi
-
             REGISTRY_DATA=$(curl -s "https://registry.terraform.io/v2/providers/323/provider-versions" | jq --arg version $VERSION '.data[] | select(.attributes.tag == $version)')
 
-            if [[ -z "$REGISTRY_DATA" ]]; then
-              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
-              sleep 300
-            else
-              echo "Registry has ingested version $VERSION"
-              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
-
-              UPDATED_BLOCKS=$(jq -nc --arg version $VERSION '[
+            if ! [[ -z $REGISTRY_DATA ]]; then
+              echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --arg version $VERSION '. += [
                 {
                   "type": "rich_text",
                   "elements": [
@@ -180,17 +147,43 @@ jobs:
                     }
                   ]
                 }
-              ]')
+              ] | @json')" >> "$GITHUB_OUTPUT"
 
+              echo "Registry has ingested version $VERSION"
+              echo "elapsed-time=$SECONDS" >> "$GITHUB_OUTPUT"
+              echo "version=$(echo $REGISTRY_DATA | jq -r '.attributes.version')" >> "$GITHUB_OUTPUT"
               break
+
+            elif [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --arg version $VERSION '. += [
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": (" Timed out while waiting for the Terraform Registry to ingest version " + $version)
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              echo "Timed out while waiting for the Terraform Registry to ingest version $VERSION" >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+
+            else
+              echo "Terraform Registry has not yet ingested version $VERSION. Continuing to wait for ingest..."
+              sleep 300
             fi
           done
-
-          echo "slack-payload-blocks=$(echo ${{ steps.parent.outputs.base-message-blocks }} | jq --argjson update "$UPDATED_BLOCKS" '. += $update | @json')" >> "$GITHUB_OUTPUT"
-
-          if [[ "$TIMED_OUT" == "true" ]]; then
-            exit 1
-          fi
 
       - name: Update Initial Slack Message
         if: ${{ success() || failure() }}
@@ -277,70 +270,92 @@ jobs:
         id: init
         run: |
           set +o pipefail
-          ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
 
-          if [[ "$ERROR" == "" ]]; then
-            echo "payload=$(jq -nc '[
-              {
-                "type": "rich_text",
-                "elements": [
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "emoji",
-                        "name": "bufo-check"
-                      },
-                      {
-                        "type": "text",
-                        "text": " Initialization on ${{ matrix.os }} succeeded"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ] | @json')" >> "$GITHUB_OUTPUT"
-          else
-            echo "payload=$(echo $ERROR | jq -c '[
-              {
-                "type": "rich_text",
-                "elements": [
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "emoji",
-                        "name": "failure"
-                      },
-                      {
-                        "type": "text",
-                        "text": " Initialization on ${{ matrix.os }} failed."
-                      }
-                    ]
-                  },
-                  {
-                    "type": "rich_text_section",
-                    "elements": [
-                      {
-                        "type": "text",
-                        "text": "\n\n The error produced during initialization was:"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "rich_text_preformatted",
-                    "elements": [
-                      {
-                        "type": "text",
-                        "text": (.["@message"] + "\n\n" + .diagnostic.detail)
-                      }
-                    ]
-                  }
-                ]
-              }
-            ] | @json')" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
+          SECONDS=${{ fromJSON(needs.registry-check.outputs.elapsed-time) }}
+
+          while :
+          do
+
+            ERROR=$(terraform init -upgrade -json | jq --slurp '.[] | select(.diagnostic.severity == "error")')
+
+            if [[ -z $ERROR ]]; then
+              echo "payload=$(jq -nc '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "bufo-check"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization on ${{ matrix.os }} succeeded"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              break
+
+            elif [[ $(($SECONDS/60)) -ge ${{ inputs.timeout }} ]]; then
+              echo "payload=$(echo $ERROR | jq -c '[
+                {
+                  "type": "rich_text",
+                  "elements": [
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "emoji",
+                          "name": "failure"
+                        },
+                        {
+                          "type": "text",
+                          "text": " Initialization on ${{ matrix.os }} failed."
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_section",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": "\n\n The error produced during initialization was:"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "rich_text_preformatted",
+                      "elements": [
+                        {
+                          "type": "text",
+                          "text": (.["@message"] + "\n\n" + .diagnostic.detail)
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ] | @json')" >> "$GITHUB_OUTPUT"
+
+              echo "Timeout was reached before a successful initialization." >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+              echo "Error received during initialization:" >> "$GITHUB_STEP_SUMMARY"
+              echo >> "$GITHUB_STEP_SUMMARY"
+              echo '```console' >> "$GITHUB_STEP_SUMMARY"
+              echo $ERROR | jq --raw-output '.["@message"] + "\n\n" + .diagnostic.detail' >> "$GITHUB_STEP_SUMMARY"
+              echo '```' >> "$GITHUB_STEP_SUMMARY"
+              exit 1
+
+            else
+              echo "Provider initialization failed, but timeout has not yet been reached. Trying again..."
+              sleep 60
+            fi
+          done
 
       - name: Update Threaded Message with Results
         if: ${{ success() || failure() }}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

This PR copies the initialization check workflow that was recently introduced in the AWSCC provider over to the mainline provider.

### Relations

Relates https://github.com/hashicorp/terraform-provider-awscc/pull/2303
Relates https://github.com/hashicorp/terraform-provider-awscc/pull/2313

### Output from Acceptance Testing

N/a, workflows
