### PR TITLE
ECS Enhanced Region import support

### DIFF
--- a/.changelog/42733.txt
+++ b/.changelog/42733.txt
@@ -1,0 +1,4 @@
+
+```release-note:enhancement
+resource/aws_ecs_service: Add `arn` attribute
+```

--- a/internal/acctest/state_id.go
+++ b/internal/acctest/state_id.go
@@ -21,3 +21,22 @@ func AttrImportStateIdFunc(resourceName, attrName string) resource.ImportStateId
 		return rs.Primary.Attributes[attrName], nil
 	}
 }
+
+// CrossRegionAttrImportStateIdFunc is a resource.ImportStateIdFunc that returns the value
+// of the specified attribute and appends the region
+func CrossRegionAttrImportStateIdFunc(resourceName, attrName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		id := rs.Primary.Attributes[attrName]
+		region, ok := rs.Primary.Attributes["region"]
+		if !ok {
+			return "", fmt.Errorf("Attribute \"region\" not found in %s", resourceName)
+		}
+
+		return id + "@" + region, nil
+	}
+}

--- a/internal/acctest/state_id.go
+++ b/internal/acctest/state_id.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // AttrImportStateIdFunc is a resource.ImportStateIdFunc that returns the value of the specified attribute
@@ -32,7 +33,7 @@ func CrossRegionAttrImportStateIdFunc(resourceName, attrName string) resource.Im
 		}
 
 		id := rs.Primary.Attributes[attrName]
-		region, ok := rs.Primary.Attributes["region"]
+		region, ok := rs.Primary.Attributes[names.AttrRegion]
 		if !ok {
 			return "", fmt.Errorf("Attribute \"region\" not found in %s", resourceName)
 		}

--- a/internal/acctest/statecheck/expect_regional_arn_format.go
+++ b/internal/acctest/statecheck/expect_regional_arn_format.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statecheck
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
+)
+
+var _ statecheck.StateCheck = expectRegionalARNFormatCheck{}
+
+type expectRegionalARNFormatCheck struct {
+	base          Base
+	attributePath tfjsonpath.Path
+	arnService    string
+	arnFormat     string
+	checkFactory  func(service string, arn string) knownvalue.Check
+}
+
+func (e expectRegionalARNFormatCheck) CheckState(ctx context.Context, request statecheck.CheckStateRequest, response *statecheck.CheckStateResponse) {
+	resource, ok := e.base.ResourceFromState(request, response)
+	if !ok {
+		return
+	}
+
+	value, err := tfjsonpath.Traverse(resource.AttributeValues, e.attributePath)
+	if err != nil {
+		response.Error = err
+		return
+	}
+
+	arnString, err := populateFromResourceState(e.arnFormat, resource)
+	if err != nil {
+		response.Error = err
+		return
+	}
+
+	knownCheck := e.checkFactory(e.arnService, arnString)
+	if err = knownCheck.CheckValue(value); err != nil {
+		response.Error = fmt.Errorf("checking value for attribute at path: %s.%s, err: %s", e.base.ResourceAddress(), e.attributePath, err)
+		return
+	}
+}
+
+func ExpectRegionalARNFormat(resourceAddress string, attributePath tfjsonpath.Path, arnService, arnFormat string) statecheck.StateCheck {
+	return expectRegionalARNFormatCheck{
+		base:          NewBase(resourceAddress),
+		attributePath: attributePath,
+		arnService:    arnService,
+		arnFormat:     arnFormat,
+		checkFactory: func(service string, arn string) knownvalue.Check {
+			return tfknownvalue.RegionalARNExact(service, arn)
+		},
+	}
+}
+
+func ExpectRegionalARNAlternateRegionFormat(resourceAddress string, attributePath tfjsonpath.Path, arnService, arnFormat string) statecheck.StateCheck {
+	return expectRegionalARNFormatCheck{
+		base:          NewBase(resourceAddress),
+		attributePath: attributePath,
+		arnService:    arnService,
+		arnFormat:     arnFormat,
+		checkFactory: func(service string, arn string) knownvalue.Check {
+			return tfknownvalue.RegionalARNAlternateRegionExact(service, arn)
+		},
+	}
+}
+
+// createDeltaString prints the map keys that are present in mapA and not present in mapB
+func createDeltaString[T any, V any](mapA map[string]T, mapB map[string]V, msgPrefix string) string {
+	deltaMsg := ""
+
+	deltaMap := make(map[string]T, len(mapA))
+	maps.Copy(deltaMap, mapA)
+	for key := range mapB {
+		delete(deltaMap, key)
+	}
+
+	deltaKeys := slices.Sorted(maps.Keys(deltaMap))
+
+	for i, k := range deltaKeys {
+		if i == 0 {
+			deltaMsg += msgPrefix
+		} else {
+			deltaMsg += ", "
+		}
+		deltaMsg += fmt.Sprintf("%q", k)
+	}
+
+	return deltaMsg
+}

