### PR TITLE
docs: replace invalid system log level in lambda function docs

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -334,7 +334,7 @@ Advanced logging settings. See [Configuring advanced logging controls for your L
 * `application_log_level` - (Optional) for JSON structured logs, choose the detail level of the logs your application sends to CloudWatch when using supported logging libraries.
 * `log_format` - (Required) select between `Text` and structured `JSON` format for your function's logs.
 * `log_group` - (Optional) the CloudWatch log group your function sends logs to.
-* `system_log_level` - (optional) for JSON structured logs, choose the detail level of the Lambda platform event logs sent to CloudWatch, such as `ERROR`, `DEBUG`, or `INFO`.
+* `system_log_level` - (optional) for JSON structured logs, choose the detail level of the Lambda platform event logs sent to CloudWatch, such as `WARN`, `DEBUG`, or `INFO`.
 
 ### snap_start
 


### PR DESCRIPTION
## Rollback Plan

Not applicable. Only documentation is updated.

## Changes to Security Controls

No security controls are modified.

### Description

In the [documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) for the resource `aws_lambda_function` an invalid value `ERROR`  is specified for `system_log_level`.
Allowed values are defined in the SDK and used as part of the validation function.

```golang
type SystemLogLevel string

// Enum values for SystemLogLevel
const (
	SystemLogLevelDebug SystemLogLevel = "DEBUG"
	SystemLogLevelInfo  SystemLogLevel = "INFO"
	SystemLogLevelWarn  SystemLogLevel = "WARN"
)
```
### Relations

Closes #42893 

### References

- [Validation function in provider](https://github.com/hashicorp/terraform-provider-aws/blob/d76c5d0ebf839e577b310753ba3e35f8f3bdf93a/internal/service/lambda/function.go#L269)

### Output from Acceptance Testing

Not applicable. Only documentation is updated. 