### PR TITLE
Draft: Support multiline athena queries

### DIFF
--- a/internal/service/athena/prepared_statement.go
+++ b/internal/service/athena/prepared_statement.go
@@ -71,7 +71,6 @@ func resourcePreparedStatement() *schema.Resource {
 		CustomizeDiff: customdiff.All(
 			customdiff.IfValue("query_statement", func(ctx context.Context, value, meta any) bool {
 				if strings.ContainsAny(value.(string), "\n") {
-					fmt.Printf("%s", value.(string))
 					return true
 				}
 				return false

--- a/internal/service/athena/prepared_statement_test.go
+++ b/internal/service/athena/prepared_statement_test.go
@@ -118,6 +118,15 @@ func TestAccAthenaPreparedStatement_update(t *testing.T) {
 					acctest.CheckResourceAttrHasSuffix(resourceName, "query_statement", updatedCondition),
 				),
 			},
+			{
+				Config: testAccPreparedStatementUsingEOTSyntax_basic(rName, updatedCondition, "desc3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPreparedStatementExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "desc3"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					acctest.CheckResourceAttrHasSuffix(resourceName, "query_statement", updatedCondition),
+				),
+			},
 		},
 	})
 }
@@ -197,6 +206,22 @@ resource "aws_athena_prepared_statement" "test" {
   name            = %[1]q
   description     = %[3]q
   query_statement = "SELECT * FROM ${aws_athena_database.test.name} WHERE %[2]s"
+  workgroup       = aws_athena_workgroup.test.name
+}
+`, rName, condition, description))
+}
+
+func testAccPreparedStatementUsingEOTSyntax_basic(rName, condition, description string) string {
+	return acctest.ConfigCompose(testAccPreparedStatementConfig_base(rName), fmt.Sprintf(`
+resource "aws_athena_prepared_statement" "test_multiline" {
+  name            = %[1]q
+  description     = %[3]q
+  query_statement = <<-EOT
+SELECT *
+FROM ${aws_athena_database.test.name}
+-- test
+WHERE %[2]s
+EOT
   workgroup       = aws_athena_workgroup.test.name
 }
 `, rName, condition, description))

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -357,6 +357,53 @@ func resourceCatalogTable() *schema.Resource {
 					},
 				},
 			},
+			"view_definition": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"is_protected": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"definer": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"representations": {
+							Type:     schema.TypeList,
+							Required: true,
+							MinItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"dialect": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"DialectVersion": {
+										Type:     schema.TypeString,
+										Required: false,
+									},
+									"ViewOriginalText": {
+										Type:     schema.TypeString,
+										Required: false,
+									},
+									"ValidationConnection": {
+										Type:     schema.TypeString,
+										Required: false,
+									},
+									"ViewExpandedText": {
+										Type:     schema.TypeString,
+										Required: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			"view_original_text": {
 				Type:         schema.TypeString,
 				Optional:     true,

--- a/internal/service/glue/catalog_table.go
+++ b/internal/service/glue/catalog_table.go
@@ -357,53 +357,6 @@ func resourceCatalogTable() *schema.Resource {
 					},
 				},
 			},
-			"view_definition": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"is_protected": {
-							Type:     schema.TypeBool,
-							Required: true,
-						},
-						"definer": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						"representations": {
-							Type:     schema.TypeList,
-							Required: true,
-							MinItems: 1,
-							Elem: &schema.Resource{
-								Schema: map[string]*schema.Schema{
-									"dialect": {
-										Type:     schema.TypeString,
-										Required: true,
-									},
-									"DialectVersion": {
-										Type:     schema.TypeString,
-										Required: false,
-									},
-									"ViewOriginalText": {
-										Type:     schema.TypeString,
-										Required: false,
-									},
-									"ValidationConnection": {
-										Type:     schema.TypeString,
-										Required: false,
-									},
-									"ViewExpandedText": {
-										Type:     schema.TypeString,
-										Required: false,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
 			"view_original_text": {
 				Type:         schema.TypeString,
 				Optional:     true,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

PR aims to fix #41469,  Allow multiline (EOT) query strings to preserve comments and line breaks without update-in-place.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #41469
or 
Closes #41469
--->

Closes #41469

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
