### PR TITLE
[Enhancement] aws_wafv2_web_acl, aws_wafv2_rule_group: Support `asn_match_statement`

### DIFF
--- a/.changelog/42965.txt
+++ b/.changelog/42965.txt
@@ -1,7 +1,7 @@
 ```release-note:enhancement
-resource/aws_wafv2_web_acl: Support `asn_match_statement`
+resource/aws_wafv2_web_acl: Add `statement.asn_match_statement` configuration block
 ```
 
 ```release-note:enhancement
-resource/aws_wafv2_rule_group: Support `asn_match_statement`
+resource/aws_wafv2_rule_group: Add `statement.asn_match_statement` configuration block
 ```

--- a/.changelog/42965.txt
+++ b/.changelog/42965.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_wafv2_web_acl: Support `asn_match_statement`
+```
+
+```release-note:enhancement
+resource/aws_wafv2_rule_group: Support `asn_match_statement`
+```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -462,7 +462,7 @@ func expandStatement(m map[string]any) *awstypes.Statement {
 	}
 
 	if v, ok := m["asn_match_statement"]; ok {
-		statement.AsnMatchStatement = expandAsnMatchStatement(v.([]any))
+		statement.AsnMatchStatement = expandASNMatchStatement(v.([]any))
 	}
 
 	if v, ok := m["byte_match_statement"]; ok {
@@ -528,7 +528,7 @@ func expandAndStatement(l []any) *awstypes.AndStatement {
 	}
 }
 
-func expandAsnMatchStatement(l []any) *awstypes.AsnMatchStatement {
+func expandASNMatchStatement(l []any) *awstypes.AsnMatchStatement {
 	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
@@ -1222,7 +1222,7 @@ func expandWebACLStatement(m map[string]any) *awstypes.Statement {
 	}
 
 	if v, ok := m["asn_match_statement"]; ok {
-		statement.AsnMatchStatement = expandAsnMatchStatement(v.([]any))
+		statement.AsnMatchStatement = expandASNMatchStatement(v.([]any))
 	}
 
 	if v, ok := m["byte_match_statement"]; ok {
@@ -2169,7 +2169,7 @@ func flattenStatement(s *awstypes.Statement) map[string]any {
 	}
 
 	if s.AsnMatchStatement != nil {
-		m["asn_match_statement"] = flattenAsnMatchStatement(s.AsnMatchStatement)
+		m["asn_match_statement"] = flattenASNMatchStatement(s.AsnMatchStatement)
 	}
 
 	if s.ByteMatchStatement != nil {
@@ -2235,7 +2235,7 @@ func flattenAndStatement(a *awstypes.AndStatement) any {
 	return []any{m}
 }
 
-func flattenAsnMatchStatement(a *awstypes.AsnMatchStatement) any {
+func flattenASNMatchStatement(a *awstypes.AsnMatchStatement) any {
 	if a == nil {
 		return []any{}
 	}
@@ -2717,7 +2717,7 @@ func flattenWebACLStatement(s *awstypes.Statement) map[string]any {
 	}
 
 	if s.AsnMatchStatement != nil {
-		m["asn_match_statement"] = flattenAsnMatchStatement(s.AsnMatchStatement)
+		m["asn_match_statement"] = flattenASNMatchStatement(s.AsnMatchStatement)
 	}
 
 	if s.ByteMatchStatement != nil {

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 	tfjson "github.com/hashicorp/terraform-provider-aws/internal/json"
-	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	itypes "github.com/hashicorp/terraform-provider-aws/internal/types"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -2241,7 +2240,7 @@ func flattenASNMatchStatement(a *awstypes.AsnMatchStatement) any {
 	}
 
 	m := map[string]any{
-		"asn_list":            tfslices.ApplyToAll(a.AsnList, func(v int64) any { return int(v) }),
+		"asn_list":            a.AsnList,
 		"forwarded_ip_config": flattenForwardedIPConfig(a.ForwardedIPConfig),
 	}
 

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -2502,6 +2502,119 @@ func TestAccWAFV2RuleGroup_Operators_maxNested(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2RuleGroup_ASNMatchStatement(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_ASNMatchStatement(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "2"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeRegional)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"name":                              ruleGroupName,
+						"priority":                          "10",
+						"action.#":                          "1",
+						"action.0.allow.#":                  "0",
+						"action.0.block.#":                  "0",
+						"action.0.count.#":                  "1",
+						"statement.#":                       "1",
+						"statement.0.asn_match_statement.#": "1",
+						"statement.0.asn_match_statement.0.asn_list.#":                              "3",
+						"statement.0.asn_match_statement.0.asn_list.0":                              "1",
+						"statement.0.asn_match_statement.0.asn_list.1":                              "2",
+						"statement.0.asn_match_statement.0.asn_list.2":                              "3",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.#":                   "1",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.0.fallback_behavior": "MATCH",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.0.header_name":       "x-forwarded-for",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_rateBasedStatement_ASNMatchStatement(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, "capacity", "100"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, ruleGroupName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrNamePrefix, ""),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeRegional)),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						"statement.#": "1",
+						"statement.0.rate_based_statement.0.custom_key.#":                                                                         "0",
+						"statement.0.rate_based_statement.0.aggregate_key_type":                                                                   "IP",
+						"statement.0.rate_based_statement.0.evaluation_window_sec":                                                                "600",
+						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                                                                "0",
+						"statement.0.rate_based_statement.0.limit":                                                                                "50000",
+						"statement.0.rate_based_statement.0.scope_down_statement.#":                                                               "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.#":                                         "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.#":                              "3",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.0":                              "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.1":                              "2",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.2":                              "3",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.#":                   "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.0.fallback_behavior": "MATCH",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.0.header_name":       "x-forwarded-for",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccPreCheckScopeRegional(ctx context.Context, t *testing.T) {
 	conn := acctest.Provider.Meta().(*conns.AWSClient).WAFV2Client(ctx)
 
@@ -5494,6 +5607,95 @@ resource "aws_wafv2_rule_group" "test" {
   visibility_config {
     cloudwatch_metrics_enabled = false
     metric_name                = "waf"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_ASNMatchStatement(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity    = 2
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  rule {
+    name     = %[1]q
+    priority = 10
+
+    action {
+      count {}
+    }
+
+    statement {
+      asn_match_statement {
+        asn_list = [1, 2, 3]
+	    forwarded_ip_config {
+	      fallback_behavior = "MATCH"
+	      header_name       = "x-forwarded-for"
+	    }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "%[1]s-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccRuleGroupConfig_rateBasedStatement_ASNMatchStatement(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 100
+  name     = %[1]q
+  scope    = "REGIONAL"
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        evaluation_window_sec = 600
+        limit                 = 50000
+        scope_down_statement {
+          asn_match_statement {
+            asn_list = [1, 2, 3]
+            forwarded_ip_config {
+			  fallback_behavior = "MATCH"
+			  header_name       = "x-forwarded-for"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
     sampled_requests_enabled   = false
   }
 }

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -2531,8 +2531,8 @@ func TestAccWAFV2RuleGroup_ASNMatchStatement(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
-						"name":                              ruleGroupName,
-						"priority":                          "10",
+						names.AttrName:                      ruleGroupName,
+						names.AttrPriority:                  "10",
 						"action.#":                          "1",
 						"action.0.allow.#":                  "0",
 						"action.0.block.#":                  "0",
@@ -5632,10 +5632,10 @@ resource "aws_wafv2_rule_group" "test" {
     statement {
       asn_match_statement {
         asn_list = [1, 2, 3]
-	    forwarded_ip_config {
-	      fallback_behavior = "MATCH"
-	      header_name       = "x-forwarded-for"
-	    }
+        forwarded_ip_config {
+          fallback_behavior = "MATCH"
+          header_name       = "x-forwarded-for"
+        }
       }
     }
 
@@ -5678,8 +5678,8 @@ resource "aws_wafv2_rule_group" "test" {
           asn_match_statement {
             asn_list = [1, 2, 3]
             forwarded_ip_config {
-			  fallback_behavior = "MATCH"
-			  header_name       = "x-forwarded-for"
+              fallback_behavior = "MATCH"
+              header_name       = "x-forwarded-for"
             }
           }
         }

--- a/internal/service/wafv2/schemas.go
+++ b/internal/service/wafv2/schemas.go
@@ -57,6 +57,7 @@ func ruleGroupRootStatementSchema(level int) *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"and_statement":                         statementSchema(level),
+				"asn_match_statement":                   asnMatchStatementSchema(),
 				"byte_match_statement":                  byteMatchStatementSchema(),
 				"geo_match_statement":                   geoMatchStatementSchema(),
 				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
@@ -100,6 +101,7 @@ func (c *schemaCache) get(level int) *schema.Schema {
 						Required: true,
 						Elem: &schema.Resource{
 							Schema: map[string]*schema.Schema{
+								"asn_match_statement":                   asnMatchStatementSchema(),
 								"byte_match_statement":                  byteMatchStatementSchema(),
 								"geo_match_statement":                   geoMatchStatementSchema(),
 								"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
@@ -131,6 +133,7 @@ func (c *schemaCache) get(level int) *schema.Schema {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"and_statement":                         previous,
+									"asn_match_statement":                   asnMatchStatementSchema(),
 									"byte_match_statement":                  byteMatchStatementSchema(),
 									"geo_match_statement":                   geoMatchStatementSchema(),
 									"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
@@ -1010,6 +1013,7 @@ func webACLRootStatementSchema(level int) *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"and_statement":                         statementSchema(level),
+				"asn_match_statement":                   asnMatchStatementSchema(),
 				"byte_match_statement":                  byteMatchStatementSchema(),
 				"geo_match_statement":                   geoMatchStatementSchema(),
 				"ip_set_reference_statement":            ipSetReferenceStatementSchema(),
@@ -1195,6 +1199,7 @@ func scopeDownStatementSchema(level int) *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"and_statement":                         statementSchema(level),
+				"asn_match_statement":                   asnMatchStatementSchema(),
 				"byte_match_statement":                  byteMatchStatementSchema(),
 				"geo_match_statement":                   geoMatchStatementSchema(),
 				"label_match_statement":                 labelMatchStatementSchema(),
@@ -1649,3 +1654,25 @@ var managedRuleGroupConfigATPResponseInspectionSchema = sync.OnceValue(func() *s
 		},
 	}
 })
+
+func asnMatchStatementSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"asn_list": {
+					Type:     schema.TypeList,
+					Required: true,
+					MaxItems: 100,
+					MinItems: 1,
+					Elem: &schema.Schema{
+						Type: schema.TypeInt,
+					},
+				},
+				"forwarded_ip_config": forwardedIPConfigSchema(),
+			},
+		},
+	}
+}

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -3564,6 +3564,120 @@ func TestAccWAFV2WebACL_dataProtectionConfigMultiple(t *testing.T) {
 	})
 }
 
+func TestAccWAFV2WebACL_ASNMatchStatement(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_ASNMatchStatement(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrScope, string(awstypes.ScopeRegional)),
+					resource.TestCheckResourceAttr(resourceName, "default_action.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.allow.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "default_action.0.block.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.cloudwatch_metrics_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.metric_name", "friendly-metric-name"),
+					resource.TestCheckResourceAttr(resourceName, "visibility_config.0.sampled_requests_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						names.AttrName:        webACLName,
+						names.AttrPriority:    "10",
+						"action.#":            "1",
+						"action.0.allow.#":    "0",
+						"action.0.block.#":    "0",
+						"action.0.count.#":    "1",
+						"visibility_config.#": "1",
+						"visibility_config.0.cloudwatch_metrics_enabled": acctest.CtFalse,
+						"visibility_config.0.metric_name":                fmt.Sprintf("%s-metric-name", webACLName),
+						"visibility_config.0.sampled_requests_enabled":   acctest.CtFalse,
+						"statement.#":                                                               "1",
+						"statement.0.asn_match_statement.#":                                         "1",
+						"statement.0.asn_match_statement.0.asn_list.#":                              "3",
+						"statement.0.asn_match_statement.0.asn_list.0":                              "1",
+						"statement.0.asn_match_statement.0.asn_list.1":                              "2",
+						"statement.0.asn_match_statement.0.asn_list.2":                              "3",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.#":                   "1",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.0.fallback_behavior": "MATCH",
+						"statement.0.asn_match_statement.0.forwarded_ip_config.0.header_name":       "x-forwarded-for",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccWAFV2WebACL_RateBased_ASNMatchStatement(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.WebACL
+	webACLName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_web_acl.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckWebACLDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWebACLConfig_rateBasedStatement_ASNMatchStatement(webACLName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWebACLExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/webacl/.+$`)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, webACLName),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtRulePound, "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "rule.*", map[string]string{
+						names.AttrName:                       "rule-1",
+						"action.#":                           "1",
+						"action.0.allow.#":                   "0",
+						"action.0.block.#":                   "0",
+						"action.0.count.#":                   "1",
+						"statement.#":                        "1",
+						"statement.0.rate_based_statement.#": "1",
+						"statement.0.rate_based_statement.0.aggregate_key_type":                                                                   "IP",
+						"statement.0.rate_based_statement.0.evaluation_window_sec":                                                                "300",
+						"statement.0.rate_based_statement.0.forwarded_ip_config.#":                                                                "0",
+						"statement.0.rate_based_statement.0.limit":                                                                                "50000",
+						"statement.0.rate_based_statement.0.scope_down_statement.#":                                                               "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.#":                                         "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.#":                              "3",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.0":                              "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.1":                              "2",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.asn_list.2":                              "3",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.#":                   "1",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.0.fallback_behavior": "MATCH",
+						"statement.0.rate_based_statement.0.scope_down_statement.0.asn_match_statement.0.forwarded_ip_config.0.header_name":       "x-forwarded-for",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWebACLImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
 func testAccCheckWebACLDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).WAFV2Client(ctx)
