### PR TITLE
docs: update description for multiple groups

### DIFF
--- a/website/docs/r/quicksight_account_subscription.html.markdown
+++ b/website/docs/r/quicksight_account_subscription.html.markdown
@@ -35,8 +35,8 @@ The following arguments are required:
 The following arguments are optional:
 
 * `active_directory_name` - (Optional) Name of your Active Directory. This field is required if `ACTIVE_DIRECTORY` is the selected authentication method of the new Amazon QuickSight account.
-* `admin_group` - (Optional) Admin group associated with your Active Directory. This field is required if `ACTIVE_DIRECTORY` is the selected authentication method of the new Amazon QuickSight account.
-* `author_group` - (Optional) Author group associated with your Active Directory.
+* `admin_group` - (Optional) Admin group associated with your Active Directory or IAM Identity Center account. This field is required if `ACTIVE_DIRECTORY` or `IAM_IDENTITY_CENTER` is the selected authentication method of the new Amazon QuickSight account.
+* `author_group` - (Optional) Author group associated with your Active Directory or IAM Identity Center account.
 * `aws_account_id` - (Optional) AWS account ID hosting the QuickSight account. Default to provider account.
 * `contact_number` - (Optional) A 10-digit phone number for the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `directory_id` - (Optional) Active Directory ID that is associated with your Amazon QuickSight account.
@@ -44,7 +44,7 @@ The following arguments are optional:
 * `first_name` - (Optional) First name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
 * `iam_identity_center_instance_arn` - (Optional) The Amazon Resource Name (ARN) for the IAM Identity Center instance.
 * `last_name` - (Optional) Last name of the author of the Amazon QuickSight account to use for future communications. This field is required if `ENTERPPRISE_AND_Q` is the selected edition of the new Amazon QuickSight account.
-* `reader_group` - (Optional) Reader group associated with your Active Directory.
+* `reader_group` - (Optional) Reader group associated with your Active Directory or IAM Identity Center account.
 * `realm` - (Optional) Realm of the Active Directory that is associated with your Amazon QuickSight account.
 
 ## Attribute Reference


### PR DESCRIPTION
## Rollback Plan

Not applicable. Only documentation is updated.

## Changes to Security Controls

Not applicable. Only documentation is updated.

### Description

In #42457 a user noticed that Terraform encounters an error when creating an `aws_quicksight_account_subscription` with 

* `authentication method = "IAM_IDENTITY_CENTER"`  and 
* no `admin_group` argument 

provided.

The AWS documentation (link in reference section) states for `admin_group`

> The admin group associated with your Active Directory or IAM Identity Center account. Either this field or the AdminProGroup field is required if ACTIVE_DIRECTORY or IAM_IDENTITY_CENTER is the selected authentication method of the new Amazon QuickSight account.

I updated the documentation accordingly - also for the the author and reader groups - and left out the `AdminProGroup` part as the provider does not support it at the moment.

### Relations

Relates #42457 
(Keeping this as Relates as I am not sure if the initial issue is limited to documentation update or also covers the implementation of the `AdminProGroup`)

### References

* [Quicksight API - CreateAccountSubscription](https://docs.aws.amazon.com/quicksight/latest/APIReference/API_CreateAccountSubscription.html)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.