### PR TITLE
Output IPv6-based public hostnames (aws_instance, aws_network_interface)

### DIFF
--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"log"
 	"maps"
+	"math/big"
+	"net"
 	"slices"
 	"strconv"
 	"strings"
@@ -694,6 +696,18 @@ func resourceInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"public_dns_name_dualstack": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_dns_name_ipv4": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_dns_name_ipv6": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"public_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -909,9 +923,11 @@ func resourceInstance() *schema.Resource {
 				return diff.HasChange("launch_template.0.name")
 			}),
 			func(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
-				// Set public_dns and public_ip to newly computed if the instance will be stopped and started
-				// as part of Update and there is already a public_ip value in state.
+				// Will the instance be stopped and started during Update?
+				// If yes, it may get a new IPv4 address. If it already has a `public_ip`
+				// value in the state, we must recompute all dependent values.
 				if diff.Id() != "" && diff.HasChanges(names.AttrInstanceType, "user_data", "user_data_base64") {
+
 					// user_data is stored in state as a hash.
 					if diff.HasChange("user_data") && !diff.HasChange(names.AttrInstanceType) {
 						if o, n := diff.GetChange("user_data"); userDataHashSum(n.(string)) == o.(string) {
@@ -921,6 +937,8 @@ func resourceInstance() *schema.Resource {
 
 					if diff.Get("public_ip").(string) != "" {
 						diff.SetNewComputed("public_dns")
+						diff.SetNewComputed("public_dns_name_dualstack")
+						diff.SetNewComputed("public_dns_name_ipv4")
 						diff.SetNewComputed("public_ip")
 					}
 				}
@@ -1232,6 +1250,11 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	d.Set("private_ip", instance.PrivateIpAddress)
 	d.Set("outpost_arn", instance.OutpostArn)
 
+	// values for these are optionally set below
+	d.Set("public_dns_name_dualstack", "")
+	d.Set("public_dns_name_ipv6", "")
+	d.Set("public_dns_name_ipv4", "")
+
 	if instance.IamInstanceProfile != nil && instance.IamInstanceProfile.Arn != nil {
 		name, err := instanceProfileARNToName(aws.ToString(instance.IamInstanceProfile.Arn))
 
@@ -1326,10 +1349,29 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 				ipv6Addresses = append(ipv6Addresses, aws.ToString(address.Ipv6Address))
 			}
 
-			if len(primaryNetworkInterface.Ipv6Addresses) > 0 {
+			var ipv6, ipv4 net.IP
+			region := meta.(*conns.AWSClient).Region(ctx)
+
+			if len(ipv6Addresses) > 0 {
 				if err := d.Set("enable_primary_ipv6", primaryNetworkInterface.Ipv6Addresses[0].IsPrimaryIpv6); err != nil {
 					return sdkdiag.AppendErrorf(diags, "setting enable_primary_ipv6: %s", err)
 				}
+
+				ipv6 = net.ParseIP(ipv6Addresses[0])
+				if ipv6 == nil {
+					return sdkdiag.AppendErrorf(diags, "parsing IPv6 address: %s", ipv6Addresses[0])
+				}
+				d.Set("public_dns_name_ipv6", calculatePublicDNSNameIPv6(region, ipv6))
+			}
+
+			ipv4 = net.ParseIP(aws.ToString(instance.PublicIpAddress))
+			if ipv4 != nil && ipv4.To4() != nil {
+				ipv4 = ipv4.To4()
+				d.Set("public_dns_name_ipv4", calculatePublicDNSNameIPv4(region, ipv4))
+			}
+
+			if ipv6 != nil && ipv4 != nil {
+				d.Set("public_dns_name_dualstack", calculatePublicDNSNameDualstack(region, ipv6, ipv4))
 			}
 		}
 	} else {
@@ -4123,4 +4165,36 @@ func hasCommonElement(slice1 []awstypes.ArchitectureType, slice2 []awstypes.Arch
 		}
 	}
 	return false
+}
+
+func calculatePublicDNSNameIPv4(region string, addr_ipv4 net.IP) string {
+	addr_ipv4 = addr_ipv4.To4()
+	return fmt.Sprintf("ec2-%d-%d-%d-%d.%s.compute.amazonaws.com", addr_ipv4[0], addr_ipv4[1], addr_ipv4[2], addr_ipv4[3], region)
+}
+
+func calculatePublicDNSNameIPv6(region string, addr_ipv6 net.IP) string {
+	n6 := big.NewInt(0)
+	n6.SetBytes(addr_ipv6)
+
+	s6 := n6.Text(36)
+	s6 = strings.Repeat("0", 25-len(s6)) + s6
+	s6 = fmt.Sprintf("%s-%s-%s-%s-%s", s6[0:5], s6[5:10], s6[10:15], s6[15:20], s6[20:25])
+
+	return fmt.Sprintf("%s.%s.ip.aws", s6, region)
+}
+
+func calculatePublicDNSNameDualstack(region string, addr_ipv6 net.IP, addr_ipv4 net.IP) string {
+	n6 := big.NewInt(0)
+	n6.SetBytes(addr_ipv6)
+
+	n4 := big.NewInt(0)
+	n4.SetBytes(addr_ipv4.To4())
+
+	s6 := n6.Text(36)
+	s6 = strings.Repeat("0", 25-len(s6)) + s6
+	s6 = fmt.Sprintf("%s-%s-%s-%s-%s", s6[0:5], s6[5:10], s6[10:15], s6[15:20], s6[20:25])
+
+	s4 := n4.Text(36)
+	s4 = strings.Repeat("0", 7-len(s4)) + s4
+	return fmt.Sprintf("%s-%s.%s.ip.aws", s6, s4, region)
 }

--- a/internal/service/ec2/ec2_instance_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
-	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 

--- a/internal/service/ec2/ec2_instance_data_source_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -326,6 +327,53 @@ func TestAccEC2InstanceDataSource_ipv6Addresses(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccEC2InstanceDataSource_publicDNSNames(t *testing.T) {
+	ctx := acctest.Context(t)
+	datasourceName := "data.aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceDataSourceConfig_publicDNSNames(rName, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// dual-stack: all DNS names present (!= null, != "")
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.NotNull()),
+					tfstatecheck.ExpectNotKnownValue(datasourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.StringExact("")),
+					tfstatecheck.ExpectNotKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.StringExact("")),
+					tfstatecheck.ExpectNotKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.StringExact("")),
+				},
+			},
+			{
+				Config: testAccInstanceDataSourceConfig_publicDNSNames(rName, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// IPv6-only: only IPv6-based name present
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.NotNull()),
+					tfstatecheck.ExpectNotKnownValue(datasourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.StringExact("")),
+				},
+			},
+		},
+	})
+}
+
+func testAccInstanceDataSourceConfig_publicDNSNames(rName string, IPv6Only bool) string {
+	return acctest.ConfigCompose(
+		testAccInstanceConfig_IPv6Dualstack(rName, IPv6Only),
+		fmt.Sprintf(`
+data "aws_instance" "test" {
+	instance_id = aws_instance.test.id
+}
+`),
+	)
 }
 
 func TestAccEC2InstanceDataSource_keyPair(t *testing.T) {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -7170,7 +7170,6 @@ resource "aws_instance" "test" {
 	)
 }
 
