### PR TITLE
r/aws_cognitoidp_user_pool: prevent crash with certain `user_pool_add_ons` values

### DIFF
--- a/.changelog/42793.txt
+++ b/.changelog/42793.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognitoidp_user_pool: Fix crash when the `user_pool_add_ons.advanced_security_additional_flows` block is non-empty, but contains only a single `nil` value.
+```

--- a/internal/service/cognitoidp/user_pool.go
+++ b/internal/service/cognitoidp/user_pool.go
@@ -1197,7 +1197,7 @@ func resourceUserPoolUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			}
 		}
 
-		if v, ok := d.GetOk("user_pool_add_ons"); ok && len(v.([]any)) > 0 {
+		if v, ok := d.GetOk("user_pool_add_ons"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 			input.UserPoolAddOns = expandUserPoolAddOnsType(v.([]any)[0].(map[string]any))
 		}
 
@@ -1849,7 +1849,7 @@ func expandUserPoolAddOnsType(tfMap map[string]any) *awstypes.UserPoolAddOnsType
 
 	apiObject := &awstypes.UserPoolAddOnsType{}
 
-	if v, ok := tfMap["advanced_security_additional_flows"].([]any); ok && len(v) > 0 {
+	if v, ok := tfMap["advanced_security_additional_flows"].([]any); ok && len(v) > 0 && v[0] != nil {
 		apiObject.AdvancedSecurityAdditionalFlows = expandAdvancedSecurityAdditionalFlowType(v[0].(map[string]any))
 	}
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Prevents a crash when the `user_pool_add_ons.advanced_security_additional_flows` block is non-empty, but contains only a single `nil` value. For example,

```
Stack trace from the terraform-provider-aws_v5.98.0_x5.exe plugin:

panic: interface conversion: interface {} is nil, not map[string]interface {}

goroutine 31 [running]:
github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp.expandUserPoolAddOnsType(0xc003c0e450)
        github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp/user_pool.go:1853 +0x1e9
github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp.resourceUserPoolUpdate({0x1e630148, 0xc003b93290}, 0xc001ea3c00, {0x1be85ec0, 0xc002fa0200})
        github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp/user_pool.go:1201 +0x1bf2
<snip>

Error: The terraform-provider-aws_v5.98.0_x5.exe plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42674
Relates #42470


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=cognitoidp TESTS=TestAccCognitoIDPUserPool_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPool_'  -timeout 360m -vet=off
2025/05/28 14:47:34 Initializing Terraform AWS Provider...

