### PR TITLE
Resolve `cloudfrontkeyvaluestore_keys_exclusive` being blocked by service quotas with large number of key value pairs

### DIFF
--- a/internal/service/cloudfrontkeyvaluestore/keys_exclusive_test.go
+++ b/internal/service/cloudfrontkeyvaluestore/keys_exclusive_test.go
@@ -35,7 +35,9 @@ func TestAccCloudFrontKeyValueStoreKeysExclusive_basic(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	var keys []string
 	var values []string
-	for i := 1; i < 6; i++ {
+
+	// Test with a large number of key value pairs to ensure batching is working correctly
+	for i := 1; i < 170; i++ {
 		keys = append(keys, sdkacctest.RandomWithPrefix(acctest.ResourcePrefix))
 		values = append(values, sdkacctest.RandomWithPrefix(acctest.ResourcePrefix))
 	}
@@ -287,6 +289,50 @@ func TestAccCloudFrontKeyValueStoreKeysExclusive_empty(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontKeyValueStoreKeysExclusive_maxBatchSize(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	maxBatchSize := sdkacctest.RandIntRange(35, 49)
+	var keys []string
+	var values []string
+	// Test with a large number of key value pairs to ensure batching is working correctly
+	for i := 1; i < 170; i++ {
+		keys = append(keys, sdkacctest.RandomWithPrefix(acctest.ResourcePrefix))
+		values = append(values, sdkacctest.RandomWithPrefix(acctest.ResourcePrefix))
+	}
+	resourceName := "aws_cloudfrontkeyvaluestore_keys_exclusive.test"
+	kvsResourceName := "aws_cloudfront_key_value_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.CloudFront)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFront),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckKeysExclusiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKeysExclusiveConfig_maxBatchSize(keys, values, rName, maxBatchSize),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKeysExclusiveExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, "key_value_store_arn", kvsResourceName, names.AttrARN),
+					resource.TestCheckResourceAttrSet(resourceName, "total_size_in_bytes"),
+					testCheckMultipleKeyValuePairs(keys, values, resourceName),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "key_value_store_arn"),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key_value_store_arn",
+				ImportStateVerifyIgnore:              []string{"max_batch_size"},
+			},
+		},
+	})
+}
+
 func testAccCheckKeysExclusiveDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontKeyValueStoreClient(ctx)
@@ -430,4 +476,35 @@ resource "aws_cloudfrontkeyvaluestore_keys_exclusive" "test" {
   ]
 }
 `, rName)
+}
+
+func testAccKeysExclusiveConfig_maxBatchSize(keys, values []string, rName string, maxBatchSize int) string {
+	keysJson, _ := json.Marshal(keys)
+	keysString := string(keysJson)
+	valuesJson, _ := json.Marshal(values)
+	valuesString := string(valuesJson)
+	return fmt.Sprintf(`
+locals {
+  key_list      = %[1]s
+  value_list    = %[2]s
+  key_value_set = { for i, v in local.key_list : local.key_list[i] => local.value_list[i] }
+}
+
+resource "aws_cloudfront_key_value_store" "test" {
+  name = %[3]q
+}
+
+resource "aws_cloudfrontkeyvaluestore_keys_exclusive" "test" {
+  key_value_store_arn = aws_cloudfront_key_value_store.test.arn
+  max_batch_size = %[4]d
+  dynamic "resource_key_value_pair" {
+    for_each = local.key_value_set
+    content {
+      key   = resource_key_value_pair.key
+      value = resource_key_value_pair.value
+
+    }
+  }
+}
+`, keysString, valuesString, rName, maxBatchSize)
 }

--- a/website/docs/r/cloudfrontkeyvaluestore_keys_exclusive.html.markdown
+++ b/website/docs/r/cloudfrontkeyvaluestore_keys_exclusive.html.markdown
@@ -53,6 +53,7 @@ The following arguments are required:
 
 The following arguments are optional:
 
+* `max_batch_size` - (Optional) Maximum resource key values pairs that will update in a single API request. AWS has a default quota of 50 keys or a 3 MB payload, whichever is reached first. Defaults to `50`.
 * `resource_key_value_pair` - (Optional) A list of all resource key value pairs associated with the KeyValueStore.
 See [`resource_key_value_pair`](#resource_key_value_pair) below.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR resolves an issue where you receive an AWS API service quota exception when attempting to update more than 50 key value pairs at once. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42789

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%  make testacc TESTARGS='-run=TestAccCloudFrontKeyValueStoreKeysExclusive' PKG=cloudfrontkeyvaluestore    
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/cloudfrontkeyvaluestore/... -v -count 1 -parallel 20  -run=TestAccCloudFrontKeyValueStoreKeysExclusive -timeout 360m -vet=off
2025/05/28 16:37:34 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_basic
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_basic
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_disappears_KeyValueStore
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_disappears_KeyValueStore
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandAddition
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandAddition
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandRemoval
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandRemoval
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_value
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_value
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_empty
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_empty
=== RUN   TestAccCloudFrontKeyValueStoreKeysExclusive_maxBatchSize
=== PAUSE TestAccCloudFrontKeyValueStoreKeysExclusive_maxBatchSize
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_basic
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_value
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandAddition
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandRemoval
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_disappears_KeyValueStore
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_maxBatchSize
=== CONT  TestAccCloudFrontKeyValueStoreKeysExclusive_empty
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_disappears_KeyValueStore (31.72s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_value (42.43s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_maxBatchSize (43.95s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandAddition (44.36s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_basic (44.45s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_outOfBandRemoval (51.29s)
--- PASS: TestAccCloudFrontKeyValueStoreKeysExclusive_empty (59.12s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cloudfrontkeyvaluestore    64.971s

...
```
