### PR TITLE
[Enhancement]aws_vpn_connection: support preshared_key_storage argument to store pre-shared key in Secretsmanager

### DIFF
--- a/internal/service/ec2/vpnsite_connection_test.go
+++ b/internal/service/ec2/vpnsite_connection_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/YakDriver/regexache"
@@ -179,6 +180,7 @@ func TestAccSiteVPNConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "local_ipv4_network_cidr", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr(resourceName, "local_ipv6_network_cidr", ""),
 					resource.TestCheckResourceAttr(resourceName, "outside_ip_address_type", "PublicIpv4"),
+					resource.TestCheckResourceAttr(resourceName, "preshared_key_storage", "Standard"),
 					resource.TestCheckResourceAttr(resourceName, "remote_ipv4_network_cidr", "0.0.0.0/0"),
 					resource.TestCheckResourceAttr(resourceName, "remote_ipv6_network_cidr", ""),
 					resource.TestCheckResourceAttr(resourceName, "routes.#", "0"),
@@ -206,6 +208,7 @@ func TestAccSiteVPNConnection_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "tunnel1_phase2_integrity_algorithms"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_phase2_lifetime_seconds", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "tunnel1_preshared_key"),
+					testAccCheckResourceAttrNotContains(resourceName, "tunnel1_preshared_key", "REDACTED"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_fuzz_percentage", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_rekey_margin_time_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel1_replay_window_size", "0"),
@@ -232,6 +235,7 @@ func TestAccSiteVPNConnection_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(resourceName, "tunnel2_phase2_integrity_algorithms"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel2_phase2_lifetime_seconds", "0"),
 					resource.TestCheckResourceAttrSet(resourceName, "tunnel2_preshared_key"),
+					testAccCheckResourceAttrNotContains(resourceName, "tunnel2_preshared_key", "REDACTED"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_fuzz_percentage", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel2_rekey_margin_time_seconds", "0"),
 					resource.TestCheckResourceAttr(resourceName, "tunnel2_replay_window_size", "0"),
@@ -1703,6 +1707,68 @@ func TestAccSiteVPNConnection_transitGatewayIDToVPNGatewayID(t *testing.T) {
 	})
 }
 