@@ -7113,6 +7227,105 @@ resource "aws_wafv2_web_acl" "test" {
         field_type = "BODY"
       }
     }
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_ASNMatchStatement(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = %[1]q
+    priority = 10
+
+    action {
+      count {}
+    }
+
+    statement {
+      asn_match_statement {
+        asn_list = [1, 2, 3]
+	    forwarded_ip_config {
+	      fallback_behavior = "MATCH"
+	      header_name       = "x-forwarded-for"
+	    }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "%[1]s-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}
+
+func testAccWebACLConfig_rateBasedStatement_ASNMatchStatement(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_web_acl" "test" {
+  name        = %[1]q
+  description = %[1]q
+  scope       = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      count {}
+    }
+
+    statement {
+      rate_based_statement {
+        limit = 50000
+        scope_down_statement {
+          asn_match_statement {
+            asn_list = [1, 2, 3]
+			forwarded_ip_config {
+			  fallback_behavior = "MATCH"
+			  header_name       = "x-forwarded-for"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
   }
 }
 `, rName)

--- a/internal/service/wafv2/web_acl_test.go
+++ b/internal/service/wafv2/web_acl_test.go
@@ -7235,8 +7235,8 @@ resource "aws_wafv2_web_acl" "test" {
 func testAccWebACLConfig_ASNMatchStatement(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_web_acl" "test" {
-  name        = %[1]q
-  scope       = "REGIONAL"
+  name  = %[1]q
+  scope = "REGIONAL"
 
   default_action {
     block {}
@@ -7253,10 +7253,10 @@ resource "aws_wafv2_web_acl" "test" {
     statement {
       asn_match_statement {
         asn_list = [1, 2, 3]
-	    forwarded_ip_config {
-	      fallback_behavior = "MATCH"
-	      header_name       = "x-forwarded-for"
-	    }
+        forwarded_ip_config {
+          fallback_behavior = "MATCH"
+          header_name       = "x-forwarded-for"
+        }
       }
     }
 
@@ -7301,9 +7301,9 @@ resource "aws_wafv2_web_acl" "test" {
         scope_down_statement {
           asn_match_statement {
             asn_list = [1, 2, 3]
-			forwarded_ip_config {
-			  fallback_behavior = "MATCH"
-			  header_name       = "x-forwarded-for"
+            forwarded_ip_config {
+              fallback_behavior = "MATCH"
+              header_name       = "x-forwarded-for"
             }
           }
         }

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -424,6 +424,7 @@ The processing guidance for a Rule, used by AWS WAF to determine whether a web r
 The `statement` block supports the following arguments:
 
 * `and_statement` - (Optional) A logical rule statement used to combine other rule statements with AND logic. See [AND Statement](#and-statement) below for details.
+* `asn_match_statement` - (Optional) Rule statement that inspects web traffic based on the Autonomous System Number (ASN) associated with the request's IP address. See [`asn_match_statement`](#asn_match_statement-block) below for details.
 * `byte_match_statement` - (Optional) A rule statement that defines a string match search for AWS WAF to apply to web requests. See [Byte Match Statement](#byte-match-statement) below for details.
 * `geo_match_statement` - (Optional) A rule statement used to identify web requests based on country of origin. See [GEO Match Statement](#geo-match-statement) below for details.
 * `label_match_statement` - (Optional) A rule statement that defines a string match search against labels that have been added to the web request by rules that have already run in the web ACL. See [Label Match Statement](#label-match-statement) below for details.
@@ -444,6 +445,15 @@ A logical rule statement used to combine other rule statements with `AND` logic.
 The `and_statement` block supports the following arguments:
 
 * `statement` - (Required) The statements to combine with `AND` logic. You can use any statements that can be nested. See [Statement](#statement) above for details.
+
+### ASN Match Statement
+
+A rule statement that inspects web traffic based on the Autonomous System Number (ASN) associated with the request's IP address.
+
+The `asn_match_statement` block supports the following arguments:
+
+* `asn_list` - (Required) List of Autonomous System Numbers (ASNs).
+* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [Forwarded IP Config](#forwarded-ip-config) below for more details.
 
 ### Byte Match Statement
 

--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -628,6 +628,7 @@ The processing guidance for a Rule, used by AWS WAF to determine whether a web r
 The `statement` block supports the following arguments:
 
 * `and_statement` - (Optional) Logical rule statement used to combine other rule statements with AND logic. See [`and_statement`](#and_statement-block) below for details.
+* `asn_match_statement` - (Optional) Rule statement that inspects web traffic based on the Autonomous System Number (ASN) associated with the request's IP address. See [`asn_match_statement`](#asn_match_statement-block) below for details.
 * `byte_match_statement` - (Optional) Rule statement that defines a string match search for AWS WAF to apply to web requests. See [`byte_match_statement`](#byte_match_statement-block) below for details.
 * `geo_match_statement` - (Optional) Rule statement used to identify web requests based on country of origin. See [`geo_match_statement`](#geo_match_statement-block) below for details.
 * `ip_set_reference_statement` - (Optional) Rule statement used to detect web requests coming from particular IP addresses or address ranges. See [`ip_set_reference_statement`](#ip_set_reference_statement-block) below for details.
@@ -650,6 +651,15 @@ A logical rule statement used to combine other rule statements with `AND` logic.
 The `and_statement` block supports the following arguments:
 
 * `statement` - (Required) Statements to combine with `AND` logic. You can use any statements that can be nested. See [`statement`](#statement-block) above for details.
+
+### `asn_match_statement` Block
+
+A rule statement that inspects web traffic based on the Autonomous System Number (ASN) associated with the request's IP address.
+
+The `asn_match_statement` block supports the following arguments:
+
+* `asn_list` - (Required) List of Autonomous System Numbers (ASNs).
+* `forwarded_ip_config` - (Optional) Configuration for inspecting IP addresses in an HTTP header that you specify, instead of using the IP address that's reported by the web request origin. See [`forwarded_ip_config`](#forwarded_ip_config-block) below for more details.
 
 ### `byte_match_statement` Block
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Support `asn_match_statement` for WAF V2 statement in `aws_wafv2_web_acl` and `aws_wafv2_rule_group`.
  * This block can also be used in `scope_down_statement` in `rate_based_statement`.

### Relations

Closes #42895

### References
* https://aws.amazon.com/jp/about-aws/whats-new/2025/06/asn-match-aws-waf/
* https://docs.aws.amazon.com/ja_jp/waf/latest/APIReference/API_Statement.html#WAF-Type-Statement-AsnMatchStatement

### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccWAFV2RuleGroup_ PKG=wafv2 
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup_'  -timeout 360m -vet=off
2025/06/11 23:50:44 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_nameGenerated
=== PAUSE TestAccWAFV2RuleGroup_nameGenerated
=== RUN   TestAccWAFV2RuleGroup_namePrefix
=== PAUSE TestAccWAFV2RuleGroup_namePrefix
=== RUN   TestAccWAFV2RuleGroup_updateRule
=== PAUSE TestAccWAFV2RuleGroup_updateRule
=== RUN   TestAccWAFV2RuleGroup_updateRuleProperties
=== PAUSE TestAccWAFV2RuleGroup_updateRuleProperties
=== RUN   TestAccWAFV2RuleGroup_byteMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_byteMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== RUN   TestAccWAFV2RuleGroup_changeNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeNameForceNew
=== RUN   TestAccWAFV2RuleGroup_changeCapacityForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeCapacityForceNew
=== RUN   TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== RUN   TestAccWAFV2RuleGroup_disappears
=== PAUSE TestAccWAFV2RuleGroup_disappears
=== RUN   TestAccWAFV2RuleGroup_RuleLabels
=== PAUSE TestAccWAFV2RuleGroup_RuleLabels
=== RUN   TestAccWAFV2RuleGroup_geoMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_geoMatchStatement
=== RUN   TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== PAUSE TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== RUN   TestAccWAFV2RuleGroup_LabelMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_LabelMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== PAUSE TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== RUN   TestAccWAFV2RuleGroup_logicalRuleStatements
=== PAUSE TestAccWAFV2RuleGroup_logicalRuleStatements
=== RUN   TestAccWAFV2RuleGroup_minimal
=== PAUSE TestAccWAFV2RuleGroup_minimal
=== RUN   TestAccWAFV2RuleGroup_regexMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_regexMatchStatement
=== RUN   TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_ruleAction
=== PAUSE TestAccWAFV2RuleGroup_ruleAction
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customResponse
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customResponse
=== RUN   TestAccWAFV2RuleGroup_sizeConstraintStatement
=== PAUSE TestAccWAFV2RuleGroup_sizeConstraintStatement
=== RUN   TestAccWAFV2RuleGroup_sqliMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_sqliMatchStatement
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2RuleGroup_xssMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_xssMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement
=== RUN   TestAccWAFV2RuleGroup_RateBased_maxNested
=== PAUSE TestAccWAFV2RuleGroup_RateBased_maxNested
=== RUN   TestAccWAFV2RuleGroup_Operators_maxNested
=== PAUSE TestAccWAFV2RuleGroup_Operators_maxNested
=== RUN   TestAccWAFV2RuleGroup_ASNMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_ASNMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== CONT  TestAccWAFV2RuleGroup_basic
=== CONT  TestAccWAFV2RuleGroup_logicalRuleStatements
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
=== CONT  TestAccWAFV2RuleGroup_geoMatchStatement
=== CONT  TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== CONT  TestAccWAFV2RuleGroup_sqliMatchStatement
=== CONT  TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_LabelMatchStatement
=== CONT  TestAccWAFV2RuleGroup_RuleLabels
=== CONT  TestAccWAFV2RuleGroup_disappears
=== CONT  TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== CONT  TestAccWAFV2RuleGroup_updateRule
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== CONT  TestAccWAFV2RuleGroup_ASNMatchStatement
=== CONT  TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2RuleGroup_RateBased_maxNested
=== CONT  TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
--- PASS: TestAccWAFV2RuleGroup_basic (46.31s)
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (48.79s)
=== CONT  TestAccWAFV2RuleGroup_xssMatchStatement
--- PASS: TestAccWAFV2RuleGroup_ASNMatchStatement (52.72s)
=== CONT  TestAccWAFV2RuleGroup_tags
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (70.52s)
=== CONT  TestAccWAFV2RuleGroup_ruleAction
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (70.52s)
=== CONT  TestAccWAFV2RuleGroup_sizeConstraintStatement
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (77.25s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customResponse
--- PASS: TestAccWAFV2RuleGroup_disappears (83.01s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
--- PASS: TestAccWAFV2RuleGroup_updateRule (87.72s)
=== CONT  TestAccWAFV2RuleGroup_regexMatchStatement
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (91.80s)
=== CONT  TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement (91.88s)
=== CONT  TestAccWAFV2RuleGroup_namePrefix
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (98.72s)
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (102.89s)
=== CONT  TestAccWAFV2RuleGroup_minimal
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (110.88s)
=== CONT  TestAccWAFV2RuleGroup_nameGenerated
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (111.68s)
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (115.75s)
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (120.83s)
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (129.42s)
--- PASS: TestAccWAFV2RuleGroup_namePrefix (53.15s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (145.35s)
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (59.56s)
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (99.32s)
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (57.02s)
--- PASS: TestAccWAFV2RuleGroup_minimal (49.74s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (156.98s)
--- PASS: TestAccWAFV2RuleGroup_nameGenerated (47.19s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (90.26s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (82.59s)
--- PASS: TestAccWAFV2RuleGroup_tags (113.94s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (168.39s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (108.54s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (102.26s)
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (267.28s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (248.55s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      350.800s
```

```console
% make testacc TESTS=TestAccWAFV2WebACL_ PKG=wafv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.9 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2WebACL_'  -timeout 360m -vet=off
2025/06/12 00:03:14 Initializing Terraform AWS Provider...
=== RUN   TestAccWAFV2WebACL_basic
=== PAUSE TestAccWAFV2WebACL_basic
=== RUN   TestAccWAFV2WebACL_nameGenerated
=== PAUSE TestAccWAFV2WebACL_nameGenerated
=== RUN   TestAccWAFV2WebACL_namePrefix
=== PAUSE TestAccWAFV2WebACL_namePrefix
=== RUN   TestAccWAFV2WebACL_Update_rule
=== PAUSE TestAccWAFV2WebACL_Update_rule
=== RUN   TestAccWAFV2WebACL_Update_ruleProperties
=== PAUSE TestAccWAFV2WebACL_Update_ruleProperties
=== RUN   TestAccWAFV2WebACL_Update_nameForceNew
=== PAUSE TestAccWAFV2WebACL_Update_nameForceNew
=== RUN   TestAccWAFV2WebACL_disappears
=== PAUSE TestAccWAFV2WebACL_disappears
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== RUN   TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== PAUSE TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
=== RUN   TestAccWAFV2WebACL_minimal
=== PAUSE TestAccWAFV2WebACL_minimal
=== RUN   TestAccWAFV2WebACL_RateBased_basic
=== PAUSE TestAccWAFV2WebACL_RateBased_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_basic
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_basic
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_body
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_body
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
=== RUN   TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== PAUSE TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
=== RUN   TestAccWAFV2WebACL_GeoMatch_basic
=== PAUSE TestAccWAFV2WebACL_GeoMatch_basic
=== RUN   TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== PAUSE TestAccWAFV2WebACL_GeoMatch_forwardedIP
=== RUN   TestAccWAFV2WebACL_LabelMatchStatement
=== PAUSE TestAccWAFV2WebACL_LabelMatchStatement
=== RUN   TestAccWAFV2WebACL_RuleLabels
=== PAUSE TestAccWAFV2WebACL_RuleLabels
=== RUN   TestAccWAFV2WebACL_IPSetReference_basic
=== PAUSE TestAccWAFV2WebACL_IPSetReference_basic
=== RUN   TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== PAUSE TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== RUN   TestAccWAFV2WebACL_RateBased_customKeys
=== PAUSE TestAccWAFV2WebACL_RateBased_customKeys
=== RUN   TestAccWAFV2WebACL_RateBased_forwardedIP
=== PAUSE TestAccWAFV2WebACL_RateBased_forwardedIP
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_basic
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_basic
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== RUN   TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== PAUSE TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== RUN   TestAccWAFV2WebACL_Custom_requestHandling
=== PAUSE TestAccWAFV2WebACL_Custom_requestHandling
=== RUN   TestAccWAFV2WebACL_Custom_response
=== PAUSE TestAccWAFV2WebACL_Custom_response
=== RUN   TestAccWAFV2WebACL_tags
=== PAUSE TestAccWAFV2WebACL_tags
=== RUN   TestAccWAFV2WebACL_RateBased_maxNested
=== PAUSE TestAccWAFV2WebACL_RateBased_maxNested
=== RUN   TestAccWAFV2WebACL_Operators_maxNested
=== PAUSE TestAccWAFV2WebACL_Operators_maxNested
=== RUN   TestAccWAFV2WebACL_tokenDomains
=== PAUSE TestAccWAFV2WebACL_tokenDomains
=== RUN   TestAccWAFV2WebACL_associationConfigCloudFront
=== PAUSE TestAccWAFV2WebACL_associationConfigCloudFront
=== RUN   TestAccWAFV2WebACL_associationConfigRegional
=== PAUSE TestAccWAFV2WebACL_associationConfigRegional
=== RUN   TestAccWAFV2WebACL_CloudFrontScope
=== PAUSE TestAccWAFV2WebACL_CloudFrontScope
=== RUN   TestAccWAFV2WebACL_ruleJSON
=== PAUSE TestAccWAFV2WebACL_ruleJSON
=== RUN   TestAccWAFV2WebACL_ruleJSONToRule
=== PAUSE TestAccWAFV2WebACL_ruleJSONToRule
=== RUN   TestAccWAFV2WebACL_dataProtectionConfig
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfig
=== RUN   TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== PAUSE TestAccWAFV2WebACL_dataProtectionConfigMultiple
=== RUN   TestAccWAFV2WebACL_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_ASNMatchStatement
=== RUN   TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== PAUSE TestAccWAFV2WebACL_RateBased_ASNMatchStatement
=== CONT  TestAccWAFV2WebACL_basic
=== CONT  TestAccWAFV2WebACL_LabelMatchStatement
=== CONT  TestAccWAFV2WebACL_RateBased_maxNested
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_basic
=== CONT  TestAccWAFV2WebACL_tags
=== CONT  TestAccWAFV2WebACL_Custom_response
=== CONT  TestAccWAFV2WebACL_Custom_requestHandling
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule
=== CONT  TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation
=== CONT  TestAccWAFV2WebACL_disappears
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_basic
=== CONT  TestAccWAFV2WebACL_IPSetReference_forwardedIP
=== CONT  TestAccWAFV2WebACL_RateBased_forwardedIP
=== CONT  TestAccWAFV2WebACL_RateBased_customKeys
=== CONT  TestAccWAFV2WebACL_IPSetReference_basic
=== CONT  TestAccWAFV2WebACL_RuleLabels
--- PASS: TestAccWAFV2WebACL_RateBased_maxNested (65.04s)
=== CONT  TestAccWAFV2WebACL_ruleJSON
--- PASS: TestAccWAFV2WebACL_basic (68.23s)
=== CONT  TestAccWAFV2WebACL_associationConfigCloudFront
    web_acl_test.go:3156: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_associationConfigCloudFront (0.00s)
=== CONT  TestAccWAFV2WebACL_RateBased_ASNMatchStatement
--- PASS: TestAccWAFV2WebACL_IPSetReference_basic (74.75s)
=== CONT  TestAccWAFV2WebACL_CloudFrontScope
    web_acl_test.go:3253: skipping tests; AWS_DEFAULT_REGION (us-west-2) not supported. Supported: [us-east-1]
--- SKIP: TestAccWAFV2WebACL_CloudFrontScope (0.00s)
=== CONT  TestAccWAFV2WebACL_associationConfigRegional
--- PASS: TestAccWAFV2WebACL_disappears (80.20s)
=== CONT  TestAccWAFV2WebACL_ASNMatchStatement
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_BotControl (90.73s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_jsonBody
--- PASS: TestAccWAFV2WebACL_LabelMatchStatement (140.93s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_forwardedIP
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ACFPRuleSet (143.91s)
=== CONT  TestAccWAFV2WebACL_GeoMatch_basic
--- PASS: TestAccWAFV2WebACL_tags (151.61s)
=== CONT  TestAccWAFV2WebACL_dataProtectionConfigMultiple
--- PASS: TestAccWAFV2WebACL_associationConfigRegional (79.34s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_urlFragment
--- PASS: TestAccWAFV2WebACL_Custom_response (163.65s)
=== CONT  TestAccWAFV2WebACL_dataProtectionConfig
--- PASS: TestAccWAFV2WebACL_RateBased_ASNMatchStatement (97.08s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_headerOrder
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig_ATPRuleSet (166.82s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_body
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_basic (171.48s)
=== CONT  TestAccWAFV2WebACL_ruleJSONToRule
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_ManagedRuleGroupConfig (172.65s)
=== CONT  TestAccWAFV2WebACL_Update_rule
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_shieldMitigation (179.13s)
=== CONT  TestAccWAFV2WebACL_Update_nameForceNew
--- PASS: TestAccWAFV2WebACL_ASNMatchStatement (101.13s)
=== CONT  TestAccWAFV2WebACL_Update_ruleProperties
--- PASS: TestAccWAFV2WebACL_RateBased_forwardedIP (194.24s)
=== CONT  TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion
--- PASS: TestAccWAFV2WebACL_ruleJSON (142.41s)
=== CONT  TestAccWAFV2WebACL_RateBased_basic
--- PASS: TestAccWAFV2WebACL_RuleGroupReference_manageShieldMitigationRule (207.58s)
=== CONT  TestAccWAFV2WebACL_minimal
--- PASS: TestAccWAFV2WebACL_RuleLabels (223.37s)
=== CONT  TestAccWAFV2WebACL_namePrefix
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_basic (226.59s)
=== CONT  TestAccWAFV2WebACL_nameGenerated
--- PASS: TestAccWAFV2WebACL_dataProtectionConfigMultiple (96.54s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint
--- PASS: TestAccWAFV2WebACL_Custom_requestHandling (254.64s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_jsonBody (174.43s)
=== CONT  TestAccWAFV2WebACL_tokenDomains
--- PASS: TestAccWAFV2WebACL_minimal (77.38s)
=== CONT  TestAccWAFV2WebACL_Operators_maxNested
--- PASS: TestAccWAFV2WebACL_IPSetReference_forwardedIP (285.82s)
=== CONT  TestAccWAFV2WebACL_ByteMatchStatement_basic
--- PASS: TestAccWAFV2WebACL_namePrefix (86.69s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_forwardedIP (170.47s)
--- PASS: TestAccWAFV2WebACL_GeoMatch_basic (174.77s)
--- PASS: TestAccWAFV2WebACL_nameGenerated (94.40s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_urlFragment (167.10s)
--- PASS: TestAccWAFV2WebACL_ruleJSONToRule (151.03s)
--- PASS: TestAccWAFV2WebACL_Update_nameForceNew (143.45s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_headerOrder (165.63s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_body (164.79s)
--- PASS: TestAccWAFV2WebACL_Update_rule (163.92s)
--- PASS: TestAccWAFV2WebACL_tokenDomains (73.68s)
--- PASS: TestAccWAFV2WebACL_ManagedRuleGroup_specifyVersion (145.03s)
--- PASS: TestAccWAFV2WebACL_RateBased_basic (138.86s)
--- PASS: TestAccWAFV2WebACL_dataProtectionConfig (187.16s)
--- PASS: TestAccWAFV2WebACL_Operators_maxNested (68.58s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja4fingerprint (112.26s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_ja3fingerprint (109.23s)
--- PASS: TestAccWAFV2WebACL_Update_ruleProperties (186.91s)
--- PASS: TestAccWAFV2WebACL_ByteMatchStatement_basic (84.60s)
--- PASS: TestAccWAFV2WebACL_RateBased_customKeys (476.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/wafv2      480.199s


```