### PR TITLE
sweepers: Prevent infinite loop when listing Permission Sets returns error

### DIFF
--- a/internal/service/ssoadmin/sweep.go
+++ b/internal/service/ssoadmin/sweep.go
@@ -68,12 +68,12 @@ func sweepAccountAssignments(region string) error {
 
 		// To sweep account assignments, we need to first determine which Permission Sets
 		// are available and then search for their respective assignments
-		input := &ssoadmin.ListPermissionSetsInput{
+		input := ssoadmin.ListPermissionSetsInput{
 			InstanceArn: aws.String(instanceArn),
 		}
 
 		var permissionSetArns []string
-		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, input)
+		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, &input)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
 			if awsv2.SkipSweepError(err) || tfawserr.ErrMessageContains(err, "ValidationException", "The operation is not supported for this Identity Center instance") {
@@ -90,13 +90,13 @@ func sweepAccountAssignments(region string) error {
 		}
 
 		for _, permissionSetArn := range permissionSetArns {
-			input := &ssoadmin.ListAccountAssignmentsInput{
+			input := ssoadmin.ListAccountAssignmentsInput{
 				AccountId:        aws.String(client.AccountID(ctx)),
 				InstanceArn:      aws.String(instanceArn),
 				PermissionSetArn: aws.String(permissionSetArn),
 			}
 
-			paginator := ssoadmin.NewListAccountAssignmentsPaginator(conn, input)
+			paginator := ssoadmin.NewListAccountAssignmentsPaginator(conn, &input)
 			for paginator.HasMorePages() {
 				page, err := paginator.NextPage(ctx)
 				if awsv2.SkipSweepError(err) {
@@ -158,11 +158,11 @@ func sweepApplications(region string) error {
 	if v, ok := dsData.GetOk(names.AttrARNs); ok && len(v.([]any)) > 0 {
 		instanceArn := v.([]any)[0].(string)
 
-		input := &ssoadmin.ListApplicationsInput{
+		input := ssoadmin.ListApplicationsInput{
 			InstanceArn: aws.String(instanceArn),
 		}
 
-		paginator := ssoadmin.NewListApplicationsPaginator(conn, input)
+		paginator := ssoadmin.NewListApplicationsPaginator(conn, &input)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
 			if awsv2.SkipSweepError(err) {
@@ -215,11 +215,11 @@ func sweepPermissionSets(region string) error {
 	if v, ok := dsData.GetOk(names.AttrARNs); ok && len(v.([]any)) > 0 {
 		instanceArn := v.([]any)[0].(string)
 
-		input := &ssoadmin.ListPermissionSetsInput{
+		input := ssoadmin.ListPermissionSetsInput{
 			InstanceArn: aws.String(instanceArn),
 		}
 
-		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, input)
+		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, &input)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
 			if awsv2.SkipSweepError(err) || tfawserr.ErrMessageContains(err, "ValidationException", "The operation is not supported for this Identity Center instance") {

--- a/internal/service/ssoadmin/sweep.go
+++ b/internal/service/ssoadmin/sweep.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssoadmin"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssoadmin/types"
-	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
@@ -46,8 +46,7 @@ func sweepAccountAssignments(region string) error {
 	}
 	conn := client.SSOAdminClient(ctx)
 
-	sweepResources := make([]sweep.Sweepable, 0)
-	var sweeperErrs *multierror.Error
+	var sweepResources []sweep.Sweepable
 
 	accessDenied := regexache.MustCompile(`AccessDeniedException: .+ is not authorized to perform:`)
 
@@ -77,12 +76,12 @@ func sweepAccountAssignments(region string) error {
 		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, input)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
-			if awsv2.SkipSweepError(err) {
+			if awsv2.SkipSweepError(err) || tfawserr.ErrMessageContains(err, "ValidationException", "The operation is not supported for this Identity Center instance") {
 				log.Printf("[WARN] Skipping SSO Account Assignment sweep for %s: %s", region, err)
-				return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+				return nil
 			}
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SSO Permission Sets for Account Assignment sweep: %w", err))
+				return fmt.Errorf("error listing SSO Permission Sets for Account Assignment sweep: %w", err)
 			}
 
 			if page != nil {
@@ -105,7 +104,7 @@ func sweepAccountAssignments(region string) error {
 					continue
 				}
 				if err != nil {
-					sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SSO Account Assignments for Permission Set (%s): %w", permissionSetArn, err))
+					return fmt.Errorf("error listing SSO Account Assignments for Permission Set (%s): %w", permissionSetArn, err)
 				}
 
 				for _, a := range page.AccountAssignments {
@@ -125,10 +124,10 @@ func sweepAccountAssignments(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping SSO Account Assignments: %w", err))
+		return fmt.Errorf("error sweeping SSO Account Assignments: %w", err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }
 
 func sweepApplications(region string) error {
@@ -139,8 +138,7 @@ func sweepApplications(region string) error {
 	}
 	conn := client.SSOAdminClient(ctx)
 
-	sweepResources := make([]sweep.Sweepable, 0)
-	var sweeperErrs *multierror.Error
+	var sweepResources []sweep.Sweepable
 
 	accessDenied := regexache.MustCompile(`AccessDeniedException: .+ is not authorized to perform:`)
 
@@ -169,26 +167,24 @@ func sweepApplications(region string) error {
 			page, err := paginator.NextPage(ctx)
 			if awsv2.SkipSweepError(err) {
 				log.Printf("[WARN] Skipping SSO Applications sweep for %s: %s", region, err)
-				return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+				return nil
 			}
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SSO Applications: %w", err))
+				return fmt.Errorf("error listing SSO Applications: %w", err)
 			}
 
 			for _, application := range page.Applications {
 				applicationARN := aws.ToString(application.ApplicationArn)
-				log.Printf("[INFO] Deleting SSO Application: %s", applicationARN)
-
 				sweepResources = append(sweepResources, framework.NewSweepResource(newResourceApplication, client, framework.NewAttribute("application_arn", applicationARN)))
 			}
 		}
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping SSO Applications: %w", err))
+		return fmt.Errorf("error sweeping SSO Applications: %w", err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }
 
 func sweepPermissionSets(region string) error {
@@ -199,8 +195,7 @@ func sweepPermissionSets(region string) error {
 	}
 	conn := client.SSOAdminClient(ctx)
 
-	sweepResources := make([]sweep.Sweepable, 0)
-	var sweeperErrs *multierror.Error
+	var sweepResources []sweep.Sweepable
 
 	accessDenied := regexache.MustCompile(`AccessDeniedException: .+ is not authorized to perform:`)
 
@@ -227,17 +222,15 @@ func sweepPermissionSets(region string) error {
 		paginator := ssoadmin.NewListPermissionSetsPaginator(conn, input)
 		for paginator.HasMorePages() {
 			page, err := paginator.NextPage(ctx)
-			if awsv2.SkipSweepError(err) {
+			if awsv2.SkipSweepError(err) || tfawserr.ErrMessageContains(err, "ValidationException", "The operation is not supported for this Identity Center instance") {
 				log.Printf("[WARN] Skipping SSO Permission Set sweep for %s: %s", region, err)
-				return sweeperErrs.ErrorOrNil() // In case we have completed some pages, but had errors
+				return nil
 			}
 			if err != nil {
-				sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error retrieving SSO Permission Sets: %w", err))
+				return fmt.Errorf("error listing SSO Permission Sets: %w", err)
 			}
 
 			for _, permissionSetArn := range page.PermissionSets {
-				log.Printf("[INFO] Deleting SSO Permission Set: %s", permissionSetArn)
-
 				r := ResourcePermissionSet()
 				d := r.Data(nil)
 				d.SetId(fmt.Sprintf("%s,%s", permissionSetArn, instanceArn))
@@ -248,8 +241,8 @@ func sweepPermissionSets(region string) error {
 	}
 
 	if err := sweep.SweepOrchestrator(ctx, sweepResources); err != nil {
-		sweeperErrs = multierror.Append(sweeperErrs, fmt.Errorf("error sweeping SSO Permission Sets: %w", err))
+		return fmt.Errorf("error sweeping SSO Permission Sets: %w", err)
 	}
 
-	return sweeperErrs.ErrorOrNil()
+	return nil
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the provider.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Prevents infinite loop when listing Permission Sets returns error that isn't handled by `awsv2.SkipSweepError`
