### PR TITLE
Technical debt: Fold `framework.WithNoOpUpdate` into `framework.ResourceWithModel`

### DIFF
--- a/docs/add-a-new-datasource.md
+++ b/docs/add-a-new-datasource.md
@@ -46,12 +46,16 @@ Data Sources use a self-registration process that adds them to the provider usin
     )
 
     // @FrameworkDataSource("aws_something_example", name="Example")
-    func newResourceExample(_ context.Context) (datasource.ResourceWithConfigure, error) {
-    	return &dataSourceExample{}, nil
+    func newExampleDataSource(_ context.Context) (datasource.DataSourceWithConfigure, error) {
+    	return &exampleDataSource{}, nil
     }
 
-    type dataSourceExample struct {
-	    framework.DataSourceWithConfigure
+    type exampleDataSource struct {
+    	framework.DataSourceWithModel[exampleDataSourceModel]
+    }
+
+    type exampleDataSourceModel {
+    	// Fields corresponding to attributes in the Schema.
     }
     ```
 

--- a/docs/add-a-new-ephemeral-resource.md
+++ b/docs/add-a-new-ephemeral-resource.md
@@ -46,12 +46,16 @@ import (
 )
 
 // @EphemeralResource("aws_something_example", name="Example")
-func newEphemeralExample(_ context.Context) (ephemeral.EphemeralResourceWithConfigure, error) {
-	return &ephemeralExample{}, nil
+func newExampleEphemeralResource(_ context.Context) (ephemeral.EphemeralResourceWithConfigure, error) {
+	return &exampleEphemeralResource{}, nil
 }
 
-type ephemeralExample struct {
-	framework.EphemeralResourceWithConfigure
+type exampleEphemeralResource struct {
+	framework.EphemeralResourceWithModel[exampleEphemeralResourceModel]
+}
+
+type exampleEphemeralResourceModel {
+	// Fields corresponding to attributes in the Schema.
 }
 ```
 

--- a/docs/add-a-new-resource.md
+++ b/docs/add-a-new-resource.md
@@ -48,12 +48,16 @@ Resources use a self-registration process that adds them to the provider using t
     )
 
     // @FrameworkResource("aws_something_example", name="Example")
-    func newResourceExample(_ context.Context) (resource.ResourceWithConfigure, error) {
+    func newExampleResource(_ context.Context) (resource.ResourceWithConfigure, error) {
     	return &resourceExample{}, nil
     }
 
-    type resourceExample struct {
-    	framework.ResourceWithConfigure
+    type exampleResource struct {
+    	framework.ResourceWithModel[exampleResourceModel]
+    }
+
+    type exampleResourceModel struct {
+    	// Fields corresponding to attributes in the Schema.
     }
     ```
 

--- a/internal/flex/flex.go
+++ b/internal/flex/flex.go
@@ -197,7 +197,7 @@ func FlattenStringValueSetCaseInsensitive(list []string) *schema.Set {
 }
 
 func FlattenStringyValueSet[E ~string](list []E) *schema.Set {
-	return schema.NewSet(schema.HashString, FlattenStringyValueList[E](list))
+	return schema.NewSet(schema.HashString, FlattenStringyValueList(list))
 }
 
 func FlattenStringValueMap(m map[string]string) map[string]any {

--- a/internal/framework/resource_with_model.go
+++ b/internal/framework/resource_with_model.go
@@ -17,8 +17,9 @@ import (
 
 // ResourceWithModel is a structure to be embedded within a Resource that has a corresponding model.
 type ResourceWithModel[T any] struct {
-	withModel[T]
 	ResourceWithConfigure
+	withNoOpUpdate[T]
+	withModel[T]
 }
 
 // ValidateModel validates the resource's model against a schema.

--- a/internal/framework/with_noop_update.go
+++ b/internal/framework/with_noop_update.go
@@ -9,11 +9,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// WithNoOpUpdate is intended to be embedded in resources which have no need of a custom Update method.
+// withNoOpUpdate is intended to be embedded in resources which have no need of a custom Update method.
 // For example, resources where only `tags` can be updated and that is handled via transparent tagging.
-type WithNoOpUpdate[T any] struct{}
+type withNoOpUpdate[T any] struct{}
 
-func (w *WithNoOpUpdate[T]) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+func (w *withNoOpUpdate[T]) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
 	var t T
 	response.Diagnostics.Append(request.Plan.Get(ctx, &t)...)
 	if response.Diagnostics.HasError() {

--- a/internal/service/apigateway/domain_name_access_association.go
+++ b/internal/service/apigateway/domain_name_access_association.go
@@ -42,7 +42,6 @@ func newDomainNameAccessAssociationResource(context.Context) (resource.ResourceW
 
 type domainNameAccessAssociationResource struct {
 	framework.ResourceWithModel[domainNameAccessAssociationResourceModel]
-	framework.WithNoOpUpdate[domainNameAccessAssociationResourceModel]
 	framework.WithImportByARN
 }
 

--- a/internal/service/appfabric/app_bundle.go
+++ b/internal/service/appfabric/app_bundle.go
@@ -41,7 +41,6 @@ func newAppBundleResource(context.Context) (resource.ResourceWithConfigure, erro
 
 type appBundleResource struct {
 	framework.ResourceWithModel[appBundleResourceModel]
-	framework.WithNoOpUpdate[appBundleResourceModel]
 	framework.WithImportByARN
 }
 

--- a/internal/service/appfabric/ingestion.go
+++ b/internal/service/appfabric/ingestion.go
@@ -44,7 +44,6 @@ func newIngestionResource(context.Context) (resource.ResourceWithConfigure, erro
 
 type ingestionResource struct {
 	framework.ResourceWithModel[ingestionResourceModel]
-	framework.WithNoOpUpdate[ingestionResourceModel]
 	framework.WithImportByID
 }
 

--- a/internal/service/backup/logically_air_gapped_vault.go
+++ b/internal/service/backup/logically_air_gapped_vault.go
@@ -49,7 +49,6 @@ func newLogicallyAirGappedVaultResource(_ context.Context) (resource.ResourceWit
 
 type logicallyAirGappedVaultResource struct {
 	framework.ResourceWithModel[logicallyAirGappedVaultResourceModel]
-	framework.WithNoOpUpdate[logicallyAirGappedVaultResourceModel]
 	framework.WithTimeouts
 	framework.WithImportByID
 }

--- a/internal/service/bedrock/guardrail_version.go
+++ b/internal/service/bedrock/guardrail_version.go
@@ -42,7 +42,6 @@ func newGuardrailVersionResource(_ context.Context) (resource.ResourceWithConfig
 
 type guardrailVersionResource struct {
 	framework.ResourceWithModel[guardrailVersionResourceModel]
-	framework.WithNoOpUpdate[guardrailVersionResourceModel]
 	framework.WithTimeouts
 }
 

--- a/internal/service/bedrock/provisioned_model_throughput.go
+++ b/internal/service/bedrock/provisioned_model_throughput.go
@@ -48,7 +48,6 @@ func newProvisionedModelThroughputResource(context.Context) (resource.ResourceWi
 
 type provisionedModelThroughputResource struct {
 	framework.ResourceWithModel[provisionedModelThroughputResourceModel]
-	framework.WithNoOpUpdate[provisionedModelThroughputResourceModel]
 	framework.WithTimeouts
 }
 

--- a/internal/service/cloudwatch/contributor_managed_insight_rule.go
+++ b/internal/service/cloudwatch/contributor_managed_insight_rule.go
@@ -58,7 +58,6 @@ const (
 
 type contributorManagedInsightRuleResource struct {
 	framework.ResourceWithModel[contributorManagedInsightRuleResourceModel]
-	framework.WithNoOpUpdate[contributorManagedInsightRuleResourceModel]
 }
 
 func (r *contributorManagedInsightRuleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/ec2/ec2_capacity_block_reservation.go
+++ b/internal/service/ec2/ec2_capacity_block_reservation.go
@@ -43,7 +43,6 @@ type capacityBlockReservationResource struct {
 	framework.ResourceWithModel[capacityBlockReservationReservationModel]
 	framework.WithTimeouts
 	framework.WithImportByID
-	framework.WithNoOpUpdate[capacityBlockReservationReservationModel]
 	framework.WithNoOpDelete
 }
 

--- a/internal/service/ec2/ec2_instance_connect_endpoint.go
+++ b/internal/service/ec2/ec2_instance_connect_endpoint.go
@@ -46,7 +46,6 @@ func newInstanceConnectEndpointResource(context.Context) (resource.ResourceWithC
 
 type instanceConnectEndpointResource struct {
 	framework.ResourceWithModel[instanceConnectEndpointResourceModel]
-	framework.WithNoOpUpdate[instanceConnectEndpointResourceModel]
 	framework.WithImportByID
 	framework.WithTimeouts
 }

--- a/internal/service/ec2/ec2_launch_template.go
+++ b/internal/service/ec2/ec2_launch_template.go
@@ -2502,11 +2502,11 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.AcceleratorManufacturers; v != nil {
-		tfMap["accelerator_manufacturers"] = flex.FlattenStringyValueSet[awstypes.AcceleratorManufacturer](v)
+		tfMap["accelerator_manufacturers"] = v
 	}
 
 	if v := apiObject.AcceleratorNames; v != nil {
-		tfMap["accelerator_names"] = flex.FlattenStringyValueSet[awstypes.AcceleratorName](v)
+		tfMap["accelerator_names"] = v
 	}
 
 	if v := apiObject.AcceleratorTotalMemoryMiB; v != nil {
@@ -2514,7 +2514,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.AcceleratorTypes; v != nil {
-		tfMap["accelerator_types"] = flex.FlattenStringyValueSet[awstypes.AcceleratorType](v)
+		tfMap["accelerator_types"] = v
 	}
 
 	if v := apiObject.AllowedInstanceTypes; v != nil {
@@ -2534,7 +2534,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.CpuManufacturers; v != nil {
-		tfMap["cpu_manufacturers"] = flex.FlattenStringyValueSet[awstypes.CpuManufacturer](v)
+		tfMap["cpu_manufacturers"] = v
 	}
 
 	if v := apiObject.ExcludedInstanceTypes; v != nil {
@@ -2542,7 +2542,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.InstanceGenerations; v != nil {
-		tfMap["instance_generations"] = flex.FlattenStringyValueSet[awstypes.InstanceGeneration](v)
+		tfMap["instance_generations"] = v
 	}
 
 	if v := apiObject.LocalStorage; v != "" {
@@ -2550,7 +2550,7 @@ func flattenInstanceRequirements(apiObject *awstypes.InstanceRequirements) map[s
 	}
 
 	if v := apiObject.LocalStorageTypes; v != nil {
-		tfMap["local_storage_types"] = flex.FlattenStringyValueSet[awstypes.LocalStorageType](v)
+		tfMap["local_storage_types"] = v
 	}
 
 	if v := apiObject.MaxSpotPriceAsPercentageOfOptimalOnDemandPrice; v != nil {

--- a/internal/service/elasticache/reserved_cache_node.go
+++ b/internal/service/elasticache/reserved_cache_node.go
@@ -45,7 +45,6 @@ func newReservedCacheNodeResource(context.Context) (resource.ResourceWithConfigu
 
 type reservedCacheNodeResource struct {
 	framework.ResourceWithModel[reservedCacheNodeResourceModel]
-	framework.WithNoOpUpdate[reservedCacheNodeResourceModel]
 	framework.WithNoOpDelete
 	framework.WithImportByID
 	framework.WithTimeouts

--- a/internal/service/lakeformation/opt_in.go
+++ b/internal/service/lakeformation/opt_in.go
@@ -54,7 +54,6 @@ const (
 type optInResource struct {
 	framework.ResourceWithModel[optInResourceModel]
 	framework.WithTimeouts
-	framework.WithNoOpUpdate[optInResourceModel]
 }
 
 func (r *optInResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -91,7 +91,7 @@ func (r *deliveryResource) Schema(ctx context.Context, request resource.SchemaRe
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[s3DeliveryConfigurationModel](ctx, 1, s3DeliveryConfigurationListOptions, listplanmodifier.UseStateForUnknown()),
+			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute(ctx, 1, s3DeliveryConfigurationListOptions, listplanmodifier.UseStateForUnknown()),
 			names.AttrTags:              tftags.TagsAttribute(),
 			names.AttrTagsAll:           tftags.TagsAttributeComputedOnly(),
 		},

--- a/internal/service/logs/delivery_source.go
+++ b/internal/service/logs/delivery_source.go
@@ -40,7 +40,6 @@ func newDeliverySourceResource(context.Context) (resource.ResourceWithConfigure,
 
 type deliverySourceResource struct {
 	framework.ResourceWithModel[deliverySourceResourceModel]
-	framework.WithNoOpUpdate[deliverySourceResourceModel]
 }
 
 func (r *deliverySourceResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {

--- a/internal/service/notificationscontacts/email_contact.go
+++ b/internal/service/notificationscontacts/email_contact.go
@@ -39,7 +39,6 @@ func newEmailContactResource(_ context.Context) (resource.ResourceWithConfigure,
 
 type emailContactResource struct {
 	framework.ResourceWithModel[emailContactResourceModel]
-	framework.WithNoOpUpdate[emailContactResourceModel]
 }
 
 func (r *emailContactResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {

--- a/internal/service/pinpointsmsvoicev2/opt_out_list.go
+++ b/internal/service/pinpointsmsvoicev2/opt_out_list.go
@@ -39,7 +39,6 @@ func newOptOutListResource(context.Context) (resource.ResourceWithConfigure, err
 
 type optOutListResource struct {
 	framework.ResourceWithModel[optOutListResourceModel]
-	framework.WithNoOpUpdate[optOutListResourceModel]
 	framework.WithImportByID
 }
 

--- a/internal/service/quicksight/namespace.go
+++ b/internal/service/quicksight/namespace.go
@@ -51,7 +51,6 @@ const (
 type namespaceResource struct {
 	framework.ResourceWithModel[namespaceResourceModel]
 	framework.WithTimeouts
-	framework.WithNoOpUpdate[namespaceResourceModel]
 	framework.WithImportByID
 }
 

--- a/internal/service/rds/integration.go
+++ b/internal/service/rds/integration.go
@@ -57,7 +57,6 @@ const (
 
 type integrationResource struct {
 	framework.ResourceWithModel[integrationResourceModel]
-	framework.WithNoOpUpdate[integrationResourceModel]
 	framework.WithImportByARN
 	framework.WithTimeouts
 }

--- a/internal/service/route53profiles/association.go
+++ b/internal/service/route53profiles/association.go
@@ -56,7 +56,6 @@ var (
 
 type associationResource struct {
 	framework.ResourceWithModel[associationResourceModel]
-	framework.WithNoOpUpdate[associationResourceModel]
 	framework.WithTimeouts
 	framework.WithImportByID
 }

--- a/internal/service/route53profiles/profile.go
+++ b/internal/service/route53profiles/profile.go
@@ -47,7 +47,6 @@ const (
 
 type profileResource struct {
 	framework.ResourceWithModel[profileResourceModel]
-	framework.WithNoOpUpdate[profileResourceModel]
 	framework.WithImportByID
 	framework.WithTimeouts
 }

--- a/internal/service/s3/directory_bucket.go
+++ b/internal/service/s3/directory_bucket.go
@@ -47,7 +47,6 @@ func newDirectoryBucketResource(context.Context) (resource.ResourceWithConfigure
 
 type directoryBucketResource struct {
 	framework.ResourceWithModel[directoryBucketResourceModel]
-	framework.WithNoOpUpdate[directoryBucketResourceModel] // Only 'force_destroy' can be updated.
 	framework.WithImportByID
 }
 

--- a/internal/service/servicequotas/template_association.go
+++ b/internal/service/servicequotas/template_association.go
@@ -28,7 +28,6 @@ func newTemplateAssociationResource(context.Context) (resource.ResourceWithConfi
 
 type resourceTemplateAssociation struct {
 	framework.ResourceWithModel[templateAssociationResourceModel]
-	framework.WithNoOpUpdate[templateAssociationResourceModel]
 	framework.WithImportByID
 }
 

--- a/internal/service/vpclattice/service_network_resource_association.go
+++ b/internal/service/vpclattice/service_network_resource_association.go
@@ -46,7 +46,6 @@ func newServiceNetworkResourceAssociationResource(_ context.Context) (resource.R
 
 type serviceNetworkResourceAssociationResource struct {
 	framework.ResourceWithModel[serviceNetworkResourceAssociationResourceModel]
-	framework.WithNoOpUpdate[serviceNetworkResourceAssociationResourceModel]
 	framework.WithImportByID
 	framework.WithTimeouts
 }

--- a/internal/service/workspaces/connection_alias.go
+++ b/internal/service/workspaces/connection_alias.go
@@ -40,7 +40,6 @@ func newConnectionAliasResource(_ context.Context) (resource.ResourceWithConfigu
 
 type connectionAliasResource struct {
 	framework.ResourceWithModel[connectionAliasResourceModel]
-	framework.WithNoOpUpdate[connectionAliasResourceModel]
 	framework.WithImportByID
 	framework.WithTimeouts
 }

--- a/internal/service/xray/resource_policy.go
+++ b/internal/service/xray/resource_policy.go
@@ -39,7 +39,6 @@ const (
 
 type resourcePolicyResource struct {
 	framework.ResourceWithModel[resourcePolicyResourceModel]
-	framework.WithNoOpUpdate[resourcePolicyResourceModel]
 }
 
 func (r *resourcePolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Avoids duplication of passing the generic model type.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccPinpointSMSVoiceV2' PKG=pinpointsmsvoicev2 ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.3 test ./internal/service/pinpointsmsvoicev2/... -v -count 1 -parallel 3  -run=TestAccPinpointSMSVoiceV2 -timeout 360m -vet=off
2025/06/04 09:06:37 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/04 09:06:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccPinpointSMSVoiceV2ConfigurationSet_basic
=== PAUSE TestAccPinpointSMSVoiceV2ConfigurationSet_basic
=== RUN   TestAccPinpointSMSVoiceV2ConfigurationSet_disappears
=== PAUSE TestAccPinpointSMSVoiceV2ConfigurationSet_disappears
=== RUN   TestAccPinpointSMSVoiceV2ConfigurationSet_tags
=== PAUSE TestAccPinpointSMSVoiceV2ConfigurationSet_tags
=== RUN   TestAccPinpointSMSVoiceV2OptOutList_basic
=== PAUSE TestAccPinpointSMSVoiceV2OptOutList_basic
=== RUN   TestAccPinpointSMSVoiceV2OptOutList_disappears
=== PAUSE TestAccPinpointSMSVoiceV2OptOutList_disappears
=== RUN   TestAccPinpointSMSVoiceV2OptOutList_tags
=== PAUSE TestAccPinpointSMSVoiceV2OptOutList_tags
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_basic
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_basic
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_full
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_full
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_disappears
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_disappears
=== RUN   TestAccPinpointSMSVoiceV2PhoneNumber_tags
=== PAUSE TestAccPinpointSMSVoiceV2PhoneNumber_tags
=== CONT  TestAccPinpointSMSVoiceV2ConfigurationSet_basic
=== CONT  TestAccPinpointSMSVoiceV2OptOutList_tags
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_disappears
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_disappears (15.52s)
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_tags
--- PASS: TestAccPinpointSMSVoiceV2ConfigurationSet_basic (15.68s)
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_full
--- PASS: TestAccPinpointSMSVoiceV2OptOutList_tags (31.02s)
=== CONT  TestAccPinpointSMSVoiceV2OptOutList_basic
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_full (28.81s)
=== CONT  TestAccPinpointSMSVoiceV2OptOutList_disappears
--- PASS: TestAccPinpointSMSVoiceV2OptOutList_basic (14.48s)
=== CONT  TestAccPinpointSMSVoiceV2PhoneNumber_basic
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_tags (32.99s)
=== CONT  TestAccPinpointSMSVoiceV2ConfigurationSet_disappears
--- PASS: TestAccPinpointSMSVoiceV2OptOutList_disappears (11.04s)
=== CONT  TestAccPinpointSMSVoiceV2ConfigurationSet_tags
--- PASS: TestAccPinpointSMSVoiceV2ConfigurationSet_disappears (10.91s)
--- PASS: TestAccPinpointSMSVoiceV2PhoneNumber_basic (17.39s)
--- PASS: TestAccPinpointSMSVoiceV2ConfigurationSet_tags (30.40s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/pinpointsmsvoicev2	90.975s
```
