### PR TITLE
corrected signing_profile_version_arns to the right property for example

### DIFF
--- a/website/docs/r/lambda_code_signing_config.html.markdown
+++ b/website/docs/r/lambda_code_signing_config.html.markdown
@@ -18,8 +18,8 @@ For information about Lambda code signing configurations and how to use them, se
 resource "aws_lambda_code_signing_config" "new_csc" {
   allowed_publishers {
     signing_profile_version_arns = [
-      aws_signer_signing_profile.example1.arn,
-      aws_signer_signing_profile.example2.arn,
+      aws_signer_signing_profile.example1.version_arn,
+      aws_signer_signing_profile.example2.version_arn,
     ]
   }
 


### PR DESCRIPTION
### Description
This issue relates to the example usage in -https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_code_signing_config#example-usage
Per, [AWS API Docs](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/lambda/model/AllowedPublishers.html#signingProfileVersionArns()), the `allowed_publishers` property consumes `signingProfileVersionArns` and not `signingProfileArns`.


### Relations

Closes #42800 

### References
https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/lambda/model/AllowedPublishers.html#signingProfileVersionArns()
