### PR TITLE
Resource Identity: Disable for Mutable Identity

### DIFF
--- a/internal/framework/flex/autoflex.go
+++ b/internal/framework/flex/autoflex.go
@@ -120,8 +120,8 @@ func findFieldFuzzy(ctx context.Context, fieldNameFrom string, typeFrom reflect.
 		if ctx.Value(fieldNamePrefixRecurse) == nil {
 			// so it will only recurse once
 			ctx = context.WithValue(ctx, fieldNamePrefixRecurse, true)
-			if strings.HasPrefix(fieldNameFrom, v) {
-				return findFieldFuzzy(ctx, strings.TrimPrefix(fieldNameFrom, v), typeFrom, typeTo, flexer)
+			if trimmed, ok := strings.CutPrefix(fieldNameFrom, v); ok {
+				return findFieldFuzzy(ctx, trimmed, typeFrom, typeTo, flexer)
 			}
 			return findFieldFuzzy(ctx, v+fieldNameFrom, typeFrom, typeTo, flexer)
 		}

--- a/internal/generate/servicepackage/service_package_gen.go.gtpl
+++ b/internal/generate/servicepackage/service_package_gen.go.gtpl
@@ -121,65 +121,67 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 				IsValidateOverrideInPartition: {{ $value.ValidateRegionOverrideInPartition }},
 			}),
 	{{- end }}
