### PR TITLE
Go-VCR: Add patch file to support enabling VCR

### DIFF
--- a/.ci/tools/go.mod
+++ b/.ci/tools/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pavius/impi v0.0.3
 	github.com/rhysd/actionlint v1.7.7
 	github.com/terraform-linters/tflint v0.58.0
+	github.com/uber-go/gopatch v0.4.0
 	mvdan.cc/gofumpt v0.8.0
 )
 
@@ -156,6 +157,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0 // indirect
 	github.com/google/go-github/v53 v53.0.0 // indirect
 	github.com/google/go-github/v67 v67.0.0 // indirect
+	github.com/google/go-intervals v0.0.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -261,6 +263,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/.ci/tools/go.sum
+++ b/.ci/tools/go.sum
@@ -1183,6 +1183,8 @@ github.com/google/go-github/v53 v53.0.0 h1:T1RyHbSnpHYnoF0ZYKiIPSgPtuJ8G6vgc0MKo
 github.com/google/go-github/v53 v53.0.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-github/v67 v67.0.0 h1:g11NDAmfaBaCO8qYdI9fsmbaRipHNWRIU/2YGvlh4rg=
 github.com/google/go-github/v67 v67.0.0/go.mod h1:zH3K7BxjFndr9QSeFibx4lTKkYS3K9nDanoI1NjaOtY=
+github.com/google/go-intervals v0.0.2 h1:FGrVEiUnTRKR8yE04qzXYaJMtnIYqobR5QbblK3ixcM=
+github.com/google/go-intervals v0.0.2/go.mod h1:MkaR3LNRfeKLPmqgJYs4E66z5InYjmCjbbr4TQlcT6Y=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
@@ -1645,6 +1647,7 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e h1:aoZm08cpOy4WuID//EZDgcC4zIxODThtZNPirFr42+A=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1879,6 +1882,8 @@ github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/uber-go/gopatch v0.4.0 h1:1/8EUo6Zk3+gtTHvOUsZs5ysCUlHj3NDjuF59zLXz2k=
+github.com/uber-go/gopatch v0.4.0/go.mod h1:TYLhs9ou9BLsCnXM3xONjnuL/XrjUSMADQXyAiqPdhE=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/.ci/tools/main.go
+++ b/.ci/tools/main.go
@@ -13,5 +13,6 @@ import (
 	_ "github.com/pavius/impi/cmd/impi"
 	_ "github.com/rhysd/actionlint/cmd/actionlint"
 	_ "github.com/terraform-linters/tflint"
+	_ "github.com/uber-go/gopatch"
 	_ "mvdan.cc/gofumpt"
 )

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -719,6 +719,7 @@ tools: prereq-go ## Install tools
 	cd .ci/tools && $(GO_VER) install github.com/pavius/impi/cmd/impi
 	cd .ci/tools && $(GO_VER) install github.com/rhysd/actionlint/cmd/actionlint
 	cd .ci/tools && $(GO_VER) install github.com/terraform-linters/tflint
+	cd .ci/tools && $(GO_VER) install github.com/uber-go/gopatch
 	cd .ci/tools && $(GO_VER) install mvdan.cc/gofumpt
 
 ts: testacc-short ## Alias to testacc-short

--- a/internal/vcr/vcr.patch
+++ b/internal/vcr/vcr.patch
@@ -1,0 +1,44 @@
+# A patch file to assist with enabling VCR support across service clients.
+#
+# This file should be passed into the [`gopatch`](https://github.com/uber-go/gopatch)
+# command like:
+#
+# % gopatch -p internal/vcr/vcr.patch ./$(PKG_NAME)/...
+#
+#####
+# Replace acceptance test structures with VCR compatible versions.
+@@
+@@
+-resource.Test(...)
++acctest.Test(ctx, ...)
+@@
+@@
+-resource.ParallelTest(...)
++acctest.ParallelTest(ctx, ...)
+
+# Replace test resource random name generation functions with VCR compatible versions.
+@@
+@@
+-import sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
+-sdkacctest.RandomWithPrefix(...)
++acctest.RandomWithPrefix(t, ...)
+@@
+@@
+-import sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
+-sdkacctest.RandInt()
++acctest.RandInt(t)
+
+# Replace test helper function (check exists/destroyed) client initialization with a
+# VCR compatible version.
+#
+# Note that the parent exists/destroy test function may need a t.Testing argument added,
+# and that applying this patch could result in code which does not compile.
+@@
+var x identifier
+@@
+-import "github.com/hashicorp/terraform-provider-aws/internal/conns"
+
+-acctest.Provider.Meta().(*conns.AWSClient).x(ctx)
++acctest.ProviderMeta(ctx, t).x(ctx)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This patch file can be used to automate the addition of VCR support across services. As additional wrapper methods are added (such as wrapping state change data structures) additional patches will be included in this file.

To apply the patch to an entire service:

```console
% gopatch -p internal/vcr/vcr.patch ./internal/service/<name>/...
```

Alternatively, the patch can be applied to a single file:

```console
% gopatch -p internal/vcr/vcr.patch ./internal/service/rds/cluster_test.go
```

Pass the `-d` flag to display the diff to stdout without applying any
changes:

```console
% gopatch -d -p internal/vcr/vcr.patch ./internal/service/rds/cluster_test.go
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25602 


