### PR TITLE
feat: remove ForceNew for email

### DIFF
--- a/.changelog/43014.txt
+++ b/.changelog/43014.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_user: Remove [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew) from `email`
+```

--- a/internal/service/quicksight/user.go
+++ b/internal/service/quicksight/user.go
@@ -52,7 +52,6 @@ func resourceUser() *schema.Resource {
 				names.AttrEmail: {
 					Type:     schema.TypeString,
 					Required: true,
-					ForceNew: true,
 				},
 				"iam_arn": {
 					Type:     schema.TypeString,

--- a/internal/service/quicksight/user_test.go
+++ b/internal/service/quicksight/user_test.go
@@ -12,6 +12,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -77,6 +78,11 @@ func TestAccQuickSightUser_withInvalidFormattedEmailStillWorks(t *testing.T) {
 			},
 			{
 				Config: testAccUserConfig_email(rName, "nottarealemailbutworks2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists(ctx, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEmail, "nottarealemailbutworks2"),


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls by this pull request.

### Description

The resource `aws_quicksight_user` contains an argument `email`. 

At the moment the argument is configured with [`ForceNew`](https://github.com/hashicorp/terraform-provider-aws/blob/4e1ffae7052c85018b1d1546e4524eaa486e661d/internal/service/quicksight/user.go#L52).  Actually `email` can be updated without re-creating the resource, hence `ForceNew` is removed from the argument.

### Relations

Closes #42944 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

I updated the existing test `TestAccQuickSightUser_withInvalidFormattedEmailStillWorks`. When changing the e-mail address, a validation checks for an `update` action (instead of `delete, create`) on the resource.

```console
❯ make testacc TESTS=TestAccQuickSightUser  PKG=quicksight
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/quicksight/... -v -count 1 -parallel 20 -run='TestAccQuickSightUser'  -timeout 360m -vet=off
2025/06/14 15:33:01 Initializing Terraform AWS Provider...
=== RUN   TestAccQuickSightUserDataSource_basic
=== PAUSE TestAccQuickSightUserDataSource_basic
=== RUN   TestAccQuickSightUser_basic
=== PAUSE TestAccQuickSightUser_basic
=== RUN   TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== PAUSE TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== RUN   TestAccQuickSightUser_withNamespace
    user_test.go:101: Environment variable QUICKSIGHT_NAMESPACE is not set
--- SKIP: TestAccQuickSightUser_withNamespace (0.00s)
=== RUN   TestAccQuickSightUser_disappears
=== PAUSE TestAccQuickSightUser_disappears
=== CONT  TestAccQuickSightUserDataSource_basic
=== CONT  TestAccQuickSightUser_disappears
=== CONT  TestAccQuickSightUser_withInvalidFormattedEmailStillWorks
=== CONT  TestAccQuickSightUser_basic
--- PASS: TestAccQuickSightUserDataSource_basic (32.36s)
--- PASS: TestAccQuickSightUser_disappears (34.16s)
--- PASS: TestAccQuickSightUser_basic (52.18s)
--- PASS: TestAccQuickSightUser_withInvalidFormattedEmailStillWorks (53.10s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight 53.317s
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/quicksight/schema  0.094s [no tests to run]`
``