-			{{- if gt (len $value.IdentityAttributes) 0 }}
-				{{- if or $.IsGlobal $value.IsGlobal }}
-					Identity: inttypes.GlobalParameterizedIdentity(
-						{{- range $value.IdentityAttributes }}
-							{{ template "IdentifierAttribute" . }}
-						{{- end }}
-					),
-				{{ else }}
-					Identity: inttypes.RegionalParameterizedIdentity(
-						{{- range $value.IdentityAttributes }}
-							{{ template "IdentifierAttribute" . }}
-						{{- end }}
-					),
-				{{- end }}
-			{{- else if $value.ARNIdentity }}
-				{{- if $.IsGlobal }}
-					{{- if $value.HasARNAttribute }}
-						Identity: inttypes.GlobalARNIdentityNamed({{ $value.ARNAttribute }},
-					{{- else }}
-						Identity: inttypes.GlobalARNIdentity(
+			{{- if not $value.MutableIdentity }}
+				{{- if gt (len $value.IdentityAttributes) 0 }}
+					{{- if or $.IsGlobal $value.IsGlobal }}
+						Identity: inttypes.GlobalParameterizedIdentity(
+							{{- range $value.IdentityAttributes }}
+								{{ template "IdentifierAttribute" . }}
+							{{- end }}
+						),
+					{{ else }}
+						Identity: inttypes.RegionalParameterizedIdentity(
+							{{- range $value.IdentityAttributes }}
+								{{ template "IdentifierAttribute" . }}
+							{{- end }}
+						),
 					{{- end }}
-				{{- else }}
-					{{- if $value.IsARNFormatGlobal }}
+				{{- else if $value.ARNIdentity }}
+					{{- if $.IsGlobal }}
 						{{- if $value.HasARNAttribute }}
-							Identity: inttypes.RegionalResourceWithGlobalARNFormatNamed({{ $value.ARNAttribute }},
+							Identity: inttypes.GlobalARNIdentityNamed({{ $value.ARNAttribute }},
 						{{- else }}
-							Identity: inttypes.RegionalResourceWithGlobalARNFormat(
+							Identity: inttypes.GlobalARNIdentity(
 						{{- end }}
 					{{- else }}
-						{{- if $value.HasARNAttribute }}
-							Identity: inttypes.RegionalARNIdentityNamed({{ $value.ARNAttribute }},
+						{{- if $value.IsARNFormatGlobal }}
+							{{- if $value.HasARNAttribute }}
+								Identity: inttypes.RegionalResourceWithGlobalARNFormatNamed({{ $value.ARNAttribute }},
+							{{- else }}
+								Identity: inttypes.RegionalResourceWithGlobalARNFormat(
+							{{- end }}
 						{{- else }}
-							Identity: inttypes.RegionalARNIdentity(
+							{{- if $value.HasARNAttribute }}
+								Identity: inttypes.RegionalARNIdentityNamed({{ $value.ARNAttribute }},
+							{{- else }}
+								Identity: inttypes.RegionalARNIdentity(
+							{{- end }}
 						{{- end }}
 					{{- end }}
-				{{- end }}
-				{{- if .HasIdentityDuplicateAttrs -}}
-					inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
-				{{- end -}}
-				),
-			{{- else if $value.SingletonIdentity }}
-				{{- if or $.IsGlobal $value.IsGlobal }}
-					Identity: inttypes.GlobalSingletonIdentity(
 						{{- if .HasIdentityDuplicateAttrs -}}
 							inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
 						{{- end -}}
-					),
-				{{ else }}
-					Identity: inttypes.RegionalSingletonIdentity(
-						{{- if .HasIdentityDuplicateAttrs -}}
-							inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
-						{{- end -}}
-					),
+						),
+				{{- else if $value.SingletonIdentity }}
+					{{- if or $.IsGlobal $value.IsGlobal }}
+						Identity: inttypes.GlobalSingletonIdentity(
+							{{- if .HasIdentityDuplicateAttrs -}}
+								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
+							{{- end -}}
+						),
+					{{ else }}
+						Identity: inttypes.RegionalSingletonIdentity(
+							{{- if .HasIdentityDuplicateAttrs -}}
+								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
+							{{- end -}}
+						),
+					{{- end }}
 				{{- end }}
-			{{- end }}
-			{{- if $value.WrappedImport }}
-				Import: inttypes.Import{
-					WrappedImport: true,
-				},
+				{{- if $value.WrappedImport }}
+					Import: inttypes.Import{
+						WrappedImport: true,
+					},
+				{{- end }}
 			{{- end }}
 		},
 {{- end }}
@@ -247,45 +249,47 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 				IsValidateOverrideInPartition: {{ $value.ValidateRegionOverrideInPartition }},
 			}),
 	{{- end }}
-			{{- if gt (len $value.IdentityAttributes) 0 }}
-				{{- if or $.IsGlobal $value.IsGlobal }}
-					Identity: inttypes.GlobalParameterizedIdentity(
-						{{- range $value.IdentityAttributes }}
-							{{ template "IdentifierAttribute" . }}
-						{{- end }}
-					),
-				{{- else }}
-					Identity: inttypes.RegionalParameterizedIdentity(
-						{{- range $value.IdentityAttributes }}
-							{{ template "IdentifierAttribute" . }}
-						{{- end }}
-					),
-				{{- end }}
-			{{- else if $value.ARNIdentity }}
-				{{- if $.IsGlobal }}
-					{{- if $value.HasARNAttribute }}
-						Identity: inttypes.GlobalARNIdentityNamed({{ $value.ARNAttribute }}, inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+			{{- if not $value.MutableIdentity }}
+				{{- if gt (len $value.IdentityAttributes) 0 }}
+					{{- if or $.IsGlobal $value.IsGlobal }}
+						Identity: inttypes.GlobalParameterizedIdentity(
+							{{- range $value.IdentityAttributes }}
+								{{ template "IdentifierAttribute" . }}
+							{{- end }}
+						),
 					{{- else }}
-						Identity: inttypes.GlobalARNIdentity(inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						Identity: inttypes.RegionalParameterizedIdentity(
+							{{- range $value.IdentityAttributes }}
+								{{ template "IdentifierAttribute" . }}
+							{{- end }}
+						),
 					{{- end }}
-				{{- else }}
-					{{- if $value.HasARNAttribute }}
-						Identity: inttypes.RegionalARNIdentityNamed({{ $value.ARNAttribute }}, inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+				{{- else if $value.ARNIdentity }}
+					{{- if $.IsGlobal }}
+						{{- if $value.HasARNAttribute }}
+							Identity: inttypes.GlobalARNIdentityNamed({{ $value.ARNAttribute }}, inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						{{- else }}
+							Identity: inttypes.GlobalARNIdentity(inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						{{- end }}
 					{{- else }}
-						Identity: inttypes.RegionalARNIdentity(inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						{{- if $value.HasARNAttribute }}
+							Identity: inttypes.RegionalARNIdentityNamed({{ $value.ARNAttribute }}, inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						{{- else }}
+							Identity: inttypes.RegionalARNIdentity(inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+						{{- end }}
+					{{- end }}
+				{{- else if $value.SingletonIdentity }}
+					{{- if or $.IsGlobal $value.IsGlobal }}
+						Identity: inttypes.GlobalSingletonIdentity(),
+					{{- else }}
+						Identity: inttypes.RegionalSingletonIdentity(),
 					{{- end }}
 				{{- end }}
-			{{- else if $value.SingletonIdentity }}
-				{{- if or $.IsGlobal $value.IsGlobal }}
-					Identity: inttypes.GlobalSingletonIdentity(),
-				{{- else }}
-					Identity: inttypes.RegionalSingletonIdentity(),
+				{{- if $value.WrappedImport }}
+					Import: inttypes.Import{
+						WrappedImport: true,
+					},
 				{{- end }}
-			{{- end }}
-			{{- if $value.WrappedImport }}
-				Import: inttypes.Import{
-					WrappedImport: true,
-				},
 			{{- end }}
 		},
 {{- end }}

--- a/internal/service/batch/job_definition_identity_gen_test.go
+++ b/internal/service/batch/job_definition_identity_gen_test.go
@@ -49,7 +49,7 @@ func TestAccBatchJobDefinition_Identity_Basic(t *testing.T) {
 					tfstatecheck.ExpectRegionalARNFormat(resourceName, tfjsonpath.New(names.AttrARN), "batch", "job-definition/{name}:{revision}"),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrARN)),
+					// Resource Identity not supported for Mutable Identity
 				},
 			},
 
@@ -84,22 +84,7 @@ func TestAccBatchJobDefinition_Identity_Basic(t *testing.T) {
 			},
 
 			// Step 4: Import block with Resource Identity
-			{
-				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/basic/"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-				},
-				ResourceName:    resourceName,
-				ImportState:     true,
-				ImportStateKind: resource.ImportBlockWithResourceIdentity,
-				ImportPlanChecks: resource.ImportPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
-					},
-				},
-			},
+			// Resource Identity not supported for Mutable Identity
 		},
 	})
 }
@@ -130,7 +115,7 @@ func TestAccBatchJobDefinition_Identity_RegionOverride(t *testing.T) {
 					tfstatecheck.ExpectRegionalARNAlternateRegionFormat(resourceName, tfjsonpath.New(names.AttrARN), "batch", "job-definition/{name}:{revision}"),
 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrARN)),
+					// Resource Identity not supported for Mutable Identity
 				},
 			},
 
@@ -149,17 +134,7 @@ func TestAccBatchJobDefinition_Identity_RegionOverride(t *testing.T) {
 			},
 
 			// Step 3: Import command without appended "@<region>"
-			{
-				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/region_override/"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-					"region":        config.StringVariable(acctest.AlternateRegion()),
-				},
-				ImportStateKind:   resource.ImportCommandWithID,
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			// Importing without appended "@<region>" for Mutable Identity
 
 			// Step 4: Import block with Import ID and appended "@<region>"
 			{
@@ -182,42 +157,10 @@ func TestAccBatchJobDefinition_Identity_RegionOverride(t *testing.T) {
 			},
 
 			// Step 5: Import block with Import ID and no appended "@<region>"
-			{
-				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/region_override/"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-					"region":        config.StringVariable(acctest.AlternateRegion()),
-				},
-				ResourceName:    resourceName,
-				ImportState:     true,
-				ImportStateKind: resource.ImportBlockWithID,
-				ImportPlanChecks: resource.ImportPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
-					},
-				},
-			},
+			// Importing without appended "@<region>" for Mutable Identity
 
 			// Step 6: Import block with Resource Identity