--- PASS: TestAccCognitoIDPUserPool_webAuthnConfiguration (30.63s)
=== CONT  TestAccCognitoIDPUserPool_smsVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesModified (36.14s)
=== CONT  TestAccCognitoIDPUserPool_disappears
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesRemoved (36.35s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsCallerARN
--- PASS: TestAccCognitoIDPUserPool_withEmail (37.57s)
=== CONT  TestAccCognitoIDPUserPool_SMS_externalID
--- PASS: TestAccCognitoIDPUserPool_schemaAttributesStringAttributeConstraints (37.89s)
=== CONT  TestAccCognitoIDPUserPool_SMS_snsRegion
--- PASS: TestAccCognitoIDPUserPool_withUserAttributeUpdateSettings (50.67s)
=== CONT  TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccCognitoIDPUserPool_withUsernameAttributes (55.52s)
=== CONT  TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccCognitoIDPUserPool_schemaAttributes (57.52s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplateUTF8 (59.91s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccCognitoIDPUserPool_withVerificationMessageTemplate (59.99s)
=== CONT  TestAccCognitoIDPUserPool_sms
--- PASS: TestAccCognitoIDPUserPool_withPasswordPolicy (60.05s)
=== CONT  TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_withAliasAttributes (60.35s)
--- PASS: TestAccCognitoIDPUserPool_usernameConfiguration (62.28s)
=== CONT  TestAccCognitoIDPUserPool_smsAuthenticationMessage
--- PASS: TestAccCognitoIDPUserPool_disappears (28.58s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag
--- PASS: TestAccCognitoIDPUserPool_addLambda (79.10s)
=== CONT  TestAccCognitoIDPUserPool_signInPolicy
--- PASS: TestAccCognitoIDPUserPool_SMS_snsRegion (47.71s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag
--- PASS: TestAccCognitoIDPUserPool_smsVerificationMessage (60.12s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag
--- PASS: TestAccCognitoIDPUserPool_update (99.81s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate (44.58s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag (44.68s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag (42.84s)
=== CONT  TestAccCognitoIDPUserPool_MFA_softwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_signInPolicy (30.02s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping
--- PASS: TestAccCognitoIDPUserPool_WithLambda_sms (109.75s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_WithLambda_email (114.57s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping
--- PASS: TestAccCognitoIDPUserPool_SMS_snsCallerARN (82.69s)
=== CONT  TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly
--- PASS: TestAccCognitoIDPUserPool_SMS_externalID (81.68s)
=== CONT  TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA
--- PASS: TestAccCognitoIDPUserPool_WithLambda_preGenerationTokenConfig (126.25s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccCognitoIDPUserPool_smsAuthenticationMessage (66.69s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag (44.00s)
=== CONT  TestAccCognitoIDPUserPool_MFA_sms
--- PASS: TestAccCognitoIDPUserPool_withLambda (129.74s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace (72.25s)
=== CONT  TestAccCognitoIDPUserPool_passwordHistorySize
--- PASS: TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add (75.14s)
=== CONT  TestAccCognitoIDPUserPool_withEmailVerificationMessage
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag (47.37s)
=== CONT  TestAccCognitoIDPUserPool_withDevice
--- PASS: TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag (89.32s)
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows
--- PASS: TestAccCognitoIDPUserPool_tags (146.92s)
=== CONT  TestAccCognitoIDPUserPool_withAdvancedSecurityMode
--- PASS: TestAccCognitoIDPUserPool_sms (97.28s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy
--- PASS: TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag (104.54s)
=== CONT  TestAccCognitoIDPUserPool_withAdminCreateUser
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly (68.08s)
=== CONT  TestAccCognitoIDPUserPool_recovery
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFAToSMS (73.33s)
=== CONT  TestAccCognitoIDPUserPool_deletionProtection
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly (72.62s)
=== CONT  TestAccCognitoIDPUserPool_basic
--- PASS: TestAccCognitoIDPUserPool_MFA_smsToSoftwareTokenMFA (74.52s)
=== CONT  TestAccCognitoIDPUserPool_userPoolTier
--- PASS: TestAccCognitoIDPUserPool_passwordHistorySize (62.67s)
=== CONT  TestAccCognitoIDPUserPool_tags_EmptyMap
--- PASS: TestAccCognitoIDPUserPool_MFA_softwareTokenMFA (87.52s)
=== CONT  TestAccCognitoIDPUserPool_tags_null
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUserAndPasswordPolicy (38.33s)
=== CONT  TestAccCognitoIDPUserPool_tags_AddOnUpdate
--- PASS: TestAccCognitoIDPUserPool_withEmailVerificationMessage (62.30s)
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityAdditionalFlows (63.77s)
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace (77.58s)
--- PASS: TestAccCognitoIDPUserPool_withDevice (65.71s)
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate (80.42s)
--- PASS: TestAccCognitoIDPUserPool_basic (36.93s)
--- PASS: TestAccCognitoIDPUserPool_MFA_smsAndSoftwareTokenMFA (96.13s)
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping (112.32s)
--- PASS: TestAccCognitoIDPUserPool_withAdminCreateUser (61.45s)
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping (108.24s)
--- PASS: TestAccCognitoIDPUserPool_withAdvancedSecurityMode (78.49s)
--- PASS: TestAccCognitoIDPUserPool_deletionProtection (54.14s)
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add (98.79s)
--- PASS: TestAccCognitoIDPUserPool_MFA_sms (99.66s)
--- PASS: TestAccCognitoIDPUserPool_tags_EmptyMap (36.92s)
--- PASS: TestAccCognitoIDPUserPool_userPoolTier (46.61s)
--- PASS: TestAccCognitoIDPUserPool_tags_null (36.48s)
--- PASS: TestAccCognitoIDPUserPool_recovery (63.96s)
--- PASS: TestAccCognitoIDPUserPool_tags_AddOnUpdate (42.95s)
--- PASS: TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly (121.90s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 246.780s
```

