### PR TITLE
docs: fix import block reference in bedrock resources

### DIFF
--- a/website/docs/r/bedrock_custom_model.html.markdown
+++ b/website/docs/r/bedrock_custom_model.html.markdown
@@ -101,8 +101,8 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 
 ```terraform
 import {
-  to       = aws_bedrock_custom_model.example
-  model_id = "arn:aws:bedrock:us-west-2:123456789012:model-customization-job/amazon.titan-text-express-v1:0:8k/1y5n57gh5y2e"
+  to = aws_bedrock_custom_model.example
+  id = "arn:aws:bedrock:us-west-2:123456789012:model-customization-job/amazon.titan-text-express-v1:0:8k/1y5n57gh5y2e"
 }
 ```
 

--- a/website/docs/r/bedrock_provisioned_model_throughput.html.markdown
+++ b/website/docs/r/bedrock_provisioned_model_throughput.html.markdown
@@ -50,8 +50,8 @@ In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashico
 
 ```terraform
 import {
-  to       = aws_bedrock_provisioned_model_throughput.example
-  model_id = "arn:aws:bedrock:us-west-2:123456789012:provisioned-model/1y5n57gh5y2e"
+  to = aws_bedrock_provisioned_model_throughput.example
+  id = "arn:aws:bedrock:us-west-2:123456789012:provisioned-model/1y5n57gh5y2e"
 }
 ```
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
None

### Description

* Updated the import block references with incorrect attributes

```
=== bedrock_custom_model.html.markdown ===
  model_id = "arn:aws:bedrock:us-west-2:123456789012:model-customization-job/amazon.titan-text-express-v1:0:8k/1y5n57gh5y2e"

=== bedrock_provisioned_model_throughput.html.markdown ===
  model_id = "arn:aws:bedrock:us-west-2:123456789012:provisioned-model/1y5n57gh5y2e"
```


### Relations

Same issues as in https://github.com/hashicorp/terraform-provider-aws/issues/42889

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
