### PR TITLE
r/aws_lb: Gracefully ignore `AccessDenied` errors from `DescribeCapacityReservation`

### DIFF
--- a/internal/service/elbv2/errors.go
+++ b/internal/service/elbv2/errors.go
@@ -4,6 +4,7 @@
 package elbv2
 
 const (
+	errCodeAccessDenied    = "AccessDenied"
 	errCodeValidationError = "ValidationError"
 )
 

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -17,6 +17,7 @@ import ( // nosemgrep:ci.semgrep.aws.multiple-service-imports
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -595,12 +596,15 @@ func resourceLoadBalancerRead(ctx context.Context, d *schema.ResourceData, meta 
 	if lb.Type == awstypes.LoadBalancerTypeEnumApplication || lb.Type == awstypes.LoadBalancerTypeEnumNetwork {
 		capacity, err := findCapacityReservationByARN(ctx, conn, d.Id())
 
-		if err != nil {
+		switch {
+		case tfawserr.ErrCodeEquals(err, errCodeAccessDenied):
+			d.Set("minimum_load_balancer_capacity", nil)
+		case err != nil:
 			return sdkdiag.AppendErrorf(diags, "reading ELBv2 Load Balancer (%s) capacity reservation: %s", d.Id(), err)
-		}
-
-		if err := d.Set("minimum_load_balancer_capacity", flattenMinimumLoadBalancerCapacity(capacity.MinimumLoadBalancerCapacity)); err != nil {
-			return sdkdiag.AppendErrorf(diags, "setting minimum_load_balancer_capacity: %s", err)
+		default:
+			if err := d.Set("minimum_load_balancer_capacity", flattenMinimumLoadBalancerCapacity(capacity.MinimumLoadBalancerCapacity)); err != nil {
+				return sdkdiag.AppendErrorf(diags, "setting minimum_load_balancer_capacity: %s", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

As https://github.com/hashicorp/terraform-provider-aws/pull/42685 introduced new IAM permission requirements, gracefully ignore `AccessDenied` errors from `DescribeCapacityReservation` during Read, e.g.

```
operation error Elastic Load Balancing v2: DescribeCapacityReservation, https response error StatusCode: 403, RequestID: 19ac3d93-272b-4134-9769-88316b3a3f39, api error AccessDenied: User: arn:aws:iam::123456789012:user/kit is not authorized to perform: elasticloadbalancing:DescribeCapacityReservation on resource: * with an explicit deny in an identity-based policy
```

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccELBV2LoadBalancer_updateCapacityReservation' PKG=elbv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/elbv2/... -v -count 1 -parallel 20  -run=TestAccELBV2LoadBalancer_updateCapacityReservation -timeout 360m -vet=off
2025/05/22 10:30:14 Initializing Terraform AWS Provider...
=== RUN   TestAccELBV2LoadBalancer_updateCapacityReservation
=== PAUSE TestAccELBV2LoadBalancer_updateCapacityReservation
=== CONT  TestAccELBV2LoadBalancer_updateCapacityReservation
--- PASS: TestAccELBV2LoadBalancer_updateCapacityReservation (324.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	329.815s
```