--- a/internal/acctest/statecheck/expect_regional_arn_format.go
+++ b/internal/acctest/statecheck/expect_regional_arn_format.go
@@ -6,8 +6,6 @@ package statecheck
 import (
 	"context"
 	"fmt"
-	"maps"
-	"slices"
 
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -72,28 +70,4 @@ func ExpectRegionalARNAlternateRegionFormat(resourceAddress string, attributePat
 			return tfknownvalue.RegionalARNAlternateRegionExact(service, arn)
 		},
 	}
-}
-
-// createDeltaString prints the map keys that are present in mapA and not present in mapB
-func createDeltaString[T any, V any](mapA map[string]T, mapB map[string]V, msgPrefix string) string {
-	deltaMsg := ""
-
-	deltaMap := make(map[string]T, len(mapA))
-	maps.Copy(deltaMap, mapA)
-	for key := range mapB {
-		delete(deltaMap, key)
-	}
-
-	deltaKeys := slices.Sorted(maps.Keys(deltaMap))
-
-	for i, k := range deltaKeys {
-		if i == 0 {
-			deltaMsg += msgPrefix
-		} else {
-			deltaMsg += ", "
-		}
-		deltaMsg += fmt.Sprintf("%q", k)
-	}
-
-	return deltaMsg
 }

