### PR TITLE
internal/vcr: add vcr support semgrep rules

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -574,6 +574,14 @@ semgrep-validate: ## Validate Semgrep configuration files
 		--config .ci/.semgrep-service-name3.yml \
 		--config .ci/semgrep/
 
+semgrep-vcr: ## Enable VCR support with Semgrep --autofix
+	@echo "make: Enable VCR support with Semgrep --autofix"
+	@echo "WARNING: Because some autofixes are inside code blocks replaced by other rules,"
+	@echo "this target may need to be run twice."
+	@semgrep $(SEMGREP_ARGS) --autofix \
+		$(if $(filter-out $(origin PKG), undefined),--include $(PKG_NAME),) \
+		--config internal/vcr/.semgrep-vcr.yml
+
 skaff: prereq-go ## Install skaff
 	@echo "make: Installing skaff..."
 	cd skaff && $(GO_VER) install github.com/hashicorp/terraform-provider-aws/skaff
@@ -928,6 +936,7 @@ yamllint: ## [CI] YAML Linting / yamllint
 	semgrep-naming \
 	semgrep-service-naming \
 	semgrep-validate \
+	semgrep-vcr \
 	semgrep \
 	skaff-check-compile \
 	skaff \

--- a/docs/makefile-cheat-sheet.md
+++ b/docs/makefile-cheat-sheet.md
@@ -150,6 +150,7 @@ Variables are often defined before the `make` call on the same line, such as `MY
 | `semgrep-naming-cae`<sup>D</sup> | Semgrep Checks / Naming Scan Caps/`AWS`/EC2 | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-service-naming`<sup>D</sup> | Semgrep Checks / Service Name Scan A-Z | ✔️ |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `semgrep-validate` | Validate Semgrep configuration files |  |  |  |
+| `semgrep-vcr` | Enable VCR support with Semgrep --autofix |  |  | `K`, `PKG`, `PKG_NAME`, `SEMGREP_ARGS` |
 | `skaff`<sup>D</sup> | Install skaff |  |  | `GO_VER` |
 | `skaff-check-compile` | Skaff Checks / Compile skaff | ✔️ |  |  |
 | `sweep`<sup>D</sup> | Run sweepers |  |  | `GO_VER`, `SWEEP_DIR`, `SWEEP_TIMEOUT`, `SWEEP`, `SWEEPARGS` |

--- a/internal/vcr/.semgrep-vcr.yml
+++ b/internal/vcr/.semgrep-vcr.yml
@@ -1,0 +1,143 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+rules:
+  - id: use-acctest-test
+    languages: [go]
+    message: "Use acctest.Test instead of resource.Test for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      resource.Test($T, $TC)
+    fix: |
+      acctest.Test(ctx, $T, $TC)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: use-acctest-paralleltest
+    languages: [go]
+    message: "Use acctest.ParallelTest instead of resource.ParallelTest for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      resource.ParallelTest($T, $TC)
+    fix: |
+      acctest.ParallelTest(ctx, $T, $TC)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: use-acctest-randomwithprefix
+    languages: [go]
+    message: "Use acctest.RandomWithPrefix instead of sdkacctest.RandomWithPrefix for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      sdkacctest.RandomWithPrefix($P)
+    fix: |
+      acctest.RandomWithPrefix(t, $P)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: use-acctest-randint
+    languages: [go]
+    message: "Use acctest.RandInt instead of sdkacctest.RandInt for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      sdkacctest.RandInt()
+    fix: |
+      acctest.RandInt(t)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: use-acctest-providermeta
+    languages: [go]
+    message: "Use acctest.ProviderMeta instead of acctest.Provider.Meta for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      acctest.Provider.Meta().(*conns.AWSClient).$C(ctx)
+    fix: |
+      acctest.ProviderMeta(ctx, t).$C(ctx)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: add-testing-t-to-destroy-testcheckfunc
+    languages: [go]
+    message: "Add a testing.T argument into destroy TestCheckFunc helpers for VCR-compatible acceptance testing"
+    severity: WARNING
+    patterns:
+      - pattern: |
+          func $F(ctx context.Context) resource.TestCheckFunc
+      - metavariable-regex:
+          metavariable: $F
+          regex: (testAccCheck.*Destroy.*)
+    fix: |
+      func $F(ctx context.Context, t *testing.T) resource.TestCheckFunc
+    paths:
+      include:
+        - "**/*_test.go"
+
+  - id: add-testing-t-to-exists-testcheckfunc
+    languages: [go]
+    message: "Add a testing.T argument into exists TestCheckFunc helpers for VCR-compatible acceptance testing"
+    severity: WARNING
+    patterns:
+      - pattern: |
+          func $F(ctx context.Context, $...ARGS) resource.TestCheckFunc
+      - pattern-not: |
+          func $F(ctx context.Context) resource.TestCheckFunc
+      - pattern-not: |
+          func $F(..., t *testing.T, ...) resource.TestCheckFunc
+      - metavariable-regex:
+          metavariable: $F
+          regex: (testAccCheck.*Exists$)
+    fix: |
+      func $F(ctx context.Context, t *testing.T, $...ARGS) resource.TestCheckFunc
+    paths:
+      include:
+        - "**/*_test.go"
+
+  # NOTE: because this matched pattern is inside another section which is replaced by a previous rule,
+  # autofix may need to be run twice in order to apply this change.
+  - id: pass-testing-t-to-destroy-testcheckfunc
+    languages: [go]
+    message: "Pass testing.T argument into destroy TestCheckFunc helpers for VCR-compatible acceptance testing"
+    severity: WARNING
+    patterns:
+      - pattern-inside: "resource.TestCase{ ... }"
+      - pattern: |
+          $F(ctx)
+      - metavariable-regex:
+          metavariable: $F
+          regex: (testAccCheck.*Destroy.*)
+    fix: |
+      $F(ctx, t)
+    paths:
+      include:
+        - "**/*_test.go"
+
+  # NOTE: because this matched pattern is inside another section which is replaced by a previous rule,
+  # autofix may need to be run twice in order to apply this change.
+  - id: pass-testing-t-to-exists-testcheckfunc
+    languages: [go]
+    message: "Pass testing.T argument into exists TestCheckFunc helpers for VCR-compatible acceptance testing"
+    severity: WARNING
+    patterns:
+      - pattern-either:
+          - pattern-inside: "Check: resource.ComposeTestCheckFunc( ... )"
+          - pattern-inside: "Check: resource.ComposeAggregateTestCheckFunc( ... )"
+      - pattern: |
+          $F(ctx, $...ARGS)
+      - pattern-not: |
+          $F(ctx)
+      - pattern-not: |
+          $F(..., t, ...)
+      - metavariable-regex:
+          metavariable: $F
+          regex: (testAccCheck.*Exists$)
+    fix: |
+      $F(ctx, t, $...ARGS)
+    paths:
+      include:
+        - "**/*_test.go"


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
These rules will apply autofixes that enable VCR support for a given service package. At this time the intent is to manually apply the rules one service at a time and run acceptance tests (both with and without VCR enabled) to verify no breakage has occurred.

A new Make target, `make semgrep-vcr`, has been added to simplify how this process is completed.

```console
% PKG=logs make semgrep-vcr
```
Because certain autofixes apply changes inside blocks which are modified by other rules, this command may need to be run twice to fully complete the process. Additionally, the resulting code may need to be reformatted and imports may need to be tidied, depending on the scope of the change.

```console
% make fmt
```

```console
% goimports -w internal/service/logs/
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25602 
Closes #42827
