### PR TITLE
feat: add configurable operation timeouts

### DIFF
--- a/internal/service/securityhub/standards_subscription.go
+++ b/internal/service/securityhub/standards_subscription.go
@@ -33,7 +33,6 @@ func resourceStandardsSubscription() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
 		Schema: map[string]*schema.Schema{
 			"standards_arn": {
 				Type:         schema.TypeString,
@@ -41,6 +40,10 @@ func resourceStandardsSubscription() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(3 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
 		},
 	}
 }
@@ -64,7 +67,7 @@ func resourceStandardsSubscriptionCreate(ctx context.Context, d *schema.Resource
 
 	d.SetId(aws.ToString(output.StandardsSubscriptions[0].StandardsSubscriptionArn))
 
-	if _, err := waitStandardsSubscriptionCreated(ctx, conn, d.Id()); err != nil {
+	if _, err := waitStandardsSubscriptionCreated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Security Hub Standards Subscription (%s) create: %s", d.Id(), err)
 	}
 
@@ -105,7 +108,7 @@ func resourceStandardsSubscriptionDelete(ctx context.Context, d *schema.Resource
 		return sdkdiag.AppendErrorf(diags, "disabling Security Hub Standard (%s): %s", d.Id(), err)
 	}
 
-	if _, err := waitStandardsSubscriptionDeleted(ctx, conn, d.Id()); err != nil {
+	if _, err := waitStandardsSubscriptionDeleted(ctx, conn, d.Id(), d.Timeout(schema.TimeoutDelete)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "waiting for Security Hub Standards Subscription (%s) delete: %s", d.Id(), err)
 	}
 
@@ -203,10 +206,8 @@ func statusStandardsSubscriptionDelete(ctx context.Context, conn *securityhub.Cl
 	}
 }
 
-func waitStandardsSubscriptionCreated(ctx context.Context, conn *securityhub.Client, arn string) (*types.StandardsSubscription, error) {
-	const (
-		timeout = 3 * time.Minute
-	)
+func waitStandardsSubscriptionCreated(ctx context.Context, conn *securityhub.Client, arn string, timeout time.Duration) (*types.StandardsSubscription, error) {
+
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(types.StandardsStatusPending),
 		Target:  enum.Slice(types.StandardsStatusReady, types.StandardsStatusIncomplete),
@@ -227,10 +228,7 @@ func waitStandardsSubscriptionCreated(ctx context.Context, conn *securityhub.Cli
 	return nil, err
 }
 
-func waitStandardsSubscriptionDeleted(ctx context.Context, conn *securityhub.Client, arn string) (*types.StandardsSubscription, error) {
-	const (
-		timeout = 3 * time.Minute
-	)
+func waitStandardsSubscriptionDeleted(ctx context.Context, conn *securityhub.Client, arn string, timeout time.Duration) (*types.StandardsSubscription, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(types.StandardsStatusDeleting),
 		Target:  []string{},

--- a/internal/service/securityhub/standards_subscription_test.go
+++ b/internal/service/securityhub/standards_subscription_test.go
@@ -127,5 +127,10 @@ data "aws_partition" "current" {}
 resource "aws_securityhub_standards_subscription" "test" {
   standards_arn = "arn:${data.aws_partition.current.partition}:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0"
   depends_on    = [aws_securityhub_account.test]
+
+  timeouts {
+    create = "3m"
+    delete = "3m"
+  }
 }
 `

--- a/website/docs/r/securityhub_standards_subscription.html.markdown
+++ b/website/docs/r/securityhub_standards_subscription.html.markdown
@@ -52,6 +52,13 @@ This resource exports the following attributes in addition to the arguments abov
 
 * `id` - The ARN of a resource that represents your subscription to a supported standard.
 
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+* `create` - (Default `3m`)
+* `delete` - (Default `3m`)
+
 ## Import
 
 In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import Security Hub standards subscriptions using the standards subscription ARN. For example:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations

Closes #42688 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
