### PR TITLE
[Enhancement] aws_lambda_function: introduce `source_code_hash_sha256` as a refreshable alternative to `source_code_hash`

### DIFF
--- a/internal/service/lambda/function.go
+++ b/internal/service/lambda/function.go
@@ -377,6 +377,12 @@ func resourceFunction() *schema.Resource {
 				Computed:         true,
 				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
 			},
+			"source_code_hash_sha256": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: verify.SuppressMissingOptionalConfigurationBlock,
+			},
 			"source_code_size": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -702,6 +708,7 @@ func resourceFunctionRead(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "setting snap_start: %s", err)
 	}
 	d.Set("source_code_hash", d.Get("source_code_hash"))
+	d.Set("source_code_hash_sha256", function.CodeSha256)
 	d.Set("source_code_size", function.CodeSize)
 	d.Set(names.AttrTimeout, function.Timeout)
 	tracingConfigMode := awstypes.TracingModePassThrough
@@ -1353,6 +1360,7 @@ func updateComputedAttributesOnPublish(_ context.Context, d *schema.ResourceDiff
 func needsFunctionCodeUpdate(d sdkv2.ResourceDiffer) bool {
 	return d.HasChange("filename") ||
 		d.HasChange("source_code_hash") ||
+		d.HasChange("source_code_hash_sha256") ||
 		d.HasChange(names.AttrS3Bucket) ||
 		d.HasChange("s3_key") ||
 		d.HasChange("s3_object_version") ||

--- a/internal/service/lambda/function_test.go
+++ b/internal/service/lambda/function_test.go
@@ -2276,6 +2276,43 @@ func TestAccLambdaFunction_skipDestroyInconsistentPlan(t *testing.T) {
 	})
 }
 
+func TestAccLambdaFunction_sourceCodeHashSHA256(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf1, conf2 lambda.GetFunctionOutput
+	resourceName := "aws_lambda_function.test"
+
+	rString := sdkacctest.RandString(8)
+	funcName := fmt.Sprintf("tf_acc_lambda_func_source_code_hash_sha256_%s", rString)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionConfig_sourceCodeHashSHA256(funcName, "lambdatest"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"filename", "publish"},
+			},
+			{
+				Config: testAccFunctionConfig_sourceCodeHashSHA256(funcName, "lambdatest_modified"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckFunctionExists(ctx, resourceName, &conf2),
+					testAccCheckSourceCodeHashSHA256Updated(&conf1, &conf2),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFunctionDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).LambdaClient(ctx)
@@ -2459,6 +2496,18 @@ func testAccCreateZipFromFiles(files map[string]string, zipFile *os.File) error 
 	}
 
 	return w.Flush()
+}
+
+func testAccCheckSourceCodeHashSHA256Updated(conf1, conf2 *lambda.GetFunctionOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c1 := conf1.Configuration
+		c2 := conf2.Configuration
+
+		if *c1.CodeSha256 == *c2.CodeSha256 {
+			return fmt.Errorf("Expected source code hash to be updated, but it is still %s", *c1.CodeSha256)
+		}
+		return nil
+	}
 }
 
 func createTempFile(prefix string) (string, *os.File, error) {
@@ -3992,6 +4041,21 @@ resource "aws_lambda_function" "test" {
   skip_destroy  = true
 }
 `, rName))
+}
+
+func testAccFunctionConfig_sourceCodeHashSHA256(rName, zipFileName string) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLambdaBase(rName, rName, rName),
+		fmt.Sprintf(`
+resource "aws_lambda_function" "test" {
+  filename                = "test-fixtures/%[2]s.zip"
+  function_name           = %[1]q
+  role                    = aws_iam_role.iam_for_lambda.arn
+  handler                 = "exports.example"
+  runtime                 = "nodejs20.x"
+  source_code_hash_sha256 = filebase64sha256("test-fixtures/%[2]s.zip")
+}
+`, rName, zipFileName))
 }
 
 func testAccPreCheckSignerSigningProfile(ctx context.Context, t *testing.T, platformID string) {

--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -57,7 +57,7 @@ resource "aws_lambda_function" "test_lambda" {
   role          = aws_iam_role.iam_for_lambda.arn
   handler       = "index.test"
 
-  source_code_hash = data.archive_file.lambda.output_base64sha256
+  source_code_hash_sha256 = data.archive_file.lambda.output_base64sha256
 
   runtime = "nodejs18.x"
 
@@ -291,7 +291,8 @@ Set the `replacement_security_group_ids` attribute to use a custom list of secur
 * `s3_key` - (Optional) S3 key of an object containing the function's deployment package. When `s3_bucket` is set, `s3_key` is required.
 * `s3_object_version` - (Optional) Object version containing the function's deployment package. Conflicts with `filename` and `image_uri`.
 * `skip_destroy` - (Optional) Set to true if you do not wish the function to be deleted at destroy time, and instead just remove the function from the Terraform state.
-* `source_code_hash` - (Optional) Virtual attribute used to trigger replacement when source code changes. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256("file.zip")` (Terraform 0.11.12 and later) or `base64sha256(file("file.zip"))` (Terraform 0.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
+* `source_code_hash` - (Optional) Virtual attribute used to trigger replacement when source code changes. Must be set to a base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. The usual way to set this is `filebase64sha256("file.zip")` (Terraform 0.11.12 and later) or `base64sha256(file("file.zip"))` (Terraform 0.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive. **NOTE** Since this is a virtual attribute, it is not refreshed via AWS API calls, and changes made outside of Terraform cannot be detected as drift.
+* `source_code_hash_sha256` – (Optional) Base64-encoded SHA256 hash of the package file specified with either `filename` or `s3_key`. This is useful for triggering function updates when the source code changes. The typical way to set this is `filebase64sha256("file.zip")` (Terraform 0.11.12 and later) or `base64sha256(file("file.zip"))` (Terraform 0.11.11 and earlier), where `"file.zip"` is the local filename of the Lambda function source archive. **NOTE** This attribute is refreshed using the `CodeSha256` value from the AWS `GetFunction` API response. Changes made outside of Terraform can be detected as drift.
 * `snap_start` - (Optional) Snap start settings block. Detailed below.
 * `tags` - (Optional) Map of tags to assign to the object. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `timeout` - (Optional) Amount of time your Lambda Function has to run in seconds. Defaults to `3`. See [Limits][5].


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description


### Relations

Relates #42826
Relates #41092
Relates #42829 

### Output from Acceptance Testing

```console



```
