### PR TITLE
feat: Add os_release_label arg to aws_emr_cluster

### DIFF
--- a/.changelog/43018.txt
+++ b/.changelog/43018.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_emr_cluster: Add `os_release_label` argument
+```

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -648,6 +648,11 @@ func resourceCluster() *schema.Resource {
 					ForceNew: true,
 					Required: true,
 				},
+				"os_release_label": {
+					Type:     schema.TypeString,
+					ForceNew: true,
+					Optional: true,
+				},
 				"placement_group_config": {
 					Type:       schema.TypeList,
 					ForceNew:   true,
@@ -922,6 +927,7 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		Name:         aws.String(name),
 		Applications: expandApplications(applications),
 
+		OSReleaseLabel:    aws.String(d.Get("os_release_label").(string)),
 		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
 		ServiceRole:       aws.String(d.Get(names.AttrServiceRole).(string)),
 		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
@@ -1118,6 +1124,7 @@ func resourceClusterRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrServiceRole, cluster.ServiceRole)
 	d.Set("security_configuration", cluster.SecurityConfiguration)
 	d.Set("autoscaling_role", cluster.AutoScalingRole)
+	d.Set("os_release_label", cluster.OSReleaseLabel)
 	d.Set("release_label", cluster.ReleaseLabel)
 	d.Set("log_encryption_kms_key_id", cluster.LogEncryptionKmsKeyId)
 	d.Set("log_uri", cluster.LogUri)

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -922,12 +922,10 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 	}
 
 	name := d.Get(names.AttrName).(string)
-	input := &emr.RunJobFlowInput{
-		Instances:    instanceConfig,
-		Name:         aws.String(name),
-		Applications: expandApplications(applications),
-
-		OSReleaseLabel:    aws.String(d.Get("os_release_label").(string)),
+	input := emr.RunJobFlowInput{
+		Applications:      expandApplications(applications),
+		Instances:         instanceConfig,
+		Name:              aws.String(name),
 		ReleaseLabel:      aws.String(d.Get("release_label").(string)),
 		ServiceRole:       aws.String(d.Get(names.AttrServiceRole).(string)),
 		VisibleToAllUsers: aws.Bool(d.Get("visible_to_all_users").(bool)),
@@ -942,48 +940,18 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		input.AdditionalInfo = aws.String(v)
 	}
 
-	if v, ok := d.GetOk("log_encryption_kms_key_id"); ok {
-		input.LogEncryptionKmsKeyId = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("log_uri"); ok {
-		input.LogUri = aws.String(v.(string))
+	if v, ok := d.GetOk("auto_termination_policy"); ok && len(v.([]any)) > 0 {
+		input.AutoTerminationPolicy = expandAutoTerminationPolicy(v.([]any))
 	}
 
 	if v, ok := d.GetOk("autoscaling_role"); ok {
 		input.AutoScalingRole = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("scale_down_behavior"); ok {
-		input.ScaleDownBehavior = awstypes.ScaleDownBehavior(v.(string))
-	}
-
-	if v, ok := d.GetOk("security_configuration"); ok {
-		input.SecurityConfiguration = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("ebs_root_volume_size"); ok {
-		input.EbsRootVolumeSize = aws.Int32(int32(v.(int)))
-	}
-
-	if v, ok := d.GetOk("custom_ami_id"); ok {
-		input.CustomAmiId = aws.String(v.(string))
-	}
-
-	if v, ok := d.GetOk("step_concurrency_level"); ok {
-		input.StepConcurrencyLevel = aws.Int32(int32(v.(int)))
-	}
-
-	if instanceProfile != "" {
-		input.JobFlowRole = aws.String(instanceProfile)
-	}
-
 	if v, ok := d.GetOk("bootstrap_action"); ok {
 		input.BootstrapActions = expandBootstrapActions(v.([]any))
 	}
-	if v, ok := d.GetOk("step"); ok {
-		input.Steps = expandStepConfigs(v.([]any))
-	}
+
 	if v, ok := d.GetOk("configurations"); ok {
 		input.Configurations = expandConfigures(v.(string))
 	}
@@ -999,20 +967,57 @@ func resourceClusterCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 	}
 
+	if v, ok := d.GetOk("custom_ami_id"); ok {
+		input.CustomAmiId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ebs_root_volume_size"); ok {
+		input.EbsRootVolumeSize = aws.Int32(int32(v.(int)))
+	}
+
+	if instanceProfile != "" {
+		input.JobFlowRole = aws.String(instanceProfile)
+	}
+
 	if v, ok := d.GetOk("kerberos_attributes"); ok {
 		input.KerberosAttributes = expandKerberosAttributes(v.([]any)[0].(map[string]any))
 	}
-	if v, ok := d.GetOk("auto_termination_policy"); ok && len(v.([]any)) > 0 {
-		input.AutoTerminationPolicy = expandAutoTerminationPolicy(v.([]any))
+
+	if v, ok := d.GetOk("log_encryption_kms_key_id"); ok {
+		input.LogEncryptionKmsKeyId = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("log_uri"); ok {
+		input.LogUri = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("os_release_label"); ok {
+		input.OSReleaseLabel = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("placement_group_config"); ok {
 		input.PlacementGroupConfigs = expandPlacementGroupConfigs(v.([]any))
 	}
 
+	if v, ok := d.GetOk("scale_down_behavior"); ok {
+		input.ScaleDownBehavior = awstypes.ScaleDownBehavior(v.(string))
+	}
+
+	if v, ok := d.GetOk("security_configuration"); ok {
+		input.SecurityConfiguration = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("step"); ok {
+		input.Steps = expandStepConfigs(v.([]any))
+	}
+
+	if v, ok := d.GetOk("step_concurrency_level"); ok {
+		input.StepConcurrencyLevel = aws.Int32(int32(v.(int)))
+	}
+
 	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (any, error) {
-			return conn.RunJobFlow(ctx, input)
+			return conn.RunJobFlow(ctx, &input)
 		},
 		func(err error) (bool, error) {
 			if tfawserr.ErrMessageContains(err, errCodeValidationException, "Invalid InstanceProfile:") {

--- a/website/docs/r/emr_cluster.html.markdown
+++ b/website/docs/r/emr_cluster.html.markdown
@@ -656,6 +656,7 @@ EOF
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value is not provided, logs are not created.
 * `master_instance_fleet` - (Optional) Configuration block to use an [Instance Fleet](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-fleet.html) for the master node type. Cannot be specified if any `master_instance_group` configuration blocks are set. Detailed below.
 * `master_instance_group` - (Optional) Configuration block to use an [Instance Group](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-instance-group-configuration.html#emr-plan-instance-groups) for the [master node type](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html#emr-plan-master).
+* `os_release_label` - (Optional) Amazon Linux release for all nodes in a cluster launch RunJobFlow request. If not specified, Amazon EMR uses the latest validated Amazon Linux release for cluster launch.
 * `placement_group_config` - (Optional) The specified placement group configuration for an Amazon EMR cluster.
 * `scale_down_behavior` - (Optional) Way that individual Amazon EC2 instances terminate when an automatic scale-in activity occurs or an `instance group` is resized.
 * `security_configuration` - (Optional) Security configuration name to attach to the EMR cluster. Only valid for EMR clusters with `release_label` 4.8.0 or greater.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `os_release_label` argument to the `aws_emr_cluster` resource.

Note that there are three existing acceptance test case failures described below, but they are unrelated to this PR.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42977

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [RunJobFlow](https://docs.aws.amazon.com/emr/latest/APIReference/API_RunJobFlow.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
Note that there are three unrelated test case that failed:

- `TestAccEMRCluster_ebs` and `TestAccEMRCluster_CustomAMI_id` failed because the core and primary instances kept failing bootstrap with a timeout. I suspect this is related to the release and application being included in the configuration. I am not familiar with EMR enough to continue troubleshooting.
- `TestAccEMRCluster_visibleToAllUsers` failed because the `visible_to_all_users` arg did not persist on an update. Looking at CloudTrail, it is as if Terraform didn't detect the change so it didn't make the API call to update the flag.

I will open two separate issues for these acceptance test failures. Meanwhile I don't think they are related to this enhancement, so I'd like a maintainer to review and merge this PR to add the feature first.

```console
$ make testacc TESTS=TestAccEMRCluster_ PKG=emr
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/emr/... -v -count 1 -parallel 8 -run='TestAccEMRCluster_'  -timeout 360m -vet=off
2025/06/14 13:50:10 Initializing Terraform AWS Provider...
=== RUN   TestAccEMRCluster_basic
=== PAUSE TestAccEMRCluster_basic
=== RUN   TestAccEMRCluster_autoTerminationPolicy
=== PAUSE TestAccEMRCluster_autoTerminationPolicy
=== RUN   TestAccEMRCluster_additionalInfo
=== PAUSE TestAccEMRCluster_additionalInfo
=== RUN   TestAccEMRCluster_disappears
=== PAUSE TestAccEMRCluster_disappears
=== RUN   TestAccEMRCluster_sJSON
=== PAUSE TestAccEMRCluster_sJSON
=== RUN   TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== RUN   TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_CoreInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_CoreInstanceGroup_name
=== PAUSE TestAccEMRCluster_CoreInstanceGroup_name
=== RUN   TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== PAUSE TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== RUN   TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== PAUSE TestAccEMRCluster_Kerberos_clusterDedicatedKdc
=== RUN   TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_bidPrice
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceCount
=== RUN   TestAccEMRCluster_MasterInstanceGroup_instanceType
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_instanceType
=== RUN   TestAccEMRCluster_MasterInstanceGroup_name
=== PAUSE TestAccEMRCluster_MasterInstanceGroup_name
=== RUN   TestAccEMRCluster_security
=== PAUSE TestAccEMRCluster_security
=== RUN   TestAccEMRCluster_Step_basic
=== PAUSE TestAccEMRCluster_Step_basic
=== RUN   TestAccEMRCluster_Step_mode
=== PAUSE TestAccEMRCluster_Step_mode
=== RUN   TestAccEMRCluster_Step_multiple
=== PAUSE TestAccEMRCluster_Step_multiple
=== RUN   TestAccEMRCluster_Step_multiple_listStates
=== PAUSE TestAccEMRCluster_Step_multiple_listStates
=== RUN   TestAccEMRCluster_Bootstrap_ordering
=== PAUSE TestAccEMRCluster_Bootstrap_ordering
=== RUN   TestAccEMRCluster_PlacementGroupConfigs
=== PAUSE TestAccEMRCluster_PlacementGroupConfigs
=== RUN   TestAccEMRCluster_terminationProtected
=== PAUSE TestAccEMRCluster_terminationProtected
=== RUN   TestAccEMRCluster_keepJob
=== PAUSE TestAccEMRCluster_keepJob
=== RUN   TestAccEMRCluster_visibleToAllUsers
=== PAUSE TestAccEMRCluster_visibleToAllUsers
=== RUN   TestAccEMRCluster_s3Logging
=== PAUSE TestAccEMRCluster_s3Logging
=== RUN   TestAccEMRCluster_s3LogEncryption
=== PAUSE TestAccEMRCluster_s3LogEncryption
=== RUN   TestAccEMRCluster_tags
=== PAUSE TestAccEMRCluster_tags
=== RUN   TestAccEMRCluster_RootVolume_size
=== PAUSE TestAccEMRCluster_RootVolume_size
=== RUN   TestAccEMRCluster_StepConcurrency_level
=== PAUSE TestAccEMRCluster_StepConcurrency_level
=== RUN   TestAccEMRCluster_ebs
=== PAUSE TestAccEMRCluster_ebs
=== RUN   TestAccEMRCluster_CustomAMI_id
=== PAUSE TestAccEMRCluster_CustomAMI_id
=== RUN   TestAccEMRCluster_InstanceFleet_basic
=== PAUSE TestAccEMRCluster_InstanceFleet_basic
=== RUN   TestAccEMRCluster_InstanceFleetMaster_only
=== PAUSE TestAccEMRCluster_InstanceFleetMaster_only
=== RUN   TestAccEMRCluster_unhealthyNodeReplacement
=== PAUSE TestAccEMRCluster_unhealthyNodeReplacement
=== RUN   TestAccEMRCluster_osReleaseLabel
=== PAUSE TestAccEMRCluster_osReleaseLabel
=== CONT  TestAccEMRCluster_basic
=== CONT  TestAccEMRCluster_Step_multiple
=== CONT  TestAccEMRCluster_tags
=== CONT  TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups
=== CONT  TestAccEMRCluster_InstanceFleet_basic
=== CONT  TestAccEMRCluster_s3LogEncryption
=== CONT  TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy
=== CONT  TestAccEMRCluster_keepJob
=== CONT  TestAccEMRCluster_PlacementGroupConfigs
--- PASS: TestAccEMRCluster_Step_multiple (343.73s)
--- PASS: TestAccEMRCluster_basic (374.19s)
=== CONT  TestAccEMRCluster_terminationProtected
--- PASS: TestAccEMRCluster_keepJob (403.30s)
=== CONT  TestAccEMRCluster_s3Logging
--- PASS: TestAccEMRCluster_CoreInstanceGroup_autoScalingPolicy (453.21s)
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceType
--- PASS: TestAccEMRCluster_tags (587.51s)
=== CONT  TestAccEMRCluster_CoreInstanceGroup_name
--- PASS: TestAccEMRCluster_terminationProtected (375.59s)
=== CONT  TestAccEMRCluster_Bootstrap_ordering
--- PASS: TestAccEMRCluster_s3LogEncryption (777.71s)
=== CONT  TestAccEMRCluster_Step_multiple_listStates
--- PASS: TestAccEMRCluster_s3Logging (514.03s)
=== CONT  TestAccEMRCluster_ebs
--- PASS: TestAccEMRCluster_PlacementGroupConfigs (580.96s)
=== CONT  TestAccEMRCluster_CustomAMI_id
--- PASS: TestAccEMRCluster_Step_multiple_listStates (421.25s)
=== CONT  TestAccEMRCluster_unhealthyNodeReplacement
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceType (789.70s)
=== CONT  TestAccEMRCluster_osReleaseLabel
--- PASS: TestAccEMRCluster_InstanceFleet_basic (1380.85s)
=== CONT  TestAccEMRCluster_InstanceFleetMaster_only
--- PASS: TestAccEMRCluster_CoreInstanceGroup_name (842.24s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_name
--- PASS: TestAccEMRCluster_Bootstrap_ordering (1086.27s)
=== CONT  TestAccEMRCluster_Step_mode
--- PASS: TestAccEMRCluster_EC2Attributes_defaultManagedSecurityGroups (1844.03s)
=== CONT  TestAccEMRCluster_Step_basic
--- PASS: TestAccEMRCluster_unhealthyNodeReplacement (691.53s)
=== CONT  TestAccEMRCluster_security
--- PASS: TestAccEMRCluster_osReleaseLabel (721.68s)
=== CONT  TestAccEMRCluster_StepConcurrency_level
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceCount
--- PASS: TestAccEMRCluster_InstanceFleetMaster_only (650.75s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_instanceType
--- PASS: TestAccEMRCluster_MasterInstanceGroup_name (696.10s)
=== CONT  TestAccEMRCluster_RootVolume_size
--- PASS: TestAccEMRCluster_Step_basic (443.22s)
=== CONT  TestAccEMRCluster_visibleToAllUsers
--- PASS: TestAccEMRCluster_security (451.73s)
=== CONT  TestAccEMRCluster_CoreInstanceGroup_instanceCount
--- PASS: TestAccEMRCluster_StepConcurrency_level (512.24s)
=== CONT  TestAccEMRCluster_CoreInstanceGroup_bidPrice
--- PASS: TestAccEMRCluster_CoreInstanceGroup_instanceCount (1046.40s)
=== CONT  TestAccEMRCluster_Kerberos_clusterDedicatedKdc
--- PASS: TestAccEMRCluster_Step_mode (794.22s)
=== CONT  TestAccEMRCluster_MasterInstanceGroup_bidPrice
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceType (655.46s)
=== CONT  TestAccEMRCluster_disappears
=== NAME  TestAccEMRCluster_visibleToAllUsers
    cluster_test.go:1297: Step 3/4 error: Check failed: Check 2/2 error: aws_emr_cluster.test: Attribute 'visible_to_all_users' expected "false", got "true"
--- PASS: TestAccEMRCluster_RootVolume_size (697.15s)
=== CONT  TestAccEMRCluster_sJSON
--- FAIL: TestAccEMRCluster_visibleToAllUsers (637.61s)
=== CONT  TestAccEMRCluster_additionalInfo
--- PASS: TestAccEMRCluster_disappears (345.48s)
=== CONT  TestAccEMRCluster_autoTerminationPolicy
--- PASS: TestAccEMRCluster_Kerberos_clusterDedicatedKdc (439.97s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_instanceCount (1091.32s)
--- PASS: TestAccEMRCluster_sJSON (308.75s)
--- PASS: TestAccEMRCluster_additionalInfo (379.02s)
--- PASS: TestAccEMRCluster_MasterInstanceGroup_bidPrice (673.73s)
--- PASS: TestAccEMRCluster_CoreInstanceGroup_bidPrice (892.45s)
--- PASS: TestAccEMRCluster_autoTerminationPolicy (708.26s)
=== NAME  TestAccEMRCluster_ebs
    cluster_test.go:1540: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for EMR Cluster (j-1VHVE90R7M3RG) create: unexpected state 'TERMINATING', wanted target 'RUNNING, WAITING'. last error: INTERNAL_ERROR: Failed to start the job flow due to an internal error

          with aws_emr_cluster.test,
          on terraform_plugin_test.tf line 193, in resource "aws_emr_cluster" "test":
         193: resource "aws_emr_cluster" "test" {

--- FAIL: TestAccEMRCluster_ebs (2933.15s)
=== NAME  TestAccEMRCluster_CustomAMI_id
    cluster_test.go:1574: Step 1/2 error: Error running apply: exit status 1

        Error: waiting for EMR Cluster (j-5ZQSNUYR6LYN) create: unexpected state 'TERMINATING', wanted target 'RUNNING, WAITING'. last error: INTERNAL_ERROR: Failed to start the job flow due to an internal error

          with aws_emr_cluster.test,
          on terraform_plugin_test.tf line 305, in resource "aws_emr_cluster" "test":
         305: resource "aws_emr_cluster" "test" {

--- FAIL: TestAccEMRCluster_CustomAMI_id (2997.24s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/emr        3922.175s
FAIL
make: *** [GNUmakefile:635: testacc] Error 1

$
...
```
