### PR TITLE
Re-enable Terraform 0.12 support

### DIFF
--- a/internal/provider/sdkv2/provider.go
+++ b/internal/provider/sdkv2/provider.go
@@ -333,16 +333,6 @@ func (p *sdkProvider) configure(ctx context.Context, d *schema.ResourceData) (an
 		terraformVersion = "0.11+compatible"
 	}
 
-	// Terraform 0.12.31 will download beta version of the provider as the latest available.
-	// See https://github.com/hashicorp/terraform/issues/36586.
-	// This check must be removed before the GA release.
-	switch {
-	case terraformVersion == "0.11+compatible", strings.HasPrefix(terraformVersion, "0.12."):
-		return nil, sdkdiag.AppendErrorf(diags, "unsupported Terraform version: %s. "+
-			"This version of Terraform is not supported with pre-release version of the Terraform AWS Provider but will be supported at GA. "+
-			"See https://developer.hashicorp.com/terraform/language/providers/requirements#v0-12-compatible-provider-requirements for details of how to specify an exact provider version to use", terraformVersion)
-	}
-
 	config := conns.Config{
 		AccessKey:                      d.Get("access_key").(string),
 		CustomCABundle:                 d.Get("custom_ca_bundle").(string),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Removes the Terraform 0.12 blockade added for v6.0.0 betas.
Because of the way the CHANGELOG is generated and the various `v6.0.0.beta` release we will have to fixup the CHANGELOG manually after release.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/43071.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/41722.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

#### Terraform v1.10.4

```console
% make sane
make: Sane Smoke Tests (x tests of Top y resources)
make: Like 'sanity' except full output and stops soon after 1st error
make: NOTE: NOT an exhaustive set of tests! Finds big problems only.
2025/06/18 11:18:58 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:18:58 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccIAMInstanceProfile_tags
=== PAUSE TestAccIAMInstanceProfile_tags
=== RUN   TestAccIAMInstanceProfile_basic
=== PAUSE TestAccIAMInstanceProfile_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_basic
=== PAUSE TestAccIAMPolicyDocumentDataSource_basic
=== RUN   TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== PAUSE TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== RUN   TestAccIAMPolicy_tags
=== PAUSE TestAccIAMPolicy_tags
=== RUN   TestAccIAMPolicy_basic
=== PAUSE TestAccIAMPolicy_basic
=== RUN   TestAccIAMPolicy_policy
=== PAUSE TestAccIAMPolicy_policy
=== RUN   TestAccIAMRolePolicyAttachment_basic
=== PAUSE TestAccIAMRolePolicyAttachment_basic
=== RUN   TestAccIAMRolePolicyAttachment_disappears
=== PAUSE TestAccIAMRolePolicyAttachment_disappears
=== RUN   TestAccIAMRolePolicyAttachment_Disappears_role
=== PAUSE TestAccIAMRolePolicyAttachment_Disappears_role
=== RUN   TestAccIAMRolePolicy_basic
=== PAUSE TestAccIAMRolePolicy_basic
=== RUN   TestAccIAMRolePolicy_unknownsInPolicy
=== PAUSE TestAccIAMRolePolicy_unknownsInPolicy
=== RUN   TestAccIAMRole_basic
=== PAUSE TestAccIAMRole_basic
=== RUN   TestAccIAMRole_namePrefix
=== PAUSE TestAccIAMRole_namePrefix
=== RUN   TestAccIAMRole_disappears
=== PAUSE TestAccIAMRole_disappears
=== RUN   TestAccIAMRole_InlinePolicy_basic
=== PAUSE TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMInstanceProfile_tags
=== CONT  TestAccIAMRolePolicyAttachment_disappears
=== CONT  TestAccIAMRole_basic
=== CONT  TestAccIAMRole_disappears
=== CONT  TestAccIAMPolicy_tags
=== CONT  TestAccIAMRole_namePrefix
=== CONT  TestAccIAMRolePolicy_basic
=== CONT  TestAccIAMRole_InlinePolicy_basic
=== CONT  TestAccIAMPolicy_policy
=== CONT  TestAccIAMPolicy_basic
=== CONT  TestAccIAMRolePolicyAttachment_basic
=== CONT  TestAccIAMPolicyDocumentDataSource_sourceConflicting
=== CONT  TestAccIAMRolePolicyAttachment_Disappears_role
=== CONT  TestAccIAMInstanceProfile_basic
=== CONT  TestAccIAMRolePolicy_unknownsInPolicy
=== CONT  TestAccIAMPolicyDocumentDataSource_basic
--- PASS: TestAccIAMPolicyDocumentDataSource_basic (13.47s)
--- PASS: TestAccIAMPolicyDocumentDataSource_sourceConflicting (13.86s)
--- PASS: TestAccIAMRole_disappears (17.62s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (18.32s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (18.85s)
--- PASS: TestAccIAMRole_basic (19.67s)
--- PASS: TestAccIAMPolicy_basic (20.18s)
--- PASS: TestAccIAMRolePolicy_basic (20.37s)
--- PASS: TestAccIAMRole_namePrefix (20.78s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (21.38s)
--- PASS: TestAccIAMInstanceProfile_basic (25.29s)
--- PASS: TestAccIAMPolicy_policy (28.39s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (28.59s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (36.82s)
--- PASS: TestAccIAMPolicy_tags (56.10s)
--- PASS: TestAccIAMInstanceProfile_tags (75.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/iam	80.983s
2025/06/18 11:21:02 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:21:02 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsGroup_basic
=== PAUSE TestAccLogsGroup_basic
=== RUN   TestAccLogsGroup_multiple
=== PAUSE TestAccLogsGroup_multiple
=== CONT  TestAccLogsGroup_basic
=== CONT  TestAccLogsGroup_multiple
--- PASS: TestAccLogsGroup_multiple (17.42s)
--- PASS: TestAccLogsGroup_basic (20.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/logs	25.339s
2025/06/18 11:21:05 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:21:05 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPCDataSource_basic
=== PAUSE TestAccVPCDataSource_basic
=== RUN   TestAccVPCRouteTableAssociation_Subnet_basic
=== PAUSE TestAccVPCRouteTableAssociation_Subnet_basic
=== RUN   TestAccVPCRouteTable_basic
=== PAUSE TestAccVPCRouteTable_basic
=== RUN   TestAccVPCSecurityGroupRule_race
=== PAUSE TestAccVPCSecurityGroupRule_race
=== RUN   TestAccVPCSecurityGroupRule_protocolChange
=== PAUSE TestAccVPCSecurityGroupRule_protocolChange
=== RUN   TestAccVPCSecurityGroup_basic
=== PAUSE TestAccVPCSecurityGroup_basic
=== RUN   TestAccVPCSecurityGroup_egressMode
=== PAUSE TestAccVPCSecurityGroup_egressMode
=== RUN   TestAccVPCSecurityGroup_vpcAllEgress
=== PAUSE TestAccVPCSecurityGroup_vpcAllEgress
=== RUN   TestAccVPCSubnet_basic
=== PAUSE TestAccVPCSubnet_basic
=== RUN   TestAccVPC_tenancy
=== PAUSE TestAccVPC_tenancy
=== CONT  TestAccVPCDataSource_basic
=== CONT  TestAccVPCSecurityGroup_basic
=== CONT  TestAccVPCRouteTable_basic
=== CONT  TestAccVPCSubnet_basic
=== CONT  TestAccVPCSecurityGroup_egressMode
=== CONT  TestAccVPCSecurityGroupRule_race
=== CONT  TestAccVPCRouteTableAssociation_Subnet_basic
=== CONT  TestAccVPCSecurityGroup_vpcAllEgress
=== CONT  TestAccVPCSecurityGroupRule_protocolChange
=== CONT  TestAccVPC_tenancy
--- PASS: TestAccVPCRouteTable_basic (24.39s)
--- PASS: TestAccVPCSecurityGroup_basic (24.48s)
--- PASS: TestAccVPCSubnet_basic (24.75s)
--- PASS: TestAccVPCSecurityGroup_vpcAllEgress (25.23s)
--- PASS: TestAccVPCRouteTableAssociation_Subnet_basic (26.50s)
--- PASS: TestAccVPCDataSource_basic (31.21s)
--- PASS: TestAccVPCSecurityGroup_egressMode (46.38s)
--- PASS: TestAccVPC_tenancy (51.59s)
--- PASS: TestAccVPCSecurityGroupRule_protocolChange (53.27s)
--- PASS: TestAccVPCSecurityGroupRule_race (164.30s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	173.386s
2025/06/18 11:21:09 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:21:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccECSService_basic
=== PAUSE TestAccECSService_basic
=== RUN   TestAccECSTaskDefinition_basic
=== PAUSE TestAccECSTaskDefinition_basic
=== CONT  TestAccECSService_basic
=== CONT  TestAccECSTaskDefinition_basic
--- PASS: TestAccECSTaskDefinition_basic (25.77s)
--- PASS: TestAccECSService_basic (74.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ecs	86.791s
2025/06/18 11:21:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:21:16 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2TargetGroup_basic
=== PAUSE TestAccELBV2TargetGroup_basic
=== CONT  TestAccELBV2TargetGroup_basic
--- PASS: TestAccELBV2TargetGroup_basic (20.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/elbv2	38.891s
2025/06/18 11:21:12 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:21:12 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccKMSKey_basic
=== PAUSE TestAccKMSKey_basic
=== CONT  TestAccKMSKey_basic
--- PASS: TestAccKMSKey_basic (29.66s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/kms	44.289s
2025/06/18 11:24:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLambdaFunction_basic
=== PAUSE TestAccLambdaFunction_basic
=== RUN   TestAccLambdaPermission_basic
=== PAUSE TestAccLambdaPermission_basic
=== CONT  TestAccLambdaFunction_basic
=== CONT  TestAccLambdaPermission_basic
--- PASS: TestAccLambdaPermission_basic (38.09s)
--- PASS: TestAccLambdaFunction_basic (41.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lambda	47.028s
2025/06/18 11:24:13 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccMetaPartitionDataSource_basic
=== PAUSE TestAccMetaPartitionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_basic
=== PAUSE TestAccMetaRegionDataSource_basic
=== RUN   TestAccMetaRegionDataSource_endpoint
=== PAUSE TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaPartitionDataSource_basic
=== CONT  TestAccMetaRegionDataSource_endpoint
=== CONT  TestAccMetaRegionDataSource_basic
--- PASS: TestAccMetaPartitionDataSource_basic (11.83s)
--- PASS: TestAccMetaRegionDataSource_endpoint (11.84s)
--- PASS: TestAccMetaRegionDataSource_basic (12.51s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/meta	21.087s
2025/06/18 11:24:16 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:17 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRoute53Record_basic
=== PAUSE TestAccRoute53Record_basic
=== RUN   TestAccRoute53Record_Latency_basic
=== PAUSE TestAccRoute53Record_Latency_basic
=== RUN   TestAccRoute53ZoneDataSource_name
=== PAUSE TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_basic
=== CONT  TestAccRoute53ZoneDataSource_name
=== CONT  TestAccRoute53Record_Latency_basic
--- PASS: TestAccRoute53ZoneDataSource_name (72.55s)
--- PASS: TestAccRoute53Record_basic (138.01s)
--- PASS: TestAccRoute53Record_Latency_basic (139.78s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/route53	151.003s
2025/06/18 11:24:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketACL_updateACL
=== PAUSE TestAccS3BucketACL_updateACL
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Security_corsUpdate
=== PAUSE TestAccS3Bucket_Security_corsUpdate
=== RUN   TestAccS3Object_basic
=== PAUSE TestAccS3Object_basic
=== CONT  TestAccS3BucketACL_updateACL
=== CONT  TestAccS3Object_basic
=== CONT  TestAccS3Bucket_Security_corsUpdate
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketPolicy_basic
--- PASS: TestAccS3Object_basic (20.55s)
--- PASS: TestAccS3BucketPolicy_basic (21.43s)
--- PASS: TestAccS3Bucket_Basic_basic (21.43s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (21.46s)
--- PASS: TestAccS3BucketACL_updateACL (33.85s)
--- PASS: TestAccS3Bucket_Security_corsUpdate (35.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	50.402s
2025/06/18 11:24:20 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:20 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSSMParameterEphemeral_basic
=== PAUSE TestAccSSMParameterEphemeral_basic
=== CONT  TestAccSSMParameterEphemeral_basic
--- PASS: TestAccSSMParameterEphemeral_basic (15.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ssm	26.869s
2025/06/18 11:24:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:27 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSecretsManagerSecret_basic
=== PAUSE TestAccSecretsManagerSecret_basic
=== CONT  TestAccSecretsManagerSecret_basic
--- PASS: TestAccSecretsManagerSecret_basic (16.13s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/secretsmanager	34.542s
2025/06/18 11:24:30 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/18 11:24:30 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSTSCallerIdentityDataSource_basic
=== PAUSE TestAccSTSCallerIdentityDataSource_basic
=== CONT  TestAccSTSCallerIdentityDataSource_basic
--- PASS: TestAccSTSCallerIdentityDataSource_basic (8.82s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sts	30.602s
```