-			{
-				ConfigDirectory: config.StaticDirectory("testdata/JobDefinition/region_override/"),
-				ConfigVariables: config.Variables{
-					acctest.CtRName: config.StringVariable(rName),
-					"region":        config.StringVariable(acctest.AlternateRegion()),
-				},
-				ResourceName:    resourceName,
-				ImportState:     true,
-				ImportStateKind: resource.ImportBlockWithResourceIdentity,
-				ImportPlanChecks: resource.ImportPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.AlternateRegion())),
-					},
-				},
-			},
+			// Resource Identity not supported for Mutable Identity
 		},
 	})
 }

--- a/internal/service/batch/service_package_gen.go
+++ b/internal/service/batch/service_package_gen.go
@@ -92,8 +92,7 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			Tags: unique.Make(inttypes.ServicePackageResourceTags{
 				IdentifierAttribute: names.AttrARN,
 			}),
-			Region:   unique.Make(inttypes.ResourceRegionDefault()),
-			Identity: inttypes.RegionalARNIdentity(inttypes.WithIdentityDuplicateAttrs(names.AttrID)),
+			Region: unique.Make(inttypes.ResourceRegionDefault()),
 		},
 		{
 			Factory:  resourceSchedulingPolicy,

--- a/internal/service/ec2/vpc_block_public_access_exclusion.go
+++ b/internal/service/ec2/vpc_block_public_access_exclusion.go
@@ -164,10 +164,11 @@ func (r *vpcBlockPublicAccessExclusionResource) Read(ctx context.Context, reques
 		return
 	}
 
-	if resource := resourceARN.Resource; strings.HasPrefix(resource, "vpc/") {
-		data.VPCID = types.StringValue(strings.TrimPrefix(resource, "vpc/"))
-	} else if strings.HasPrefix(resource, "subnet/") {
-		data.SubnetID = types.StringValue(strings.TrimPrefix(resource, "subnet/"))
+	resource := resourceARN.Resource
+	if trimmed, ok := strings.CutPrefix(resource, "vpc/"); ok {
+		data.VPCID = types.StringValue(trimmed)
+	} else if trimmed, ok := strings.CutPrefix(resource, "subnet/"); ok {
+		data.SubnetID = types.StringValue(trimmed)
 	} else {
 		response.Diagnostics.AddError("parsing Resource_ARN", fmt.Sprintf("unknown resource type: %s", resource))
 

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-plugin-testing/tfversion"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	tfknownvalue "github.com/hashicorp/terraform-provider-aws/internal/acctest/knownvalue"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfroute53 "github.com/hashicorp/terraform-provider-aws/internal/service/route53"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -96,6 +95,7 @@ func TestAccRoute53Record_Identity_Basic(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx),
 		Steps: []resource.TestStep{
+			// Step 1: Setup
 			{
 				Config: testAccRecordConfig_basic(zoneName.String(), recordName.String()),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -103,19 +103,20 @@ func TestAccRoute53Record_Identity_Basic(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(fmt.Sprintf(`^[[:alnum:]]+_%s_A$`, recordName.String())))),
-					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
-						names.AttrAccountID: tfknownvalue.AccountID(),
-						"zone_id":           knownvalue.NotNull(),
-						names.AttrName:      knownvalue.NotNull(),
-						names.AttrType:      knownvalue.NotNull(),
-						"set_identifier":    knownvalue.Null(),
-					}),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("zone_id")),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrType)),
+					// statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+					// 	names.AttrAccountID: tfknownvalue.AccountID(),
+					// 	"zone_id":           knownvalue.NotNull(),
+					// 	names.AttrName:      knownvalue.NotNull(),
+					// 	names.AttrType:      knownvalue.NotNull(),
+					// 	"set_identifier":    knownvalue.Null(),
+					// }),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("zone_id")),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrType)),
 				},
 			},
 
