### PR TITLE
r/aws_cloudwatch_log_stream: return first match during read

### DIFF
--- a/.changelog/42719.txt
+++ b/.changelog/42719.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_log_stream: Fix to return the first matched stream name during the read operation. This fixes a performance regression introduced in `v5.83.0`.
+```

--- a/.changelog/42719.txt
+++ b/.changelog/42719.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudwatch_log_stream: Fix to return the first matched stream name during the read operation. This fixes a performance regression introduced in `v5.83.0`.
+resource/aws_cloudwatch_log_stream: Fix to return the first matched stream name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
 ```

--- a/internal/service/logs/stream.go
+++ b/internal/service/logs/stream.go
@@ -153,7 +153,7 @@ func findLogStreamByTwoPartKey(ctx context.Context, conn *cloudwatchlogs.Client,
 }
 
 func findLogStream(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogStreamsInput, filter tfslices.Predicate[*awstypes.LogStream]) (*awstypes.LogStream, error) { // nosemgrep:ci.logs-in-func-name
-	output, err := findLogStreams(ctx, conn, input, filter, withReturnFirstMatch())
+	output, err := findLogStreams(ctx, conn, input, filter, tfslices.WithReturnFirstMatch())
 
 	if err != nil {
 		return nil, err
@@ -162,9 +162,9 @@ func findLogStream(ctx context.Context, conn *cloudwatchlogs.Client, input *clou
 	return tfresource.AssertSingleValueResult(output)
 }
 
-func findLogStreams(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogStreamsInput, filter tfslices.Predicate[*awstypes.LogStream], optFn ...filterOptionsFunc) ([]awstypes.LogStream, error) { // nosemgrep:ci.logs-in-func-name
+func findLogStreams(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogStreamsInput, filter tfslices.Predicate[*awstypes.LogStream], optFns ...tfslices.FinderOptionsFunc) ([]awstypes.LogStream, error) { // nosemgrep:ci.logs-in-func-name
 	var output []awstypes.LogStream
-	opts := newFilterOptions(optFn)
+	opts := tfslices.NewFinderOptions(optFns)
 
 	pages := cloudwatchlogs.NewDescribeLogStreamsPaginator(conn, input)
 	for pages.HasMorePages() {
@@ -184,7 +184,7 @@ func findLogStreams(ctx context.Context, conn *cloudwatchlogs.Client, input *clo
 		for _, v := range page.LogStreams {
 			if filter(&v) {
 				output = append(output, v)
-				if opts.shouldReturnFirstMatch() {
+				if opts.ReturnFirstMatch() {
 					return output, nil
 				}
 			}
@@ -192,28 +192,4 @@ func findLogStreams(ctx context.Context, conn *cloudwatchlogs.Client, input *clo
 	}
 
 	return output, nil
-}
-
-type filterOptions struct {
-	returnFirstMatch bool
-}
-
-func newFilterOptions(optFn []filterOptionsFunc) *filterOptions {
-	opts := &filterOptions{}
-	for _, fn := range optFn {
-		fn(opts)
-	}
-	return opts
-}
-
-func (o *filterOptions) shouldReturnFirstMatch() bool {
-	return o.returnFirstMatch
-}
-
-type filterOptionsFunc func(*filterOptions)
-
-func withReturnFirstMatch() filterOptionsFunc {
-	return func(o *filterOptions) {
-		o.returnFirstMatch = true
-	}
 }

--- a/internal/slices/options.go
+++ b/internal/slices/options.go
@@ -1,0 +1,28 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package slices
+
+type FinderOptions struct {
+	returnFirstMatch bool
+}
+
+func NewFinderOptions(optFns []FinderOptionsFunc) *FinderOptions {
+	opts := &FinderOptions{}
+	for _, fn := range optFns {
+		fn(opts)
+	}
+	return opts
+}
+
+func (o *FinderOptions) ReturnFirstMatch() bool {
+	return o.returnFirstMatch
+}
+
+type FinderOptionsFunc func(*FinderOptions)
+
+func WithReturnFirstMatch() FinderOptionsFunc {
+	return func(o *FinderOptions) {
+		o.returnFirstMatch = true
+	}
+}


### PR DESCRIPTION



<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Addresses a performance regression introduced in `v5.83.0` which can surface in log groups with large numbers of stream prefixes matching a stream name. The read operation will once again return the first stream with an exact name match, rather than exhausting the full list of results from the `DesribeLogStreams` API before asserting only a single result is found.

This fix introduces a `filterOptions` struct to prototype how a generic options structure that can be shared across finders might be designed. If we opt to extend this to finders in other packages we can migrate this struct and associated methods to a shared location. If, instead, we feel this desired behavior is specific only to this service, we can replace this approach with a simple boolean argument on the `findLogStreams` function instead.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42713

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
- https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=logs TESTS=TestAccLogsStream_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsStream_'  -timeout 360m -vet=off
2025/05/21 16:31:16 Initializing Terraform AWS Provider...

--- PASS: TestAccLogsStream_Disappears_logGroup (13.89s)
--- PASS: TestAccLogsStream_disappears (13.96s)
--- PASS: TestAccLogsStream_basic (15.73s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       21.260s
```
