### PR TITLE
Don't retry on InsufficientInstanceCapacity error

### DIFF
--- a/internal/service/ec2/acc_test.go
+++ b/internal/service/ec2/acc_test.go
@@ -27,6 +27,7 @@ func testAccErrorCheckSkip(t *testing.T) resource.ErrorCheckFunc {
 			"HostLimitExceeded",
 			"ReservationCapacityExceeded",
 			"InsufficientInstanceCapacity",
+			"InsufficientVolumeCapacity",
 			"There is no Spot capacity available that matches your request",
 		),
 		acctest.ErrorCheckSkipMessagesMatches(t,

--- a/internal/service/ec2/errors.go
+++ b/internal/service/ec2/errors.go
@@ -23,6 +23,7 @@ const (
 	errCodeIPAMOrganizationAccountNotRegistered                    = "IpamOrganizationAccountNotRegistered"
 	errCodeIncorrectState                                          = "IncorrectState"
 	errCodeInsufficientInstanceCapacity                            = "InsufficientInstanceCapacity"
+	errCodeInsufficientVolumeCapacity                              = "InsufficientVolumeCapacity"
 	errCodeInvalidAMIIDNotFound                                    = "InvalidAMIID.NotFound"
 	errCodeInvalidAMIIDUnavailable                                 = "InvalidAMIID.Unavailable"
 	errCodeInvalidAddressNotFound                                  = "InvalidAddress.NotFound"

--- a/internal/service/ec2/service_package.go
+++ b/internal/service/ec2/service_package.go
@@ -27,6 +27,10 @@ func (p *servicePackage) withExtraOptions(_ context.Context, config map[string]a
 					return aws.TrueTernary
 				}
 
+				if tfawserr.ErrCodeEquals(err, errCodeInsufficientVolumeCapacity) { // CreateCapacityReservation, RunInstances
+					return aws.TrueTernary
+				}
+
 				if tfawserr.ErrMessageContains(err, errCodeOperationNotPermitted, "Endpoint cannot be created while another endpoint is being created") { // CreateClientVpnEndpoint
 					return aws.TrueTernary
 				}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
