### PR TITLE
Documentation - data source aws_secretsmanager_secret_rotation attributes fix

### DIFF
--- a/website/docs/d/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/d/secretsmanager_secret_rotation.html.markdown
@@ -32,4 +32,10 @@ This data source exports the following attributes in addition to the arguments a
 
 * `rotation_enabled` - Specifies whether automatic rotation is enabled for this secret.
 * `rotation_lambda_arn` - Amazon Resource Name (ARN) of the lambda function used for rotation.
-* `rotation_rules` - Configuration block for rotation rules. Includes properties `automaticallyAfterDays`, `duration`, and `scheduleExpression`.
+* `rotation_rules` - Configuration block for rotation rules. See [`rotation_rules`](#rotation_rules) below.
+
+### rotation_rules
+
+* `automatically_after_days` - Number of days between automatic scheduled rotations of the secret.
+* `duration` - Length of the rotation window in hours.
+* `schedule_expression` - A `cron()` or `rate()` expression that defines the schedule for rotating the secret.

--- a/website/docs/d/secretsmanager_secret_rotation.html.markdown
+++ b/website/docs/d/secretsmanager_secret_rotation.html.markdown
@@ -30,6 +30,6 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
-* `rotation_enabled` - ARN of the secret.
-* `rotation_lambda_arn` - Decrypted part of the protected secret information that was originally provided as a string.
-* `rotation_rules` - Decrypted part of the protected secret information that was originally provided as a binary. Base64 encoded.
+* `rotation_enabled` - Specifies whether automatic rotation is enabled for this secret.
+* `rotation_lambda_arn` - Amazon Resource Name (ARN) of the lambda function used for rotation.
+* `rotation_rules` - Configuration block for rotation rules. Includes properties `automaticallyAfterDays`, `duration`, and `scheduleExpression`.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

N/A

## Changes to Security Controls

No changes.

### Description
Should fix up incorrect documentation relating to aws_secretsmanager_secret_rotation data source attributes [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_rotation#attribute-reference)


### Relations
Closes #42781

### References
N/A


### Output from Acceptance Testing
N/A
