### PR TITLE
r/aws_logs: add return first match option to resource finders

### DIFF
--- a/.changelog/42896.txt
+++ b/.changelog/42896.txt
@@ -1,0 +1,18 @@
+```release-note:bug
+resource/aws_cloudwatch_log_destination: Fix to return the first matched destination name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```
+```release-note:bug
+resource/aws_cloudwatch_log_group: Fix to return the first matched group name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```
+```release-note:bug
+resource/aws_cloudwatch_log_metric_filter: Fix to return the first matched filter name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```
+```release-note:bug
+resource/aws_cloudwatch_log_query_definition: Fix to return the first matched query definition ID during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```
+```release-note:bug
+resource/aws_cloudwatch_log_resource_policy: Fix to return the first matched policy name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```
+```release-note:bug
+resource/aws_cloudwatch_log_subscription_filter: Fix to return the first matched filter name during the read operation. This fixes a regression introduced in [v5.83.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#5830-january--9-2025)
+```

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -91,7 +91,7 @@ func (r *deliveryResource) Schema(ctx context.Context, request resource.SchemaRe
 					listplanmodifier.UseStateForUnknown(),
 				},
 			},
-			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute[s3DeliveryConfigurationModel](ctx, 1, s3DeliveryConfigurationListOptions, listplanmodifier.UseStateForUnknown()),
+			"s3_delivery_configuration": framework.ResourceOptionalComputedListOfObjectsAttribute(ctx, 1, s3DeliveryConfigurationListOptions, listplanmodifier.UseStateForUnknown()),
 			names.AttrTags:              tftags.TagsAttribute(),
 			names.AttrTagsAll:           tftags.TagsAttributeComputedOnly(),
 		},

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -256,7 +256,7 @@ func findLogGroupByName(ctx context.Context, conn *cloudwatchlogs.Client, name s
 }
 
 func findLogGroup(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogGroupsInput, filter tfslices.Predicate[*awstypes.LogGroup]) (*awstypes.LogGroup, error) {
-	output, err := findLogGroups(ctx, conn, input, filter)
+	output, err := findLogGroups(ctx, conn, input, filter, tfslices.WithReturnFirstMatch)
 
 	if err != nil {
 		return nil, err
@@ -265,8 +265,9 @@ func findLogGroup(ctx context.Context, conn *cloudwatchlogs.Client, input *cloud
 	return tfresource.AssertSingleValueResult(output)
 }
 
-func findLogGroups(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogGroupsInput, filter tfslices.Predicate[*awstypes.LogGroup]) ([]awstypes.LogGroup, error) {
+func findLogGroups(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogGroupsInput, filter tfslices.Predicate[*awstypes.LogGroup], optFns ...tfslices.FinderOptionsFunc) ([]awstypes.LogGroup, error) {
 	var output []awstypes.LogGroup
+	opts := tfslices.NewFinderOptions(optFns)
 
 	pages := cloudwatchlogs.NewDescribeLogGroupsPaginator(conn, input)
 	for pages.HasMorePages() {
@@ -279,6 +280,9 @@ func findLogGroups(ctx context.Context, conn *cloudwatchlogs.Client, input *clou
 		for _, v := range page.LogGroups {
 			if filter(&v) {
 				output = append(output, v)
+				if opts.ReturnFirstMatch() {
+					return output, nil
+				}
 			}
 		}
 	}

--- a/internal/service/logs/stream.go
+++ b/internal/service/logs/stream.go
@@ -153,7 +153,7 @@ func findLogStreamByTwoPartKey(ctx context.Context, conn *cloudwatchlogs.Client,
 }
 
 func findLogStream(ctx context.Context, conn *cloudwatchlogs.Client, input *cloudwatchlogs.DescribeLogStreamsInput, filter tfslices.Predicate[*awstypes.LogStream]) (*awstypes.LogStream, error) { // nosemgrep:ci.logs-in-func-name
-	output, err := findLogStreams(ctx, conn, input, filter, tfslices.WithReturnFirstMatch())
+	output, err := findLogStreams(ctx, conn, input, filter, tfslices.WithReturnFirstMatch)
 
 	if err != nil {
 		return nil, err

--- a/internal/slices/options.go
+++ b/internal/slices/options.go
@@ -21,8 +21,11 @@ func (o *FinderOptions) ReturnFirstMatch() bool {
 
 type FinderOptionsFunc func(*FinderOptions)
 
-func WithReturnFirstMatch() FinderOptionsFunc {
-	return func(o *FinderOptions) {
-		o.returnFirstMatch = true
-	}
+// WithReturnFirstMatch is a finder option to enable paginated operations to short
+// circuit after the first filter match
+//
+// This option should only be used when only a single match will ever be returned
+// from the specified filter.
+var WithReturnFirstMatch = func(o *FinderOptions) {
+	o.returnFirstMatch = true
 }


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Prior to a recent refactoring of the finders in the `logs` package, the behavior of calls to paginated APIs was to return immediately upon finding a match to the provided filter (e.g. and exact log stream name). The refactor changed this behavior slightly to iterate over all pages of the response instead and assert that the filtered output contains only a single result. While this change ensures filters are written accurately (any filtered response containing multiple values will now trigger an error), it introduced a potential performance regression when paginating over large sets of resources, especially in configurations which contain many instances of one of the impacted resources.

This change adds functional option argument to the impacted resource finders, allowing the calling function to indicate the first filter match should be returned to match the pre-existing behavior. In a future major version we can consider removing the "return first match" behavior in favor of fully exhausting all pages to ensure the accuracy of the provided filter.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #40594
Relates #42713
Relates #42719

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=logs TESTS="TestAccLogsDelivery_|TestAccLogsDestination_|TestAccLogsGroup_|TestAccLogsMetricFilter_|TestAccLogsQueryDefinition_|TestAccLogsResourcePolicy_|TestAccLogsStream_|TestAccLogsSubscriptionFilter_"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsDelivery_|TestAccLogsDestination_|TestAccLogsGroup_|TestAccLogsMetricFilter_|TestAccLogsQueryDefinition_|TestAccLogsResourcePolicy_|TestAccLogsStream_|TestAccLogsSubscriptionFilter_'  -timeout 360m -vet=off
2025/06/06 11:08:00 Initializing Terraform AWS Provider...

--- PASS: TestAccLogsGroup_skipDestroy (23.57s)
=== CONT  TestAccLogsMetricFilter_basic
--- PASS: TestAccLogsGroup_multiple (24.15s)
=== CONT  TestAccLogsGroup_skipDestroyInconsistentPlan
--- PASS: TestAccLogsGroup_logGroupClass (24.29s)
=== CONT  TestAccLogsDestination_tags_EmptyTag_OnCreate
--- PASS: TestAccLogsQueryDefinition_disappears (25.12s)
=== CONT  TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace
--- PASS: TestAccLogsStream_Disappears_logGroup (25.48s)
=== CONT  TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add
--- PASS: TestAccLogsMetricFilter_disappears (25.86s)
=== CONT  TestAccLogsMetricFilter_many
--- PASS: TestAccLogsStream_disappears (26.00s)
=== CONT  TestAccLogsMetricFilter_update
--- PASS: TestAccLogsQueryDefinition_basic (28.33s)
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream
--- PASS: TestAccLogsQueryDefinition_rename (39.78s)
=== CONT  TestAccLogsSubscriptionFilter_roleARN
--- PASS: TestAccLogsQueryDefinition_logGroups (42.36s)
=== CONT  TestAccLogsSubscriptionFilter_distribution
--- PASS: TestAccLogsSubscriptionFilter_basic (43.04s)
=== CONT  TestAccLogsDestination_basic
--- PASS: TestAccLogsMetricFilter_basic (20.93s)
=== CONT  TestAccLogsGroup_disappears
--- PASS: TestAccLogsGroup_skipDestroyInconsistentPlan (29.33s)
=== CONT  TestAccLogsGroup_namePrefix
--- PASS: TestAccLogsSubscriptionFilter_many (54.19s)
=== CONT  TestAccLogsGroup_nameGenerate
--- PASS: TestAccLogsMetricFilter_many (29.38s)
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsDestination_update
--- PASS: TestAccLogsGroup_retentionPolicy (56.56s)
--- PASS: TestAccLogsMetricFilter_update (37.37s)
=== CONT  TestAccLogsDestination_disappears
--- PASS: TestAccLogsGroup_kmsKey (66.45s)
=== CONT  TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace
--- PASS: TestAccLogsGroup_disappears (23.35s)
=== CONT  TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag
--- PASS: TestAccLogsDestination_tags_DefaultTags_emptyResourceTag (79.15s)
=== CONT  TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag
--- PASS: TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag (79.25s)
=== CONT  TestAccLogsMetricFilter_Disappears_logGroup
--- PASS: TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag (79.53s)
=== CONT  TestAccLogsDestination_tags_EmptyMap
--- PASS: TestAccLogsGroup_namePrefix (26.45s)
=== CONT  TestAccLogsDestination_tags_AddOnUpdate
--- PASS: TestAccLogsGroup_basic (26.45s)
=== CONT  TestAccLogsDestination_tags_DefaultTags_overlapping
--- PASS: TestAccLogsGroup_nameGenerate (28.81s)
=== CONT  TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly
--- PASS: TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream (68.81s)
=== CONT  TestAccLogsDestination_tags_null
--- PASS: TestAccLogsMetricFilter_Disappears_logGroup (21.56s)
=== CONT  TestAccLogsResourcePolicy_ignoreEquivalent
--- PASS: TestAccLogsSubscriptionFilter_distribution (58.76s)
=== CONT  TestAccLogsStream_basic
--- PASS: TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly (101.37s)
=== CONT  TestAccLogsSubscriptionFilter_Disappears_logGroup
--- PASS: TestAccLogsDestination_basic (68.94s)
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace (91.81s)
=== CONT  TestAccLogsResourcePolicy_basic
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnCreate (95.94s)
=== CONT  TestAccLogsSubscriptionFilter_disappears
--- PASS: TestAccLogsStream_basic (22.30s)
=== CONT  TestAccLogsDestination_tags_ComputedTag_OnCreate
--- PASS: TestAccLogsDestination_disappears (63.71s)
=== CONT  TestAccLogsDestination_tags_DefaultTags_nonOverlapping
--- PASS: TestAccLogsResourcePolicy_ignoreEquivalent (28.51s)
=== CONT  TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add
--- PASS: TestAccLogsSubscriptionFilter_roleARN (91.07s)
=== CONT  TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add (114.28s)
--- PASS: TestAccLogsSubscriptionFilter_Disappears_logGroup (39.26s)
--- PASS: TestAccLogsDestination_tags (151.58s)
--- PASS: TestAccLogsSubscriptionFilter_disappears (35.58s)
--- PASS: TestAccLogsResourcePolicy_basic (39.60s)
--- PASS: TestAccLogsDestination_tags_DefaultTags_providerOnly (157.35s)
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace (94.60s)
--- PASS: TestAccLogsDestination_tags_EmptyMap (83.19s)
--- PASS: TestAccLogsDestination_tags_null (73.91s)
--- PASS: TestAccLogsDestination_tags_AddOnUpdate (91.25s)
--- PASS: TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly (92.35s)
--- PASS: TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag (109.99s)
--- PASS: TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag (101.10s)
--- PASS: TestAccLogsDestination_update (127.35s)
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnCreate (67.94s)
--- PASS: TestAccLogsDestination_tags_DefaultTags_overlapping (111.35s)
--- PASS: TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag (65.01s)
--- PASS: TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose (89.22s)
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add (77.82s)
--- PASS: TestAccLogsDestination_tags_DefaultTags_nonOverlapping (96.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       229.536s
```
