### PR TITLE
[Enhancement] Add multi-tenant CloudFront distribution support

### DIFF
--- a/internal/service/cloudfront/distribution.go
+++ b/internal/service/cloudfront/distribution.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
@@ -68,6 +69,12 @@ func resourceDistribution() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringLenBetween(0, 128),
+			},
+			"connection_mode": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          awstypes.ConnectionModeDirect,
+				ValidateDiagFunc: enum.Validate[awstypes.ConnectionMode](),
 			},
 			"continuous_deployment_policy_id": {
 				Type:     schema.TypeString,
@@ -786,6 +793,62 @@ func resourceDistribution() *schema.Resource {
 			},
 			names.AttrTags:    tftags.TagsSchema(),
 			names.AttrTagsAll: tftags.TagsSchemaComputed(),
+			"tenant_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"parameter_definition": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"definition": {
+										Type:     schema.TypeList,
+										Optional: true,
+										MaxItems: 1,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"string_schema_config": {
+													Type:     schema.TypeList,
+													Optional: true,
+													MaxItems: 1,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"required": {
+																Type:     schema.TypeBool,
+																Required: true,
+															},
+															"comment": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"default_value": {
+																Type:         schema.TypeString,
+																Optional:     true,
+																ValidateFunc: validation.StringLenBetween(1, 256),
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+										ValidateFunc: validation.All(
+											validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9-_]+$`), "must contain alphanumeric, underscores or dashes only"),
+											validation.StringLenBetween(1, 128),
+										),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"trusted_key_groups": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -962,6 +1025,7 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	// Not having this set for staging distributions causes IllegalUpdate errors when making updates of any kind.
 	// If this absolutely must not be optional/computed, the policy ID will need to be retrieved and set for each
 	// API call for staging distributions.
+	d.Set("connection_mode", distributionConfig.ConnectionMode)
 	d.Set("continuous_deployment_policy_id", distributionConfig.ContinuousDeploymentPolicyId)
 	if distributionConfig.CustomErrorResponses != nil {
 		if err := d.Set("custom_error_response", flattenCustomErrorResponses(distributionConfig.CustomErrorResponses)); err != nil {
@@ -1010,6 +1074,9 @@ func resourceDistributionRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	d.Set("staging", distributionConfig.Staging)
 	d.Set(names.AttrStatus, output.Distribution.Status)
+	if err := d.Set("tenant_config", flattenTenantConfig(distributionConfig.TenantConfig)); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting tenant_config: %s", err)
+	}
 	if err := d.Set("trusted_key_groups", flattenActiveTrustedKeyGroups(output.Distribution.ActiveTrustedKeyGroups)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting trusted_key_groups: %s", err)
 	}
@@ -1327,6 +1394,7 @@ func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConf
 		CacheBehaviors:               expandCacheBehaviors(d.Get("ordered_cache_behavior").([]any)),
 		CallerReference:              aws.String(id.UniqueId()),
 		Comment:                      aws.String(d.Get(names.AttrComment).(string)),
+		ConnectionMode:               awstypes.ConnectionMode(d.Get("connection_mode").(string)),
 		ContinuousDeploymentPolicyId: aws.String(d.Get("continuous_deployment_policy_id").(string)),
 		CustomErrorResponses:         expandCustomErrorResponses(d.Get("custom_error_response").(*schema.Set).List()),
 		DefaultCacheBehavior:         expandDefaultCacheBehavior(d.Get("default_cache_behavior").([]any)[0].(map[string]any)),
@@ -1337,6 +1405,7 @@ func expandDistributionConfig(d *schema.ResourceData) *awstypes.DistributionConf
 		Origins:                      expandOrigins(d.Get("origin").(*schema.Set).List()),
 		PriceClass:                   awstypes.PriceClass(d.Get("price_class").(string)),
 		Staging:                      aws.Bool(d.Get("staging").(bool)),
+		TenantConfig:                 expandTenantConfig(d.Get("tenant_config").([]any)[0].(map[string]any)),
 		WebACLId:                     aws.String(d.Get("web_acl_id").(string)),
 	}
 
@@ -1465,6 +1534,66 @@ func expandCacheBehaviors(tfList []any) *awstypes.CacheBehaviors {
 		Items:    items,
 		Quantity: aws.Int32(int32(len(items))),
 	}
+}
+
+func expandTenantConfig(tfMap map[string]any) *awstypes.TenantConfig {
+	tenantConfig := &awstypes.TenantConfig{}
+	if tfMap == nil {
+		return tenantConfig
+	}
+	if v, ok := tfMap["parameter_definition"]; ok && v != nil {
+		var defs []awstypes.ParameterDefinition
+		for _, defRaw := range v.([]any) {
+			defMap, ok := defRaw.(map[string]any)
+			if !ok {
+				continue
+			}
+			paramDef := awstypes.ParameterDefinition{}
+			if name, ok := defMap["name"].(string); ok {
+				paramDef.Name = aws.String(name)
+			}
+			if defList, ok := defMap["definition"].([]any); ok && len(defList) > 0 {
+				defSchemaMap, ok := defList[0].(map[string]any)
+				if ok {
+					if strSchemaList, ok := defSchemaMap["string_schema_config"].([]any); ok && len(strSchemaList) > 0 {
+						strSchemaMap, ok := strSchemaList[0].(map[string]any)
+						if ok {
+							paramDef.Definition = &awstypes.ParameterDefinitionSchema{
+								StringSchema: &awstypes.StringSchemaConfig{
+									Required:     aws.Bool(strSchemaMap["required"].(bool)),
+									Comment:      aws.String(strSchemaMap["comment"].(string)),
+									DefaultValue: aws.String(strSchemaMap["default_value"].(string)),
+								},
+							}
+						}
+					}
+				}
+			}
+			defs = append(defs, paramDef)
+		}
+		tenantConfig.ParameterDefinitions = defs
+	}
+
+	return tenantConfig
+}
+
+func flattenTenantConfig(apiObject *awstypes.TenantConfig) map[string]any {
+	tfMap := make(map[string]any)
+	if apiObject.ParameterDefinitions != nil {
+		for _, v := range apiObject.ParameterDefinitions {
+			tfMap["parameter_definition"] = append(tfMap["parameter_definition"].([]any), map[string]any{
+				"name": aws.ToString(v.Name),
+				"definition": []any{map[string]any{
+					"string_schema_config": []any{map[string]any{
+						"required":      aws.ToBool(v.Definition.StringSchema.Required),
+						"comment":       aws.ToString(v.Definition.StringSchema.Comment),
+						"default_value": aws.ToString(v.Definition.StringSchema.DefaultValue),
+					}},
+				}},
+			})
+		}
+	}
+	return tfMap
 }
 
 func flattenCacheBehavior(apiObject *awstypes.CacheBehavior) map[string]any {

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -1525,6 +1525,35 @@ func TestAccCloudFrontDistribution_grpcConfig(t *testing.T) {
 	})
 }
 
+func TestAccCloudFrontDistribution_multiTenant(t *testing.T) {
+	ctx := acctest.Context(t)
+	var distribution awstypes.Distribution
+	resourceName := "aws_cloudfront_distribution.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckPartitionHasService(t, names.CloudFrontEndpointID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CloudFrontServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDistributionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDistributionConfig_multiTenant(false, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDistributionExists(ctx, resourceName, &distribution),
+					resource.TestCheckResourceAttr(resourceName, "connection_mode", "tenant-only"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.name", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema_config.0.required", acctest.CtTrue),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema_config.0.comment", "test"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_config.0.parameter_definition.0.definition.0.string_schema_config.0.default_value", "test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDistributionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CloudFrontClient(ctx)
@@ -4663,4 +4692,65 @@ resource "aws_cloudfront_distribution" "test" {
   }
 }
 `
+}
+
+func testAccDistributionConfig_multiTenant(enabled, retainOnDelete bool) string {
+	return fmt.Sprintf(`
+resource "aws_cloudfront_distribution" "test" {
+  enabled          = %[1]t
+  retain_on_delete = %[2]t
+
+  connection_mode = "tenant-only"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "test"
+    viewer_protocol_policy = "allow-all"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "all"
+      }
+    }
+  }
+
+  origin {
+    domain_name = "www.example.com"
+    origin_id   = "test"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  tenant_config {
+    parameter_definition {
+      name = "test"
+      definition {
+        string_schema_config {
+          required = true
+          comment = "test"
+          default_value = "test"
+        }
+      }
+    } 
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+`, enabled, retainOnDelete)
 }

--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -292,12 +292,38 @@ resource "aws_cloudwatch_log_delivery" "example" {
 }
 ```
 
+### CloudFront multi-tenant distribution
+
+The example below creates a [CloudFront multi-tenant distribution](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/template-preconfigured-origin-settings.html)
+
+```tf
+resource "aws_cloudfront_distribution" "example" {
+  connection_mode = "tenant-only"
+
+  tenant_config {
+    parameter_definition {
+      name = "test"
+      definition {
+        string_schema_config {
+          required = true
+          comment = "test"
+          default_value = "test"
+        }
+      }
+    } 
+  }
+
+  # other config...
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `aliases` (Optional) - Extra CNAMEs (alternate domain names), if any, for this distribution.
 * `comment` (Optional) - Any comments you want to include about the distribution.
+* `connection_mode` (Optional) - The connection mode to filter distributions by. Allowed values are `direct` and `tenant-only`. The default is `direct`.
 * `continuous_deployment_policy_id` (Optional) - Identifier of a continuous deployment policy. This argument should only be set on a production distribution. See the [`aws_cloudfront_continuous_deployment_policy` resource](./cloudfront_continuous_deployment_policy.html.markdown) for additional details.
 * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
 * `default_cache_behavior` (Required) - [Default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum one). Requires either `cache_policy_id` (preferred) or `forwarded_values` (deprecated) be set.
@@ -313,6 +339,7 @@ This resource supports the following arguments:
 * `restrictions` (Required) - The [restriction configuration](#restrictions-arguments) for this distribution (maximum one).
 * `staging` (Optional) - A Boolean that indicates whether this is a staging distribution. Defaults to `false`.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `tenant_config` - (Optional) The [tenant configuration](#tenant-config-arguments) for this distribution.
 * `viewer_certificate` (Required) - The [SSL configuration](#viewer-certificate-arguments) for this distribution (maximum one).
 * `web_acl_id` (Optional) - Unique identifier that specifies the AWS WAF web ACL, if any, to associate with this distribution. To specify a web ACL created using the latest version of AWS WAF (WAFv2), use the ACL ARN, for example `aws_wafv2_web_acl.example.arn`. To specify a web ACL created using AWS WAF Classic, use the ACL ID, for example `aws_waf_web_acl.example.id`. The WAF Web ACL must exist in the WAF Global (CloudFront) region and the credentials configuring this argument must have `waf:GetWebACL` permissions assigned.
 * `retain_on_delete` (Optional) - Disables the distribution instead of deleting it when destroying the resource through Terraform. If this is set, the distribution needs to be deleted manually afterwards. Default: `false`.
@@ -495,6 +522,22 @@ The arguments of `geo_restriction` are:
 
 * `locations` (Required) - [ISO 3166-1-alpha-2 codes][4] for which you want CloudFront either to distribute your content (`whitelist`) or not distribute your content (`blacklist`). If the type is specified as `none` an empty array can be used.
 * `restriction_type` (Required) - Method that you want to use to restrict distribution of your content by country: `none`, `whitelist`, or `blacklist`.
+
+#### Tenant Config Arguments
+The `tenant_config` block configures multi-tenant settings for the CloudFront distribution.
+
+* `parameter_definition` (Optional) - One or more parameter definition blocks for tenant configuration. Each block supports:
+  * `name` (Required) - Name of the parameter.
+  * `definition` (Required) - Definition block specifying the parameter schema.
+
+##### Definition Arguments
+
+Each `definition` block supports the following arguments:
+
+* `string_schema_config` (Optional) - Configuration block for string schema. Supports:
+  * `required` (Required) - Whether the defined parameter is required.
+  * `comment` (Optional) - A comment to describe the parameter.
+  * `default_value` (Optional) - The default value of the parameter.
 
 #### Viewer Certificate Arguments
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
- Introduced `connection_mode` and `tenant_config` attributes to the CloudFront distribution resource.
- Updated documentation to include examples and argument references for multi-tenant configurations.
- Added acceptance tests for multi-tenant distribution scenarios.

### Relations

Relates #42409

### References
https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateDistribution.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
