### PR TITLE
add ValidateAttribute to listOf custom type

### DIFF
--- a/internal/framework/types/listof.go
+++ b/internal/framework/types/listof.go
@@ -50,6 +50,10 @@ func ListOfStringEnumType[T enum.Valueser[T]]() listTypeOf[StringEnum[T]] {
 				return diags
 			}
 
+			if enumVal.IsNull() || enumVal.IsUnknown() {
+				continue
+			}
+
 			if !slices.Contains(val.ValueEnum().Values(), val.ValueEnum()) {
 				parentPath := fmt.Sprintf("%v[%d]", path, index)
 				diags.AddAttributeError(

--- a/internal/framework/types/listof.go
+++ b/internal/framework/types/listof.go
@@ -6,9 +6,12 @@ package types
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
@@ -16,29 +19,60 @@ import (
 )
 
 var (
-	_ basetypes.ListTypable  = (*listTypeOf[basetypes.StringValue])(nil)
-	_ basetypes.ListValuable = (*ListValueOf[basetypes.StringValue])(nil)
+	_ basetypes.ListTypable       = (*listTypeOf[basetypes.StringValue])(nil)
+	_ basetypes.ListValuable      = (*ListValueOf[basetypes.StringValue])(nil)
+	_ xattr.ValidateableAttribute = (*ListValueOf[basetypes.StringValue])(nil)
 )
 
 var (
 	// ListOfStringType is a custom type used for defining a List of strings.
-	ListOfStringType = listTypeOf[basetypes.StringValue]{basetypes.ListType{ElemType: basetypes.StringType{}}}
+	ListOfStringType = listTypeOf[basetypes.StringValue]{basetypes.ListType{ElemType: basetypes.StringType{}}, nil}
 
 	// ListOfARNType is a custom type used for defining a List of ARNs.
-	ListOfARNType = listTypeOf[ARN]{basetypes.ListType{ElemType: ARNType}}
+	ListOfARNType = listTypeOf[ARN]{basetypes.ListType{ElemType: ARNType}, nil}
 )
+
+type validateAttributeFunc func(context.Context, path.Path, []attr.Value) diag.Diagnostics
 
 // TODO Replace with Go 1.24 generic type alias when available.
 func ListOfStringEnumType[T enum.Valueser[T]]() listTypeOf[StringEnum[T]] {
-	return listTypeOf[StringEnum[T]]{basetypes.ListType{ElemType: StringEnumType[T]()}}
+	validateFunc := func(ctx context.Context, path path.Path, values []attr.Value) diag.Diagnostics {
+		var diags diag.Diagnostics
+		for index, enumVal := range values {
+			val, ok := enumVal.(StringEnum[T])
+			if !ok {
+				diags.AddAttributeError(
+					path,
+					"Invalid String Enum Type",
+					fmt.Sprintf("Expected type: %v, got: %v", StringEnum[T]{}.Type(ctx), enumVal.Type(ctx)),
+				)
+
+				return diags
+			}
+
+			if !slices.Contains(val.ValueEnum().Values(), val.ValueEnum()) {
+				parentPath := fmt.Sprintf("%v[%d]", path, index)
+				diags.AddAttributeError(
+					path,
+					"Invalid String Enum Value",
+					fmt.Sprintf("Value [%s] at attribute %v is not a valid enum value. Valid values are: %s",
+						val.ValueString(), parentPath, val.ValueEnum().Values()),
+				)
+			}
+		}
+		return diags
+	}
+
+	return listTypeOf[StringEnum[T]]{basetypes.ListType{ElemType: StringEnumType[T]()}, validateFunc}
 }
 
 type listTypeOf[T attr.Value] struct {
 	basetypes.ListType
+	validateAttributeFunc validateAttributeFunc
 }
 
 func newListTypeOf[T attr.Value](ctx context.Context) listTypeOf[T] {
-	return listTypeOf[T]{basetypes.ListType{ElemType: newAttrTypeOf[T](ctx)}}
+	return listTypeOf[T]{basetypes.ListType{ElemType: newAttrTypeOf[T](ctx)}, nil}
 }
 
 func (t listTypeOf[T]) Equal(o attr.Type) bool {
@@ -73,7 +107,7 @@ func (t listTypeOf[T]) ValueFromList(ctx context.Context, in basetypes.ListValue
 		return NewListValueOfUnknown[T](ctx), diags
 	}
 
-	return ListValueOf[T]{ListValue: v}, diags
+	return ListValueOf[T]{ListValue: v, validateAttributeFunc: t.validateAttributeFunc}, diags
 }
 
 func (t listTypeOf[T]) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
@@ -104,6 +138,7 @@ func (t listTypeOf[T]) ValueType(ctx context.Context) attr.Value {
 
 type ListValueOf[T attr.Value] struct {
 	basetypes.ListValue
+	validateAttributeFunc validateAttributeFunc
 }
 
 type (
@@ -123,6 +158,14 @@ func (v ListValueOf[T]) Equal(o attr.Value) bool {
 
 func (v ListValueOf[T]) Type(ctx context.Context) attr.Type {
 	return newListTypeOf[T](ctx)
+}
+
+func (v ListValueOf[T]) ValidateAttribute(ctx context.Context, req xattr.ValidateAttributeRequest, resp *xattr.ValidateAttributeResponse) {
+	if v.IsNull() || v.IsUnknown() || v.validateAttributeFunc == nil {
+		return
+	}
+
+	resp.Diagnostics.Append(v.validateAttributeFunc(ctx, req.Path, v.Elements())...)
 }
 
 func NewListValueOfNull[T attr.Value](ctx context.Context) ListValueOf[T] {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

To properly validate values in a list the `ValidateAttribute` interface must be implemented. This implements and adds custom validation for StringEnumTypes.

#### usage 

```go
names.AttrPermissions: schema.ListAttribute{
    CustomType: fwtypes.ListOfStringEnumType[awstypes.ScopePermission](),
    Optional: true,
},
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Relates #42338

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
go test -count=1 -v internal/framework/types/listof_test.go
=== RUN   TestListOfStringFromTerraform
=== PAUSE TestListOfStringFromTerraform
=== RUN   TestListOfValidateAttribute
=== PAUSE TestListOfValidateAttribute
=== CONT  TestListOfStringFromTerraform
=== CONT  TestListOfValidateAttribute
=== RUN   TestListOfValidateAttribute/unknown_value
=== PAUSE TestListOfValidateAttribute/unknown_value
=== RUN   TestListOfValidateAttribute/valid_values
=== PAUSE TestListOfValidateAttribute/valid_values
=== RUN   TestListOfValidateAttribute/invalid_values
=== RUN   TestListOfStringFromTerraform/values
=== PAUSE TestListOfStringFromTerraform/values
=== CONT  TestListOfStringFromTerraform/values
=== PAUSE TestListOfValidateAttribute/invalid_values
=== RUN   TestListOfValidateAttribute/null_value
=== PAUSE TestListOfValidateAttribute/null_value
=== CONT  TestListOfValidateAttribute/unknown_value
=== CONT  TestListOfValidateAttribute/valid_values
=== CONT  TestListOfValidateAttribute/null_value
=== CONT  TestListOfValidateAttribute/invalid_values
--- PASS: TestListOfValidateAttribute (0.00s)
    --- PASS: TestListOfValidateAttribute/unknown_value (0.00s)
    --- PASS: TestListOfValidateAttribute/valid_values (0.00s)
    --- PASS: TestListOfValidateAttribute/null_value (0.00s)
    --- PASS: TestListOfValidateAttribute/invalid_values (0.00s)
--- PASS: TestListOfStringFromTerraform (0.00s)
    --- PASS: TestListOfStringFromTerraform/values (0.00s)
PASS
ok  	command-line-arguments	0.517s
```
