### PR TITLE
[POC] Go-VCR: Wrap state change data structures

### DIFF
--- a/.teamcity/scripts/provider_tests/acceptance_tests.sh
+++ b/.teamcity/scripts/provider_tests/acceptance_tests.sh
@@ -59,6 +59,7 @@ TF_ACC=1 go test \
     ./internal/sdkv2/... \
     ./internal/semver/... \
     ./internal/slices/... \
+    ./internal/state/... \
     ./internal/sweep/... \
     ./internal/tags/... \
     ./internal/tfresource/... \

--- a/.teamcity/scripts/provider_tests/unit_tests.sh
+++ b/.teamcity/scripts/provider_tests/unit_tests.sh
@@ -31,6 +31,7 @@ go test \
     ./internal/sdkv2/... \
     ./internal/semver/... \
     ./internal/slices/... \
+    ./internal/state/... \
     ./internal/sweep/... \
     ./internal/tags/... \
     ./internal/tfresource/... \

--- a/internal/acctest/vcr.go
+++ b/internal/acctest/vcr.go
@@ -393,7 +393,7 @@ func closeVCRRecorder(ctx context.Context, t *testing.T) {
 	defer randomnessSources.Unlock()
 
 	if ok {
-		if !t.Failed() {
+		if !t.Failed() && !t.Skipped() {
 			t.Log("persisting randomness seed")
 			if err := writeSeedToFile(s.seed, vcrSeedFile(vcr.Path(), t.Name())); err != nil {
 				t.Error(err)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,0 +1,31 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/vcr"
+	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
+)
+
+// NewStateChangeConf is a wrapper around the retry.StateChangeConf data structure
+// to enable compatibility with VCR testing
+//
+// When VCR testing is enabled in replay mode, the Delay and PollInterval fields are
+// overridden to allow interactions to be replayed with no observable delay between
+// state change refreshes.
+func NewStateChangeConf(ctx context.Context, stateConf retry.StateChangeConf) *retry.StateChangeConf {
+	if inContext, ok := conns.FromContext(ctx); ok && inContext.VCREnabled() {
+		if mode, _ := vcr.Mode(); mode == recorder.ModeReplayOnly {
+			stateConf.Delay = time.Millisecond * 1
+			stateConf.PollInterval = time.Millisecond * 1
+		}
+	}
+
+	return &stateConf
+}

--- a/internal/vcr/.semgrep-vcr.yml
+++ b/internal/vcr/.semgrep-vcr.yml
@@ -141,3 +141,19 @@ rules:
     paths:
       include:
         - "**/*_test.go"
+
+  - id: wrap-statechangeconf
+    languages: [go]
+    message: "Use state.NewStateChangeConf to wrap state change data structures for VCR-compatible acceptance testing"
+    severity: WARNING
+    pattern: |
+      &retry.StateChangeConf{
+        $...CFG,
+      }
+    fix: |
+      state.NewStateChangeConf(ctx, retry.StateChangeConf{
+        $...CFG,
+      })
+    paths:
+      include:
+        - "**/*.go"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
A proof-of-concept for wrapping state change data structures from the Terraform Plugin-SDK V2 `retry` package with logic to enable replayed VCR acceptance tests. Specifically, when VCR is enabled the delay and poll interval between state change checks is reduced to allow replayed interactions to quickly pass through the CRUD handler's waiting logic. This can significantly reduce test execution times for resources which are slow to provision. For example, ElastiCache clusters:

Standard:

```
--- PASS: TestAccElastiCacheCluster_Engine_redis (681.65s)
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (681.67s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        687.358s
```

Replayed Interaction:

```
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (10.49s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (10.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        16.336s
```

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25602
Relates #43039 (an alternative implementation)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Prototyping with the `elasticache` service, test execution times for basic cluster resource configurations were reduced to ~10 seconds.

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_worktrees/f-vcr-status-check/testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_Engine_redis
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.3 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_Engine_redis'  -timeout 360m -vet=off
2025/06/09 16:14:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/09 16:14:19 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (10.49s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (10.50s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        16.336s
```