--- a/internal/acctest/statecheck/format.go
+++ b/internal/acctest/statecheck/format.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package statecheck
+
+import (
+	"fmt"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func populateFromResourceState(format string, state *tfjson.StateResource) (string, error) {
+	var buf strings.Builder
+	for format != "" {
+		var (
+			stuff string
+			found bool
+		)
+		stuff, format, found = strings.Cut(format, "{")
+		buf.WriteString(stuff)
+		if found {
+			var param string
+			param, format, found = strings.Cut(format, "}")
+			if !found {
+				return "", fmt.Errorf("missing closing '}' in format %q", format)
+			}
+
+			attr, ok := state.AttributeValues[param]
+			if !ok {
+				return "", fmt.Errorf("attribute %q not found in resource %q, referenced in format %q", param, state.Address, format)
+			}
+			fmt.Fprintf(&buf, "%v", attr)
+		}
+	}
+
+	return buf.String(), nil
+
+}

--- a/internal/acctest/statecheck/format.go
+++ b/internal/acctest/statecheck/format.go
@@ -35,5 +35,4 @@ func populateFromResourceState(format string, state *tfjson.StateResource) (stri
 	}
 
 	return buf.String(), nil
-
 }

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -329,9 +329,11 @@ func resourceClusterDelete(ctx context.Context, d *schema.ResourceData, meta any
 
 func resourceClusterImport(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 	d.Set(names.AttrName, d.Id())
+
+	region := d.Get(names.AttrRegion).(string)
 	d.SetId(arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
+		Partition: names.PartitionForRegion(region).ID(),
+		Region:    region,
 		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
 		Service:   "ecs",
 		Resource:  "cluster/" + d.Id(),

--- a/internal/service/ecs/cluster.go
+++ b/internal/service/ecs/cluster.go
@@ -26,7 +26,7 @@ import (
 )
 
 // @SDKResource("aws_ecs_cluster", name="Cluster")
-// @Tags(identifierAttribute="id")
+// @Tags(identifierAttribute="arn")
 func resourceCluster() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceClusterCreate,

--- a/internal/service/ecs/cluster_test.go
+++ b/internal/service/ecs/cluster_test.go
@@ -9,10 +9,15 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/hashicorp/terraform-plugin-testing/compare"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfecs "github.com/hashicorp/terraform-provider-aws/internal/service/ecs"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -35,7 +40,7 @@ func TestAccECSCluster_basic(t *testing.T) {
 				Config: testAccClusterConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ecs", fmt.Sprintf("cluster/%s", rName)),
+					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "ecs", "cluster/{name}"),
 					resource.TestCheckResourceAttr(resourceName, "configuration.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "default_capacity_provider_strategy.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -50,7 +55,70 @@ func TestAccECSCluster_basic(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccECSCluster_Identity_Basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.Cluster
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_basic(rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckClusterExists(ctx, resourceName, &v),
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectRegionalARNFormat(resourceName, tfjsonpath.New(names.AttrARN), "ecs", "cluster/{name}"),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccECSCluster_Identity_RegionOverride(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_ecs_cluster.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ECSServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             acctest.CheckDestroyNoop,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccClusterConfig_regionOverride(rName),
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectRegionalARNAlternateRegionFormat(resourceName, tfjsonpath.New(names.AttrARN), "ecs", "cluster/{name}"),
+					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
+				},
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: acctest.CrossRegionAttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -104,7 +172,7 @@ func TestAccECSCluster_tags(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -154,7 +222,7 @@ func TestAccECSCluster_serviceConnectDefaults(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -244,7 +312,7 @@ func TestAccECSCluster_configuration(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -289,7 +357,7 @@ func TestAccECSCluster_managedStorageConfiguration(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -305,7 +373,7 @@ func TestAccECSCluster_managedStorageConfiguration(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
-				ImportStateId:     rName,
+				ImportStateIdFunc: acctest.AttrImportStateIdFunc(resourceName, names.AttrName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -366,6 +434,16 @@ resource "aws_ecs_cluster" "test" {
   name = %[1]q
 }
 `, rName)
+}
+
+func testAccClusterConfig_regionOverride(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ecs_cluster" "test" {
+  region = %[2]q
+
+  name = %[1]q
+}
+`, rName, acctest.AlternateRegion())
 }
 
 func testAccClusterConfig_tags1(rName, tag1Key, tag1Value string) string {

--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -1704,14 +1704,18 @@ func resourceServiceImport(ctx context.Context, d *schema.ResourceData, meta any
 	log.Printf("[DEBUG] Importing ECS service %s from cluster %s", serviceName, clusterName)
 
 	d.SetId(serviceName)
+
+	region := d.Get(names.AttrRegion).(string)
+
 	clusterArn := arn.ARN{
-		Partition: meta.(*conns.AWSClient).Partition(ctx),
-		Region:    meta.(*conns.AWSClient).Region(ctx),
+		Partition: names.PartitionForRegion(region).ID(),
+		Region:    region,
 		Service:   "ecs",
 		AccountID: meta.(*conns.AWSClient).AccountID(ctx),
 		Resource:  fmt.Sprintf("cluster/%s", clusterName),
 	}.String()
 	d.Set("cluster", clusterArn)
+
 	return []*schema.ResourceData{d}, nil
 }
 

--- a/internal/service/ecs/service_package_gen.go
+++ b/internal/service/ecs/service_package_gen.go
@@ -90,7 +90,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			TypeName: "aws_ecs_cluster",
 			Name:     "Cluster",
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
-				IdentifierAttribute: names.AttrID,
+				IdentifierAttribute: names.AttrARN,
 			}),
 			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -89,6 +89,7 @@ func TestAccECSService_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -98,10 +99,12 @@ func TestAccECSService_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_basic(rName),
+				Config: testAccServiceConfig_basic(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "alarms.#", "0"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ecs", fmt.Sprintf("service/%s/%s", clusterName, rName)),
+					resource.TestCheckResourceAttrPair(resourceName, "cluster", "aws_ecs_cluster.test", names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "service_registries.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scheduling_strategy", "REPLICA"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_rebalancing", "DISABLED"),
@@ -115,10 +118,11 @@ func TestAccECSService_basic(t *testing.T) {
 			},
 
 			{
-				Config: testAccServiceConfig_modified(rName),
+				Config: testAccServiceConfig_modified(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "alarms.#", "0"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "ecs", fmt.Sprintf("service/%s/%s", clusterName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "service_registries.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scheduling_strategy", "REPLICA"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone_rebalancing", "DISABLED"),
@@ -178,6 +182,7 @@ func TestAccECSService_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -187,7 +192,7 @@ func TestAccECSService_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_basic(rName),
+				Config: testAccServiceConfig_basic(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfecs.ResourceService(), resourceName),
@@ -1003,6 +1008,7 @@ func TestAccECSService_forceNewDeployment(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1012,7 +1018,7 @@ func TestAccECSService_forceNewDeployment(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_basic(rName),
+				Config: testAccServiceConfig_basic(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "0"),
@@ -1024,7 +1030,7 @@ func TestAccECSService_forceNewDeployment(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_forceNewDeployment(rName),
+				Config: testAccServiceConfig_forceNewDeployment(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "1"),
@@ -1045,6 +1051,7 @@ func TestAccECSService_forceNewDeploymentTriggers(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1054,7 +1061,7 @@ func TestAccECSService_forceNewDeploymentTriggers(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_forceNewDeployment(rName),
+				Config: testAccServiceConfig_forceNewDeployment(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "1"),
@@ -1068,7 +1075,7 @@ func TestAccECSService_forceNewDeploymentTriggers(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_forceNewDeploymentTriggers(rName),
+				Config: testAccServiceConfig_forceNewDeploymentTriggers(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "force_new_deployment", acctest.CtTrue),
@@ -1091,6 +1098,7 @@ func TestAccECSService_PlacementStrategy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var service awstypes.Service
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	clusterName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_ecs_service.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -1100,7 +1108,7 @@ func TestAccECSService_PlacementStrategy_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceConfig_basic(rName),
+				Config: testAccServiceConfig_basic(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "0"),
@@ -1112,7 +1120,7 @@ func TestAccECSService_PlacementStrategy_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_placementStrategy(rName),
+				Config: testAccServiceConfig_placementStrategy(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "1"),
@@ -1126,7 +1134,7 @@ func TestAccECSService_PlacementStrategy_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_randomPlacementStrategy(rName),
+				Config: testAccServiceConfig_randomPlacementStrategy(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "1"),
@@ -1140,7 +1148,7 @@ func TestAccECSService_PlacementStrategy_basic(t *testing.T) {
 				},
 			},
 			{
-				Config: testAccServiceConfig_multiplacementStrategy(rName),
+				Config: testAccServiceConfig_multiplacementStrategy(rName, clusterName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceExists(ctx, resourceName, &service),
 					resource.TestCheckResourceAttr(resourceName, "ordered_placement_strategy.#", "2"),
@@ -2013,14 +2021,14 @@ func testAccCheckServiceExists(ctx context.Context, name string, service *awstyp
 	}
 }
 
-func testAccServiceConfig_basic(rName string) string {
+func testAccServiceConfig_basic(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2041,17 +2049,17 @@ resource "aws_ecs_service" "test" {
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 1
 }
-`, rName)
+`, rName, clusterName)
 }
 
-func testAccServiceConfig_modified(rName string) string {
+func testAccServiceConfig_modified(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2072,7 +2080,7 @@ resource "aws_ecs_service" "test" {
   task_definition = aws_ecs_task_definition.test.arn
   desired_count   = 2
 }
-`, rName)
+`, rName, clusterName)
 }
 
 func testAccServiceConfig_launchTypeFargateBase(rName string) string {
@@ -2605,14 +2613,14 @@ resource "aws_ecs_service" "test" {
 `, rName))
 }
 
-func testAccServiceConfig_forceNewDeployment(rName string) string {
+func testAccServiceConfig_forceNewDeployment(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2639,17 +2647,17 @@ resource "aws_ecs_service" "test" {
     field = "memory"
   }
 }
-`, rName)
+`, rName, clusterName)
 }
 
-func testAccServiceConfig_forceNewDeploymentTriggers(rName string) string {
+func testAccServiceConfig_forceNewDeploymentTriggers(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2680,17 +2688,17 @@ resource "aws_ecs_service" "test" {
     update = timestamp()
   }
 }
-`, rName)
+`, rName, clusterName)
 }
 
-func testAccServiceConfig_placementStrategy(rName string) string {
+func testAccServiceConfig_placementStrategy(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2716,7 +2724,7 @@ resource "aws_ecs_service" "test" {
     field = "memory"
   }
 }
-`, rName)
+`, rName, clusterName)
 }
 
 func testAccServiceConfig_placementStrategyType(rName string, placementStrategyType string) string {
@@ -2754,14 +2762,14 @@ resource "aws_ecs_service" "test" {
 `, rName, placementStrategyType)
 }
 
-func testAccServiceConfig_randomPlacementStrategy(rName string) string {
+func testAccServiceConfig_randomPlacementStrategy(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2786,17 +2794,17 @@ resource "aws_ecs_service" "test" {
     type = "random"
   }
 }
-`, rName)
+`, rName, clusterName)
 }
 
-func testAccServiceConfig_multiplacementStrategy(rName string) string {
+func testAccServiceConfig_multiplacementStrategy(rName, clusterName string) string {
 	return fmt.Sprintf(`
 resource "aws_ecs_cluster" "test" {
-  name = %[1]q
+  name = %[2]q
 }
 
 resource "aws_ecs_task_definition" "test" {
-  family = %[1]q
+  family = %[2]q
 
   container_definitions = <<DEFINITION
 [
@@ -2827,7 +2835,7 @@ resource "aws_ecs_service" "test" {
     type  = "spread"
   }
 }
-`, rName)
+`, rName, clusterName)
 }
 
 func testAccServiceConfig_placementConstraint(rName string) string {

--- a/website/docs/r/ecs_service.html.markdown
+++ b/website/docs/r/ecs_service.html.markdown
@@ -341,7 +341,7 @@ For more information, see [Task Networking](https://docs.aws.amazon.com/AmazonEC
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `id` - ARN that identifies the service.
+* `arn` - ARN that identifies the service.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 
 ## Timeouts


### PR DESCRIPTION
### Description

The ECS resource types `aws_ecs_cluster` and `aws_ecs_service` have custom import functions that didn't handle Enhanced Regions.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ecs TESTS=TestAccECSCluster_

--- PASS: TestAccECSCluster_disappears (29.48s)
--- PASS: TestAccECSCluster_basic (31.56s)
--- PASS: TestAccECSCluster_Identity_Basic (33.16s)
--- PASS: TestAccECSCluster_Identity_RegionOverride (33.23s)
--- PASS: TestAccECSCluster_tags (48.86s)
--- PASS: TestAccECSCluster_configuration (54.73s)
--- PASS: TestAccECSCluster_containerInsights (64.95s)
--- PASS: TestAccECSCluster_managedStorageConfiguration (65.90s)
--- PASS: TestAccECSCluster_serviceConnectDefaults (133.08s)
```

```console
% make testacc PKG=ecs TESTS=TestAccECSService_

--- PASS: TestAccECSService_DeploymentControllerType_external (72.38s)
--- PASS: TestAccECSService_forceNewDeployment (94.48s)
--- PASS: TestAccECSService_clusterName (95.58s)
--- PASS: TestAccECSService_deploymentCircuitBreaker (97.25s)
--- PASS: TestAccECSService_DeploymentValues_minZeroMaxOneHundred (97.52s)
--- PASS: TestAccECSService_DeploymentValues_basic (97.84s)
--- PASS: TestAccECSService_alarmsUpdate (104.39s)
--- PASS: TestAccECSService_familyAndRevision (106.05s)
--- PASS: TestAccECSService_alarmsAdd (112.12s)
--- PASS: TestAccECSService_VolumeConfiguration_throughputTypeChange (117.32s)
--- PASS: TestAccECSService_basic (118.51s)
--- PASS: TestAccECSService_CapacityProviderStrategy_forceNewDeployment (124.98s)
--- PASS: TestAccECSService_iamRole (37.19s)
--- PASS: TestAccECSService_VolumeConfiguration_tagSpecifications (70.64s)
--- PASS: TestAccECSService_ServiceRegistries_basic (156.26s)
--- PASS: TestAccECSService_executeCommand (63.54s)
--- PASS: TestAccECSService_Tags_managed (62.06s)
--- PASS: TestAccECSService_VolumeConfiguration_update (163.34s)
--- PASS: TestAccECSService_Tags_propagate (71.15s)
--- PASS: TestAccECSService_Tags_basic (70.71s)
--- PASS: TestAccECSService_PlacementStrategy_unnormalized (61.13s)
--- PASS: TestAccECSService_ServiceRegistries_removal (115.21s)
--- PASS: TestAccECSService_Identity_RegionOverride (65.99s)
--- PASS: TestAccECSService_Identity_Basic (63.54s)
--- PASS: TestAccECSService_ServiceConnect_basic (150.84s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_basic (33.01s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeploy (258.93s)
--- PASS: TestAccECSService_ServiceRegistries_container (140.80s)
--- PASS: TestAccECSService_ServiceConnect_remove (148.65s)
--- PASS: TestAccECSService_ServiceConnect_full (165.77s)
--- PASS: TestAccECSService_loadBalancerChanges (286.43s)
--- PASS: TestAccECSService_multipleTargetGroups (289.87s)
--- PASS: TestAccECSService_DaemonSchedulingStrategy_setDeploymentMinimum (41.07s)
--- PASS: TestAccECSService_alb (295.42s)
--- PASS: TestAccECSService_PlacementStrategy_missing (1.26s)
--- PASS: TestAccECSService_CapacityProviderStrategy_basic (140.06s)
--- PASS: TestAccECSService_ServiceConnect_ingressPortOverride (164.29s)
--- PASS: TestAccECSService_LaunchTypeEC2_network (76.94s)
--- PASS: TestAccECSService_replicaSchedulingStrategy (62.41s)
--- PASS: TestAccECSService_ServiceConnect_tls_with_empty_timeout (166.62s)
--- PASS: TestAccECSService_healthCheckGracePeriodSeconds (328.81s)
--- PASS: TestAccECSService_PlacementConstraints_basic (74.28s)
--- PASS: TestAccECSService_PlacementConstraints_emptyExpression (71.60s)
--- PASS: TestAccECSService_disappears (180.21s)
--- PASS: TestAccECSService_ServiceRegistries_changes (232.86s)
--- PASS: TestAccECSService_VolumeConfiguration_basic (62.64s)
--- PASS: TestAccECSService_LaunchTypeFargate_platformVersion (143.92s)
--- PASS: TestAccECSService_forceNewDeploymentTriggers (72.39s)
--- PASS: TestAccECSService_AvailabilityZoneRebalancing (77.20s)
--- PASS: TestAccECSService_PlacementStrategy_basic (92.53s)
--- PASS: TestAccECSService_LaunchTypeFargate_basic (142.63s)
--- PASS: TestAccECSService_LaunchTypeFargate_waitForSteadyState (170.27s)
--- PASS: TestAccECSService_LaunchTypeFargate_updateWaitForSteadyState (203.81s)
--- PASS: TestAccECSService_CapacityProviderStrategy_update (195.83s)
--- PASS: TestAccECSService_DeploymentControllerType_codeDeployUpdateDesiredCountAndHealthCheckGracePeriod (512.63s)
--- PASS: TestAccECSService_LatticeConfigurations (634.99s)
```