-
 func testAccInstanceConfig_ebsKMSKeyARN(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(), fmt.Sprintf(`
 resource "aws_kms_key" "test" {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1393,6 +1393,43 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 	})
 }
 
+func TestAccEC2Instance_publicDNSNames(t *testing.T) {
+	ctx := acctest.Context(t)
+	resourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfig_IPv6Dualstack(rName, false),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// dual-stack: all DNS names present (!= null, != "")
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.NotNull()),
+					tfstatecheck.ExpectNotKnownValue(resourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.StringExact("")),
+					tfstatecheck.ExpectNotKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.StringExact("")),
+					tfstatecheck.ExpectNotKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.StringExact("")),
+				},
+			},
+			{
+				Config: testAccInstanceConfig_IPv6Dualstack(rName, true),
+				ConfigStateChecks: []statecheck.StateCheck{
+					// IPv6-only: only IPv6-based name present
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_dualstack"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv4"), knownvalue.StringExact("")),
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.NotNull()),
+					tfstatecheck.ExpectNotKnownValue(resourceName, tfjsonpath.New("public_dns_name_ipv6"), knownvalue.StringExact("")),
+				},
+			},
+		},
+	})
+}
+
 func TestAccEC2Instance_networkInstanceSecurityGroups(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Instance
@@ -7084,6 +7121,55 @@ resource "aws_instance" "test" {
 }
 `, rName, ipv6AddressCount))
 }