+			// Step 2: Import command
 			{
 				ImportStateKind:   resource.ImportCommandWithID,
 				ResourceName:      resourceName,
@@ -123,6 +124,7 @@ func TestAccRoute53Record_Identity_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 
+			// Step 3: Import block with Import ID
 			{
 				ImportStateKind: resource.ImportBlockWithID,
 				ResourceName:    resourceName,
@@ -138,20 +140,21 @@ func TestAccRoute53Record_Identity_Basic(t *testing.T) {
 				},
 			},
 
-			{
-				ImportStateKind: resource.ImportBlockWithResourceIdentity,
-				ResourceName:    resourceName,
-				ImportState:     true,
-				ImportPlanChecks: resource.ImportPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(recordName.String())),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("A")),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("set_identifier"), knownvalue.StringExact("")),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(fmt.Sprintf(`^[[:alnum:]]+_%s_A$`, recordName.String())))),
-					},
-				},
-			},
+			// // Step 4: Import block with Resource Identity
+			// {
+			// 	ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			// 	ResourceName:    resourceName,
+			// 	ImportState:     true,
+			// 	ImportPlanChecks: resource.ImportPlanChecks{
+			// 		PreApply: []plancheck.PlanCheck{
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact(recordName.String())),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("A")),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("set_identifier"), knownvalue.StringExact("")),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(fmt.Sprintf(`^[[:alnum:]]+_%s_A$`, recordName.String())))),
+			// 		},
+			// 	},
+			// },
 		},
 	})
 }