+func TestAccSiteVPNConnection_preSharedKeyStorage(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBgpAsn := sdkacctest.RandIntRange(64512, 65534)
+	resourceName := "aws_vpn_connection.test"
+	var vpn awstypes.VpnConnection
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckVPNConnectionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSiteVPNConnectionConfig_preSharedKeyStorage(rName, rBgpAsn, "SecretsManager"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(ctx, resourceName, &vpn),
+					resource.TestCheckResourceAttr(resourceName, "preshared_key_storage", "SecretsManager"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "preshared_key_arn", "secretsmanager", regexache.MustCompile(`secret:s2svpn!vpn-*`)),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel1_preshared_key", "REDACTED"),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel2_preshared_key", "REDACTED"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vgw_telemetry"},
+			},
+			{
+				Config: testAccSiteVPNConnectionConfig_preSharedKeyStorage(rName, rBgpAsn, "Standard"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(ctx, resourceName, &vpn),
+					resource.TestCheckResourceAttr(resourceName, "preshared_key_storage", "Standard"),
+					testAccCheckResourceAttrNotContains(resourceName, "tunnel1_preshared_key", "REDACTED"),
+					testAccCheckResourceAttrNotContains(resourceName, "tunnel2_preshared_key", "REDACTED"),
+				),
+			},
+			{
+				Config: testAccSiteVPNConnectionConfig_preSharedKeyStorage(rName, rBgpAsn, "SecretsManager"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(ctx, resourceName, &vpn),
+					resource.TestCheckResourceAttr(resourceName, "preshared_key_storage", "SecretsManager"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "preshared_key_arn", "secretsmanager", regexache.MustCompile(`secret:s2svpn!vpn-*`)),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel1_preshared_key", "REDACTED"),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel2_preshared_key", "REDACTED"),
+				),
+			},
+			{
+				Config: testAccSiteVPNConnectionConfig_basic(rName, rBgpAsn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccVPNConnectionExists(ctx, resourceName, &vpn),
+					resource.TestCheckResourceAttr(resourceName, "preshared_key_storage", "SecretsManager"),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, "preshared_key_arn", "secretsmanager", regexache.MustCompile(`secret:s2svpn!vpn-*`)),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel1_preshared_key", "REDACTED"),
+					acctest.CheckResourceAttrContains(resourceName, "tunnel2_preshared_key", "REDACTED"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVPNConnectionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EC2Client(ctx)
@@ -1762,6 +1828,15 @@ func testAccCheckVPNConnectionNotRecreated(before, after *awstypes.VpnConnection
 
 		return nil
 	}
+}
+
+func testAccCheckResourceAttrNotContains(name, key, substr string) resource.TestCheckFunc {
+	return resource.TestCheckResourceAttrWith(name, key, func(value string) error {
+		if !strings.Contains(value, substr) {
+			return nil
+		}
+		return fmt.Errorf("%s: Attribute '%s' expected not contains %#v, got %#v", name, key, substr, value)
+	})
 }
 
 func testAccSiteVPNConnectionConfig_basic(rName string, rBgpAsn int) string {
@@ -2677,6 +2752,33 @@ resource "aws_vpn_connection" "test" {
   }
 }
 `, rName, rBgpAsn, useTransitGateway)
+}
+
+func testAccSiteVPNConnectionConfig_preSharedKeyStorage(rName string, rBgpAsn int, preSharedKeyStorage string) string {
+	return fmt.Sprintf(`
+resource "aws_vpn_gateway" "test" {
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_customer_gateway" "test" {
+  bgp_asn    = %[2]d
+  ip_address = "178.0.0.1"
+  type       = "ipsec.1"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_vpn_connection" "test" {
+  vpn_gateway_id         = aws_vpn_gateway.test.id
+  customer_gateway_id    = aws_customer_gateway.test.id
+  type                   = "ipsec.1"
+  preshared_key_storage  = %[3]q
+}
+`, rName, rBgpAsn, preSharedKeyStorage)
 }
 
 // Test our VPN tunnel config XML parsing

--- a/website/docs/r/vpn_connection.html.markdown
+++ b/website/docs/r/vpn_connection.html.markdown
@@ -129,6 +129,7 @@ This resource supports the following arguments:
 * `vpn_gateway_id` - (Optional) The ID of the Virtual Private Gateway.
 * `static_routes_only` - (Optional, Default `false`) Whether the VPN connection uses static routes exclusively. Static routes must be used for devices that don't support BGP.
 * `enable_acceleration` - (Optional, Default `false`) Indicate whether to enable acceleration for the VPN connection. Supports only EC2 Transit Gateway.
+* `preshared_key_storage` - (Optional) Storage mode for the pre-shared key (PSK). Valid values are `Standard` (stored in the Site-to-Site VPN service) or `SecretsManager` (stored in AWS Secrets Manager).
 * `tags` - (Optional) Tags to apply to the connection. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `local_ipv4_network_cidr` - (Optional, Default `0.0.0.0/0`) The IPv4 CIDR on the customer gateway (on-premises) side of the VPN connection.
 * `local_ipv6_network_cidr` - (Optional, Default `::/0`) The IPv6 CIDR on the customer gateway (on-premises) side of the VPN connection.
@@ -203,19 +204,20 @@ This resource exports the following attributes in addition to the arguments abov
 * `customer_gateway_configuration` - The configuration information for the VPN connection's customer gateway (in the native XML format).
 * `customer_gateway_id` - The ID of the customer gateway to which the connection is attached.
 * `routes` - The static routes associated with the VPN connection. Detailed below.
+* `preshared_key_arn` - ARN of the Secrets Manager secret storing the pre-shared key(s) for the VPN connection. Note that even if it returns a valid Secrets Manager ARN, the pre-shared key(s) will not be stored in Secrets Manager unless the `preshared_key_storage` argument is set to `SecretsManager`.
 * `static_routes_only` - Whether the VPN connection uses static routes exclusively.
 * `tags_all` - A map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 * `transit_gateway_attachment_id` - When associated with an EC2 Transit Gateway (`transit_gateway_id` argument), the attachment ID. See also the [`aws_ec2_tag` resource](/docs/providers/aws/r/ec2_tag.html) for tagging the EC2 Transit Gateway VPN Attachment.
 * `tunnel1_address` - The public IP address of the first VPN tunnel.
 * `tunnel1_cgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side).
 * `tunnel1_vgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side).
-* `tunnel1_preshared_key` - The preshared key of the first VPN tunnel.
+* `tunnel1_preshared_key` - The preshared key of the first VPN tunnel. If `preshared_key_storage` is set to `SecretsManager`, it returns strings indicating the keys are redacted and the actual values are stored in Secrets Manager.
 * `tunnel1_bgp_asn` - The bgp asn number of the first VPN tunnel.
 * `tunnel1_bgp_holdtime` - The bgp holdtime of the first VPN tunnel.
 * `tunnel2_address` - The public IP address of the second VPN tunnel.
 * `tunnel2_cgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side).
 * `tunnel2_vgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side).
-* `tunnel2_preshared_key` - The preshared key of the second VPN tunnel.
+* `tunnel2_preshared_key` - The preshared key of the second VPN tunnel. If `preshared_key_storage` is set to `SecretsManager`, it returns strings indicating the keys are redacted and the actual values are stored in Secrets Manager.
 * `tunnel2_bgp_asn` - The bgp asn number of the second VPN tunnel.
 * `tunnel2_bgp_holdtime` - The bgp holdtime of the second VPN tunnel.
 * `vgw_telemetry` - Telemetry for the VPN tunnels. Detailed below.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


### Description

* Add support for the `preshared_key_storage` argument, which allows storing pre-shared keys in AWS Secrets Manager.

  * Following the existing naming convention (e.g., `tunnel1_preshared_key`), I used `preshared_key_` instead of `pre_shared_key_`.

* The `CreateVpnConnection` API accepts the `preshared_key_storage` parameter, but `DescribeVpnConnection` does not return it; instead, it returns `preshared_key_arn`.

* In the read process, `preshared_key_storage` is inferred based on the fact that `tunnel1_preshared_key` is returned as REDACTED when `preshared_key_storage` is set to `SecretsManager`.
  Note that `preshared_key_arn` may still return a valid ARN for Secrets Manager even when `preshared_key_storage` is not set to `SecretsManager`.
  Therefore, `preshared_key_arn` alone cannot be used to determine the value of `preshared_key_storage`.

* In the update process, `preshared_key_storage` is updated via `ModifyVpnTunnelOptions`, not `ModifyVpnConnection`.

  * Note: `ModifyVpnTunnelOptions` requires updating each tunnel individually.


### Relations

Closes #42797

### References
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpnConnection.html
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ModifyVpnTunnelOptions.html

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccSiteVPNConnection_basic PKG=ec2               
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccSiteVPNConnection_basic'  -timeout 360m -vet=off
2025/05/31 01:37:46 Initializing Terraform AWS Provider...
=== RUN   TestAccSiteVPNConnection_basic
=== PAUSE TestAccSiteVPNConnection_basic
=== CONT  TestAccSiteVPNConnection_basic
--- PASS: TestAccSiteVPNConnection_basic (270.92s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        275.236s

```
