### PR TITLE
Add attribute validation to SetOf custom type

### DIFF
--- a/internal/framework/types/listof.go
+++ b/internal/framework/types/listof.go
@@ -50,7 +50,7 @@ func ListOfStringEnumType[T enum.Valueser[T]]() listTypeOf[StringEnum[T]] {
 				return diags
 			}
 
-			if enumVal.IsNull() || enumVal.IsUnknown() {
+			if val.IsNull() || val.IsUnknown() {
 				continue
 			}
 

--- a/internal/framework/types/setof_test.go
+++ b/internal/framework/types/setof_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/attr/xattr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
@@ -50,6 +51,59 @@ func TestSetOfStringFromTerraform(t *testing.T) {
 
 			if diff := cmp.Diff(val, test.expected); diff != "" {
 				t.Errorf("unexpected diff (+wanted, -got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetOfValidateAttribute(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		val         []attr.Value
+		expectError bool
+	}{
+		"null value": {
+			val: []attr.Value{
+				fwtypes.StringEnumNull[mockEnum](),
+			},
+		},
+		"unknown value": {
+			val: []attr.Value{
+				fwtypes.StringEnumUnknown[mockEnum](),
+			},
+		},
+		"valid values": { // lintignore:AWSAT003,AWSAT005
+			val: []attr.Value{
+				fwtypes.StringEnumValue[mockEnum]("red"),
+				fwtypes.StringEnumValue[mockEnum]("blue"),
+			},
+		},
+		"invalid values": {
+			val: []attr.Value{
+				fwtypes.StringEnumValue[mockEnum]("blue"),
+				fwtypes.StringEnumValue[mockEnum]("green"),
+			},
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			req := xattr.ValidateAttributeRequest{}
+			resp := xattr.ValidateAttributeResponse{}
+
+			listOfEnums := fwtypes.SetOfStringEnumType[mockEnum]()
+			values, _ := listOfEnums.ValueFromSet(ctx, types.SetValueMust(fwtypes.StringEnumType[mockEnum](), test.val))
+
+			// asserting here because we know the interface is implemented
+			eval := values.(fwtypes.SetValueOf[fwtypes.StringEnum[mockEnum]])
+			eval.ValidateAttribute(ctx, req, &resp)
+			if resp.Diagnostics.HasError() != test.expectError {
+				t.Errorf("resp.Diagnostics.HasError() = %t, want = %t", resp.Diagnostics.HasError(), test.expectError)
 			}
 		})
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Validate elements of a set when validation is required.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

--->

Closes #42872

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -v -count=1 ./internal/framework/types/... -run=TestSetOf

=== RUN   TestSetOfStringFromTerraform
=== PAUSE TestSetOfStringFromTerraform
=== RUN   TestSetOfValidateAttribute
=== PAUSE TestSetOfValidateAttribute
=== CONT  TestSetOfStringFromTerraform
=== CONT  TestSetOfValidateAttribute
=== RUN   TestSetOfValidateAttribute/null_value
=== PAUSE TestSetOfValidateAttribute/null_value
=== RUN   TestSetOfValidateAttribute/unknown_value
=== PAUSE TestSetOfValidateAttribute/unknown_value
=== RUN   TestSetOfValidateAttribute/valid_values
=== PAUSE TestSetOfValidateAttribute/valid_values
=== RUN   TestSetOfValidateAttribute/invalid_values
=== PAUSE TestSetOfValidateAttribute/invalid_values
=== CONT  TestSetOfValidateAttribute/null_value
=== CONT  TestSetOfValidateAttribute/valid_values
=== CONT  TestSetOfValidateAttribute/invalid_values
=== RUN   TestSetOfStringFromTerraform/values
=== PAUSE TestSetOfStringFromTerraform/values
=== CONT  TestSetOfStringFromTerraform/values
=== CONT  TestSetOfValidateAttribute/unknown_value
--- PASS: TestSetOfValidateAttribute (0.00s)
    --- PASS: TestSetOfValidateAttribute/null_value (0.00s)
    --- PASS: TestSetOfValidateAttribute/valid_values (0.00s)
    --- PASS: TestSetOfValidateAttribute/invalid_values (0.00s)
    --- PASS: TestSetOfValidateAttribute/unknown_value (0.00s)
--- PASS: TestSetOfStringFromTerraform (0.00s)
    --- PASS: TestSetOfStringFromTerraform/values (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/framework/types	0.263s
```

```console
% make testacc TESTARGS="-run=TestAccCloudFrontVPCOrigin_basic" PKG=cloudfront

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/cloudfront/... -v -count 1 -parallel 20  -run=TestAccCloudFrontVPCOrigin_basic -timeout 360m -vet=off
2025/06/05 12:19:27 Initializing Terraform AWS Provider...
=== RUN   TestAccCloudFrontVPCOrigin_basic
=== PAUSE TestAccCloudFrontVPCOrigin_basic
=== CONT  TestAccCloudFrontVPCOrigin_basic
--- PASS: TestAccCloudFrontVPCOrigin_basic (999.72s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/cloudfront	1005.477s
```
