### PR TITLE
Use HasChanges over HasChangesExcept for performnce

### DIFF
--- a/internal/service/wafv2/web_acl.go
+++ b/internal/service/wafv2/web_acl.go
@@ -384,7 +384,27 @@ func resourceWebACLUpdate(ctx context.Context, d *schema.ResourceData, meta any)
 	var diags diag.Diagnostics
 	conn := meta.(*conns.AWSClient).WAFV2Client(ctx)
 
-	if d.HasChangesExcept(names.AttrTags, names.AttrTagsAll) {
+	// HasChangesExcept can perform _very_ slowly when presented with a large number of unchanged (or ignored)
+	// attributes e.g. rule blocks in this case
+	if d.HasChanges(
+		"application_integration_url",
+		"association_config",
+		"capacity",
+		"captcha_config",
+		"challenge_config",
+		"custom_response_body",
+		"data_protection_config",
+		names.AttrDefaultAction,
+		names.AttrDescription,
+		"lock_token",
+		names.AttrName,
+		names.AttrNamePrefix,
+		"rule_json",
+		names.AttrRule,
+		names.AttrScope,
+		"token_domains",
+		"visibility_config",
+	) {
 		aclName := d.Get(names.AttrName).(string)
 		aclScope := d.Get(names.AttrScope).(string)
 		aclLockToken := d.Get("lock_token").(string)


### PR DESCRIPTION
Use HasChanges over HasChangesExcept performs badly with large numbers of ignored attributes

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc ACCTEST_PARALLELISM=3 TESTS=TestAccWAFV2WebACL_ PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/wafv2/... -v -count 1 -parallel 3 -run='TestAccWAFV2WebACL_'  -timeout 360m -vet=off
2025/05/23 10:34:27 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_nameGenerated
=== PAUSE TestAccWAFV2WebACL_nameGenerated
=== RUN   TestAccWAFV2WebACL_namePrefix
=== PAUSE TestAccWAFV2WebACL_namePrefix
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== RUN   TestAccWAFV2WebACL_ruleJSON
=== PAUSE TestAccWAFV2WebACL_ruleJSON
=== RUN   TestAccWAFV2WebACL_ruleJSONToRule
=== PAUSE TestAccWAFV2WebACL_ruleJSONToRule
=== RUN   TestAccWAFV2WebACL_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfig
=== RUN   TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== CONT  TestAccWAFV2WebACL_tags
--- PASS: TestAccWAFV2WebACL_basic (28.65s)
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:3253: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.00s)
=== CONT  TestAccWAFV2WebACL_dataProtectionConfigMultiple
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (50.55s)
=== CONT  TestAccWAFV2WebACL_dataProtectionConfig
--- PASS: TestAccWAFV2WebACL_dataProtectionConfigMultiple (22.63s)
=== CONT  TestAccWAFV2WebACL_ruleJSONToRule
--- PASS: TestAccWAFV2WebACL_tags (56.82s)
=== CONT  TestAccWAFV2WebACL_ruleJSON
--- PASS: TestAccWAFV2WebACL_ruleJSONToRule (35.45s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_ruleJSON (38.83s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_dataProtectionConfig (53.10s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (40.07s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (40.92s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_urlFragment (40.29s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (39.65s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (40.24s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (40.23s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint (40.26s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (41.69s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (42.40s)
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
--- PASS: TestAccWAFV2WebACL_minimal (20.78s)
=== CONT  TestAccWAFV2WebACL_Custom_response
--- PASS: TestAccWAFV2WebACL_RateBased_basic (41.23s)
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (42.11s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
--- PASS: TestAccWAFV2WebACL_Custom_response (55.80s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (72.33s)
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (59.54s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (25.41s)
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (66.78s)
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (51.30s)
=== CONT  TestAccWAFV2WebACL_disappears
--- PASS: TestAccWAFV2WebACL_disappears (19.32s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (20.20s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (75.59s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (39.93s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (40.00s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (43.23s)
=== CONT  TestAccWAFV2WebACL_tokenDomains
--- PASS: TestAccWAFV2WebACL_tokenDomains (22.72s)
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (22.86s)
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
    web_acl_test.go:3156: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfigCloudFront (0.00s)
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (69.41s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (219.76s)
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (27.46s)
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
--- PASS: TestAccWAFV2WebACL_RuleLabels (40.95s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (26.57s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (40.83s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_Update_rule (43.56s)
=== CONT  TestAccWAFV2WebACL_namePrefix
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (37.87s)
=== CONT  TestAccWAFV2WebACL_nameGenerated
--- PASS: TestAccWAFV2WebACL_namePrefix (22.98s)
--- PASS: TestAccWAFV2WebACL_nameGenerated (22.73s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (60.85s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      680.589s

```
