### PR TITLE
Don't validate `region` if partition is empty

### DIFF
--- a/internal/conns/awsclient.go
+++ b/internal/conns/awsclient.go
@@ -100,8 +100,8 @@ func (c *AWSClient) Partition(context.Context) string {
 // that value is returned, otherwise the configured Region is returned.
 func (c *AWSClient) Region(ctx context.Context) string {
 	if inContext, ok := FromContext(ctx); ok {
-		if v := inContext.OverrideRegion(); v != "" {
-			return v
+		if r := inContext.OverrideRegion(); r != "" {
+			return r
 		}
 	}
 
@@ -311,9 +311,9 @@ func (c *AWSClient) EC2PublicDNSNameForIP(ctx context.Context, ip string) string
 // ValidateInContextRegionInPartition verifies that the value of the top-level `region` attribute is in the configured AWS partition.
 func (c *AWSClient) ValidateInContextRegionInPartition(ctx context.Context) error {
 	if inContext, ok := FromContext(ctx); ok {
-		if v := inContext.OverrideRegion(); v != "" {
-			if got, want := names.PartitionForRegion(v).ID(), c.Partition(ctx); got != want {
-				return fmt.Errorf("partition (%s) for per-resource Region (%s) is not the provider's configured partition (%s)", got, v, want)
+		if r, p := inContext.OverrideRegion(), c.Partition(ctx); r != "" && p != "" {
+			if got, want := names.PartitionForRegion(r).ID(), p; got != want {
+				return fmt.Errorf("partition (%s) for per-resource Region (%s) is not the provider's configured partition (%s)", got, r, want)
 			}
 		}
 	}

--- a/internal/conns/awsclient_test.go
+++ b/internal/conns/awsclient_test.go
@@ -231,6 +231,12 @@ func TestAWSClientValidateInContextRegionInPartition(t *testing.T) { // nosemgre
 			Region:   endpoints.CnNorth1RegionID,
 			Expected: true,
 		},
+		{
+			Name:      "Empty partition, valid",
+			AWSClient: &AWSClient{},
+			Region:    "ash",
+			Expected:  true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/internal/conns/awsclient_test.go
+++ b/internal/conns/awsclient_test.go
@@ -4,7 +4,6 @@
 package conns
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,7 +18,7 @@ var (
 func TestAWSClientPartitionHostname(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	testCases := []struct {
 		Name      string
 		AWSClient *AWSClient
@@ -60,7 +59,7 @@ func TestAWSClientPartitionHostname(t *testing.T) { // nosemgrep:ci.aws-in-func-
 func TestAWSClientRegionalHostname(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	testCases := []struct {
 		Name      string
 		AWSClient *AWSClient
@@ -107,7 +106,7 @@ func TestAWSClientRegionalHostname(t *testing.T) { // nosemgrep:ci.aws-in-func-n
 func TestAWSClientEC2PrivateDNSNameForIP(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	testCases := []struct {
 		Name      string
 		AWSClient *AWSClient
@@ -154,7 +153,7 @@ func TestAWSClientEC2PrivateDNSNameForIP(t *testing.T) { // nosemgrep:ci.aws-in-
 func TestAWSClientEC2PublicDNSNameForIP(t *testing.T) { // nosemgrep:ci.aws-in-func-name
 	t.Parallel()
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	testCases := []struct {
 		Name      string
 		AWSClient *AWSClient
@@ -193,6 +192,56 @@ func TestAWSClientEC2PublicDNSNameForIP(t *testing.T) { // nosemgrep:ci.aws-in-f
 
 			if got != testCase.Expected {
 				t.Errorf("got %s, expected %s", got, testCase.Expected)
+			}
+		})
+	}
+}
+
+func TestAWSClientValidateInContextRegionInPartition(t *testing.T) { // nosemgrep:ci.aws-in-func-name
+	t.Parallel()
+
+	ctx := t.Context()
+	testCases := []struct {
+		Name      string
+		AWSClient *AWSClient
+		Region    string
+		Expected  bool
+	}{
+		{
+			Name: "AWS Commercial, valid",
+			AWSClient: &AWSClient{
+				partition: standardPartition,
+			},
+			Region:   endpoints.ApNortheast1RegionID,
+			Expected: true,
+		},
+		{
+			Name: "AWS Commercial, invalid",
+			AWSClient: &AWSClient{
+				partition: standardPartition,
+			},
+			Region:   endpoints.UsGovWest1RegionID,
+			Expected: false,
+		},
+		{
+			Name: "AWS China, valid",
+			AWSClient: &AWSClient{
+				partition: chinaPartition,
+			},
+			Region:   endpoints.CnNorth1RegionID,
+			Expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx = NewResourceContext(ctx, "test", "Test", testCase.Region)
+			err := testCase.AWSClient.ValidateInContextRegionInPartition(ctx)
+
+			if got := err == nil; got != testCase.Expected {
+				t.Errorf("got %t, expected %t", got, testCase.Expected)
 			}
 		})
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

When connecting to non-Amazon, [AWS-compatible APIs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/custom-service-endpoints) the `AWSClient.partition` field may be empty. In these cases don't validate the top-level `region` argument.