+
+// Returns a VPC, subnet, and EC2 instance, with public IP addresses: either dual-stack or IPv6-only.
+// All resources are named "test".
+func testAccInstanceConfig_IPv6Dualstack(rName string, IPv6Only bool) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigAvailableAZsNoOptInDefaultExclude(),
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = %[2]t ? null : "10.1.0.0/16"
+
+  assign_generated_ipv6_cidr_block = true
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block        = %[2]t ? null : "10.1.1.0/24"
+  vpc_id            = aws_vpc.test.id
+  availability_zone = data.aws_availability_zones.available.names[0]
+  ipv6_cidr_block   = cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)
+
+  assign_ipv6_address_on_creation = true
+
+  ipv6_native 									 = %[2]t
+  enable_resource_name_dns_aaaa_record_on_launch = %[2]t
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_instance" "test" {
+  ami                = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type      = "t3.nano" # IPv6-only support requires the Nitro hypervisor, so t2 is out
+  subnet_id          = aws_subnet.test.id
+
+  associate_public_ip_address = !%[2]t
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, IPv6Only),
+	)
+}
+
 
 func testAccInstanceConfig_ebsKMSKeyARN(rName string) string {
 	return acctest.ConfigCompose(acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(), fmt.Sprintf(`

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -345,6 +345,10 @@ func resourceNetworkInterface() *schema.Resource {
 					return diff.HasChange("ipv6_addresses") || diff.HasChange("ipv6_address_count") || diff.HasChange("ipv6_address_list")
 				}
 			}),
+			customdiff.ComputedIf("public_dns_names_ipv6", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
+				// This condition is enough, because it's computed _after_ ipv6_addresses in the sequence.
+				return diff.HasChange("ipv6_addresses")
+			}),
 		),
 	}
 }

--- a/internal/service/ec2/vpc_network_interface.go
+++ b/internal/service/ec2/vpc_network_interface.go
@@ -576,7 +576,9 @@ func resourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData, m
 		}
 		dns_names_ipv6 = append(dns_names_ipv6, calculatePublicDNSNameIPv6(region, ipv6))
 	}
-	d.Set("public_dns_names_ipv6", dns_names_ipv6)
+	if err := d.Set("public_dns_names_ipv6", dns_names_ipv6); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting public_dns_names_ipv6: %s", err)
+	}
 
 	d.Set("mac_address", eni.MacAddress)
 	d.Set("outpost_arn", eni.OutpostArn)

--- a/internal/service/ec2/vpc_network_interface_data_source.go
+++ b/internal/service/ec2/vpc_network_interface_data_source.go
@@ -241,7 +241,9 @@ func dataSourceNetworkInterfaceRead(ctx context.Context, d *schema.ResourceData,
 		}
 		dns_names_ipv6 = append(dns_names_ipv6, calculatePublicDNSNameIPv6(region, ipv6))
 	}
-	d.Set("public_dns_names_ipv6", dns_names_ipv6)
+	if err := d.Set("public_dns_names_ipv6", dns_names_ipv6); err != nil {
+		return sdkdiag.AppendErrorf(diags, "setting public_dns_names_ipv6: %s", err)
+	}
 
 	setTagsOut(ctx, eni.TagSet)
 

--- a/internal/service/ec2/vpc_network_interface_data_source_test.go
+++ b/internal/service/ec2/vpc_network_interface_data_source_test.go
@@ -147,6 +147,7 @@ func TestAccVPCNetworkInterfaceDataSource_publicIPAssociation(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, names.AttrDescription, resourceName, names.AttrDescription),
 					resource.TestCheckResourceAttr(datasourceName, "interface_type", "interface"),
 					resource.TestCheckResourceAttr(datasourceName, "ipv6_addresses.#", "0"),
+					resource.TestCheckResourceAttr(datasourceName, "public_dns_names_ipv6.#", "0"),
 					resource.TestCheckResourceAttrSet(datasourceName, "mac_address"),
 					resource.TestCheckResourceAttr(datasourceName, "outpost_arn", ""),
 					acctest.CheckResourceAttrAccountID(ctx, datasourceName, names.AttrOwnerID),

--- a/internal/service/ec2/vpc_network_interface_test.go
+++ b/internal/service/ec2/vpc_network_interface_test.go
@@ -89,6 +89,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 					testAccCheckENIExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_dns_names_ipv6.#", "1"),
 				),
 			},
 			{
@@ -103,6 +104,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 					testAccCheckENIExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "public_dns_names_ipv6.#", "2"),
 				),
 			},
 			{
@@ -111,6 +113,7 @@ func TestAccVPCNetworkInterface_ipv6(t *testing.T) {
 					testAccCheckENIExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "public_dns_names_ipv6.#", "1"),
 				),
 			},
 		},

--- a/website/docs/d/instance.html.markdown
+++ b/website/docs/d/instance.html.markdown
@@ -108,6 +108,9 @@ interpolation.
     * `hostname_type` - Type of hostname for EC2 instances.
 * `private_ip` - Private IP address assigned to the Instance.
 * `public_dns` - Public DNS name assigned to the Instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
+* `public_dns_name_dualstack` - Public DNS name that resolves to the both IPv6 (AAAA) and IPv4 (A) addresses of the instance. Only available if the instance has both.
+* `public_dns_name_ipv4` - Public DNS name that resolves to the instance's public IPv4 address. Only available if the instance has a public IPv4 address assigned.
+* `public_dns_name_ipv6` - Public DNS name that resolves to the instance's IPv6 address. Only available if the instance has IPv6 addresses on its primary network interface.
 * `public_ip` - Public IP address assigned to the Instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `root_block_device` - Root block device mappings of the Instance
     * `device_name` - Physical name of the device.

--- a/website/docs/d/network_interface.html.markdown
+++ b/website/docs/d/network_interface.html.markdown
@@ -40,6 +40,7 @@ This data source exports the following attributes in addition to the arguments a
 * `private_dns_name` - Private DNS name.
 * `private_ip` - Private IPv4 address of the network interface within the subnet.
 * `private_ips` - Private IPv4 addresses associated with the network interface.
+* `public_dns_names_ipv6` - List of public DNS names which resolve to the addresses in `ipv6_addresses`.
 * `requester_id` - ID of the entity that launched the instance on your behalf.
 * `security_groups` - List of security groups for the network interface.
 * `subnet_id` - ID of the subnet.

--- a/website/docs/r/instance.html.markdown
+++ b/website/docs/r/instance.html.markdown
@@ -447,6 +447,9 @@ This resource exports the following attributes in addition to the arguments abov
 * `primary_network_interface_id` - ID of the instance's primary network interface.
 * `private_dns` - Private DNS name assigned to the instance. Can only be used inside the Amazon EC2, and only available if you've enabled DNS hostnames for your VPC.
 * `public_dns` - Public DNS name assigned to the instance. For EC2-VPC, this is only available if you've enabled DNS hostnames for your VPC.
+* `public_dns_name_dualstack` - Public DNS name that resolves to the both IPv6 (AAAA) and IPv4 (A) addresses of the instance. Only available if the instance has both.
+* `public_dns_name_ipv4` - Public DNS name that resolves to the instance's public IPv4 address. Only available if the instance has a public IPv4 address assigned.
+* `public_dns_name_ipv6` - Public DNS name that resolves to the instance's IPv6 address. Only available if the instance has IPv6 addresses on its primary network interface.
 * `public_ip` - Public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip` as this field will change after the EIP is attached.
 * `tags_all` - Map of tags assigned to the resource, including those inherited from the provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block).
 

--- a/website/docs/r/network_interface.html.markdown
+++ b/website/docs/r/network_interface.html.markdown
@@ -66,6 +66,7 @@ The following arguments are optional:
 * `private_ip_list_enabled` - (Optional) Whether `private_ip_list` is allowed and controls the IPs to assign to the ENI and `private_ips` and `private_ips_count` become read-only. Default is `false`.
 * `private_ips` - (Optional) List of private IPs to assign to the ENI without regard to order.
 * `private_ips_count` - (Optional) Number of secondary private IPs to assign to the ENI. The total number of private IPs will be 1 + `private_ips_count`, as a primary private IP will be assiged to an ENI by default.
+* `public_dns_names_ipv6` - (Optional) List of public DNS names which resolve to the addresses in `ipv6_address_list`, in the same order.
 * `security_groups` - (Optional) List of security group IDs to assign to the ENI.
 * `source_dest_check` - (Optional) Whether to enable source destination checking for the ENI. Default true.
 * `tags` - (Optional) Map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.


### PR DESCRIPTION
### Changes to Security Controls
None.

### Description
This changes `aws_instance` and `aws_network_interface` resources and data sources to output IPv6-based public hostnames mentioned in issue #42758. That is, on top of the existing `public_dns` attributes, it adds:

  * for `aws_instance`:
      - `public_dns_name_dualstack`
      - `public_dns_name_ipv6`
      - `public_dns_name_ipv4` (for consistency)
  * for `aws_network_interface`:
     - `public_dns_names_ipv6` only.

The important thing here are the DNS names on `aws_instance`. Running a dual-stack network should be as convenient as an IPv4-only network. The additions to `aws_network_interface` are more of a nice-to-have.

Some reasoning for the little decisions in this PR:

  * For EC2 instances, we just want _a_ name for it, and don't care much which interface it is (if it has multiple). For ENIs it makes sense to provide more information, but there is no obvious way to pick one address, or a (v6, v4) address pair. While IPv6-only names might still make sense here, dual-stack names do not.
  * `calculatePublicDNSName*` functions assume proper input, as I see no good way to constrain their input types.
  * In acceptance tests for `aws_network_interface`, I figured that what's good enough for `ipv6_addresses` ought to be good enough for `public_dns_names_ipv6`, which is a function of it.
  * AWS also supports IPv6 [ULAs and "private GUAs"][1], which are not globally routable. This PR contains no special handling of them -- I figure that they're odd enough that whoever uses them can just ignore these attributes. And besides, only ULAs have a known CIDR (`fd00::/8`).

[1]: https://aws.amazon.com/blogs/networking-and-content-delivery/understanding-ipv6-addressing-on-aws-and-designing-a-scalable-addressing-plan/

### Relations
Closes #42758

### Output from Acceptance Testing

```console
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='^TestAcc(VPCNetworkInterface(_ipv6$|DataSource_publicIPAssociation)|EC2Instance(DataSource)?_publicDNSNames)'  -timeout 360m -vet=off
2025/06/15 02:24:59 Initializing Terraform AWS Provider...
=== RUN   TestAccEC2InstanceDataSource_publicDNSNames
=== PAUSE TestAccEC2InstanceDataSource_publicDNSNames
=== RUN   TestAccEC2Instance_publicDNSNames
=== PAUSE TestAccEC2Instance_publicDNSNames
=== RUN   TestAccVPCNetworkInterfaceDataSource_publicIPAssociation
=== PAUSE TestAccVPCNetworkInterfaceDataSource_publicIPAssociation
=== RUN   TestAccVPCNetworkInterface_ipv6
=== PAUSE TestAccVPCNetworkInterface_ipv6
=== CONT  TestAccEC2InstanceDataSource_publicDNSNames
=== CONT  TestAccVPCNetworkInterfaceDataSource_publicIPAssociation
=== CONT  TestAccEC2Instance_publicDNSNames
=== CONT  TestAccVPCNetworkInterface_ipv6
--- PASS: TestAccVPCNetworkInterfaceDataSource_publicIPAssociation (34.78s)
--- PASS: TestAccVPCNetworkInterface_ipv6 (95.40s)
--- PASS: TestAccEC2InstanceDataSource_publicDNSNames (220.12s)
--- PASS: TestAccEC2Instance_publicDNSNames (465.66s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        465.754s
```
