### PR TITLE
fix: replace bucket arn with bucket name

### DIFF
--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -117,7 +117,7 @@ resource "aws_quicksight_data_source" "example" {
   parameters {
     s3 {
       manifest_file_location {
-        bucket = aws_s3_bucket.example.arn
+        bucket = aws_s3_bucket.example.bucket
         key    = aws_s3_object.example.key
       }
       role_arn = aws_iam_role.example.arn


### PR DESCRIPTION
## Rollback Plan

Not applicable - only documentation is updated.

## Changes to Security Controls

None

### Description

The [2nd example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source#s3-data-source-with-iam-role-arn) for the usage of resource [`aws_quicksight_data_source`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source) contains an invalid configuration. In below code it references `aws_s3_bucket.example.arn`, it should read `aws_s3_bucket.example.bucket`.

```hcl
resource "aws_quicksight_data_source" "example" {
  data_source_id = "example-id"
  name           = "manifest in S3"

  parameters {
    s3 {
      manifest_file_location {
        bucket = aws_s3_bucket.example.arn
        key    = aws_s3_object.example.key
      }
      role_arn = aws_iam_role.example.arn
    }
  }

  type = "S3"
}
```

### Relations

Closes #42764 

### References

* [Resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/quicksight_data_source#bucket-1) mentioning the use of bucket name.
* [Test code](https://github.com/hashicorp/terraform-provider-aws/blob/8f8b0cf9e3b108a5764e273c191417391e78d9df/internal/service/quicksight/data_source_test.go#L481) showing the use of `bucket` instead of `arn`

### Output from Acceptance Testing

Not applicable. Only documentation is updated.