### PR TITLE
bump default timeout for Transit Gateway Route Table Association to 15m

### DIFF
--- a/internal/service/ec2/wait.go
+++ b/internal/service/ec2/wait.go
@@ -46,7 +46,7 @@ const (
 	transitGatewayPeeringAttachmentUpdatedTimeout      = 10 * time.Minute
 	transitGatewayPolicyTableAssociationCreatedTimeout = 5 * time.Minute
 	transitGatewayPolicyTableAssociationDeletedTimeout = 10 * time.Minute
-	transitGatewayRouteTableAssociationCreatedTimeout  = 5 * time.Minute
+	transitGatewayRouteTableAssociationCreatedTimeout  = 15 * time.Minute
 	transitGatewayRouteTableAssociationDeletedTimeout  = 10 * time.Minute
 	transitGatewayPrefixListReferenceTimeout           = 5 * time.Minute
 	transitGatewayRouteCreatedTimeout                  = 2 * time.Minute


### PR DESCRIPTION
This fixes #42705 by increasing `create` wait timeouts for `aws_ec2_transit_gateway_route_table_association` from 5 minutes to 15 minutes to accommodate longer association times without failures.