### PR TITLE
[Enhancement] Adding parameters to the datasource aws_db_parameter_group

### DIFF
--- a/.changelog/42765.txt
+++ b/.changelog/42765.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+datasource/aws_db_parameter_group: added parameter block
+```

--- a/internal/service/rds/parameter_group_data_source.go
+++ b/internal/service/rds/parameter_group_data_source.go
@@ -127,7 +127,7 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 				}
 			}
 			if !paramFound {
-				log.Printf("[DEBUG] Not persisting %s to state, as its source is %q and it isn't in the config", aws.ToString(parameter.ParameterName), aws.ToString(parameter.Source))
+				log.Printf("[DEBUG] Not getting %s, as its source is %q and it isn't in the config", aws.ToString(parameter.ParameterName), aws.ToString(parameter.Source))
 			}
 		}
 	}

--- a/internal/service/rds/parameter_group_data_source.go
+++ b/internal/service/rds/parameter_group_data_source.go
@@ -5,12 +5,17 @@ package rds
 
 import (
 	"context"
+	"log"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -37,6 +42,29 @@ func dataSourceParameterGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			names.AttrParameter: {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"apply_method": {
+							Type:             schema.TypeString,
+							Optional:         true,
+							Default:          types.ApplyMethodImmediate,
+							ValidateDiagFunc: enum.ValidateIgnoreCase[types.ApplyMethod](),
+						},
+						names.AttrName: {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						names.AttrValue: {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Set: parameterHash,
+			},
 		},
 	}
 }
@@ -56,6 +84,57 @@ func dataSourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, m
 	d.Set(names.AttrDescription, output.Description)
 	d.Set(names.AttrFamily, output.DBParameterGroupFamily)
 	d.Set(names.AttrName, output.DBParameterGroupName)
+
+	input := rds.DescribeDBParametersInput{
+		DBParameterGroupName: aws.String(d.Id()),
+	}
+
+	configParams := d.Get(names.AttrParameter).(*schema.Set)
+	if configParams.Len() < 1 {
+		input.Source = aws.String(parameterSourceUser)
+	}
+
+	parameters, err := findDBParameters(ctx, conn, &input, tfslices.PredicateTrue[*types.Parameter]())
+
+	if err != nil {
+		return sdkdiag.AppendErrorf(diags, "reading RDS DB Parameter Group (%s) parameters: %s", d.Id(), err)
+	}
+
+	var userParams []types.Parameter
+	if configParams.Len() < 1 {
+		userParams = parameters
+	} else {
+		for _, parameter := range parameters {
+			if parameter.Source == nil || parameter.ParameterName == nil {
+				continue
+			}
+
+			if aws.ToString(parameter.Source) == parameterSourceUser {
+				userParams = append(userParams, parameter)
+				continue
+			}
+
+			var paramFound bool
+			for _, cp := range expandParameters(configParams.List()) {
+				if cp.ParameterName == nil {
+					continue
+				}
+
+				if aws.ToString(cp.ParameterName) == aws.ToString(parameter.ParameterName) {
+					userParams = append(userParams, parameter)
+					paramFound = true
+					break
+				}
+			}
+			if !paramFound {
+				log.Printf("[DEBUG] Not persisting %s to state, as its source is %q and it isn't in the config", aws.ToString(parameter.ParameterName), aws.ToString(parameter.Source))
+			}
+		}
+	}
+
+	if err := d.Set(names.AttrParameter, flattenParameters(userParams)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting parameter: %s", err)
+	}
 
 	return diags
 }

--- a/internal/service/rds/parameter_group_data_source_test.go
+++ b/internal/service/rds/parameter_group_data_source_test.go
@@ -31,6 +31,11 @@ func TestAccRDSParameterGroupDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrFamily, resourceName, names.AttrFamily),
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
+						names.AttrName:  "client_encoding",
+						names.AttrValue: "UTF8",
+					}),
 				),
 			},
 		},

--- a/website/docs/d/db_parameter_group.html.markdown
+++ b/website/docs/d/db_parameter_group.html.markdown
@@ -32,3 +32,12 @@ This data source exports the following attributes in addition to the arguments a
 * `arn` - ARN of the parameter group.
 * `family` - Family of the parameter group.
 * `description` - Description of the parameter group.
+* `parameter` - The DB parameters block. See [`parameter` Block](#parameter-block) below for more details.
+
+### `parameter` Block
+
+The `parameter` blocks support the following arguments:
+
+* `name` - The name of the DB parameter.
+* `value` - The value of the DB parameter.
+* `apply_method` - "immediate" or "pending-reboot".


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Currently using datasource `aws_db_parameter_group` does not expose parameters. In my case I had to use workaround with `null, local-exec, aws-cli` - would be much easier to have direct access to these parameters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
