### PR TITLE
docs: update key in resource import statement

### DIFF
--- a/website/docs/r/inspector2_filter.html.markdown
+++ b/website/docs/r/inspector2_filter.html.markdown
@@ -150,8 +150,8 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 
 ```terraform
 import {
-  to  = aws_inspector2_filter.example
-  arn = "arn:aws:inspector2:us-east-1:111222333444:owner/111222333444/filter/abcdefgh12345678"
+  to = aws_inspector2_filter.example
+  id = "arn:aws:inspector2:us-east-1:111222333444:owner/111222333444/filter/abcdefgh12345678"
 }
 ```
 


### PR DESCRIPTION
## Rollback Plan

Not applicable. Only documentation is updated.

## Changes to Security Controls

No security controls are modified.

### Description

The import statement for the resource [aws_inspector2_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/inspector2_filter) uses `arn` instead of `id` as key:

```hcl
import {
  to  = aws_inspector2_filter.example
  arn = "arn:aws:inspector2:us-east-1:111222333444:owner/111222333444/filter/abcdefgh12345678"
}
```

This pull requests updates the import statement so that it no longer throws errors.

### Relations

Closes #42889 

### References


### Output from Acceptance Testing

Not applicable. Only documentation is updated.