### PR TITLE
[bug fix] aws_lambda_function: Add reset logic for source_code_hash when update fails

### DIFF
--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -781,6 +781,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			_, err := conn.PutFunctionCodeSigningConfig(ctx, input)
 
 			if err != nil {
+				resetSourceCodeHash(d)
 				return sdkdiag.AppendErrorf(diags, "setting Lambda Function (%s) code signing config: %s", d.Id(), err)
 			}
 		} else {
@@ -789,6 +790,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			})
 
 			if err != nil {
+				resetSourceCodeHash(d)
 				return sdkdiag.AppendErrorf(diags, "deleting Lambda Function (%s) code signing config: %s", d.Id(), err)
 			}
 		}
@@ -803,6 +805,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		if d.HasChange("dead_letter_config") {
 			if v, ok := d.GetOk("dead_letter_config"); ok && len(v.([]any)) > 0 {
 				if v.([]any)[0] == nil {
+					resetSourceCodeHash(d)
 					return sdkdiag.AppendErrorf(diags, "nil dead_letter_config supplied for function: %s", d.Id())
 				}
 
@@ -924,10 +927,12 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		})
 
 		if err != nil {
+			resetSourceCodeHash(d)
 			return sdkdiag.AppendErrorf(diags, "updating Lambda Function (%s) configuration: %s", d.Id(), err)
 		}
 
 		if _, err := waitFunctionUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			resetSourceCodeHash(d)
 			return sdkdiag.AppendErrorf(diags, "waiting for Lambda Function (%s) configuration update: %s", d.Id(), err)
 		}
 	}
@@ -957,6 +962,7 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 				old, _ := d.GetChange("filename")
 				d.Set("filename", old)
 
+				resetSourceCodeHash(d)
 				return sdkdiag.AppendErrorf(diags, "reading ZIP file (%s): %s", v, err)
 			}
 
@@ -981,11 +987,13 @@ func resourceFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta an
 					d.Set(key, old)
 				}
 			}
+			resetSourceCodeHash(d)
 
 			return sdkdiag.AppendErrorf(diags, "updating Lambda Function (%s) code: %s", d.Id(), err)
 		}
 
 		if _, err := waitFunctionUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			resetSourceCodeHash(d)
 			return sdkdiag.AppendErrorf(diags, "updating Lambda Function (%s) code: waiting for completion: %s", d.Id(), err)
 		}
 	}
@@ -1592,4 +1600,14 @@ func flattenSnapStart(apiObject *awstypes.SnapStartResponse) []any {
 	}
 
 	return []any{tfMap}
+}
+
+// source_code_hash in the state is updated even if the update fails, and it cannot be refreshed (as it is a virtual attribute).
+// Therefore, reset it to the previous value when the update fails.
+// https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#how-errors-affect-state
+func resetSourceCodeHash(d *schema.ResourceData) {
+	if d.HasChange("source_code_hash") {
+		old, _ := d.GetChange("source_code_hash")
+		d.Set("source_code_hash", old)
+	}
 }


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description


### Relations

Closes #42826 

### References
https://developer.hashicorp.com/terraform/plugin/framework/diagnostics#how-errors-affect-state

### Output from Acceptance Testing

```console


```
