### PR TITLE
feat:add input argument to enable worker replacement strategy

### DIFF
--- a/.changelog/43041.txt
+++ b/.changelog/43041.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_mwaa_environment: Add `worker_replacement_strategy` attribute
+```

--- a/internal/service/mwaa/environment.go
+++ b/internal/service/mwaa/environment.go
@@ -297,6 +297,12 @@ func resourceEnvironment() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"worker_replacement_strategy": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.WorkerReplacementStrategy](),
+			},
 		},
 
 		CustomizeDiff: customdiff.Sequence(
@@ -465,6 +471,7 @@ func resourceEnvironmentRead(ctx context.Context, d *schema.ResourceData, meta a
 	if err := d.Set("last_updated", flattenLastUpdate(environment.LastUpdate)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting last_updated: %s", err)
 	}
+	d.Set("worker_replacement_strategy", environment.LastUpdate.WorkerReplacementStrategy)
 	if err := d.Set(names.AttrLoggingConfiguration, flattenLoggingConfiguration(environment.LoggingConfiguration)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting logging_configuration: %s", err)
 	}
@@ -593,6 +600,10 @@ func resourceEnvironmentUpdate(ctx context.Context, d *schema.ResourceData, meta
 
 		if d.HasChange("weekly_maintenance_window_start") {
 			input.WeeklyMaintenanceWindowStart = aws.String(d.Get("weekly_maintenance_window_start").(string))
+		}
+
+		if d.HasChange("worker_replacement_strategy") {
+			input.WorkerReplacementStrategy = awstypes.WorkerReplacementStrategy(d.Get("worker_replacement_strategy").(string))
 		}
 
 		_, err := conn.UpdateEnvironment(ctx, input)

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -472,6 +472,47 @@ func TestAccMWAAEnvironment_updateAirflowVersionMinor(t *testing.T) {
 	})
 }
 
+func TestAccMWAAEnvironment_updateAirflowWorkerReplacementStrategy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var environment1, environment2 awstypes.Environment
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_mwaa_environment.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.MWAAServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnvironmentConfig_airflowWorkerReplacementStrategy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment1),
+					resource.TestCheckResourceAttr(resourceName, "worker_replacement_strategy", "FORCED"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccEnvironmentConfig_airflowWorkerReplacementStrategy(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists(ctx, resourceName, &environment2),
+					testAccCheckEnvironmentNotRecreated(&environment2, &environment1),
+					resource.TestCheckResourceAttr(resourceName, "worker_replacement_strategy", "GRACEFUL"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckEnvironmentExists(ctx context.Context, n string, v *awstypes.Environment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -1010,8 +1051,26 @@ resource "aws_mwaa_environment" "test" {
   }
 
   source_bucket_arn = aws_s3_bucket.test.arn
-
   airflow_version = %[2]q
 }
 `, rName, airflowVersion))
+}
+
+func testAccEnvironmentConfig_airflowWorkerReplacementStrategy(rName string) string {
+	return acctest.ConfigCompose(testAccEnvironmentConfig_base(rName), fmt.Sprintf(`
+resource "aws_mwaa_environment" "test" {
+  dag_s3_path        = aws_s3_object.dags.key
+  execution_role_arn = aws_iam_role.test.arn
+  name               = %[1]q
+
+	worker_replacement_strategy = "GRACEFUL"
+  network_configuration {
+    security_group_ids = [aws_security_group.test.id]
+    subnet_ids         = aws_subnet.private[*].id
+  }
+
+  source_bucket_arn = aws_s3_bucket.test.arn
+  airflow_version = "2.4.3"
+}
+`, rName))
 }

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -1051,7 +1051,7 @@ resource "aws_mwaa_environment" "test" {
   }
 
   source_bucket_arn = aws_s3_bucket.test.arn
-  airflow_version = %[2]q
+  airflow_version   = %[2]q
 }
 `, rName, airflowVersion))
 }
@@ -1059,18 +1059,17 @@ resource "aws_mwaa_environment" "test" {
 func testAccEnvironmentConfig_airflowWorkerReplacementStrategy(rName string) string {
 	return acctest.ConfigCompose(testAccEnvironmentConfig_base(rName), fmt.Sprintf(`
 resource "aws_mwaa_environment" "test" {
-  dag_s3_path        = aws_s3_object.dags.key
-  execution_role_arn = aws_iam_role.test.arn
-  name               = %[1]q
-
-	worker_replacement_strategy = "GRACEFUL"
+  dag_s3_path                 = aws_s3_object.dags.key
+  execution_role_arn          = aws_iam_role.test.arn
+  name                        = %[1]q
+  worker_replacement_strategy = "GRACEFUL"
   network_configuration {
     security_group_ids = [aws_security_group.test.id]
     subnet_ids         = aws_subnet.private[*].id
   }
 
   source_bucket_arn = aws_s3_bucket.test.arn
-  airflow_version = "2.4.3"
+  airflow_version   = "2.4.3"
 }
 `, rName))
 }


### PR DESCRIPTION
### Description
Added support for the `worker_replacement_strategy` input argument to the module, enabling its use with AWS MWAA environments via the `UpdateEnvironment` API:
https://aws.amazon.com/about-aws/whats-new/2025/05/amazon-mwaa-option-update-environments-without-interrupting-task-execution/

### Relations
Closes #42842

### Output from Acceptance Testing
Test to verify that the worker_replacement_strategy is set to the value `GRACEFUL`:
```console
% make testacc TESTS=updateAirflowWorkerReplacementStrategy PKG=mwaa
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/mwaa/... -v -count 1 -parallel 20 -run='updateAirflowWorkerReplacementStrategy'  -timeout 360m -vet=off
2025/06/16 22:51:45 Initializing Terraform AWS Provider...
=== RUN   TestAccMWAAEnvironment_updateAirflowWorkerReplacementStrategy
=== PAUSE TestAccMWAAEnvironment_updateAirflowWorkerReplacementStrategy
=== CONT  TestAccMWAAEnvironment_updateAirflowWorkerReplacementStrategy
--- PASS: TestAccMWAAEnvironment_updateAirflowWorkerReplacementStrategy (3733.88s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	3739.289s
```

Test to verify nothing was broken previously:
```console
% make testacc TESTS=TestAccMWAAEnvironment_basic PKG=mwaa
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/mwaa/... -v -count 1 -parallel 20 -run='TestAccMWAAEnvironment_basic'  -timeout 360m -vet=off
2025/06/17 00:13:33 Initializing Terraform AWS Provider...
=== RUN   TestAccMWAAEnvironment_basic
=== PAUSE TestAccMWAAEnvironment_basic
=== CONT  TestAccMWAAEnvironment_basic
--- PASS: TestAccMWAAEnvironment_basic (2827.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/mwaa	2832.816s
...
```