### PR TITLE
[doc fix] aws_api_gateway_domain_name_access_association: fix the example

### DIFF
--- a/website/docs/r/api_gateway_domain_name_access_association.html.markdown
+++ b/website/docs/r/api_gateway_domain_name_access_association.html.markdown
@@ -16,7 +16,7 @@ Creates a domain name access association resource between an access association 
 resource "aws_api_gateway_domain_name_access_association" "example" {
   access_association_source      = aws_vpc_endpoint.example.id
   access_association_source_type = "VPCE"
-  domain_name_arn                = aws_api_gateway_domain_name.example.domain_name_arn
+  domain_name_arn                = aws_api_gateway_domain_name.example.arn
 }
 ```
 


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Fix the documentation for the `aws_api_gateway_domain_name_access_association` resource:

  * Use the `arn` attribute of the `aws_apigateway_domain_name` resource instead of `domain_name_arn`, which does not exist.

  * The use of `arn` is correct, as shown in the acceptance tests for the `aws_api_gateway_domain_name_access_association` resource, where the `arn` attribute of `aws_apigateway_domain_name` is passed as the `domain_name_arn` argument.

### Relations

Closes #42798 

