### PR TITLE
docs: fix textual description of the workspace configuration example

### DIFF
--- a/website/docs/r/grafana_workspace.html.markdown
+++ b/website/docs/r/grafana_workspace.html.markdown
@@ -62,7 +62,7 @@ resource "aws_grafana_workspace" "example" {
 }
 ```
 
-The optional argument `configuration` is a JSON string that enables the unified `Grafana Alerting` (Grafana version 10 or newer) and `Plugins Management` (Grafana version 9 or newer) on the Grafana Workspaces.
+The optional argument `configuration` is a JSON string that disables the unified `Grafana Alerting` (Grafana version 10 or newer) and enables `Plugin Management` (Grafana version 9 or newer) on the Grafana Workspaces.
 
 For more information about using Grafana alerting, and the effects of turning it on or off, see [Alerts in Grafana version 10](https://docs.aws.amazon.com/grafana/latest/userguide/v10-alerts.html).
 
@@ -77,7 +77,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `configuration` - (Optional) The configuration string for the workspace that you create. For more information about the format and configuration options available, see [Working in your Grafana workspace](https://docs.aws.amazon.com/grafana/latest/userguide/AMG-configure-workspace.html).
-* `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `XRAY`
+* `data_sources` - (Optional) The data sources for the workspace. Valid values are `AMAZON_OPENSEARCH_SERVICE`, `ATHENA`, `CLOUDWATCH`, `PROMETHEUS`, `REDSHIFT`, `SITEWISE`, `TIMESTREAM`, `TWINMAKER`, XRAY`
 * `description` - (Optional) The workspace description.
 * `grafana_version` - (Optional) Specifies the version of Grafana to support in the new workspace. Supported values are `8.4`, `9.4` and `10.4`. If not specified, defaults to the latest version.
 * `name` - (Optional) The Grafana workspace name.


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security controls have been modified.

### Description

The  example `Workspace configuration options` for the the resource [aws_grafana_workspace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/grafana_workspace#example-usage) consists of code and a textual description. Both are out of sync for `unifiedAlerting`.  In the code `enabled`  is set to `false`, in the text it is mentioned that unified alerting is enabled:

```hcl
configuration = jsonencode(
    {
      "plugins" = {
        "pluginAdminEnabled" = true
      },
      "unifiedAlerting" = {
        "enabled" = false
      }
    }
  )
}
```

>The optional argument configuration is a JSON string that enables the unified Grafana Alerting (Grafana version 10 or newer) and Plugins Management (Grafana version 9 or newer) on the Grafana Workspaces.

- The textual description is updated to be in sync with the code.
- In addition,  `TWINMAKER` is added as valid data source. The [validation function for `data_source`](https://github.com/hashicorp/terraform-provider-aws/blob/f7a3b98da589ab1d52756b0dcee0dbf2de83d635/internal/service/grafana/workspace.go#L87C47-L87C61) relies on  [`DataSourceType`](https://github.com/aws/aws-sdk-go-v2/blob/e6c02cdac88a318c65b484823eb8fd7ab8ece7c1/service/grafana/types/enums.go#L50) of the Go SDK v2.   `TWINMAKER` was added to [`DataSourceType`] approx three years ago.

### Relations

Closes #42958 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

Not applicable. Only documentation is outdated.