@@ -170,6 +173,7 @@ func TestAccRoute53Record_Identity_SetIdentifier(t *testing.T) {
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             testAccCheckRecordDestroy(ctx),
 		Steps: []resource.TestStep{
+			// Step 1: Setup
 			{
 				Config: testAccRecordConfig_healthCheckIdTypeCNAME(),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -177,25 +181,29 @@ func TestAccRoute53Record_Identity_SetIdentifier(t *testing.T) {
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(`^[[:alnum:]]+_test_CNAME_set-id$`))),
-					statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
-						names.AttrAccountID: tfknownvalue.AccountID(),
-						"zone_id":           knownvalue.NotNull(),
-						names.AttrName:      knownvalue.NotNull(),
-						names.AttrType:      knownvalue.NotNull(),
-						"set_identifier":    knownvalue.NotNull(),
-					}),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("zone_id")),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrType)),
-					statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("set_identifier")),
+					// statecheck.ExpectIdentity(resourceName, map[string]knownvalue.Check{
+					// 	names.AttrAccountID: tfknownvalue.AccountID(),
+					// 	"zone_id":           knownvalue.NotNull(),
+					// 	names.AttrName:      knownvalue.NotNull(),
+					// 	names.AttrType:      knownvalue.NotNull(),
+					// 	"set_identifier":    knownvalue.NotNull(),
+					// }),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("zone_id")),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrName)),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New(names.AttrType)),
+					// statecheck.ExpectIdentityValueMatchesState(resourceName, tfjsonpath.New("set_identifier")),
 				},
 			},
+
+			// Step 2: Import command
 			{
 				ImportStateKind:   resource.ImportCommandWithID,
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+
+			// Step 3: Import block with Import ID
 			{
 				ImportStateKind: resource.ImportBlockWithID,
 				ResourceName:    resourceName,
@@ -210,20 +218,22 @@ func TestAccRoute53Record_Identity_SetIdentifier(t *testing.T) {
 					},
 				},
 			},
-			{
-				ImportStateKind: resource.ImportBlockWithResourceIdentity,
-				ResourceName:    resourceName,
-				ImportState:     true,
-				ImportPlanChecks: resource.ImportPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact("test")),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("CNAME")),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("set_identifier"), knownvalue.StringExact("set-id")),
-						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(`^[[:alnum:]]+_test_CNAME_set-id$`))),
-					},
-				},
-			},
+
+			// // Step 4: Import block with Resource Identity
+			// {
+			// 	ImportStateKind: resource.ImportBlockWithResourceIdentity,
+			// 	ResourceName:    resourceName,
+			// 	ImportState:     true,
+			// 	ImportPlanChecks: resource.ImportPlanChecks{
+			// 		PreApply: []plancheck.PlanCheck{
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("zone_id"), knownvalue.NotNull()),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrName), knownvalue.StringExact("test")),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrType), knownvalue.StringExact("CNAME")),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New("set_identifier"), knownvalue.StringExact("set-id")),
+			// 			plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrID), knownvalue.StringRegexp(regexache.MustCompile(`^[[:alnum:]]+_test_CNAME_set-id$`))),
+			// 		},
+			// 	},
+			// },
 		},
 	})
 }

--- a/internal/service/route53/service_package_gen.go
+++ b/internal/service/route53/service_package_gen.go
@@ -123,12 +123,6 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 			TypeName: "aws_route53_record",
 			Name:     "Record",
 			Region:   unique.Make(inttypes.ResourceRegionDisabled()),
-			Identity: inttypes.GlobalParameterizedIdentity(
-				inttypes.StringIdentityAttribute("zone_id", true),
-				inttypes.StringIdentityAttribute(names.AttrName, true),
-				inttypes.StringIdentityAttribute(names.AttrType, true),
-				inttypes.StringIdentityAttribute("set_identifier", false),
-			),
 		},
 		{
 			Factory:  resourceTrafficPolicy,

--- a/internal/vault/helper/pgpkeys/keybase.go
+++ b/internal/vault/helper/pgpkeys/keybase.go
@@ -35,8 +35,8 @@ func FetchKeybasePubkeys(input []string) (map[string]string, error) {
 
 	usernames := make([]string, 0, len(input))
 	for _, v := range input {
-		if strings.HasPrefix(v, kbPrefix) {
-			usernames = append(usernames, strings.TrimSuffix(strings.TrimPrefix(v, kbPrefix), "\n"))
+		if trimmed, ok := strings.CutPrefix(v, kbPrefix); ok {
+			usernames = append(usernames, strings.TrimSuffix(trimmed, "\n"))
 		}
 	}
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Disables Resource Identity for resource types with Mutable Identity, as it is not fully supported.

Includes fix to `modern-check` issue
