### PR TITLE
r/aws_elasticache_replication_group: fix crash reading empty node groups

### DIFF
--- a/.changelog/42726.txt
+++ b/.changelog/42726.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_elasticache_replication_group: Fix crash during read operations where configuration endpoint and node groups are nil and empty, respectively
+```

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -715,7 +715,7 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 	if rgp.ConfigurationEndpoint != nil {
 		d.Set(names.AttrPort, rgp.ConfigurationEndpoint.Port)
 		d.Set("configuration_endpoint_address", rgp.ConfigurationEndpoint.Address)
-	} else {
+	} else if len(rgp.NodeGroups) > 0 {
 		log.Printf("[DEBUG] ElastiCache Replication Group (%s) Configuration Endpoint is nil", d.Id())
 
 		if rgp.NodeGroups[0].PrimaryEndpoint != nil {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Previously, if both `ConfigurationEndpoint` was nil and `NodeGroups` was an empty list, the provider would panic during the read operation while attempting to set port and endpoint address arguments. This change adds a check for empty `NodeGroups` to prevent `index out of range` errors under these conditions.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42720


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup_multiAzInVPC
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup_multiAzInVPC'  -timeout 360m -vet=off
2025/05/22 10:42:49 Initializing Terraform AWS Provider...

--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (881.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        887.441s
```

