### PR TITLE
Add support for iot thing mqtt5_configuration

### DIFF
--- a/.changelog/42964.txt
+++ b/.changelog/42964.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_iot_thing_type: Add support for mqtt5_configuration and propagating attributes
+```

--- a/internal/service/iot/thing_type.go
+++ b/internal/service/iot/thing_type.go
@@ -79,6 +79,38 @@ func resourceThingType() *schema.Resource {
 								ValidateFunc: validThingTypeSearchableAttribute,
 							},
 						},
+						"mqtt5_configuration": {
+							Type:     schema.TypeList,
+							MaxItems: 1,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"propagating_attributes": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"connection_attribute": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validThingTypeMqttPropagatingConnectionAttribute,
+												},
+												"thing_attribute": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validThingTypeMqttPropagatingThingAttribute,
+												},
+												"user_property_key": {
+													Type:         schema.TypeString,
+													Optional:     true,
+													ValidateFunc: validThingTypeMqttPropagatingUserPropertyKey,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/internal/service/iot/thing_type_test.go
+++ b/internal/service/iot/thing_type_test.go
@@ -93,6 +93,10 @@ func TestAccIoTThingType_full(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "foo"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "bar"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.searchable_attributes.*", "baz"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.mqtt_configuration.0.propagating_attributes.0.user_property_key", "iot:ClientId"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.mqtt_configuration.0.propagating_attributes.0.connection_attribute", "iot:ClientId"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.mqtt_configuration.0.propagating_attributes.1.user_property_key", "test"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "properties.0.mqtt_configuration.0.propagating_attributes.1.thing_attribute", "attribute"),
 				),
 			},
 			{
@@ -214,6 +218,18 @@ resource "aws_iot_thing_type" "test" {
   properties {
     description           = "MyDescription"
     searchable_attributes = ["foo", "bar", "baz"]
+		mqtt5_configuration {
+			propagating_attributes = [
+				{
+					user_property_key = "iot:ClientId"
+					connection_attribute = "iot:ClientId"
+				},
+				{
+					user_property_key = "test"
+					thing_attribute = "attribute"
+				}
+			]
+		}
   }
 }
 `, rName, deprecated)

--- a/internal/service/iot/validate.go
+++ b/internal/service/iot/validate.go
@@ -46,6 +46,45 @@ func validThingTypeSearchableAttribute(v any, k string) (ws []string, errors []e
 	return
 }
 
+func validThingTypeMqttPropagatingConnectionAttribute(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 128 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 128 characters", k))
+	}
+	if !regexache.MustCompile(`[a-zA-Z0-9:.]+`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, colons  and dots allowed in %q", k))
+	}
+	return
+}
+
+func validThingTypeMqttPropagatingThingAttribute(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 128 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 128 characters", k))
+	}
+	if !regexache.MustCompile(`[a-zA-Z0-9_.,@/:#-]+`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, underscores, dots, commas, arobases, slashes, colons, hashes and hyphens allowed in %q", k))
+	}
+	return
+}
+
+func validThingTypeMqttPropagatingUserPropertyKey(v any, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 128 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 128 characters", k))
+	}
+	if !regexache.MustCompile(`[a-zA-Z0-9:$.]+`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters, colons, dollar signs and dots allowed in %q", k))
+	}
+	return
+}
+
 func validTopicRuleCloudWatchAlarmStateValue(v any, s string) ([]string, []error) {
 	switch v.(string) {
 	case

--- a/website/docs/r/iot_thing_type.html.markdown
+++ b/website/docs/r/iot_thing_type.html.markdown
@@ -27,6 +27,11 @@ This resource supports the following arguments:
 * `properties` - (Optional), Configuration block that can contain the following properties of the thing type:
     * `description` - (Optional, Forces New Resource) The description of the thing type.
     * `searchable_attributes` - (Optional, Forces New Resource) A list of searchable thing attribute names.
+    * `mqtt5_configuration` - (Optional) Configuration block that can contain the following properties
+        * `propagating_attributes` - (Optional) List of propagating attribute configuration
+            * `user_property_key` - The key of the user property key-value pair.
+            * `connection_attribute` - The attribute associated with the connection between a device and AWS IoT Core.
+            * `thing_attribute` - The user-defined thing attribute that is propagating for MQTT 5 message enrichment.
 * `tags` - (Optional) Key-value mapping of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ## Attribute Reference


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds support for propagating attributes

  * https://docs.aws.amazon.com/iot/latest/developerguide/thing-types-propagating-attributes.htmlo
  * https://docs.aws.amazon.com/en_us/iot/latest/apireference/API_Mqtt5Configuration.html

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #41146

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
I don't have access to an AWS account where I can run acceptance tests, so I'm hoping the pipeline does
