### PR TITLE
fix: region instead of name in examples for aws_region

### DIFF
--- a/docs/running-and-writing-acceptance-tests.md
+++ b/docs/running-and-writing-acceptance-tests.md
@@ -1520,9 +1520,9 @@ resource "aws_iam_role_policy_attachment" "test" {
 
 #### Hardcoded Region
 
-- __Uses aws_region Data Source__: Any hardcoded AWS Region configuration, e.g., `us-west-2`, should be replaced with the [`aws_region` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region). A common pattern is declaring `data "aws_region" "current" {}` and referencing it via `data.aws_region.current.name`
+- __Uses aws_region Data Source__: Any hardcoded AWS Region configuration, e.g., `us-west-2`, should be replaced with the [`aws_region` data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region). A common pattern is declaring `data "aws_region" "current" {}` and referencing it via `data.aws_region.current.region`
 
-Here's an example of using `aws_region` and `data.aws_region.current.name`:
+Here's an example of using `aws_region` and `data.aws_region.current.region`:
 
 ```terraform
 data "aws_region" "current" {}
@@ -1530,7 +1530,7 @@ data "aws_region" "current" {}
 resource "aws_route53_zone" "test" {
   vpc {
     vpc_id     = aws_vpc.test.id
-    vpc_region = data.aws_region.current.name
+    vpc_region = data.aws_region.current.region
   }
 }
 ```

--- a/examples/api-gateway-websocket-chat-app/main.tf
+++ b/examples/api-gateway-websocket-chat-app/main.tf
@@ -226,7 +226,7 @@ resource "aws_iam_policy" "OnConnectCloudWatchLogsPolicy" {
     {
       "Effect": "Allow",
       "Action": "logs:CreateLogGroup",
-      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     },
     {
       "Effect": "Allow",
@@ -235,7 +235,7 @@ resource "aws_iam_policy" "OnConnectCloudWatchLogsPolicy" {
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.OnConnectFunction.function_name}:*"
+        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.OnConnectFunction.function_name}:*"
       ]
     }
   ]
@@ -310,7 +310,7 @@ resource "aws_iam_policy" "OnDisconnectCloudWatchLogsPolicy" {
     {
       "Effect": "Allow",
       "Action": "logs:CreateLogGroup",
-      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     },
     {
       "Effect": "Allow",
@@ -319,7 +319,7 @@ resource "aws_iam_policy" "OnDisconnectCloudWatchLogsPolicy" {
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.OnDisconnectFunction.function_name}:*"
+        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.OnDisconnectFunction.function_name}:*"
       ]
     }
   ]
@@ -394,7 +394,7 @@ resource "aws_iam_policy" "SendMessageCloudWatchLogsPolicy" {
     {
       "Effect": "Allow",
       "Action": "logs:CreateLogGroup",
-      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     },
     {
       "Effect": "Allow",
@@ -403,7 +403,7 @@ resource "aws_iam_policy" "SendMessageCloudWatchLogsPolicy" {
         "logs:PutLogEvents"
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.SendMessageFunction.function_name}:*"
+        "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${aws_lambda_function.SendMessageFunction.function_name}:*"
       ]
     }
   ]

--- a/examples/ecs-alb/main.tf
+++ b/examples/ecs-alb/main.tf
@@ -72,7 +72,7 @@ resource "aws_launch_configuration" "app" {
   instance_type        = var.instance_type
   iam_instance_profile = aws_iam_instance_profile.app.name
   user_data = templatefile("${path.module}/cloud-config.yml", {
-    aws_region         = data.aws_region.current.name
+    aws_region         = data.aws_region.current.region
     ecs_cluster_name   = aws_ecs_cluster.main.name
     ecs_log_level      = "info"
     ecs_agent_version  = "latest"
@@ -155,7 +155,7 @@ resource "aws_ecs_task_definition" "ghost" {
   container_definitions = templatefile("${path.module}/task-definition.json", {
     image_url        = "ghost:latest"
     container_name   = "ghost"
-    log_group_region = data.aws_region.current.name
+    log_group_region = data.aws_region.current.region
     log_group_name   = aws_cloudwatch_log_group.app.name
   })
 }

--- a/examples/elasticsearch-domain/main.tf
+++ b/examples/elasticsearch-domain/main.tf
@@ -51,7 +51,7 @@ resource "aws_elasticsearch_domain" "test" {
             "AWS": "*"
           },
           "Action": "es:*",
-          "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
+          "Resource": "arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
         }
     ]
 }

--- a/examples/ivschat/main.tf
+++ b/examples/ivschat/main.tf
@@ -47,7 +47,7 @@ resource "aws_lambda_permission" "example" {
   function_name  = aws_lambda_function.example.function_name
   principal      = "ivschat.amazonaws.com"
   source_account = data.aws_caller_identity.current.account_id
-  source_arn     = "arn:aws:ivschat:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:room/*"
+  source_arn     = "arn:aws:ivschat:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:room/*"
 }
 
 resource "aws_s3_bucket" "example" {

--- a/examples/sagemaker/main.tf
+++ b/examples/sagemaker/main.tf
@@ -110,7 +110,7 @@ resource "aws_sagemaker_model" "foo" {
   execution_role_arn = aws_iam_role.foo.arn
 
   primary_container {
-    image          = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/foo:latest"
+    image          = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/foo:latest"
     model_data_url = "https://s3-us-west-2.amazonaws.com/${aws_s3_bucket.foo.bucket}/model.tar.gz"
   }
 

--- a/examples/workspaces/main.tf
+++ b/examples/workspaces/main.tf
@@ -88,7 +88,7 @@ locals {
 
   workspaces_az_id_strings = lookup(
     local.region_workspaces_az_id_strings,
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     join(",", data.aws_availability_zones.available.zone_ids),
   )
   workspaces_az_ids = split(",", local.workspaces_az_id_strings)

--- a/internal/acctest/configs.go
+++ b/internal/acctest/configs.go
@@ -271,7 +271,7 @@ data "aws_region" "provider_test" {}
 
 # Required to initialize the provider.
 data "aws_service" "provider_test" {
-  region     = data.aws_region.provider_test.name
+  region     = data.aws_region.provider_test.region
   service_id = "s3"
 }
 `
@@ -715,7 +715,7 @@ resource "aws_iam_role_policy" "test" {
         "bedrock:InvokeModel"
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
       ]
     }
   ]
@@ -821,7 +821,7 @@ resource "null_resource" "db_setup" {
   provisioner "local-exec" {
     command = <<EOT
       sleep 60
-      export PGPASSWORD=$(aws secretsmanager get-secret-value --secret-id '${aws_rds_cluster.test.master_user_secret[0].secret_arn}' --version-stage AWSCURRENT --region ${data.aws_region.current.name} --query SecretString --output text | jq -r '."password"')
+      export PGPASSWORD=$(aws secretsmanager get-secret-value --secret-id '${aws_rds_cluster.test.master_user_secret[0].secret_arn}' --version-stage AWSCURRENT --region ${data.aws_region.current.region} --query SecretString --output text | jq -r '."password"')
       psql -h ${aws_rds_cluster.test.endpoint} -U ${aws_rds_cluster.test.master_username} -d ${aws_rds_cluster.test.database_name} -c "CREATE EXTENSION IF NOT EXISTS vector;"
       psql -h ${aws_rds_cluster.test.endpoint} -U ${aws_rds_cluster.test.master_username} -d ${aws_rds_cluster.test.database_name} -c "CREATE SCHEMA IF NOT EXISTS bedrock_integration;"
       psql -h ${aws_rds_cluster.test.endpoint} -U ${aws_rds_cluster.test.master_username} -d ${aws_rds_cluster.test.database_name} -c "CREATE SCHEMA IF NOT EXISTS bedrock_new;"
@@ -878,7 +878,7 @@ resource "aws_iam_role_policy" "test_update" {
         "bedrock:InvokeModel"
       ],
       "Resource": [
-        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
       ]
     }
   ]

--- a/internal/provider/sdkv2/provider_acc_test.go
+++ b/internal/provider/sdkv2/provider_acc_test.go
@@ -1044,7 +1044,7 @@ data "aws_region" "provider_test" {}
 
 # Required to initialize the provider.
 data "aws_service" "provider_test" {
-  region     = data.aws_region.provider_test.name
+  region     = data.aws_region.provider_test.region
   service_id = "s3"
 }
 `

--- a/internal/service/acmpca/certificate_data_source_test.go
+++ b/internal/service/acmpca/certificate_data_source_test.go
@@ -82,8 +82,8 @@ data "aws_partition" "current" {}
 
 const testAccCertificateDataSourceConfig_nonExistent = `
 data "aws_acmpca_certificate" "test" {
-  arn                       = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate-authority/does-not-exist/certificate/does-not-exist"
-  certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate-authority/does-not-exist"
+  arn                       = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:certificate-authority/does-not-exist/certificate/does-not-exist"
+  certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:certificate-authority/does-not-exist"
 }
 
 data "aws_caller_identity" "current" {}

--- a/internal/service/apigateway/domain_name_access_association_test.go
+++ b/internal/service/apigateway/domain_name_access_association_test.go
@@ -147,7 +147,7 @@ resource "aws_api_gateway_domain_name" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/rest_api_test.go
+++ b/internal/service/apigateway/rest_api_test.go
@@ -1712,7 +1712,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -1762,7 +1762,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -1771,7 +1771,7 @@ resource "aws_vpc_endpoint" "test" {
 resource "aws_vpc_endpoint" "test2" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -1823,7 +1823,7 @@ resource "aws_vpc_endpoint" "test" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -1908,7 +1908,7 @@ resource "aws_vpc_endpoint" "test" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -1992,7 +1992,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/basic/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/basic/main_gen.tf
@@ -37,7 +37,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/region_override/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/region_override/main_gen.tf
@@ -51,7 +51,7 @@ resource "aws_vpc_endpoint" "test" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags/main_gen.tf
@@ -39,7 +39,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/tagsComputed1/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/tagsComputed1/main_gen.tf
@@ -43,7 +43,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/tagsComputed2/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/tagsComputed2/main_gen.tf
@@ -44,7 +44,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags_defaults/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags_defaults/main_gen.tf
@@ -45,7 +45,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags_ignore/main_gen.tf
+++ b/internal/service/apigateway/testdata/DomainNameAccessAssociation/tags_ignore/main_gen.tf
@@ -48,7 +48,7 @@ resource "aws_subnet" "test" {
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apigateway/testdata/tmpl/domain_name_access_association_tags.gtpl
+++ b/internal/service/apigateway/testdata/tmpl/domain_name_access_association_tags.gtpl
@@ -44,7 +44,7 @@ resource "aws_vpc_endpoint" "test" {
 {{- template "region" }}
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.test.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/basic/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/basic/main_gen.tf
@@ -39,7 +39,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/region_override/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/region_override/main_gen.tf
@@ -47,7 +47,7 @@ resource "aws_vpc_endpoint" "test" {
   region = var.region
 
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/tags/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/tags/main_gen.tf
@@ -41,7 +41,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/tagsComputed1/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/tagsComputed1/main_gen.tf
@@ -45,7 +45,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/tagsComputed2/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/tagsComputed2/main_gen.tf
@@ -46,7 +46,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/tags_defaults/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/tags_defaults/main_gen.tf
@@ -47,7 +47,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/VPCIngressConnection/tags_ignore/main_gen.tf
+++ b/internal/service/apprunner/testdata/VPCIngressConnection/tags_ignore/main_gen.tf
@@ -50,7 +50,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/testdata/tmpl/vpc_ingress_connection_tags.gtpl
+++ b/internal/service/apprunner/testdata/tmpl/vpc_ingress_connection_tags.gtpl
@@ -42,7 +42,7 @@ resource "aws_apprunner_service" "test" {
 resource "aws_vpc_endpoint" "test" {
 {{- template "region" }}
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/apprunner/vpc_ingress_connection_test.go
+++ b/internal/service/apprunner/vpc_ingress_connection_test.go
@@ -147,7 +147,7 @@ resource "aws_apprunner_service" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.apprunner.requests"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.apprunner.requests"
   vpc_endpoint_type = "Interface"
 
   subnet_ids = aws_subnet.test[*].id

--- a/internal/service/appsync/graphql_api_test.go
+++ b/internal/service/appsync/graphql_api_test.go
@@ -1940,7 +1940,7 @@ data "aws_iam_policy_document" "test" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:appsync:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}::apis/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:appsync:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}::apis/*"]
       variable = "aws:SourceArn"
     }
   }

--- a/internal/service/appsync/source_api_association_test.go
+++ b/internal/service/appsync/source_api_association_test.go
@@ -239,7 +239,7 @@ data "aws_iam_policy_document" "test" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:appsync:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}::apis/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:appsync:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}::apis/*"]
       variable = "aws:SourceArn"
     }
   }

--- a/internal/service/autoscaling/launch_configuration_test.go
+++ b/internal/service/autoscaling/launch_configuration_test.go
@@ -899,7 +899,7 @@ data "aws_region" "current" {}
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_launch_configuration" "test" {

--- a/internal/service/backup/report_plan_test.go
+++ b/internal/service/backup/report_plan_test.go
@@ -377,7 +377,7 @@ resource "aws_backup_report_plan" "test" {
       data.aws_caller_identity.current.id
     ]
     regions = [
-      data.aws_region.current.name
+      data.aws_region.current.region
     ]
     report_template = "RESTORE_JOB_REPORT"
   }

--- a/internal/service/backup/selection_data_source_test.go
+++ b/internal/service/backup/selection_data_source_test.go
@@ -73,7 +73,7 @@ resource "aws_backup_selection" "test" {
   not_resources = []
 
   resources = [
-    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
+    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
 }
 

--- a/internal/service/backup/selection_test.go
+++ b/internal/service/backup/selection_test.go
@@ -328,7 +328,7 @@ resource "aws_backup_selection" "test" {
   }
 
   resources = [
-    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
+    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
 }
 `, rName))
@@ -357,7 +357,7 @@ resource "aws_backup_selection" "test" {
   }
 
   resources = [
-    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
+    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
 }
 `, rName))
@@ -489,7 +489,7 @@ resource "aws_backup_selection" "test" {
   }
 
   resources = [
-    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
+    "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*"
   ]
 }
 `, rName))

--- a/internal/service/bedrock/custom_model_test.go
+++ b/internal/service/bedrock/custom_model_test.go
@@ -359,7 +359,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/model_invocation_logging_configuration_test.go
+++ b/internal/service/bedrock/model_invocation_logging_configuration_test.go
@@ -241,7 +241,7 @@ resource "aws_s3_bucket_policy" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]
@@ -270,7 +270,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/basic/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/basic/main_gen.tf
@@ -72,7 +72,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/region_override/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/region_override/main_gen.tf
@@ -86,7 +86,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/tags/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/tags/main_gen.tf
@@ -74,7 +74,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/tagsComputed1/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/tagsComputed1/main_gen.tf
@@ -78,7 +78,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/tagsComputed2/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/tagsComputed2/main_gen.tf
@@ -79,7 +79,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/tags_defaults/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/tags_defaults/main_gen.tf
@@ -80,7 +80,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/CustomModel/tags_ignore/main_gen.tf
+++ b/internal/service/bedrock/testdata/CustomModel/tags_ignore/main_gen.tf
@@ -83,7 +83,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/ModelInvocationLoggingConfiguration/basic/main_gen.tf
+++ b/internal/service/bedrock/testdata/ModelInvocationLoggingConfiguration/basic/main_gen.tf
@@ -51,7 +51,7 @@ resource "aws_s3_bucket_policy" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]
@@ -80,7 +80,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/ModelInvocationLoggingConfiguration/region_override/main_gen.tf
+++ b/internal/service/bedrock/testdata/ModelInvocationLoggingConfiguration/region_override/main_gen.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_policy" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]
@@ -90,7 +90,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/tmpl/custom_model_tags.gtpl
+++ b/internal/service/bedrock/testdata/tmpl/custom_model_tags.gtpl
@@ -79,7 +79,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnEquals": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:model-customization-job/*"
       }
     }
   }]

--- a/internal/service/bedrock/testdata/tmpl/model_invocation_logging_configuration_basic.gtpl
+++ b/internal/service/bedrock/testdata/tmpl/model_invocation_logging_configuration_basic.gtpl
@@ -53,7 +53,7 @@ resource "aws_s3_bucket_policy" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]
@@ -83,7 +83,7 @@ resource "aws_iam_role" "test" {
         "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "aws:SourceArn": "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       }
     }
   }]

--- a/internal/service/bedrockagent/data_source_test.go
+++ b/internal/service/bedrockagent/data_source_test.go
@@ -684,7 +684,7 @@ resource "aws_bedrockagent_data_source" "test" {
     parsing_configuration {
       parsing_strategy = "BEDROCK_FOUNDATION_MODEL"
       bedrock_foundation_model_configuration {
-        model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+        model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
         parsing_prompt {
           parsing_prompt_string = "Transcribe the text content from an image page and output in Markdown syntax (not code blocks)."
         }

--- a/internal/service/bedrockagent/knowledge_base_test.go
+++ b/internal/service/bedrockagent/knowledge_base_test.go
@@ -502,7 +502,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -538,7 +538,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -572,7 +572,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -610,7 +610,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -680,7 +680,7 @@ data "aws_iam_policy_document" "test_trust" {
       test     = "ArnLike"
       variable = "aws:SourceArn"
       values = [
-        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
+        "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:knowledge-base/*"
       ]
     }
   }
@@ -704,7 +704,7 @@ data "aws_iam_policy_document" "test" {
       "bedrock:InvokeModel",
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:foundation-model/%[3]s",
+      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:foundation-model/%[3]s",
     ]
   }
 
@@ -794,7 +794,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -831,7 +831,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }
@@ -907,7 +907,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
   knowledge_base_configuration {
     type = "VECTOR"
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
       embedding_model_configuration {
         bedrock_embedding_model_configuration {
           dimensions          = 1024

--- a/internal/service/ce/tags_data_source_test.go
+++ b/internal/service/ce/tags_data_source_test.go
@@ -128,7 +128,7 @@ data "aws_ce_tags" "test" {
   filter {
     dimension {
       key           = "REGION"
-      values        = [data.aws_region.current.name]
+      values        = [data.aws_region.current.region]
       match_options = ["EQUALS"]
     }
   }

--- a/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration_test.go
+++ b/internal/service/chimesdkmediapipelines/media_insights_pipeline_configuration_test.go
@@ -530,21 +530,21 @@ resource "aws_chimesdkmediapipelines_media_insights_pipeline_configuration" "tes
   elements {
     type = "LambdaFunctionSink"
     lambda_function_sink_configuration {
-      insights_target = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:MyFunction"
+      insights_target = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:function:MyFunction"
     }
   }
 
   elements {
     type = "SnsTopicSink"
     sns_topic_sink_configuration {
-      insights_target = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/MyTopic"
+      insights_target = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:topic/MyTopic"
     }
   }
 
   elements {
     type = "SqsQueueSink"
     sqs_queue_sink_configuration {
-      insights_target = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:queue/MyQueue"
+      insights_target = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:queue/MyQueue"
     }
   }
 

--- a/internal/service/chimesdkvoice/sip_media_application_test.go
+++ b/internal/service/chimesdkvoice/sip_media_application_test.go
@@ -276,7 +276,7 @@ func testAccSipMediaApplicationConfig_basic(rName string) string {
 		fmt.Sprintf(`
 resource "aws_chimesdkvoice_sip_media_application" "test" {
   name       = %[1]q
-  aws_region = data.aws_region.current.name
+  aws_region = data.aws_region.current.region
   endpoints {
     lambda_arn = aws_lambda_function.test.arn
   }
@@ -290,7 +290,7 @@ func testAccSipMediaApplicationConfig_tags1(rName, tagKey1, tagValue1 string) st
 		fmt.Sprintf(`
 resource "aws_chimesdkvoice_sip_media_application" "test" {
   name       = %[1]q
-  aws_region = data.aws_region.current.name
+  aws_region = data.aws_region.current.region
   endpoints {
     lambda_arn = aws_lambda_function.test.arn
   }
@@ -308,7 +308,7 @@ func testAccSipMediaApplicationConfig_tags2(rName, tagKey1, tagValue1, tagKey2, 
 		fmt.Sprintf(`
 resource "aws_chimesdkvoice_sip_media_application" "test" {
   name       = %[1]q
-  aws_region = data.aws_region.current.name
+  aws_region = data.aws_region.current.region
   endpoints {
     lambda_arn = aws_lambda_function.test.arn
   }

--- a/internal/service/chimesdkvoice/sip_rule_test.go
+++ b/internal/service/chimesdkvoice/sip_rule_test.go
@@ -222,7 +222,7 @@ resource "aws_lambda_function" "test" {
 
 resource "aws_chimesdkvoice_sip_media_application" "test" {
   name       = %[1]q
-  aws_region = data.aws_region.current.name
+  aws_region = data.aws_region.current.region
   endpoints {
     lambda_arn = aws_lambda_function.test.arn
   }
@@ -243,7 +243,7 @@ resource "aws_chimesdkvoice_sip_rule" "test" {
   target_applications {
     priority                 = 1
     sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
-    aws_region               = data.aws_region.current.name
+    aws_region               = data.aws_region.current.region
   }
 }
 `, rName))
@@ -261,7 +261,7 @@ resource "aws_chimesdkvoice_sip_rule" "test" {
   target_applications {
     priority                 = 1
     sip_media_application_id = aws_chimesdkvoice_sip_media_application.test.id
-    aws_region               = data.aws_region.current.name
+    aws_region               = data.aws_region.current.region
   }
 }
 `, rName))

--- a/internal/service/cloudformation/stack_test.go
+++ b/internal/service/cloudformation/stack_test.go
@@ -1007,7 +1007,7 @@ resource "aws_cloudformation_stack" "test" {
     VpcCIDR = %[3]q
   }
 
-  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_object.object.key}"
+  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${aws_s3_object.object.key}"
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }
@@ -1029,7 +1029,7 @@ resource "aws_cloudformation_stack" "test" {
     VpcCIDR = %[3]q
   }
 
-  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${aws_s3_object.object.key}"
+  template_url       = "https://${aws_s3_bucket.b.id}.s3-${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${aws_s3_object.object.key}"
   on_failure         = "DELETE"
   timeout_in_minutes = 1
 }

--- a/internal/service/cloudformation/type_data_source_test.go
+++ b/internal/service/cloudformation/type_data_source_test.go
@@ -189,7 +189,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 data "aws_cloudformation_type" "test" {
-  arn = "arn:${data.aws_partition.current.partition}:cloudformation:${data.aws_region.current.name}::type/resource/AWS-Athena-WorkGroup"
+  arn = "arn:${data.aws_partition.current.partition}:cloudformation:${data.aws_region.current.region}::type/resource/AWS-Athena-WorkGroup"
 }
 `
 }

--- a/internal/service/cloudfront/distribution_test.go
+++ b/internal/service/cloudfront/distribution_test.go
@@ -585,7 +585,7 @@ func TestAccCloudFrontDistribution_Origin_originShield(t *testing.T) {
 		CheckDestroy:             testAccCheckDistributionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccDistributionConfig_originItem(rName, originShieldItem(`null`, `data.aws_region.current.name`)),
+				Config:      testAccDistributionConfig_originItem(rName, originShieldItem(`null`, `data.aws_region.current.region`)),
 				ExpectError: regexache.MustCompile(`Missing required argument`),
 			},
 			{

--- a/internal/service/cloudtrail/service_account_data_source_test.go
+++ b/internal/service/cloudtrail/service_account_data_source_test.go
@@ -64,6 +64,6 @@ const testAccServiceAccountDataSourceConfig_region = `
 data "aws_region" "current" {}
 
 data "aws_cloudtrail_service_account" "regional" {
-  region = data.aws_region.current.name
+  region = data.aws_region.current.region
 }
 `

--- a/internal/service/cloudtrail/testdata/Trail/basic/main_gen.tf
+++ b/internal/service/cloudtrail/testdata/Trail/basic/main_gen.tf
@@ -38,7 +38,7 @@ resource "aws_s3_bucket_policy" "test" {
         Resource = aws_s3_bucket.test.arn
         Condition = {
           StringEquals = {
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       },
@@ -53,7 +53,7 @@ resource "aws_s3_bucket_policy" "test" {
         Condition = {
           StringEquals = {
             "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       }

--- a/internal/service/cloudtrail/testdata/Trail/region_override/main_gen.tf
+++ b/internal/service/cloudtrail/testdata/Trail/region_override/main_gen.tf
@@ -46,7 +46,7 @@ resource "aws_s3_bucket_policy" "test" {
         Resource = aws_s3_bucket.test.arn
         Condition = {
           StringEquals = {
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       },
@@ -61,7 +61,7 @@ resource "aws_s3_bucket_policy" "test" {
         Condition = {
           StringEquals = {
             "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       }

--- a/internal/service/cloudtrail/testdata/tmpl/trail_tags.gtpl
+++ b/internal/service/cloudtrail/testdata/tmpl/trail_tags.gtpl
@@ -40,7 +40,7 @@ resource "aws_s3_bucket_policy" "test" {
         Resource = aws_s3_bucket.test.arn
         Condition = {
           StringEquals = {
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       },
@@ -55,7 +55,7 @@ resource "aws_s3_bucket_policy" "test" {
         Condition = {
           StringEquals = {
             "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/${var.rName}"
           }
         }
       }

--- a/internal/service/cloudtrail/trail_test.go
+++ b/internal/service/cloudtrail/trail_test.go
@@ -980,7 +980,7 @@ resource "aws_s3_bucket_policy" "test" {
         Resource = aws_s3_bucket.test.arn
         Condition = {
           StringEquals = {
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
           }
         }
       },
@@ -995,7 +995,7 @@ resource "aws_s3_bucket_policy" "test" {
         Condition = {
           StringEquals = {
             "s3:x-amz-acl"  = "bucket-owner-full-control"
-            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/%[1]s"
           }
         }
       }

--- a/internal/service/cloudwatch/metric_alarm_test.go
+++ b/internal/service/cloudwatch/metric_alarm_test.go
@@ -1066,7 +1066,7 @@ resource "aws_instance" "test" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_actions       = ["arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.name}:ec2:%[2]s"]
+  alarm_actions       = ["arn:${data.aws_partition.current.partition}:automate:${data.aws_region.current.region}:ec2:%[2]s"]
   alarm_description   = "Status checks have failed for system"
   alarm_name          = %[1]q
   comparison_operator = "GreaterThanThreshold"
@@ -1118,7 +1118,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_cloudwatch_metric_alarm" "test" {
-  alarm_actions       = ["arn:${data.aws_partition.current.partition}:swf:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:action/actions/AWS_EC2.InstanceId.Reboot/1.0"]
+  alarm_actions       = ["arn:${data.aws_partition.current.partition}:swf:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:action/actions/AWS_EC2.InstanceId.Reboot/1.0"]
   alarm_description   = "Status checks have failed, rebooting system."
   alarm_name          = %[1]q
   comparison_operator = "GreaterThanThreshold"

--- a/internal/service/cloudwatch/metric_stream_test.go
+++ b/internal/service/cloudwatch/metric_stream_test.go
@@ -630,7 +630,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/%[2]s"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
   output_format = "json"
 }
 `, rName, arnSuffix)
@@ -645,7 +645,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/%[2]s"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/%[2]s"
   output_format = "json"
 
   tags = {
@@ -664,7 +664,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
   include_filter {
@@ -687,7 +687,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
   include_filter {
@@ -712,7 +712,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
   exclude_filter {
@@ -735,7 +735,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
   exclude_filter {
@@ -760,7 +760,7 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_stream" "test" {
   name          = %[1]q
   role_arn      = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/MyRole"
-  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
+  firehose_arn  = "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:deliverystream/MyFirehose"
   output_format = "json"
 
   statistics_configuration {

--- a/internal/service/codepipeline/codepipeline_test.go
+++ b/internal/service/codepipeline/codepipeline_test.go
@@ -3252,7 +3252,7 @@ resource "aws_codepipeline" "test" {
           configuration   = {}
           commands        = ["exit 0"]
           input_artifacts = ["test"]
-          region          = data.aws_region.current.name
+          region          = data.aws_region.current.region
           role_arn        = aws_iam_role.codepipeline_role.arn
           name            = "CheckByCommandsRule"
 
@@ -3531,7 +3531,7 @@ resource "aws_codepipeline" "test" {
           configuration   = {}
           commands        = ["exit 1"]
           input_artifacts = ["test"]
-          region          = data.aws_region.current.name
+          region          = data.aws_region.current.region
           role_arn        = aws_iam_role.codepipeline_role.arn
           name            = "CheckByCommandsRule"
 

--- a/internal/service/cognitoidentity/pool_test.go
+++ b/internal/service/cognitoidentity/pool_test.go
@@ -657,13 +657,13 @@ resource "aws_cognito_identity_pool" "test" {
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Ab129faBb"
+    provider_name           = "cognito-idp.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.region}_Ab129faBb"
     server_side_token_check = false
   }
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.region}_Zr231apJu"
     server_side_token_check = false
   }
 }
@@ -682,7 +682,7 @@ resource "aws_cognito_identity_pool" "test" {
 
   cognito_identity_providers {
     client_id               = "6lhlkkfbfb4q5kpp90urffae"
-    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.region}_Zr231apJu"
     server_side_token_check = false
   }
 }
@@ -701,13 +701,13 @@ resource "aws_cognito_identity_pool" "test" {
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Ab129faBb"
+    provider_name           = "cognito-idp.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.region}_Ab129faBb"
     server_side_token_check = false
   }
 
   cognito_identity_providers {
     client_id               = "7lhlkkfbfb4q5kpp90urffao"
-    provider_name           = "cognito-idp.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.name}_Zr231apJu"
+    provider_name           = "cognito-idp.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/${data.aws_region.current.region}_Zr231apJu"
     server_side_token_check = false
   }
 

--- a/internal/service/cognitoidp/user_group_test.go
+++ b/internal/service/cognitoidp/user_group_test.go
@@ -241,7 +241,7 @@ resource "aws_iam_role" "test" {
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "cognito-identity.amazonaws.com:aud": "${data.aws_region.current.name}:12345678-dead-beef-cafe-123456790ab"
+          "cognito-identity.amazonaws.com:aud": "${data.aws_region.current.region}:12345678-dead-beef-cafe-123456790ab"
         },
         "ForAnyValue:StringLike": {
           "cognito-identity.amazonaws.com:amr": "authenticated"

--- a/internal/service/comprehend/document_classifier_test.go
+++ b/internal/service/comprehend/document_classifier_test.go
@@ -2782,7 +2782,7 @@ resource "aws_vpc_endpoint_route_table_association" "test" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_vpc_endpoint_policy" "s3" {
@@ -2890,7 +2890,7 @@ resource "aws_vpc_endpoint_route_table_association" "test" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_vpc_endpoint_policy" "s3" {

--- a/internal/service/comprehend/entity_recognizer_test.go
+++ b/internal/service/comprehend/entity_recognizer_test.go
@@ -2102,7 +2102,7 @@ resource "aws_vpc_endpoint_route_table_association" "test" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_vpc_endpoint_policy" "s3" {
@@ -2223,7 +2223,7 @@ resource "aws_vpc_endpoint_route_table_association" "test" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_vpc_endpoint_policy" "s3" {

--- a/internal/service/configservice/configuration_aggregator_test.go
+++ b/internal/service/configservice/configuration_aggregator_test.go
@@ -244,7 +244,7 @@ resource "aws_config_configuration_aggregator" "test" {
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
   }
 }
 `, rName)
@@ -307,7 +307,7 @@ resource "aws_config_configuration_aggregator" "test" {
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
   }
 
   tags = {
@@ -328,7 +328,7 @@ resource "aws_config_configuration_aggregator" "test" {
 
   account_aggregation_source {
     account_ids = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
   }
 
   tags = {

--- a/internal/service/connect/bot_association_data_source_test.go
+++ b/internal/service/connect/bot_association_data_source_test.go
@@ -84,7 +84,7 @@ resource "aws_connect_instance" "test" {
 resource "aws_connect_bot_association" "test" {
   instance_id = aws_connect_instance.test.id
   lex_bot {
-    lex_region = data.aws_region.current.name
+    lex_region = data.aws_region.current.region
     name       = aws_lex_bot.test.name
   }
 }

--- a/internal/service/controltower/control_test.go
+++ b/internal/service/controltower/control_test.go
@@ -202,7 +202,7 @@ func testAccControlConfig_basic(ouName string) string {
 		testAccControlConfigBase(ouName),
 		`
 resource "aws_controltower_control" "test" {
-  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.name}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
+  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.region}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
   target_identifier  = data.aws_organizations_organizational_unit.test.arn
 }
 `)
@@ -218,7 +218,7 @@ func testAccControlConfig_parameters(ouName string) string {
 		testAccControlConfigBase(ouName),
 		`
 resource "aws_controltower_control" "test" {
-  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.name}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
+  control_identifier = "arn:${data.aws_partition.current.partition}:controltower:${data.aws_region.current.region}::control/AWS-GR_DISALLOW_CROSS_REGION_NETWORKING"
   target_identifier  = data.aws_organizations_organizational_unit.test.arn
 
   parameters {

--- a/internal/service/datasync/agent_test.go
+++ b/internal/service/datasync/agent_test.go
@@ -395,7 +395,7 @@ resource "aws_datasync_agent" "test" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
-  service_name       = "com.amazonaws.${data.aws_region.current.name}.datasync"
+  service_name       = "com.amazonaws.${data.aws_region.current.region}.datasync"
   vpc_id             = aws_vpc.test.id
   security_group_ids = [aws_security_group.test.id]
   subnet_ids         = [aws_subnet.test[0].id]

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -2051,7 +2051,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "dms.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+        "Service": "dms.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -2494,7 +2494,7 @@ resource "aws_dms_endpoint" "test" {
   engine_name   = "opensearch"
 
   elasticsearch_settings {
-    endpoint_uri            = "search-estest.es.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint_uri            = "search-estest.es.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
     service_access_role_arn = aws_iam_role.test.arn
   }
 
@@ -2513,7 +2513,7 @@ resource "aws_dms_endpoint" "test" {
   engine_name                 = "elasticsearch"
   extra_connection_attributes = "errorRetryDuration=400;"
   elasticsearch_settings {
-    endpoint_uri               = "search-estest.es.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint_uri               = "search-estest.es.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
     service_access_role_arn    = aws_iam_role.test.arn
     full_load_error_percentage = 20
   }
@@ -2533,7 +2533,7 @@ resource "aws_dms_endpoint" "test" {
   engine_name   = "elasticsearch"
 
   elasticsearch_settings {
-    endpoint_uri            = "search-estest.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
+    endpoint_uri            = "search-estest.${data.aws_region.current.region}.es.${data.aws_partition.current.dns_suffix}"
     error_retry_duration    = %[2]d
     service_access_role_arn = aws_iam_role.test.arn
   }
@@ -2553,7 +2553,7 @@ resource "aws_dms_endpoint" "test" {
   engine_name   = "elasticsearch"
 
   elasticsearch_settings {
-    endpoint_uri            = "search-estest.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
+    endpoint_uri            = "search-estest.${data.aws_region.current.region}.es.${data.aws_partition.current.dns_suffix}"
     use_new_mapping_type    = %[2]t
     service_access_role_arn = aws_iam_role.test.arn
   }
@@ -2573,7 +2573,7 @@ resource "aws_dms_endpoint" "test" {
   engine_name   = "elasticsearch"
 
   elasticsearch_settings {
-    endpoint_uri               = "search-estest.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
+    endpoint_uri               = "search-estest.${data.aws_region.current.region}.es.${data.aws_partition.current.dns_suffix}"
     full_load_error_percentage = %[2]d
     service_access_role_arn    = aws_iam_role.test.arn
   }

--- a/internal/service/dms/replication_task_test.go
+++ b/internal/service/dms/replication_task_test.go
@@ -703,7 +703,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "%[1]s-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -714,7 +714,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "%[1]s-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/basic/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/basic/main_gen.tf
@@ -34,7 +34,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -45,7 +45,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/region_override/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/region_override/main_gen.tf
@@ -42,7 +42,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -55,7 +55,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/tags/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/tags/main_gen.tf
@@ -36,7 +36,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -47,7 +47,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/tagsComputed1/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/tagsComputed1/main_gen.tf
@@ -40,7 +40,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -51,7 +51,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/tagsComputed2/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/tagsComputed2/main_gen.tf
@@ -41,7 +41,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -52,7 +52,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/tags_defaults/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/tags_defaults/main_gen.tf
@@ -42,7 +42,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -53,7 +53,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationConfig/tags_ignore/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationConfig/tags_ignore/main_gen.tf
@@ -45,7 +45,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -56,7 +56,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/data.tags/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/data.tags/main_gen.tf
@@ -60,7 +60,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -71,7 +71,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/data.tags_defaults/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/data.tags_defaults/main_gen.tf
@@ -66,7 +66,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -77,7 +77,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/data.tags_ignore/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/data.tags_ignore/main_gen.tf
@@ -69,7 +69,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -80,7 +80,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/tags/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/tags/main_gen.tf
@@ -55,7 +55,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -66,7 +66,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/tagsComputed1/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/tagsComputed1/main_gen.tf
@@ -59,7 +59,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -70,7 +70,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/tagsComputed2/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/tagsComputed2/main_gen.tf
@@ -60,7 +60,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -71,7 +71,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/tags_defaults/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/tags_defaults/main_gen.tf
@@ -61,7 +61,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -72,7 +72,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/ReplicationTask/tags_ignore/main_gen.tf
+++ b/internal/service/dms/testdata/ReplicationTask/tags_ignore/main_gen.tf
@@ -64,7 +64,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -75,7 +75,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/tmpl/replication_config_tags.gtpl
+++ b/internal/service/dms/testdata/tmpl/replication_config_tags.gtpl
@@ -37,7 +37,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -49,7 +49,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dms/testdata/tmpl/replication_task_tags.gtpl
+++ b/internal/service/dms/testdata/tmpl/replication_task_tags.gtpl
@@ -51,7 +51,7 @@ resource "aws_dms_endpoint" "source" {
   endpoint_id   = "${var.rName}-source"
   endpoint_type = "source"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"
@@ -62,7 +62,7 @@ resource "aws_dms_endpoint" "target" {
   endpoint_id   = "${var.rName}-target"
   endpoint_type = "target"
   engine_name   = "aurora"
-  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.name}.rds.${data.aws_partition.current.dns_suffix}"
+  server_name   = "tf-test-cluster.cluster-xxxxxxx.${data.aws_region.current.region}.rds.${data.aws_partition.current.dns_suffix}"
   port          = 3306
   username      = "tftest"
   password      = "tftest"

--- a/internal/service/dynamodb/global_table_test.go
+++ b/internal/service/dynamodb/global_table_test.go
@@ -210,7 +210,7 @@ resource "aws_dynamodb_global_table" "test" {
   name = %[1]q
 
   replica {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `, rName)
@@ -262,7 +262,7 @@ resource "aws_dynamodb_global_table" "test" {
   name = aws_dynamodb_table.test.name
 
   replica {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `)
@@ -280,7 +280,7 @@ resource "aws_dynamodb_global_table" "test" {
   }
 
   replica {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `)
@@ -294,7 +294,7 @@ resource "aws_dynamodb_global_table" "test" {
   name = %[1]q
 
   replica {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `, tableName))

--- a/internal/service/dynamodb/tag_test.go
+++ b/internal/service/dynamodb/tag_test.go
@@ -239,12 +239,12 @@ resource "aws_dynamodb_table" "test" {
   }
 
   replica {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_dynamodb_tag" "test" {
-  resource_arn = replace(aws_dynamodb_table.test.arn, data.aws_region.alternate.name, data.aws_region.current.name)
+  resource_arn = replace(aws_dynamodb_table.test.arn, data.aws_region.alternate.name, data.aws_region.current.region)
   key          = "testkey"
   value        = "testvalue"
 }

--- a/internal/service/ec2/ebs_snapshot_copy_test.go
+++ b/internal/service/ec2/ebs_snapshot_copy_test.go
@@ -246,7 +246,7 @@ func testAccEBSSnapshotCopyConfig_basic(rName string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(rName), `
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
 }
 `)
 }
@@ -255,7 +255,7 @@ func testAccEBSSnapshotCopyConfig_storageTier(rName string) string {
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
   storage_tier       = "archive"
 
   tags = {
@@ -269,7 +269,7 @@ func testAccEBSSnapshotCopyConfig_tags1(rName, tagKey1, tagValue1 string) string
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
 
   tags = {
     %[1]q = %[2]q
@@ -282,7 +282,7 @@ func testAccEBSSnapshotCopyConfig_tags2(rName, tagKey1, tagValue1, tagKey2, tagV
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
 
   tags = {
     %[1]q = %[2]q
@@ -297,7 +297,7 @@ func testAccEBSSnapshotCopyConfig_description(rName string) string {
 resource "aws_ebs_snapshot_copy" "test" {
   description        = "Copy Snapshot Acceptance Test"
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
 
   tags = {
     Name = %[1]q
@@ -363,7 +363,7 @@ resource "aws_kms_key" "test" {
 
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id = aws_ebs_snapshot.test.id
-  source_region      = data.aws_region.current.name
+  source_region      = data.aws_region.current.region
   encrypted          = true
   kms_key_id         = aws_kms_key.test.arn
 
@@ -378,7 +378,7 @@ func testAccEBSSnapshotCopyConfig_completionDurationMinutes(rName string, durant
 	return acctest.ConfigCompose(testAccEBSSnapshotCopyBaseConfig(rName), fmt.Sprintf(`
 resource "aws_ebs_snapshot_copy" "test" {
   source_snapshot_id          = aws_ebs_snapshot.test.id
-  source_region               = data.aws_region.current.name
+  source_region               = data.aws_region.current.region
   completion_duration_minutes = %[2]d
 
   tags = {

--- a/internal/service/ec2/ec2_ami_copy_test.go
+++ b/internal/service/ec2/ec2_ami_copy_test.go
@@ -245,7 +245,7 @@ resource "aws_ami" "test" {
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 
   tags = {
     %[2]q = %[3]q
@@ -270,7 +270,7 @@ resource "aws_ami" "test" {
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 
   tags = {
     %[2]q = %[3]q
@@ -296,7 +296,7 @@ resource "aws_ami" "test" {
 resource "aws_ami_copy" "test" {
   name              = %q
   source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 `, rName, rName))
 }
@@ -318,7 +318,7 @@ resource "aws_ami_copy" "test" {
   description       = %q
   name              = %q
   source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 `, rName, description, rName))
 }
@@ -340,7 +340,7 @@ resource "aws_ami" "test" {
 resource "aws_ami_copy" "test" {
   name              = "%s-copy"
   source_ami_id     = aws_ami.test.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 `, rName, rName))
 }
@@ -368,7 +368,7 @@ resource "aws_ami" "test" {
 resource "aws_ami_copy" "test" {
   name                    = "%s-copy"
   source_ami_id           = aws_ami.test.id
-  source_ami_region       = data.aws_region.current.name
+  source_ami_region       = data.aws_region.current.region
   destination_outpost_arn = data.aws_outposts_outpost.test.arn
 }
 `, rName, rName))

--- a/internal/service/ec2/ec2_ami_launch_permission_test.go
+++ b/internal/service/ec2/ec2_ami_launch_permission_test.go
@@ -266,7 +266,7 @@ resource "aws_ami_copy" "test" {
   description       = %[1]q
   name              = %[1]q
   source_ami_id     = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_ami_launch_permission" "test" {
@@ -292,7 +292,7 @@ resource "aws_ami_copy" "test" {
   description       = %[1]q
   name              = %[1]q
   source_ami_id     = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
   deprecation_time  = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.deprecation_time
 
   depends_on = [aws_ec2_image_block_public_access.test]
@@ -315,7 +315,7 @@ resource "aws_ami_copy" "test" {
   description       = %[1]q
   name              = %[1]q
   source_ami_id     = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_ami_launch_permission" "test" {
@@ -340,7 +340,7 @@ resource "aws_ami_copy" "test" {
   description       = %[1]q
   name              = %[1]q
   source_ami_id     = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_ami_launch_permission" "test" {

--- a/internal/service/ec2/ec2_eip_test.go
+++ b/internal/service/ec2/ec2_eip_test.go
@@ -1196,7 +1196,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   tier = "free"
 }
@@ -1204,7 +1204,7 @@ resource "aws_vpc_ipam" "test" {
 resource "aws_vpc_ipam_pool" "test_pool" {
   address_family   = "ipv4"
   ipam_scope_id    = aws_vpc_ipam.test.public_default_scope_id
-  locale           = data.aws_region.current.name
+  locale           = data.aws_region.current.region
   public_ip_source = "amazon"
   description      = "Test Amazon CIDR Pool"
   aws_service      = "ec2"
@@ -1250,7 +1250,7 @@ data "aws_region" current {}
 
 resource "aws_eip" "test" {
   domain               = "vpc"
-  network_border_group = data.aws_region.current.name
+  network_border_group = data.aws_region.current.region
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
+++ b/internal/service/ec2/transitgateway_peering_attachment_accepter_test.go
@@ -174,7 +174,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "test" {
   provider = "awsalternate"
 
   peer_account_id         = aws_ec2_transit_gateway.test.owner_id
-  peer_region             = data.aws_region.current.name
+  peer_region             = data.aws_region.current.region
   peer_transit_gateway_id = aws_ec2_transit_gateway.test.id
   transit_gateway_id      = aws_ec2_transit_gateway.peer.id
 

--- a/internal/service/ec2/transitgateway_policy_table_association_test.go
+++ b/internal/service/ec2/transitgateway_policy_table_association_test.go
@@ -175,7 +175,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     asn_ranges = ["65022-65534"]
 
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
     }
   }
 

--- a/internal/service/ec2/vpc_default_route_table_test.go
+++ b/internal/service/ec2/vpc_default_route_table_test.go
@@ -955,7 +955,7 @@ resource "aws_internet_gateway" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_vpc.test.default_route_table_id]
 
   tags = {

--- a/internal/service/ec2/vpc_endpoint_data_source_test.go
+++ b/internal/service/ec2/vpc_endpoint_data_source_test.go
@@ -268,7 +268,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -297,7 +297,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -324,7 +324,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -354,7 +354,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -399,7 +399,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   route_table_ids = [
     aws_route_table.test.id,
@@ -452,7 +452,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
   vpc_endpoint_type   = "Interface"
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   private_dns_enabled = false
 
   subnet_ids = [

--- a/internal/service/ec2/vpc_endpoint_private_dns_test.go
+++ b/internal/service/ec2/vpc_endpoint_private_dns_test.go
@@ -246,7 +246,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 
   tags = {
@@ -275,7 +275,7 @@ resource "aws_vpc" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 
   tags = {

--- a/internal/service/ec2/vpc_endpoint_route_table_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_route_table_association_test.go
@@ -137,7 +137,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/vpc_endpoint_security_group_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_security_group_association_test.go
@@ -233,7 +233,7 @@ resource "aws_security_group" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 
   tags = {

--- a/internal/service/ec2/vpc_endpoint_subnet_association_test.go
+++ b/internal/service/ec2/vpc_endpoint_subnet_association_test.go
@@ -150,7 +150,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
   vpc_endpoint_type   = "Interface"
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   security_group_ids  = [data.aws_security_group.test.id]
   private_dns_enabled = false
 

--- a/internal/service/ec2/vpc_endpoint_test.go
+++ b/internal/service/ec2/vpc_endpoint_test.go
@@ -1157,7 +1157,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 `, rName)
 }
@@ -1185,7 +1185,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   route_table_ids = [
     aws_route_table.test.id,
@@ -1251,7 +1251,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   route_table_ids = []
 
@@ -1304,7 +1304,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 }
 `, rName)
@@ -1324,7 +1324,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   private_dns_enabled = false
   vpc_endpoint_type   = "Interface"
 }
@@ -1347,7 +1347,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "gateway" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -1356,7 +1356,7 @@ resource "aws_vpc_endpoint" "gateway" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.s3"
   private_dns_enabled = true
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
@@ -1395,7 +1395,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "gateway" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -1404,7 +1404,7 @@ resource "aws_vpc_endpoint" "gateway" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.s3"
   private_dns_enabled = local.private_dns_enabled
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
@@ -1443,7 +1443,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.s3"
   private_dns_enabled = true
   vpc_endpoint_type   = "Interface"
   ip_address_type     = "ipv4"
@@ -1564,7 +1564,7 @@ func testAccVPCEndpointConfig_interfaceSubnet(rName string) string {
 		fmt.Sprintf(`
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = false
 
@@ -1590,7 +1590,7 @@ func testAccVPCEndpointConfig_interfaceSubnetModified(rName string) string {
 		fmt.Sprintf(`
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = true
 
@@ -1669,7 +1669,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.athena"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.athena"
   vpc_endpoint_type = "Interface"
   ip_address_type   = "dualstack"
 
@@ -1700,7 +1700,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.ec2"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type = "Interface"
 
   subnet_configuration {
@@ -1754,7 +1754,7 @@ resource "aws_subnet" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.athena"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.athena"
   vpc_endpoint_type = "Interface"
   ip_address_type   = "ipv6"
 
@@ -1791,7 +1791,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     %[2]q = %[3]q
@@ -1814,7 +1814,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     %[2]q = %[3]q

--- a/internal/service/ec2/vpc_ipam_byoip_test.go
+++ b/internal/service/ec2/vpc_ipam_byoip_test.go
@@ -193,14 +193,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -228,14 +228,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -267,14 +267,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -307,14 +307,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -347,14 +347,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -390,14 +390,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56
@@ -434,14 +434,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family                    = "ipv6"
   ipam_scope_id                     = aws_vpc_ipam.test.public_default_scope_id
-  locale                            = data.aws_region.current.name
+  locale                            = data.aws_region.current.region
   publicly_advertisable             = false
   aws_service                       = "ec2"
   allocation_default_netmask_length = 56

--- a/internal/service/ec2/vpc_ipam_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_data_source_test.go
@@ -53,7 +53,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam" "test" {
   description = "My IPAM"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {

--- a/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_allocation_test.go
@@ -353,14 +353,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {

--- a/internal/service/ec2/vpc_ipam_pool_cidr_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_cidr_test.go
@@ -198,7 +198,7 @@ resource "aws_vpc_ipam" "test" {
   description = "test"
 
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   cascade = true
@@ -209,7 +209,7 @@ const TestAccIPAMPoolCIDRConfig_privatePool = `
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 `
 
@@ -217,7 +217,7 @@ const TestAccIPAMPoolCIDRConfig_privatePoolWithCIDR = `
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "testparent" {
@@ -228,7 +228,7 @@ resource "aws_vpc_ipam_pool_cidr" "testparent" {
 resource "aws_vpc_ipam_pool" "testchild" {
   address_family      = "ipv4"
   ipam_scope_id       = aws_vpc_ipam.test.private_default_scope_id
-  locale              = data.aws_region.current.name
+  locale              = data.aws_region.current.region
   source_ipam_pool_id = aws_vpc_ipam_pool.test.id
 }
 `

--- a/internal/service/ec2/vpc_ipam_pool_test.go
+++ b/internal/service/ec2/vpc_ipam_pool_test.go
@@ -351,7 +351,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `
@@ -390,7 +390,7 @@ var testAccIPAMPoolConfig_ipv6 = acctest.ConfigCompose(testAccIPAMPoolConfig_bas
 resource "aws_vpc_ipam_pool" "test" {
   address_family        = "ipv6"
   ipam_scope_id         = aws_vpc_ipam.test.public_default_scope_id
-  locale                = data.aws_region.current.name
+  locale                = data.aws_region.current.region
   publicly_advertisable = false
 }
 `)
@@ -399,7 +399,7 @@ var testAccIPAMPoolConfig_ipv6PublicIPAmazon = acctest.ConfigCompose(testAccIPAM
 resource "aws_vpc_ipam_pool" "test" {
   address_family   = "ipv6"
   ipam_scope_id    = aws_vpc_ipam.test.public_default_scope_id
-  locale           = data.aws_region.current.name
+  locale           = data.aws_region.current.region
   public_ip_source = "amazon"
   aws_service      = "ec2"
 }
@@ -409,7 +409,7 @@ var testAccIPAMPoolConfig_ipv6Contiguous = acctest.ConfigCompose(testAccIPAMPool
 resource "aws_vpc_ipam_pool" "test" {
   address_family        = "ipv6"
   ipam_scope_id         = aws_vpc_ipam.test.public_default_scope_id
-  locale                = data.aws_region.current.name
+  locale                = data.aws_region.current.region
   public_ip_source      = "byoip"
   aws_service           = "ec2"
   publicly_advertisable = false
@@ -451,6 +451,6 @@ resource "aws_vpc_ipam_scope" "test" {
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv6"
   ipam_scope_id  = aws_vpc_ipam_scope.test.id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 `)

--- a/internal/service/ec2/vpc_ipam_preview_next_cidr_data_source_test.go
+++ b/internal/service/ec2/vpc_ipam_preview_next_cidr_data_source_test.go
@@ -101,14 +101,14 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {

--- a/internal/service/ec2/vpc_ipam_preview_next_cidr_test.go
+++ b/internal/service/ec2/vpc_ipam_preview_next_cidr_test.go
@@ -105,14 +105,14 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {

--- a/internal/service/ec2/vpc_ipam_resource_discovery_association_test.go
+++ b/internal/service/ec2/vpc_ipam_resource_discovery_association_test.go
@@ -171,14 +171,14 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam" "test" {
   description = "test ipam"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test ipam resource discovery"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `

--- a/internal/service/ec2/vpc_ipam_resource_discovery_test.go
+++ b/internal/service/ec2/vpc_ipam_resource_discovery_test.go
@@ -240,7 +240,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `
@@ -251,7 +251,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test ipam"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `
@@ -268,7 +268,7 @@ data "aws_region" "alternate" {
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   operating_regions {
     region_name = data.aws_region.alternate.name
@@ -284,7 +284,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   tags = {
     %[1]q = %[2]q
@@ -300,7 +300,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam_resource_discovery" "test" {
   description = "test"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   tags = {
     %[1]q = %[2]q

--- a/internal/service/ec2/vpc_ipam_scope_test.go
+++ b/internal/service/ec2/vpc_ipam_scope_test.go
@@ -178,7 +178,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `

--- a/internal/service/ec2/vpc_ipam_test.go
+++ b/internal/service/ec2/vpc_ipam_test.go
@@ -363,7 +363,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `
@@ -373,7 +373,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   cascade = true
 }
@@ -387,7 +387,7 @@ resource "aws_vpc_ipam" "test" {
   description = %[1]q
 
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `, description)
@@ -403,7 +403,7 @@ data "aws_region" "alternate" {
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   operating_regions {
@@ -419,7 +419,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -435,7 +435,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -452,7 +452,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
   tier = "%s"
 }
@@ -467,7 +467,7 @@ resource "aws_vpc_ipam" "test" {
   enable_private_gua = %[1]t
 
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 `, enablePrivateGUA)

--- a/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_managed_prefix_list_data_source_test.go
@@ -88,7 +88,7 @@ const testAccVPCManagedPrefixListDataSourceConfig_basic = `
 data "aws_region" "current" {}
 
 data "aws_ec2_managed_prefix_list" "s3_by_name" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 data "aws_ec2_managed_prefix_list" "s3_by_id" {
@@ -148,7 +148,7 @@ data "aws_region" "current" {}
 data "aws_ec2_managed_prefix_list" "s3_by_name" {
   filter {
     name   = "prefix-list-name"
-    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+    values = ["com.amazonaws.${data.aws_region.current.region}.s3"]
   }
 }
 

--- a/internal/service/ec2/vpc_network_insights_analysis_test.go
+++ b/internal/service/ec2/vpc_network_insights_analysis_test.go
@@ -294,7 +294,7 @@ data "aws_partition" "current" {}
 
 resource "aws_ec2_network_insights_analysis" "test" {
   network_insights_path_id = aws_ec2_network_insights_path.test.id
-  filter_in_arns           = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:%[2]s"]
+  filter_in_arns           = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:%[2]s"]
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/vpc_prefix_list_data_source_test.go
+++ b/internal/service/ec2/vpc_prefix_list_data_source_test.go
@@ -81,7 +81,7 @@ data "aws_prefix_list" "s3_by_id" {
 }
 
 data "aws_prefix_list" "s3_by_name" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 `
 
@@ -91,7 +91,7 @@ data "aws_region" "current" {}
 data "aws_prefix_list" "s3_by_name" {
   filter {
     name   = "prefix-list-name"
-    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+    values = ["com.amazonaws.${data.aws_region.current.region}.s3"]
   }
 }
 
@@ -107,11 +107,11 @@ const testAccVPCPrefixListDataSourceConfig_nameDoesNotOverrideFilter = `
 data "aws_region" "current" {}
 
 data "aws_prefix_list" "test" {
-  name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
 
   filter {
     name   = "prefix-list-name"
-    values = ["com.amazonaws.${data.aws_region.current.name}.s3"]
+    values = ["com.amazonaws.${data.aws_region.current.region}.s3"]
   }
 }
 `

--- a/internal/service/ec2/vpc_route_data_source_test.go
+++ b/internal/service/ec2/vpc_route_data_source_test.go
@@ -568,7 +568,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 }
 

--- a/internal/service/ec2/vpc_route_table_test.go
+++ b/internal/service/ec2/vpc_route_table_test.go
@@ -2173,7 +2173,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 }
 `, rName)

--- a/internal/service/ec2/vpc_route_test.go
+++ b/internal/service/ec2/vpc_route_test.go
@@ -2679,7 +2679,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 }
 `, rName)

--- a/internal/service/ec2/vpc_security_group_ingress_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_test.go
@@ -774,7 +774,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test1" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -783,7 +783,7 @@ resource "aws_vpc_endpoint" "test1" {
 
 resource "aws_vpc_endpoint" "test2" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
 
   tags = {
     Name = %[1]q

--- a/internal/service/ec2/vpc_security_group_rule_test.go
+++ b/internal/service/ec2/vpc_security_group_rule_test.go
@@ -1862,7 +1862,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id       = aws_vpc.test.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 
   tags = {
     Name = %[1]q
@@ -2034,7 +2034,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 
   tags = {

--- a/internal/service/ec2/vpc_security_group_test.go
+++ b/internal/service/ec2/vpc_security_group_test.go
@@ -4122,7 +4122,7 @@ resource "aws_route_table" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 
   tags = {
@@ -4185,7 +4185,7 @@ resource "aws_route_table" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 
   tags = {
@@ -4248,7 +4248,7 @@ resource "aws_route_table" "test" {
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id          = aws_vpc.test.id
-  service_name    = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name    = "com.amazonaws.${data.aws_region.current.region}.s3"
   route_table_ids = [aws_route_table.test.id]
 
   policy = <<POLICY

--- a/internal/service/ec2/vpc_test.go
+++ b/internal/service/ec2/vpc_test.go
@@ -1007,7 +1007,7 @@ data "aws_availability_zone" "test" {
 resource "aws_vpc" "test" {
   assign_generated_ipv6_cidr_block     = true
   cidr_block                           = "10.1.0.0/16"
-  ipv6_cidr_block_network_border_group = %[2]t ? data.aws_availability_zone.test.network_border_group : data.aws_region.current.name
+  ipv6_cidr_block_network_border_group = %[2]t ? data.aws_availability_zone.test.network_border_group : data.aws_region.current.region
 
   tags = {
     Name = %[1]q
@@ -1100,7 +1100,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -1111,7 +1111,7 @@ resource "aws_vpc_ipam" "test" {
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 
   tags = {
     Name = %[1]q
@@ -1161,7 +1161,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -1172,7 +1172,7 @@ resource "aws_vpc_ipam" "test" {
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv6"
   ipam_scope_id  = aws_vpc_ipam.test.public_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
   aws_service    = "ec2"
 
   public_ip_source              = "amazon"

--- a/internal/service/ecr/registry_policy_test.go
+++ b/internal/service/ecr/registry_policy_test.go
@@ -156,7 +156,7 @@ resource "aws_ecr_registry_policy" "test" {
           "AWS" : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
         },
         "Action" : "ecr:ReplicateImage",
-        "Resource" : "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*",
+        "Resource" : "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/*",
       }
     ]
   })
@@ -187,7 +187,7 @@ resource "aws_ecr_registry_policy" "test" {
           "ecr:CreateRepository"
         ],
         "Resource" : [
-          "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"
+          "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/*"
         ]
       }
     ]

--- a/internal/service/ecs/service_test.go
+++ b/internal/service/ecs/service_test.go
@@ -5026,7 +5026,7 @@ resource "aws_route_table_association" "test" {
 data "aws_ec2_managed_prefix_list" "test" {
   filter {
     name   = "prefix-list-name"
-    values = ["com.amazonaws.${data.aws_region.current.name}.vpc-lattice"]
+    values = ["com.amazonaws.${data.aws_region.current.region}.vpc-lattice"]
   }
 }
 

--- a/internal/service/ecs/task_definition_test.go
+++ b/internal/service/ecs/task_definition_test.go
@@ -3522,7 +3522,7 @@ resource "aws_ecs_task_definition" "test" {
         logDriver = "awslogs"
         options = {
           "awslogs-group"         = aws_cloudwatch_log_group.test.name
-          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-region"        = data.aws_region.current.region
           "awslogs-stream-prefix" = "ecs"
         }
       }

--- a/internal/service/elasticbeanstalk/environment_test.go
+++ b/internal/service/elasticbeanstalk/environment_test.go
@@ -805,7 +805,7 @@ func testAccEnvironmentConfig_platformARN(rName, platformNameWithVersion string,
 resource "aws_elastic_beanstalk_environment" "test" {
   application  = aws_elastic_beanstalk_application.test.name
   name         = %[1]q
-  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.name}::platform/%[2]s"
+  platform_arn = "arn:${data.aws_partition.current.partition}:elasticbeanstalk:${data.aws_region.current.region}::platform/%[2]s"
 
   setting {
     namespace = "aws:ec2:vpc"

--- a/internal/service/elasticsearch/domain_data_source_test.go
+++ b/internal/service/elasticsearch/domain_data_source_test.go
@@ -125,7 +125,7 @@ resource "aws_elasticsearch_domain" "test" {
       "Action": "es:*",
       "Principal": "*",
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
+      "Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*",
       "Condition": {
         "IpAddress": {
           "aws:SourceIp": [
@@ -255,7 +255,7 @@ resource "aws_elasticsearch_domain" "test" {
       "Action": "es:*",
       "Principal": "*",
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*"
+      "Resource": "arn:${data.aws_partition.current.partition}:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${local.random_name}/*"
     }
   ]
 }

--- a/internal/service/elb/service_account_data_source_test.go
+++ b/internal/service/elb/service_account_data_source_test.go
@@ -62,6 +62,6 @@ const testAccServiceAccountDataSourceConfig_explicitRegion = `
 data "aws_region" "current" {}
 
 data "aws_elb_service_account" "regional" {
-  region = data.aws_region.current.name
+  region = data.aws_region.current.region
 }
 `

--- a/internal/service/elbv2/listener_rule_test.go
+++ b/internal/service/elbv2/listener_rule_test.go
@@ -4279,7 +4279,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_lb_listener_rule" "error" {
-  listener_arn = "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:111111111111:listener/app/example/1234567890abcdef/1234567890abcdef"
+  listener_arn = "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.region}:111111111111:listener/app/example/1234567890abcdef/1234567890abcdef"
   priority     = 100
 
   action {
@@ -4513,7 +4513,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 resource "aws_lb_listener_rule" "static" {
-  listener_arn = "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.name}:111111111111:listener/app/test/xxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxx"
+  listener_arn = "arn:${data.aws_partition.current.partition}:elasticloadbalancing:${data.aws_region.current.region}:111111111111:listener/app/test/xxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxx"
   priority     = 100
 
   action {

--- a/internal/service/elbv2/load_balancer_test.go
+++ b/internal/service/elbv2/load_balancer_test.go
@@ -2436,7 +2436,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -2447,7 +2447,7 @@ resource "aws_vpc_ipam" "test" {
 resource "aws_vpc_ipam_pool" "test_pool" {
   address_family   = "ipv4"
   ipam_scope_id    = aws_vpc_ipam.test.public_default_scope_id
-  locale           = data.aws_region.current.name
+  locale           = data.aws_region.current.region
   public_ip_source = "amazon"
   description      = "Test Amazon CIDR Pool"
   aws_service      = "ec2"
@@ -2623,7 +2623,7 @@ func testAccLoadBalancerConfig_IPAMPools_modify(rName string) string {
 resource "aws_vpc_ipam_pool" "test_pool2" {
   address_family   = "ipv4"
   ipam_scope_id    = aws_vpc_ipam.test.public_default_scope_id
-  locale           = data.aws_region.current.name
+  locale           = data.aws_region.current.region
   public_ip_source = "amazon"
   description      = "Test Amazon CIDR Pool 2"
   aws_service      = "ec2"
@@ -2669,7 +2669,7 @@ func testAccLoadBalancerConfig_IPAMPools_modify_destroyALB(rName string) string 
 resource "aws_vpc_ipam_pool" "test_pool2" {
   address_family   = "ipv4"
   ipam_scope_id    = aws_vpc_ipam.test.public_default_scope_id
-  locale           = data.aws_region.current.name
+  locale           = data.aws_region.current.region
   public_ip_source = "amazon"
   description      = "Test Amazon CIDR Pool 2"
   aws_service      = "ec2"

--- a/internal/service/emr/security_configuration_test.go
+++ b/internal/service/emr/security_configuration_test.go
@@ -184,7 +184,7 @@ resource "aws_emr_security_configuration" "test" {
       },
       "LocalDiskEncryptionConfiguration": {
         "EncryptionKeyProviderType": "AwsKms",
-        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
+        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
       }
     },
     "EnableInTransitEncryption": false,
@@ -212,7 +212,7 @@ resource "aws_emr_security_configuration" "test" {
       },
       "LocalDiskEncryptionConfiguration": {
         "EncryptionKeyProviderType": "AwsKms",
-        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
+        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
       }
     },
     "EnableInTransitEncryption": false,
@@ -242,7 +242,7 @@ resource "aws_emr_security_configuration" "test" {
       },
       "LocalDiskEncryptionConfiguration": {
         "EncryptionKeyProviderType": "AwsKms",
-        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
+        "AwsKmsKey": "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:alias/tf_emr_test_key"
       }
     },
     "EnableInTransitEncryption": false,

--- a/internal/service/emr/studio_test.go
+++ b/internal/service/emr/studio_test.go
@@ -412,7 +412,7 @@ resource "aws_kms_key" "test" {
         "StringEquals": {
           "kms:CallerAccount": "${data.aws_caller_identity.current.account_id}",
           "kms:EncryptionContext:aws:s3:arn": "${aws_s3_bucket.test.arn}",
-          "kms:ViaService": "s3.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "s3.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     }

--- a/internal/service/emrserverless/application_test.go
+++ b/internal/service/emrserverless/application_test.go
@@ -753,7 +753,7 @@ resource "aws_imagebuilder_container_recipe" "test_version1" {
   platform_override = "Linux"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/hello-world-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -774,7 +774,7 @@ resource "aws_imagebuilder_container_recipe" "test_version2" {
   platform_override = "Linux"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/hello-world-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/hello-world-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -4178,7 +4178,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   iceberg_configuration {
     role_arn       = aws_iam_role.firehose.arn
     s3_backup_mode = "FailedDataOnly"
-    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
 
     s3_configuration {
       bucket_arn = aws_s3_bucket.bucket.arn
@@ -4206,7 +4206,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   iceberg_configuration {
     role_arn           = aws_iam_role.firehose.arn
     s3_backup_mode     = "FailedDataOnly"
-    catalog_arn        = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    catalog_arn        = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
     buffering_interval = 900
     buffering_size     = 100
     retry_duration     = 900
@@ -4237,7 +4237,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   iceberg_configuration {
     role_arn       = aws_iam_role.firehose.arn
     s3_backup_mode = "FailedDataOnly"
-    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
 
     s3_configuration {
       bucket_arn = aws_s3_bucket.bucket.arn
@@ -4283,7 +4283,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test" {
   iceberg_configuration {
     role_arn       = aws_iam_role.firehose.arn
     s3_backup_mode = "FailedDataOnly"
-    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    catalog_arn    = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
 
     s3_configuration {
       bucket_arn = aws_s3_bucket.bucket.arn

--- a/internal/service/glacier/vault_test.go
+++ b/internal/service/glacier/vault_test.go
@@ -345,7 +345,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
+          "Resource": "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
        }
     ]
 }
@@ -381,7 +381,7 @@ resource "aws_glacier_vault" "test" {
              "glacier:AbortMultipartUpload",
              "glacier:CompleteMultipartUpload"
           ],
-          "Resource": ["arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
+          "Resource": ["arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"]
        }
     ]
 }
@@ -440,7 +440,7 @@ resource "aws_glacier_vault" "test" {
         "glacier:CompleteMultipartUpload",
       ]
       Resource = [
-        "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s",
+        "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s",
       ]
     }]
   })
@@ -472,7 +472,7 @@ resource "aws_glacier_vault" "test" {
         "glacier:InitiateMultipartUpload",
         "glacier:AbortMultipartUpload",
       ]
-      Resource = "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
+      Resource = "arn:${data.aws_partition.current.partition}:glacier:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:vaults/%[1]s"
     }]
   })
 }

--- a/internal/service/globalaccelerator/endpoint_group_test.go
+++ b/internal/service/globalaccelerator/endpoint_group_test.go
@@ -863,7 +863,7 @@ resource "aws_globalaccelerator_endpoint_group" "test" {
     weight      = 10
   }
 
-  endpoint_group_region         = data.aws_region.current.name
+  endpoint_group_region         = data.aws_region.current.region
   health_check_interval_seconds = 30
   health_check_port             = 1234
   health_check_protocol         = "TCP"

--- a/internal/service/glue/catalog_database_test.go
+++ b/internal/service/glue/catalog_database_test.go
@@ -400,7 +400,7 @@ locals {
   # Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonredshift.html#amazonredshift-resources-for-iam-policies
   data_share_arn = format("arn:%s:redshift:%s:%s:datashare:%s/%s",
     data.aws_partition.current.id,
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     data.aws_caller_identity.current.account_id,
     aws_redshiftserverless_namespace.test.namespace_id,
     "tfacctest",
@@ -420,7 +420,7 @@ resource "aws_redshift_data_share_consumer_association" "test" {
   data_share_arn = local.data_share_arn
   consumer_arn = format("arn:%s:glue:%s:%s:catalog",
     data.aws_partition.current.id,
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     data.aws_caller_identity.current.account_id,
   )
 }

--- a/internal/service/glue/catalog_table_optimizer_test.go
+++ b/internal/service/glue/catalog_table_optimizer_test.go
@@ -344,9 +344,9 @@ resource "aws_iam_role_policy" "test" {
           "glue:GetTable"
         ]
         Resource = [
-          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_glue_catalog_database.test.name}/${aws_glue_catalog_table.test.name}",
-          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:database/${aws_glue_catalog_database.test.name}",
-          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_glue_catalog_database.test.name}/${aws_glue_catalog_table.test.name}",
+          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:database/${aws_glue_catalog_database.test.name}",
+          "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
         ]
       },
       {
@@ -356,7 +356,7 @@ resource "aws_iam_role_policy" "test" {
           "logs:CreateLogStream",
           "logs:PutLogEvents"
         ]
-        Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/iceberg-compaction/logs:*"
+        Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws-glue/iceberg-compaction/logs:*"
       }
     ]
   })

--- a/internal/service/glue/catalog_table_test.go
+++ b/internal/service/glue/catalog_table_test.go
@@ -1434,7 +1434,7 @@ resource "aws_glue_catalog_table" "test" {
     catalog_id    = aws_glue_catalog_table.test2.catalog_id
     database_name = aws_glue_catalog_table.test2.database_name
     name          = aws_glue_catalog_table.test2.name
-    region        = data.aws_region.current.name
+    region        = data.aws_region.current.region
   }
 }
 

--- a/internal/service/glue/resource_policy_test.go
+++ b/internal/service/glue/resource_policy_test.go
@@ -241,7 +241,7 @@ data "aws_region" "current" {}
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions   = [%[1]q]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"
@@ -266,7 +266,7 @@ data "aws_region" "current" {}
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions   = [%[1]q]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"
@@ -296,7 +296,7 @@ resource "aws_glue_resource_policy" "test" {
       Action = "glue:CreateTable"
       Effect = "Allow"
       Resource = [
-        "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+        "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       ]
       Principal = {
         AWS = "*"
@@ -323,7 +323,7 @@ resource "aws_glue_resource_policy" "test" {
       Action = [
         "glue:CreateTable",
       ]
-      Resource = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      Resource = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
       Principal = {
         AWS = ["*"]
       }

--- a/internal/service/glue/testdata/ResourcePolicy/basic/main_gen.tf
+++ b/internal/service/glue/testdata/ResourcePolicy/basic/main_gen.tf
@@ -8,7 +8,7 @@ resource "aws_glue_resource_policy" "test" {
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions   = ["glue:CreateTable"]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"

--- a/internal/service/glue/testdata/ResourcePolicy/region_override/main_gen.tf
+++ b/internal/service/glue/testdata/ResourcePolicy/region_override/main_gen.tf
@@ -10,7 +10,7 @@ resource "aws_glue_resource_policy" "test" {
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions   = ["glue:CreateTable"]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"

--- a/internal/service/glue/testdata/tmpl/resource_policy_basic.gtpl
+++ b/internal/service/glue/testdata/tmpl/resource_policy_basic.gtpl
@@ -6,7 +6,7 @@ resource "aws_glue_resource_policy" "test" {
 data "aws_iam_policy_document" "glue-example-policy" {
   statement {
     actions   = ["glue:CreateTable"]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"

--- a/internal/service/grafana/workspace_test.go
+++ b/internal/service/grafana/workspace_test.go
@@ -720,7 +720,7 @@ resource "aws_vpc_endpoint" "test" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.grafana-workspace"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.grafana-workspace"
   subnet_ids          = [aws_subnet.test[count.index].id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id
@@ -760,7 +760,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_endpoint" "test" {
   private_dns_enabled = false
   security_group_ids  = [aws_security_group.test.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.grafana-workspace"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.grafana-workspace"
   subnet_ids          = aws_subnet.test[*].id
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.test.id

--- a/internal/service/guardduty/filter_test.go
+++ b/internal/service/guardduty/filter_test.go
@@ -244,7 +244,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
 
     criterion {
@@ -280,7 +280,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
 
     criterion {
@@ -315,7 +315,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
 
     criterion {

--- a/internal/service/guardduty/malware_protection_plan_test.go
+++ b/internal/service/guardduty/malware_protection_plan_test.go
@@ -413,7 +413,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -434,7 +434,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 
@@ -609,7 +609,7 @@ data "aws_iam_policy_document" "test2" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -630,7 +630,7 @@ data "aws_iam_policy_document" "test2" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/publishing_destination_test.go
+++ b/internal/service/guardduty/publishing_destination_test.go
@@ -132,7 +132,7 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {
@@ -148,7 +148,7 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {

--- a/internal/service/guardduty/testdata/Filter/tags/main_gen.tf
+++ b/internal/service/guardduty/testdata/Filter/tags/main_gen.tf
@@ -10,7 +10,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 

--- a/internal/service/guardduty/testdata/Filter/tagsComputed1/main_gen.tf
+++ b/internal/service/guardduty/testdata/Filter/tagsComputed1/main_gen.tf
@@ -12,7 +12,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 

--- a/internal/service/guardduty/testdata/Filter/tagsComputed2/main_gen.tf
+++ b/internal/service/guardduty/testdata/Filter/tagsComputed2/main_gen.tf
@@ -12,7 +12,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 

--- a/internal/service/guardduty/testdata/Filter/tags_defaults/main_gen.tf
+++ b/internal/service/guardduty/testdata/Filter/tags_defaults/main_gen.tf
@@ -16,7 +16,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 

--- a/internal/service/guardduty/testdata/Filter/tags_ignore/main_gen.tf
+++ b/internal/service/guardduty/testdata/Filter/tags_ignore/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 

--- a/internal/service/guardduty/testdata/MalwareProtectionPlan/tags/main_gen.tf
+++ b/internal/service/guardduty/testdata/MalwareProtectionPlan/tags/main_gen.tf
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/testdata/MalwareProtectionPlan/tagsComputed1/main_gen.tf
+++ b/internal/service/guardduty/testdata/MalwareProtectionPlan/tagsComputed1/main_gen.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/testdata/MalwareProtectionPlan/tagsComputed2/main_gen.tf
+++ b/internal/service/guardduty/testdata/MalwareProtectionPlan/tagsComputed2/main_gen.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/testdata/MalwareProtectionPlan/tags_defaults/main_gen.tf
+++ b/internal/service/guardduty/testdata/MalwareProtectionPlan/tags_defaults/main_gen.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/testdata/MalwareProtectionPlan/tags_ignore/main_gen.tf
+++ b/internal/service/guardduty/testdata/MalwareProtectionPlan/tags_ignore/main_gen.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/guardduty/testdata/tmpl/filter_tags.gtpl
+++ b/internal/service/guardduty/testdata/tmpl/filter_tags.gtpl
@@ -7,7 +7,7 @@ resource "aws_guardduty_filter" "test" {
   finding_criteria {
     criterion {
       field  = "region"
-      equals = [data.aws_region.current.name]
+      equals = [data.aws_region.current.region]
     }
   }
 {{- template "tags" . }}

--- a/internal/service/guardduty/testdata/tmpl/malware_protection_plan_tags.gtpl
+++ b/internal/service/guardduty/testdata/tmpl/malware_protection_plan_tags.gtpl
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
 
     condition {
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "test" {
     ]
     effect = "Allow"
     resources = [
-      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+      "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
     ]
   }
 

--- a/internal/service/iam/testdata/Policy/data.tags/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/data.tags/main_gen.tf
@@ -18,7 +18,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/data.tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/data.tags_defaults/main_gen.tf
@@ -24,7 +24,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/data.tags_ignore/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/data.tags_ignore/main_gen.tf
@@ -27,7 +27,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/tags/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags/main_gen.tf
@@ -13,7 +13,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/tagsComputed1/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsComputed1/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/tagsComputed2/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tagsComputed2/main_gen.tf
@@ -15,7 +15,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/tags_defaults/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags_defaults/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/Policy/tags_ignore/main_gen.tf
+++ b/internal/service/iam/testdata/Policy/tags_ignore/main_gen.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/iam/testdata/tmpl/policy_tags.gtpl
+++ b/internal/service/iam/testdata/tmpl/policy_tags.gtpl
@@ -10,7 +10,7 @@ resource "aws_iam_policy" "test" {
         "ec2:Describe*"
       ],
       "Effect": "Allow",
-      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     }
   ]
 }

--- a/internal/service/imagebuilder/container_recipe_data_source_test.go
+++ b/internal/service/imagebuilder/container_recipe_data_source_test.go
@@ -68,11 +68,11 @@ resource "aws_ecr_repository" "test" {
 resource "aws_imagebuilder_container_recipe" "test" {
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF

--- a/internal/service/imagebuilder/container_recipe_test.go
+++ b/internal/service/imagebuilder/container_recipe_test.go
@@ -754,11 +754,11 @@ func testAccContainerRecipeConfig_name(rName string) string {
 resource "aws_imagebuilder_container_recipe" "test" {
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -782,15 +782,15 @@ func testAccContainerRecipeConfig_component(rName string) string {
 resource "aws_imagebuilder_container_recipe" "test" {
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/aws-cli-version-2-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/aws-cli-version-2-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -839,7 +839,7 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
@@ -879,11 +879,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   description = "description"
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -923,11 +923,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_uri = "s3://${aws_s3_bucket.test.bucket}/${aws_s3_object.test.key}"
@@ -952,11 +952,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -987,11 +987,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1024,11 +1024,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1061,11 +1061,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1103,11 +1103,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1150,11 +1150,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1187,11 +1187,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1225,11 +1225,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1262,11 +1262,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1299,11 +1299,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1334,11 +1334,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1379,11 +1379,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1417,11 +1417,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1448,11 +1448,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1481,11 +1481,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1515,11 +1515,11 @@ resource "aws_imagebuilder_container_recipe" "test" {
   name = %[1]q
 
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF
@@ -1550,7 +1550,7 @@ resource "aws_imagebuilder_container_recipe" "test" {
   platform_override = "Linux"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF

--- a/internal/service/imagebuilder/container_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/container_recipes_data_source_test.go
@@ -49,11 +49,11 @@ resource "aws_ecr_repository" "test" {
 resource "aws_imagebuilder_container_recipe" "test" {
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-2/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-2/x.x.x"
   version        = "1.0.0"
 
   component {
-    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+    component_arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
   }
 
   dockerfile_template_data = <<EOF

--- a/internal/service/imagebuilder/distribution_configuration_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_data_source_test.go
@@ -135,7 +135,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       data_type      = "aws:ec2:image"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 

--- a/internal/service/imagebuilder/distribution_configuration_test.go
+++ b/internal/service/imagebuilder/distribution_configuration_test.go
@@ -1292,7 +1292,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, description)
@@ -1316,7 +1316,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 
   distribution {
@@ -1344,7 +1344,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, amiTagKey, amiTagValue)
@@ -1362,7 +1362,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       description = %[2]q
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, description)
@@ -1385,7 +1385,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       kms_key_id = aws_kms_key.test.arn
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1408,7 +1408,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       kms_key_id = aws_kms_key.test2.arn
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1428,7 +1428,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, userGroup)
@@ -1448,7 +1448,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, userId)
@@ -1469,7 +1469,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
         organization_arns = [aws_organizations_organization.test.arn]
       }
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1495,7 +1495,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
         organizational_unit_arns = [aws_organizations_organizational_unit.test.arn]
       }
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
   `, rName)
@@ -1513,7 +1513,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = %[2]q
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, name)
@@ -1531,7 +1531,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       target_account_ids = [%[2]q]
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, targetAccountId)
@@ -1552,7 +1552,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, repositoryName)
@@ -1575,7 +1575,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       description = %[2]q
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, description)
@@ -1598,7 +1598,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       container_tags = [%[2]q]
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, containerTag)
@@ -1619,7 +1619,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       enabled    = %[2]s
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, enabled)
@@ -1650,7 +1650,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1681,7 +1681,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1703,7 +1703,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       max_parallel_launches = %[2]d
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, maxParallelLaunches)
@@ -1728,7 +1728,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, targetResourceCount)
@@ -1755,7 +1755,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       account_id         = data.aws_caller_identity.current.account_id
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1782,7 +1782,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       account_id         = data.aws_caller_identity.current.account_id
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1813,7 +1813,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       }
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
   `, rName, accountId)
@@ -1833,7 +1833,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
 
   distribution {
     license_configuration_arns = [aws_licensemanager_license_configuration.test.id]
-    region                     = data.aws_region.current.name
+    region                     = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1853,7 +1853,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
 
   distribution {
     license_configuration_arns = [aws_licensemanager_license_configuration.test2.id]
-    region                     = data.aws_region.current.name
+    region                     = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1871,7 +1871,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName)
@@ -1891,7 +1891,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       role_name         = "role-name"
       s3_bucket         = aws_s3_bucket.test.id
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, diskImageFormat)
@@ -1911,7 +1911,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       role_name         = %[2]q
       s3_bucket         = aws_s3_bucket.test.id
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, roleName)
@@ -1931,7 +1931,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       role_name         = "role-name"
       s3_bucket         = aws_s3_bucket.test.id
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, s3Bucket)
@@ -1952,7 +1952,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       s3_bucket         = aws_s3_bucket.test.id
       s3_prefix         = %[2]q
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, s3Prefix)
@@ -1969,7 +1969,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       parameter_name = %[2]q
       data_type      = %[3]q
     }
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 `, rName, parameterName, dataType)
@@ -1987,7 +1987,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 
   tags = {
@@ -2009,7 +2009,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 
   tags = {

--- a/internal/service/imagebuilder/distribution_configurations_data_source_test.go
+++ b/internal/service/imagebuilder/distribution_configurations_data_source_test.go
@@ -50,7 +50,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "test-{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 

--- a/internal/service/imagebuilder/image_data_source_test.go
+++ b/internal/service/imagebuilder/image_data_source_test.go
@@ -121,7 +121,7 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 data "aws_imagebuilder_image" "test" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
 }
 `
 }
@@ -129,7 +129,7 @@ data "aws_imagebuilder_image" "test" {
 func testAccImageDataSourceConfig_arnSelf(rName string) string {
 	return fmt.Sprintf(`
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.2"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/1.0.2"
 }
 
 data "aws_region" "current" {}
@@ -218,7 +218,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -330,7 +330,7 @@ resource "aws_ecr_repository" "test" {
 }
 
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.2"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/1.0.2"
 }
 
 resource "aws_imagebuilder_container_recipe" "test" {
@@ -346,7 +346,7 @@ EOF
 
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-latest/x.x.x"
   version        = "1.0.0"
   target_repository {
     repository_name = aws_ecr_repository.test.name

--- a/internal/service/imagebuilder/image_pipeline_data_source_test.go
+++ b/internal/service/imagebuilder/image_pipeline_data_source_test.go
@@ -137,7 +137,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -172,7 +172,7 @@ EOF
 
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-latest/x.x.x"
   version        = "1.0.0"
 
   target_repository {

--- a/internal/service/imagebuilder/image_pipeline_test.go
+++ b/internal/service/imagebuilder/image_pipeline_test.go
@@ -812,7 +812,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -876,7 +876,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 
   lifecycle {
@@ -903,7 +903,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 
   lifecycle {
@@ -939,7 +939,7 @@ resource "aws_imagebuilder_image_recipe" "test2" {
   }
 
   name         = "%[1]s-2"
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -976,7 +976,7 @@ EOF
 
   name           = "%[1]s-2"
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-latest/x.x.x"
   version        = "1.0.0"
 
   target_repository {

--- a/internal/service/imagebuilder/image_pipelines_data_source_test.go
+++ b/internal/service/imagebuilder/image_pipelines_data_source_test.go
@@ -95,7 +95,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 

--- a/internal/service/imagebuilder/image_recipe_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipe_data_source_test.go
@@ -99,7 +99,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name             = %[1]q
-  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version          = "1.0.0"
   user_data_base64 = base64encode("helloworld")
 }

--- a/internal/service/imagebuilder/image_recipe_test.go
+++ b/internal/service/imagebuilder/image_recipe_test.go
@@ -822,7 +822,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, deviceName))
@@ -844,7 +844,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, deleteOnTermination))
@@ -866,7 +866,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, encrypted))
@@ -888,7 +888,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, iops))
@@ -915,7 +915,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -947,7 +947,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -970,7 +970,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, throughput))
@@ -992,7 +992,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, volumeSize))
@@ -1014,7 +1014,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, volumeType))
@@ -1034,7 +1034,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, noDevice))
@@ -1054,7 +1054,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, virtualName))
@@ -1065,11 +1065,11 @@ func testAccImageRecipeConfig_component(rName string) string {
 		testAccImageRecipeBaseConfig(rName),
 		fmt.Sprintf(`
 data "aws_imagebuilder_component" "aws-cli-version-2-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/aws-cli-version-2-linux/x.x.x"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/aws-cli-version-2-linux/x.x.x"
 }
 
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/x.x.x"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/x.x.x"
 }
 
 resource "aws_imagebuilder_image_recipe" "test" {
@@ -1086,7 +1086,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -1125,7 +1125,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, command))
@@ -1177,7 +1177,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName)
@@ -1194,7 +1194,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
 
   description  = %[2]q
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName, description))
@@ -1210,7 +1210,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -1226,7 +1226,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 
   tags = {
@@ -1246,7 +1246,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 
   tags = {
@@ -1267,7 +1267,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name              = %[1]q
-  parent_image      = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image      = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version           = "1.0.0"
   working_directory = %[2]q
 }
@@ -1364,7 +1364,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -1384,7 +1384,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))
@@ -1400,7 +1400,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 
   systems_manager_agent {
@@ -1420,7 +1420,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name             = %[1]q
-  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image     = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version          = "1.0.0"
   user_data_base64 = base64encode("hello world")
 }
@@ -1465,7 +1465,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/windows-server-2022-english-full-base-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/windows-server-2022-english-full-base-x86/x.x.x"
   version      = "1.0.0"
 }
 `, rName))

--- a/internal/service/imagebuilder/image_recipes_data_source_test.go
+++ b/internal/service/imagebuilder/image_recipes_data_source_test.go
@@ -97,7 +97,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -127,7 +127,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 

--- a/internal/service/imagebuilder/image_test.go
+++ b/internal/service/imagebuilder/image_test.go
@@ -391,7 +391,7 @@ func testAccCheckImageExists(ctx context.Context, n string) resource.TestCheckFu
 func testAccImageBaseConfig(rName string) string {
 	return fmt.Sprintf(`
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.2"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/1.0.2"
 }
 
 data "aws_region" "current" {}
@@ -480,7 +480,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -507,7 +507,7 @@ resource "aws_imagebuilder_distribution_configuration" "test" {
       name = "{{ imagebuilder:buildDate }}"
     }
 
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
   }
 }
 
@@ -923,7 +923,7 @@ resource "aws_ecr_repository" "test" {
 }
 
 data "aws_imagebuilder_component" "update-linux" {
-  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:component/update-linux/1.0.2"
+  arn = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:component/update-linux/1.0.2"
 }
 
 resource "aws_imagebuilder_container_recipe" "test" {
@@ -939,7 +939,7 @@ EOF
 
   name           = %[1]q
   container_type = "DOCKER"
-  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-x86-latest/x.x.x"
+  parent_image   = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-x86-latest/x.x.x"
   version        = "1.0.0"
   target_repository {
     repository_name = aws_ecr_repository.test.name

--- a/internal/service/imagebuilder/lifecycle_policy_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_test.go
@@ -424,7 +424,7 @@ resource "aws_imagebuilder_lifecycle_policy" "test" {
     exclusion_rules {
       amis {
         is_public = true
-        regions   = [data.aws_region.current.name]
+        regions   = [data.aws_region.current.region]
         last_launched {
           unit  = "WEEKS"
           value = 2
@@ -463,7 +463,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 
@@ -506,7 +506,7 @@ resource "aws_imagebuilder_image_recipe" "test" {
   }
 
   name         = %[1]q
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "2.0.0"
 }
 

--- a/internal/service/iot/ca_certificate_test.go
+++ b/internal/service/iot/ca_certificate_test.go
@@ -465,7 +465,7 @@ resource "aws_iot_ca_certificate" "test" {
     "policy": {
       "Type": "AWS::IoT::Policy",
       "Properties": {
-        "PolicyDocument":"{ \"Version\": \"2012-10-17\", \"Statement\": [{ \"Effect\": \"Allow\", \"Action\":[\"iot:Publish\"], \"Resource\": [\"arn:${data.aws_partition.current.partition}:iot:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:topic/foo/bar\"] }] }"
+        "PolicyDocument":"{ \"Version\": \"2012-10-17\", \"Statement\": [{ \"Effect\": \"Allow\", \"Action\":[\"iot:Publish\"], \"Resource\": [\"arn:${data.aws_partition.current.partition}:iot:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:topic/foo/bar\"] }] }"
       }
     }
   } 

--- a/internal/service/iot/topic_rule_test.go
+++ b/internal/service/iot/topic_rule_test.go
@@ -2721,7 +2721,7 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   elasticsearch {
-    endpoint = "https://domain.${data.aws_region.current.name}.es.${data.aws_partition.current.dns_suffix}"
+    endpoint = "https://domain.${data.aws_region.current.region}.es.${data.aws_partition.current.dns_suffix}"
     id       = "myIdentifier"
     index    = %[2]q
     type     = "mydocument"
@@ -2968,7 +2968,7 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   kafka {
-    destination_arn = "arn:${data.aws_partition.current.partition}:iot:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:ruledestination/vpc/pretend-this-is-a-uuid"
+    destination_arn = "arn:${data.aws_partition.current.partition}:iot:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:ruledestination/vpc/pretend-this-is-a-uuid"
     topic           = %[2]q
 
     client_properties = {
@@ -3027,7 +3027,7 @@ resource "aws_iot_topic_rule" "test" {
   sql_version = "2015-10-08"
 
   lambda {
-    function_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}:123456789012:function:ProcessKinesisRecords"
+    function_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}:123456789012:function:ProcessKinesisRecords"
   }
 }
 `, rName)
@@ -3105,7 +3105,7 @@ resource "aws_iot_topic_rule" "test" {
   sns {
     message_format = %[2]q
     role_arn       = aws_iam_role.test.arn
-    target_arn     = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}:123456789012:my_corporate_topic"
+    target_arn     = "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}:123456789012:my_corporate_topic"
   }
 }
 `, rName, messageFormat))

--- a/internal/service/kafkaconnect/connector_test.go
+++ b/internal/service/kafkaconnect/connector_test.go
@@ -354,7 +354,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [

--- a/internal/service/kendra/data_source_test.go
+++ b/internal/service/kendra/data_source_test.go
@@ -1921,7 +1921,7 @@ data "aws_iam_policy_document" "test_index" {
       "logs:CreateLogGroup"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
     ]
   }
 
@@ -1933,7 +1933,7 @@ data "aws_iam_policy_document" "test_index" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
     ]
   }
 }

--- a/internal/service/kendra/experience_test.go
+++ b/internal/service/kendra/experience_test.go
@@ -680,7 +680,7 @@ data "aws_iam_policy_document" "test" {
       "logs:CreateLogGroup"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
     ]
   }
   statement {
@@ -691,7 +691,7 @@ data "aws_iam_policy_document" "test" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
     ]
   }
 }
@@ -716,7 +716,7 @@ data "aws_iam_policy_document" "experience" {
       "kendra:DescribeFaq"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:kendra:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:index/${aws_kendra_index.test.id}"
+      "arn:${data.aws_partition.current.partition}:kendra:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:index/${aws_kendra_index.test.id}"
     ]
   }
 }

--- a/internal/service/kendra/faq_test.go
+++ b/internal/service/kendra/faq_test.go
@@ -376,7 +376,7 @@ data "aws_iam_policy_document" "test_index" {
       "logs:CreateLogGroup"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
     ]
   }
 
@@ -388,7 +388,7 @@ data "aws_iam_policy_document" "test_index" {
       "logs:PutLogEvents"
     ]
     resources = [
-      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
+      "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
     ]
   }
 }

--- a/internal/service/kendra/index_test.go
+++ b/internal/service/kendra/index_test.go
@@ -1480,7 +1480,7 @@ resource "aws_iam_role" "access_cw" {
         {
           Action   = ["logs:CreateLogGroup"]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
+          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
         },
         {
           Action = [
@@ -1489,7 +1489,7 @@ resource "aws_iam_role" "access_cw" {
             "logs:PutLogEvents"
           ]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
+          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
         },
       ]
     })
@@ -1524,7 +1524,7 @@ resource "aws_iam_role" "access_sm" {
         {
           Action   = ["logs:CreateLogGroup"]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
+          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*"
         },
         {
           Action = [
@@ -1533,17 +1533,17 @@ resource "aws_iam_role" "access_sm" {
             "logs:PutLogEvents"
           ]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
+          Resource = "arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/kendra/*:log-stream:*"
         },
         {
           Action   = ["secretsmanager:GetSecretValue"]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:example"
+          Resource = "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:example"
         },
         {
           Action   = ["kms:Decrypt"]
           Effect   = "Allow"
-          Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/example"
+          Resource = "arn:${data.aws_partition.current.partition}:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/example"
           Condition = {
             StringLike = {
               "kms:ViaService" = ["secretsmanager.*.amazonaws.com"]

--- a/internal/service/kinesisanalyticsv2/application_test.go
+++ b/internal/service/kinesisanalyticsv2/application_test.go
@@ -4537,7 +4537,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "InputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.input.name
         }
       }
@@ -4546,7 +4546,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "OutputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.output.name
         }
       }
@@ -4613,7 +4613,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "InputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.input.name
         }
       }
@@ -4622,7 +4622,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "OutputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.output.name
         }
       }
@@ -4848,7 +4848,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "InputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.input.name
         }
       }
@@ -4857,7 +4857,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "OutputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.output.name
         }
       }
@@ -4916,7 +4916,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "InputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.input.name
         }
       }
@@ -4925,7 +4925,7 @@ resource "aws_kinesisanalyticsv2_application" "test" {
         property_group_id = "OutputStream0"
 
         property_map = {
-          "aws.region"  = data.aws_region.current.name
+          "aws.region"  = data.aws_region.current.region
           "stream.name" = aws_kinesis_stream.output.name
         }
       }

--- a/internal/service/lambda/runtime_management_config_test.go
+++ b/internal/service/lambda/runtime_management_config_test.go
@@ -230,7 +230,7 @@ data "aws_region" "current" {}
 resource "aws_lambda_runtime_management_config" "test" {
   function_name       = aws_lambda_function.test.function_name
   update_runtime_on   = "Manual"
-  runtime_version_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.name}::runtime:%[1]s"
+  runtime_version_arn = "arn:${data.aws_partition.current.partition}:lambda:${data.aws_region.current.region}::runtime:%[1]s"
 }
 `, runtimeVersion))
 }

--- a/internal/service/logs/delivery_source_test.go
+++ b/internal/service/logs/delivery_source_test.go
@@ -314,7 +314,7 @@ resource "aws_bedrockagent_knowledge_base" "test" {
 
   knowledge_base_configuration {
     vector_knowledge_base_configuration {
-      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/%[2]s"
+      embedding_model_arn = "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/%[2]s"
     }
     type = "VECTOR"
   }

--- a/internal/service/logs/destination_policy_test.go
+++ b/internal/service/logs/destination_policy_test.go
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/destination_test.go
+++ b/internal/service/logs/destination_test.go
@@ -215,7 +215,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -413,7 +413,7 @@ resource "aws_iam_role" "cloudwatchlogs" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "logs.${data.aws_region.current.name}.amazonaws.com"
+        "Service": "logs.${data.aws_region.current.region}.amazonaws.com"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -433,7 +433,7 @@ resource "aws_iam_role_policy" "cloudwatchlogs" {
     {
       "Effect": "Allow",
       "Action": "firehose:*",
-      "Resource": "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      "Resource": "arn:${data.aws_partition.current.partition}:firehose:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"
     },
     {
       "Effect": "Allow",
@@ -481,7 +481,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "logs.${data.aws_region.current.name}.amazonaws.com"
+        "Service": "logs.${data.aws_region.current.region}.amazonaws.com"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -710,7 +710,7 @@ resource "aws_iam_role" "test2" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "logs.${data.aws_region.current.name}.amazonaws.com"
+        "Service": "logs.${data.aws_region.current.region}.amazonaws.com"
       },
       "Effect": "Allow",
       "Sid": ""

--- a/internal/service/logs/testdata/Destination/tags/main_gen.tf
+++ b/internal/service/logs/testdata/Destination/tags/main_gen.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/testdata/Destination/tagsComputed1/main_gen.tf
+++ b/internal/service/logs/testdata/Destination/tagsComputed1/main_gen.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/testdata/Destination/tagsComputed2/main_gen.tf
+++ b/internal/service/logs/testdata/Destination/tagsComputed2/main_gen.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/testdata/Destination/tags_defaults/main_gen.tf
+++ b/internal/service/logs/testdata/Destination/tags_defaults/main_gen.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/testdata/Destination/tags_ignore/main_gen.tf
+++ b/internal/service/logs/testdata/Destination/tags_ignore/main_gen.tf
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/logs/testdata/tmpl/destination_tags.gtpl
+++ b/internal/service/logs/testdata/tmpl/destination_tags.gtpl
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "role" {
       type = "Service"
 
       identifiers = [
-        "logs.${data.aws_region.current.name}.amazonaws.com",
+        "logs.${data.aws_region.current.region}.amazonaws.com",
       ]
     }
 

--- a/internal/service/m2/deployment_test.go
+++ b/internal/service/m2/deployment_test.go
@@ -231,7 +231,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "secretsmanager" {
   vpc_id            = aws_vpc.test.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
+  service_name      = "com.amazonaws.${data.aws_region.current.region}.secretsmanager"
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [

--- a/internal/service/macie2/classification_export_configuration_test.go
+++ b/internal/service/macie2/classification_export_configuration_test.go
@@ -204,8 +204,8 @@ resource "aws_s3_bucket_policy" "test" {
             },
             "ArnLike" : {
               "aws:SourceArn" : [
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
               ]
             }
           }

--- a/internal/service/macie2/findings_filter_test.go
+++ b/internal/service/macie2/findings_filter_test.go
@@ -549,7 +549,7 @@ resource "aws_macie2_findings_filter" "test" {
   finding_criteria {
     criterion {
       field = "region"
-      eq    = [data.aws_region.current.name]
+      eq    = [data.aws_region.current.region]
     }
   }
   depends_on = [aws_macie2_account.test]
@@ -570,7 +570,7 @@ resource "aws_macie2_findings_filter" "test" {
   finding_criteria {
     criterion {
       field = "region"
-      eq    = [data.aws_region.current.name]
+      eq    = [data.aws_region.current.region]
     }
     criterion {
       field = "sample"
@@ -600,7 +600,7 @@ resource "aws_macie2_findings_filter" "test" {
   finding_criteria {
     criterion {
       field = "region"
-      eq    = [data.aws_region.current.name]
+      eq    = [data.aws_region.current.region]
     }
     criterion {
       field = "sample"

--- a/internal/service/macie2/testdata/ClassificationExportConfiguration/basic/main_gen.tf
+++ b/internal/service/macie2/testdata/ClassificationExportConfiguration/basic/main_gen.tf
@@ -59,8 +59,8 @@ resource "aws_s3_bucket_policy" "test" {
             },
             "ArnLike" : {
               "aws:SourceArn" : [
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
               ]
             }
           }

--- a/internal/service/macie2/testdata/ClassificationExportConfiguration/region_override/main_gen.tf
+++ b/internal/service/macie2/testdata/ClassificationExportConfiguration/region_override/main_gen.tf
@@ -67,8 +67,8 @@ resource "aws_s3_bucket_policy" "test" {
             },
             "ArnLike" : {
               "aws:SourceArn" : [
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
               ]
             }
           }

--- a/internal/service/macie2/testdata/tmpl/classification_export_configuration_basic.gtpl
+++ b/internal/service/macie2/testdata/tmpl/classification_export_configuration_basic.gtpl
@@ -61,8 +61,8 @@ resource "aws_s3_bucket_policy" "test" {
             },
             "ArnLike" : {
               "aws:SourceArn" : [
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
-                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:classification-job/*"
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:export-configuration:*",
+                "arn:${data.aws_partition.current.partition}:macie2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:classification-job/*"
               ]
             }
           }

--- a/internal/service/mediastore/container_policy_test.go
+++ b/internal/service/mediastore/container_policy_test.go
@@ -151,7 +151,7 @@ resource "aws_media_store_container_policy" "test" {
         AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
       }
       Effect   = "Allow"
-      Resource = "arn:${data.aws_partition.current.partition}:mediastore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:container/${aws_media_store_container.test.name}/*"
+      Resource = "arn:${data.aws_partition.current.partition}:mediastore:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:container/${aws_media_store_container.test.name}/*"
       Condition = {
         Bool = {
           "aws:SecureTransport" = "true"

--- a/internal/service/meta/service_data_source_test.go
+++ b/internal/service/meta/service_data_source_test.go
@@ -215,7 +215,7 @@ data "aws_region" "current" {}
 
 data "aws_service" "test" {
   reverse_dns_prefix = "com.amazonaws"
-  region             = data.aws_region.current.name
+  region             = data.aws_region.current.region
   service_id         = "s3"
 }
 `

--- a/internal/service/mwaa/environment_test.go
+++ b/internal/service/mwaa/environment_test.go
@@ -934,7 +934,7 @@ resource "aws_kms_key" "test" {
     {
       "Effect": "Allow",
       "Principal": {
-        "Service": "logs.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+        "Service": "logs.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
       },
       "Action": "kms:*",
       "Resource": "*"

--- a/internal/service/neptune/cluster_test.go
+++ b/internal/service/neptune/cluster_test.go
@@ -1488,7 +1488,7 @@ resource "aws_kms_key" "test" {
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     },
@@ -1504,7 +1504,7 @@ resource "aws_kms_key" "test" {
       "Resource": "*",
       "Condition": {
         "StringNotEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     }
@@ -1797,7 +1797,7 @@ resource "aws_kms_key" "test1" {
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     },
@@ -1813,7 +1813,7 @@ resource "aws_kms_key" "test1" {
       "Resource": "*",
       "Condition": {
         "StringNotEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     }
@@ -1860,7 +1860,7 @@ resource "aws_kms_key" "test2" {
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     },
@@ -1876,7 +1876,7 @@ resource "aws_kms_key" "test2" {
       "Resource": "*",
       "Condition": {
         "StringNotEquals": {
-          "kms:ViaService": "rds.${data.aws_region.current.name}.amazonaws.com"
+          "kms:ViaService": "rds.${data.aws_region.current.region}.amazonaws.com"
         }
       }
     }

--- a/internal/service/networkfirewall/firewall_policy_data_source_test.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source_test.go
@@ -216,7 +216,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
 
     # Managed rule group required for override block.
     stateful_rule_group_reference {
-      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.name}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
+      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
 
       override {
         action = "DROP_TO_ALERT"

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -1493,7 +1493,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
     stateless_default_actions          = ["aws:pass"]
 
     stateful_rule_group_reference {
-      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.name}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
+      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
     }
   }
 }
@@ -1556,7 +1556,7 @@ resource "aws_networkfirewall_firewall_policy" "test" {
     stateless_default_actions          = ["aws:pass"]
 
     stateful_rule_group_reference {
-      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.name}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
+      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/MalwareDomainsActionOrder"
 
       override {
         action = %[2]q

--- a/internal/service/networkmanager/connect_attachment_test.go
+++ b/internal/service/networkmanager/connect_attachment_test.go
@@ -301,7 +301,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     vpn_ecmp_support = false
     asn_ranges       = ["64512-64555"]
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
       asn      = 64512
     }
   }

--- a/internal/service/networkmanager/connect_peer_test.go
+++ b/internal/service/networkmanager/connect_peer_test.go
@@ -302,7 +302,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     asn_ranges         = ["64512-64555"]
     inside_cidr_blocks = ["172.16.0.0/16"]
     edge_locations {
-      location           = data.aws_region.current.name
+      location           = data.aws_region.current.region
       asn                = 64512
       inside_cidr_blocks = ["172.16.0.0/18"]
     }

--- a/internal/service/networkmanager/dx_gateway_attachment_test.go
+++ b/internal/service/networkmanager/dx_gateway_attachment_test.go
@@ -340,7 +340,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     vpn_ecmp_support = false
     asn_ranges       = ["64512-64555"]
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
       asn      = 64512
     }
   }
@@ -450,7 +450,7 @@ func testAccDirectConnectGatewayAttachmentConfig_basic(rName string, requireAcce
 resource "aws_networkmanager_dx_gateway_attachment" "test" {
   core_network_id            = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   direct_connect_gateway_arn = aws_dx_gateway.test.arn
-  edge_locations             = [data.aws_region.current.name]
+  edge_locations             = [data.aws_region.current.region]
 }
 `)
 }
@@ -460,7 +460,7 @@ func testAccDirectConnectGatewayAttachmentConfig_Accepted_basic(rName string) st
 resource "aws_networkmanager_dx_gateway_attachment" "test" {
   core_network_id            = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   direct_connect_gateway_arn = aws_dx_gateway.test.arn
-  edge_locations             = [data.aws_region.current.name]
+  edge_locations             = [data.aws_region.current.region]
 }
 
 resource "aws_networkmanager_attachment_accepter" "test" {
@@ -495,7 +495,7 @@ func testAccDirectConnectGatewayAttachmentConfig_tags1(rName, tagKey1, tagValue1
 resource "aws_networkmanager_dx_gateway_attachment" "test" {
   core_network_id            = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   direct_connect_gateway_arn = aws_dx_gateway.test.arn
-  edge_locations             = [data.aws_region.current.name]
+  edge_locations             = [data.aws_region.current.region]
 
   tags = {
     %[1]q = %[2]q
@@ -509,7 +509,7 @@ func testAccDirectConnectGatewayAttachmentConfig_tags2(rName, tagKey1, tagValue1
 resource "aws_networkmanager_dx_gateway_attachment" "test" {
   core_network_id            = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   direct_connect_gateway_arn = aws_dx_gateway.test.arn
-  edge_locations             = [data.aws_region.current.name]
+  edge_locations             = [data.aws_region.current.region]
 
   tags = {
     %[1]q = %[2]q

--- a/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
+++ b/internal/service/networkmanager/site_to_site_vpn_attachment_test.go
@@ -242,7 +242,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     vpn_ecmp_support = false
     asn_ranges       = ["64512-64555"]
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
       asn      = 64512
     }
   }

--- a/internal/service/networkmanager/transit_gateway_peering_test.go
+++ b/internal/service/networkmanager/transit_gateway_peering_test.go
@@ -231,7 +231,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     asn_ranges = ["65022-65534"]
 
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
     }
   }
 

--- a/internal/service/networkmanager/vpc_attachment_test.go
+++ b/internal/service/networkmanager/vpc_attachment_test.go
@@ -733,7 +733,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     vpn_ecmp_support = false
     asn_ranges       = ["64512-64555"]
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
       asn      = 64512
     }
   }

--- a/internal/service/opensearch/inbound_connection_accepter_test.go
+++ b/internal/service/opensearch/inbound_connection_accepter_test.go
@@ -154,13 +154,13 @@ resource "aws_opensearch_outbound_connection" "test" {
   connection_alias = "%s"
   local_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_1.domain_name
   }
 
   remote_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_2.domain_name
   }
 }

--- a/internal/service/opensearch/outbound_connection_test.go
+++ b/internal/service/opensearch/outbound_connection_test.go
@@ -196,13 +196,13 @@ resource "aws_opensearch_outbound_connection" "test" {
 
   local_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_1.domain_name
   }
 
   remote_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_2.domain_name
   }
 }
@@ -318,13 +318,13 @@ resource "aws_opensearch_outbound_connection" "test" {
 
   local_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_1.domain_name
   }
 
   remote_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.domain_2.domain_name
   }
 }

--- a/internal/service/osis/pipeline_test.go
+++ b/internal/service/osis/pipeline_test.go
@@ -419,7 +419,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -466,7 +466,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -517,7 +517,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -569,7 +569,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -620,7 +620,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -681,7 +681,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"
@@ -750,7 +750,7 @@ resource "aws_osis_pipeline" "test" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.test.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "test"
                     threshold:
                       event_collect_timeout: "60s"

--- a/internal/service/pinpoint/app_test.go
+++ b/internal/service/pinpoint/app_test.go
@@ -564,8 +564,8 @@ resource "aws_lambda_permission" "test" {
   statement_id  = "AllowExecutionFromPinpoint"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.test.function_name
-  principal     = "pinpoint.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
-  source_arn    = "arn:${data.aws_partition.current.partition}:mobiletargeting:${data.aws_region.current.name}:${data.aws_caller_identity.aws.account_id}:/apps/*"
+  principal     = "pinpoint.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
+  source_arn    = "arn:${data.aws_partition.current.partition}:mobiletargeting:${data.aws_region.current.region}:${data.aws_caller_identity.aws.account_id}:/apps/*"
 }
 `, rName)
 }

--- a/internal/service/quicksight/data_source_test.go
+++ b/internal/service/quicksight/data_source_test.go
@@ -452,7 +452,7 @@ resource "aws_s3_object" "test" {
     fileLocations = [
       {
         URIs = [
-          "https://${aws_s3_bucket.test.id}.s3.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}/%[1]s-test-data.csv"
+          "https://${aws_s3_bucket.test.id}.s3.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}/%[1]s-test-data.csv"
         ]
       }
     ]

--- a/internal/service/rds/cluster_instance_test.go
+++ b/internal/service/rds/cluster_instance_test.go
@@ -1665,7 +1665,7 @@ resource "aws_rds_cluster" "alternate" {
   storage_encrypted             = true
   skip_final_snapshot           = true
   replication_source_identifier = aws_rds_cluster.test.arn
-  source_region                 = data.aws_region.current.name
+  source_region                 = data.aws_region.current.region
 
   depends_on = [
     aws_rds_cluster_instance.test,

--- a/internal/service/rds/cluster_test.go
+++ b/internal/service/rds/cluster_test.go
@@ -5048,7 +5048,7 @@ resource "aws_rds_cluster" "alternate" {
   storage_encrypted             = true
   skip_final_snapshot           = true
   replication_source_identifier = aws_rds_cluster.test.arn
-  source_region                 = data.aws_region.current.name
+  source_region                 = data.aws_region.current.region
 
   depends_on = [
     aws_rds_cluster_instance.test,
@@ -5188,7 +5188,7 @@ resource "aws_rds_cluster" "alternate" {
   storage_encrypted             = true
   skip_final_snapshot           = true
   replication_source_identifier = aws_rds_cluster.test.arn
-  source_region                 = data.aws_region.current.name
+  source_region                 = data.aws_region.current.region
 
   depends_on = [
     aws_rds_cluster_instance.test,
@@ -5210,7 +5210,7 @@ resource "aws_rds_cluster" "alternate" {
   kms_key_id           = aws_kms_key.test.arn
   storage_encrypted    = true
   skip_final_snapshot  = true
-  source_region        = data.aws_region.current.name
+  source_region        = data.aws_region.current.region
 
   depends_on = [
     aws_rds_cluster_instance.test,
@@ -5476,7 +5476,7 @@ resource "aws_rds_cluster" "secondary" {
   cluster_identifier        = %[5]q
   db_subnet_group_name      = aws_db_subnet_group.alternate.name
   skip_final_snapshot       = true
-  source_region             = data.aws_region.current.name
+  source_region             = data.aws_region.current.region
   global_cluster_identifier = aws_rds_global_cluster.test.id
   engine                    = aws_rds_global_cluster.test.engine
   engine_version            = aws_rds_global_cluster.test.engine_version
@@ -5581,7 +5581,7 @@ resource "aws_rds_cluster" "secondary" {
   cluster_identifier             = %[5]q
   db_subnet_group_name           = aws_db_subnet_group.alternate.name
   skip_final_snapshot            = true
-  source_region                  = data.aws_region.current.name
+  source_region                  = data.aws_region.current.region
   global_cluster_identifier      = aws_rds_global_cluster.test.id
   enable_global_write_forwarding = true
   engine                         = aws_rds_global_cluster.test.engine
@@ -5696,7 +5696,7 @@ resource "aws_rds_cluster" "secondary" {
   global_cluster_identifier     = aws_rds_global_cluster.test.id
   replication_source_identifier = aws_rds_cluster.primary.arn
   skip_final_snapshot           = true
-  source_region                 = data.aws_region.current.name
+  source_region                 = data.aws_region.current.region
 }
 
 resource "aws_rds_cluster_instance" "secondary" {

--- a/internal/service/rds/custom_db_engine_version_test.go
+++ b/internal/service/rds/custom_db_engine_version_test.go
@@ -356,7 +356,7 @@ data "aws_region" "current" {}
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = %[2]q
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_rds_custom_db_engine_version" "test" {
@@ -375,7 +375,7 @@ data "aws_region" "current" {}
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = %[2]q
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_rds_custom_db_engine_version" "test" {
@@ -436,7 +436,7 @@ data "aws_region" "current" {}
 resource "aws_ami_copy" "test" {
   name              = %[1]q
   source_ami_id     = %[2]q
-  source_ami_region = data.aws_region.current.name
+  source_ami_region = data.aws_region.current.region
 }
 
 resource "aws_rds_custom_db_engine_version" "test" {

--- a/internal/service/rds/instance_test.go
+++ b/internal/service/rds/instance_test.go
@@ -9439,7 +9439,7 @@ resource "aws_secretsmanager_secret" "example" {
         "aws:sourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:sourceArn": "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:*"
+        "aws:sourceArn": "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db:*"
       }
     }
   }]
@@ -9524,7 +9524,7 @@ resource "aws_secretsmanager_secret" "example-2" {
         "aws:sourceAccount": "${data.aws_caller_identity.current.account_id}"
       },
       "ArnLike": {
-        "aws:sourceArn": "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:db:*"
+        "aws:sourceArn": "arn:${data.aws_partition.current.partition}:rds:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:db:*"
       }
     }
   }]

--- a/internal/service/redshift/data_share_authorization_test.go
+++ b/internal/service/redshift/data_share_authorization_test.go
@@ -175,7 +175,7 @@ resource "aws_redshift_data_share_authorization" "test" {
   # Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonredshift.html#amazonredshift-resources-for-iam-policies
   data_share_arn = format("arn:%s:redshift:%s:%s:datashare:%s/%s",
     data.aws_partition.current.id,
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     data.aws_caller_identity.current.account_id,
     aws_redshiftserverless_namespace.test.namespace_id,
     "tfacctest",

--- a/internal/service/redshift/data_share_consumer_association_test.go
+++ b/internal/service/redshift/data_share_consumer_association_test.go
@@ -198,7 +198,7 @@ locals {
   # Ref: https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonredshift.html#amazonredshift-resources-for-iam-policies
   data_share_arn = format("arn:%s:redshift:%s:%s:datashare:%s/%s",
     data.aws_partition.current.id,
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     data.aws_caller_identity.current.account_id,
     aws_redshiftserverless_namespace.test.namespace_id,
     "tfacctest",
@@ -222,7 +222,7 @@ resource "aws_redshift_data_share_consumer_association" "test" {
   depends_on = [aws_redshift_data_share_authorization.test]
 
   data_share_arn  = local.data_share_arn
-  consumer_region = data.aws_region.current.name
+  consumer_region = data.aws_region.current.region
 }
 `)
 }

--- a/internal/service/resourceexplorer2/search_data_source_test.go
+++ b/internal/service/resourceexplorer2/search_data_source_test.go
@@ -120,7 +120,7 @@ resource "aws_resourceexplorer2_view" "test" {
 data "aws_resourceexplorer2_search" "test" {
   depends_on = [aws_resourceexplorer2_view.test]
 
-  query_string = "region:${data.aws_region.current.name}"
+  query_string = "region:${data.aws_region.current.region}"
   view_arn     = aws_resourceexplorer2_view.test.arn
 }
 `, rName, indexType)

--- a/internal/service/route53/health_check_test.go
+++ b/internal/service/route53/health_check_test.go
@@ -640,7 +640,7 @@ data "aws_region" "current" {}
 resource "aws_route53_health_check" "test" {
   type                            = "CLOUDWATCH_METRIC"
   cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.test.alarm_name
-  cloudwatch_alarm_region         = data.aws_region.current.name
+  cloudwatch_alarm_region         = data.aws_region.current.region
   insufficient_data_health_status = "Healthy"
 }
 `
@@ -664,7 +664,7 @@ data "aws_region" "current" {}
 resource "aws_route53_health_check" "test" {
   type                            = "CLOUDWATCH_METRIC"
   cloudwatch_alarm_name           = aws_cloudwatch_metric_alarm.test.alarm_name
-  cloudwatch_alarm_region         = data.aws_region.current.name
+  cloudwatch_alarm_region         = data.aws_region.current.region
   insufficient_data_health_status = "Healthy"
 
   triggers = {

--- a/internal/service/route53/record_test.go
+++ b/internal/service/route53/record_test.go
@@ -3594,7 +3594,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "test" {
   vpc_id              = aws_vpc.test.id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type   = "Interface"
   private_dns_enabled = false
   subnet_ids          = aws_subnet.test[*].id

--- a/internal/service/route53/traffic_policy_document_data_source_test.go
+++ b/internal/service/route53/traffic_policy_document_data_source_test.go
@@ -191,12 +191,12 @@ data "aws_route53_traffic_policy_document" "test" {
   endpoint {
     id    = "my_elb"
     type  = "elastic-load-balancer"
-    value = "elb-111111.${data.aws_region.current.name}.elb.amazonaws.com"
+    value = "elb-111111.${data.aws_region.current.region}.elb.amazonaws.com"
   }
   endpoint {
     id     = "site_down_banner"
     type   = "s3-website"
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
     value  = "www.example.com"
   }
 

--- a/internal/service/route53/zone_association_test.go
+++ b/internal/service/route53/zone_association_test.go
@@ -381,7 +381,7 @@ resource "aws_route53_zone" "test" {
 
   vpc {
     vpc_id     = aws_vpc.test.id
-    vpc_region = data.aws_region.current.name
+    vpc_region = data.aws_region.current.region
   }
 
   lifecycle {
@@ -409,7 +409,7 @@ resource "aws_route53_vpc_association_authorization" "test" {
 
   vpc_id     = aws_vpc.test.id
   zone_id    = aws_route53_zone.test.id
-  vpc_region = data.aws_region.current.name
+  vpc_region = data.aws_region.current.region
 }
 
 data "aws_region" "current" {}

--- a/internal/service/s3control/access_point_test.go
+++ b/internal/service/s3control/access_point_test.go
@@ -528,7 +528,7 @@ data "aws_iam_policy_document" "test" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
+      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
     ]
 
     principals {
@@ -573,7 +573,7 @@ data "aws_iam_policy_document" "test" {
     ]
 
     resources = [
-      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
+      "arn:${data.aws_partition.current.partition}:s3:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:accesspoint/%[1]s/object/*",
     ]
 
     principals {

--- a/internal/service/sagemaker/flow_definition_test.go
+++ b/internal/service/sagemaker/flow_definition_test.go
@@ -355,7 +355,7 @@ resource "aws_sagemaker_flow_definition" "test" {
     task_count                            = 1
     task_description                      = %[1]q
     task_title                            = %[1]q
-    workteam_arn                          = "arn:${data.aws_partition.current.partition}:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
+    workteam_arn                          = "arn:${data.aws_partition.current.partition}:sagemaker:${data.aws_region.current.region}:394669845002:workteam/public-crowd/default"
 
     public_workforce_task_price {
       amount_in_usd {

--- a/internal/service/sagemaker/model_test.go
+++ b/internal/service/sagemaker/model_test.go
@@ -804,11 +804,11 @@ locals {
     sa-east-1      = "270155090741"
   }
 
-  account = local.region_account_map[data.aws_region.current.name]
+  account = local.region_account_map[data.aws_region.current.region]
 
   model_package_name = format(
     "arn:aws:sagemaker:%%s:%%s:model-package/hf-textgeneration-gpt2-cpu-b73b575105d336b680d151277ebe4ee0",
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     local.account
   )
 }
@@ -1097,7 +1097,7 @@ resource "aws_sagemaker_model" "test" {
       s3_data_source {
         compression_type = "None"
         s3_data_type     = "S3Prefix"
-        s3_uri           = format("s3://jumpstart-private-cache-prod-%%s/meta-textgeneration/meta-textgeneration-llama-2-13b-f/artifacts/inference-prepack/v1.0.0/", data.aws_region.current.name)
+        s3_uri           = format("s3://jumpstart-private-cache-prod-%%s/meta-textgeneration/meta-textgeneration-llama-2-13b-f/artifacts/inference-prepack/v1.0.0/", data.aws_region.current.region)
         model_access_config {
           accept_eula = true
         }

--- a/internal/service/sagemaker/prebuilt_ecr_image_data_source_test.go
+++ b/internal/service/sagemaker/prebuilt_ecr_image_data_source_test.go
@@ -442,7 +442,7 @@ data "aws_region" "current" {}
 data "aws_sagemaker_prebuilt_ecr_image" "test" {
   repository_name = %[1]q
   image_tag       = %[2]q
-  region          = data.aws_region.current.name
+  region          = data.aws_region.current.region
 }
 `, repository_name, image_tag))
 }

--- a/internal/service/secretsmanager/secret_test.go
+++ b/internal/service/secretsmanager/secret_test.go
@@ -438,7 +438,7 @@ resource "aws_secretsmanager_secret" "test" {
 
   replica {
     kms_key_id = aws_kms_key.test.key_id
-    region     = data.aws_region.alternate.name
+    region     = data.aws_region.alternate.region
   }
 }
 `, rName, force_overwrite_replica_secret))
@@ -468,7 +468,7 @@ resource "aws_secretsmanager_secret" "test" {
 
   replica {
     kms_key_id = aws_kms_key.test2.key_id
-    region     = data.aws_region.third.name
+    region     = data.aws_region.third.region
   }
 }
 `, rName, force_overwrite_replica_secret))

--- a/internal/service/securityhub/automation_rule_test.go
+++ b/internal/service/securityhub/automation_rule_test.go
@@ -449,7 +449,7 @@ resource "aws_securityhub_automation_rule" "test" {
       }
       related_findings {
         id          = %[1]q
-        product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:product/aws/inspector"
+        product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:product/aws/inspector"
       }
       severity {
         label   = "CRITICAL"
@@ -508,7 +508,7 @@ resource "aws_securityhub_automation_rule" "test" {
       }
       related_findings {
         id          = %[1]q
-        product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:product/aws/inspector"
+        product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:product/aws/inspector"
       }
       severity {
         label   = "LOW"

--- a/internal/service/securityhub/product_subscription_test.go
+++ b/internal/service/securityhub/product_subscription_test.go
@@ -132,6 +132,6 @@ data "aws_partition" "current" {}
 
 resource "aws_securityhub_product_subscription" "example" {
   depends_on  = [aws_securityhub_account.example]
-  product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.name}::product/aws/guardduty"
+  product_arn = "arn:${data.aws_partition.current.partition}:securityhub:${data.aws_region.current.region}::product/aws/guardduty"
 }
 `)

--- a/internal/service/securitylake/aws_log_source_test.go
+++ b/internal/service/securitylake/aws_log_source_test.go
@@ -282,7 +282,7 @@ func testAccAWSLogSourceConfig_basic() string {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = "ROUTE53"
   }
   depends_on = [aws_securitylake_data_lake.test]
@@ -297,7 +297,7 @@ func testAccAWSLogSourceConfig_sourceVersion(version string) string {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts       = [data.aws_caller_identity.current.account_id]
-    regions        = [data.aws_region.current.name]
+    regions        = [data.aws_region.current.region]
     source_name    = "ROUTE53"
     source_version = %[1]q
   }
@@ -313,7 +313,7 @@ func testAccAWSLogSourceConfig_multiRegion(rName string) string {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name, data.aws_region.alternate.name]
+    regions     = [data.aws_region.current.region, data.aws_region.alternate.name]
     source_name = "ROUTE53"
   }
 
@@ -333,7 +333,7 @@ func testAccAWSLogSourceConfig_multiple() string {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = "ROUTE53"
   }
   depends_on = [aws_securitylake_data_lake.test]
@@ -342,7 +342,7 @@ resource "aws_securitylake_aws_log_source" "test" {
 resource "aws_securitylake_aws_log_source" "test2" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = "S3_DATA"
   }
   depends_on = [aws_securitylake_data_lake.test]

--- a/internal/service/securitylake/subscriber_test.go
+++ b/internal/service/securitylake/subscriber_test.go
@@ -554,7 +554,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = "ROUTE53"
   }
   depends_on = [aws_securitylake_data_lake.test]
@@ -666,7 +666,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = "ROUTE53"
   }
   depends_on = [aws_securitylake_data_lake.test]
@@ -701,7 +701,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts       = [data.aws_caller_identity.current.account_id]
-    regions        = [data.aws_region.current.name]
+    regions        = [data.aws_region.current.region]
     source_name    = "ROUTE53"
     source_version = "1.0"
   }
@@ -738,7 +738,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts       = [data.aws_caller_identity.current.account_id]
-    regions        = [data.aws_region.current.name]
+    regions        = [data.aws_region.current.region]
     source_name    = "ROUTE53"
     source_version = "1.0"
   }
@@ -769,7 +769,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts       = [data.aws_caller_identity.current.account_id]
-    regions        = [data.aws_region.current.name]
+    regions        = [data.aws_region.current.region]
     source_name    = "ROUTE53"
     source_version = "1.0"
   }
@@ -800,7 +800,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = %[2]q
   }
   depends_on = [
@@ -841,7 +841,7 @@ resource "aws_securitylake_aws_log_source" "test" {
 
   source {
     accounts    = [data.aws_caller_identity.current.account_id]
-    regions     = [data.aws_region.current.name]
+    regions     = [data.aws_region.current.region]
     source_name = local.source_names[count.index]
   }
   depends_on = [aws_securitylake_data_lake.test]
@@ -876,7 +876,7 @@ resource "aws_securitylake_subscriber" "test" {
 resource "aws_securitylake_aws_log_source" "test" {
   source {
     accounts       = [data.aws_caller_identity.current.account_id]
-    regions        = [data.aws_region.current.name]
+    regions        = [data.aws_region.current.region]
     source_name    = "ROUTE53"
     source_version = "2.0"
   }

--- a/internal/service/serverlessrepo/cloudformation_stack_test.go
+++ b/internal/service/serverlessrepo/cloudformation_stack_test.go
@@ -348,7 +348,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 }
 `, stackName, appARN)
@@ -371,7 +371,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = %[3]q
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 
   tags = {
@@ -398,7 +398,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = %[3]q
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 
   tags = {
@@ -426,7 +426,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 }
 `, stackName, appARN, version)
@@ -451,7 +451,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 }
 `, stackName, appARN, version)
@@ -471,7 +471,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 }
 
@@ -499,7 +499,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 
   tags = {
@@ -526,7 +526,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
 
   parameters = {
     functionName = "func-%[1]s"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 
   tags = {

--- a/internal/service/servicecatalog/provisioned_product_test.go
+++ b/internal/service/servicecatalog/provisioned_product_test.go
@@ -844,7 +844,7 @@ resource "aws_servicecatalog_provisioned_product" "test" {
 
   stack_set_provisioning_preferences {
     accounts                = [data.aws_caller_identity.current.account_id]
-    regions                 = [data.aws_region.current.name]
+    regions                 = [data.aws_region.current.region]
     failure_tolerance_count = %[3]d
     max_concurrency_count   = %[4]d
   }

--- a/internal/service/servicecatalog/service_action_test.go
+++ b/internal/service/servicecatalog/service_action_test.go
@@ -201,7 +201,7 @@ data "aws_iam_policy_document" "test" {
       type = "Service"
 
       identifiers = [
-        "servicecatalog.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}",
+        "servicecatalog.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}",
       ]
     }
 

--- a/internal/service/servicequotas/template_test.go
+++ b/internal/service/servicequotas/template_test.go
@@ -255,7 +255,7 @@ func testAccTemplateConfig_basic(quotaCode, serviceCode, value string) string {
 data "aws_region" "current" {}
 
 resource "aws_servicequotas_template" "test" {
-  aws_region   = data.aws_region.current.name
+  aws_region   = data.aws_region.current.region
   quota_code   = %[1]q
   service_code = %[2]q
   value        = %[3]s
@@ -268,7 +268,7 @@ func testAccTemplateConfig_region(quotaCode, serviceCode, value string) string {
 data "aws_region" "current" {}
 
 resource "aws_servicequotas_template" "test" {
-  region       = data.aws_region.current.name
+  region       = data.aws_region.current.region
   quota_code   = %[1]q
   service_code = %[2]q
   value        = %[3]s

--- a/internal/service/sfn/alias_test.go
+++ b/internal/service/sfn/alias_test.go
@@ -238,7 +238,7 @@ resource "aws_iam_role" "for_sfn" {
   "Statement": [{
     "Effect": "Allow",
     "Principal": {
-      "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
     },
     "Action": "sts:AssumeRole"
   }]

--- a/internal/service/sfn/state_machine_test.go
+++ b/internal/service/sfn/state_machine_test.go
@@ -749,7 +749,7 @@ resource "aws_iam_role" "for_sfn" {
   "Statement": [{
     "Effect": "Allow",
     "Principal": {
-      "Service": "states.${data.aws_region.current.name}.amazonaws.com"
+      "Service": "states.${data.aws_region.current.region}.amazonaws.com"
     },
     "Action": "sts:AssumeRole"
   }]

--- a/internal/service/shield/protection_group_test.go
+++ b/internal/service/shield/protection_group_test.go
@@ -388,7 +388,7 @@ resource "aws_shield_protection_group" "test" {
   protection_group_id = "%[1]s"
   aggregation         = "MAX"
   pattern             = "ARBITRARY"
-  members             = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"]
+  members             = ["arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"]
 }
 `, rName))
 }

--- a/internal/service/shield/protection_health_check_association_test.go
+++ b/internal/service/shield/protection_health_check_association_test.go
@@ -181,7 +181,7 @@ resource "aws_eip" "test" {
 }
 resource "aws_shield_protection" "test" {
   name         = %[1]q
-  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"
+  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"
 }
 resource "aws_route53_health_check" "test" {
   fqdn              = "example.com"

--- a/internal/service/shield/protection_test.go
+++ b/internal/service/shield/protection_test.go
@@ -777,7 +777,7 @@ resource "aws_eip" "test" {
 
 resource "aws_shield_protection" "test" {
   name         = %[1]q
-  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"
+  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.test.id}"
 }
 `, rName)
 }

--- a/internal/service/sns/topic_subscription_test.go
+++ b/internal/service/sns/topic_subscription_test.go
@@ -1485,7 +1485,7 @@ resource "aws_sns_topic_subscription" "test" {
   topic_arn = provider::aws::arn_build(
     data.aws_partition.current.id,
     "sns",
-    data.aws_region.current.name,
+    data.aws_region.current.region,
     data.aws_caller_identity.current.account_id,
     %[1]q,
   )

--- a/internal/service/sns/topic_test.go
+++ b/internal/service/sns/topic_test.go
@@ -810,7 +810,7 @@ resource "aws_sns_topic" "test" {
         "AWS": "*"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}::example"
     }
   ],
   "Version": "2012-10-17",
@@ -839,7 +839,7 @@ resource "aws_sns_topic" "test" {
         "AWS": "${aws_iam_role.example.arn}"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}::example"
     }
   ],
   "Version": "2012-10-17",
@@ -919,7 +919,7 @@ resource "aws_sns_topic" "test" {
         "AWS": "arn:${data.aws_partition.current.partition}:iam::123456789012:role/wooo"
       },
       "Action": "sns:Publish",
-      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.name}::example"
+      "Resource": "arn:${data.aws_partition.current.partition}:sns:${data.aws_region.current.region}::example"
     }
   ],
   "Version": "2012-10-17",

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -1053,7 +1053,7 @@ resource "aws_sqs_queue" "test" {
       "Effect": "Allow",
       "Principal": "*",
       "Action": "sqs:SendMessage",
-      "Resource": "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${local.queue_name}",
+      "Resource": "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${local.queue_name}",
       "Condition": {
         "ArnEquals": {
           "aws:SourceArn": "${aws_sns_topic.test.arn}"
@@ -1105,7 +1105,7 @@ resource "aws_sqs_queue" "test" {
         "sqs:DeleteMessage",
         "sqs:ListQueues",
       ]
-      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:%[1]s"
+      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:%[1]s"
       Condition = {
         ArnEquals = {
           "aws:SourceArn" = aws_sns_topic.test.arn
@@ -1155,7 +1155,7 @@ resource "aws_sqs_queue" "test" {
         "sqs:SendMessage",
         "sqs:DeleteMessage",
       ]
-      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:%[1]s"
+      Resource = "arn:${data.aws_partition.current.partition}:sqs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:%[1]s"
       Condition = {
         ArnEquals = {
           "aws:SourceArn" = aws_sns_topic.test.arn

--- a/internal/service/ssm/service_setting_test.go
+++ b/internal/service/ssm/service_setting_test.go
@@ -111,7 +111,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 resource "aws_ssm_service_setting" "test" {
-  setting_id    = "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:servicesetting/ssm/parameter-store/high-throughput-enabled"
+  setting_id    = "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:servicesetting/ssm/parameter-store/high-throughput-enabled"
   setting_value = %[1]q
 }
 `, settingValue)

--- a/internal/service/ssmcontacts/testdata/Contact/data.tags/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/data.tags/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/data.tags_defaults/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/data.tags_defaults/main_gen.tf
@@ -25,7 +25,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/data.tags_ignore/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/data.tags_ignore/main_gen.tf
@@ -28,7 +28,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/tags/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/tags/main_gen.tf
@@ -14,7 +14,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/tagsComputed1/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/tagsComputed1/main_gen.tf
@@ -18,7 +18,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/tagsComputed2/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/tagsComputed2/main_gen.tf
@@ -19,7 +19,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/tags_defaults/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/tags_defaults/main_gen.tf
@@ -20,7 +20,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Contact/tags_ignore/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Contact/tags_ignore/main_gen.tf
@@ -23,7 +23,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/basic/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/basic/main_gen.tf
@@ -34,7 +34,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/data.tags/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/data.tags/main_gen.tf
@@ -41,7 +41,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/data.tags_defaults/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/data.tags_defaults/main_gen.tf
@@ -47,7 +47,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/data.tags_ignore/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/data.tags_ignore/main_gen.tf
@@ -50,7 +50,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/tags/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/tags/main_gen.tf
@@ -36,7 +36,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/tagsComputed1/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/tagsComputed1/main_gen.tf
@@ -40,7 +40,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/tagsComputed2/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/tagsComputed2/main_gen.tf
@@ -41,7 +41,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/tags_defaults/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/tags_defaults/main_gen.tf
@@ -42,7 +42,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/Rotation/tags_ignore/main_gen.tf
+++ b/internal/service/ssmcontacts/testdata/Rotation/tags_ignore/main_gen.tf
@@ -45,7 +45,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/tmpl/contact_tags.gtpl
+++ b/internal/service/ssmcontacts/testdata/tmpl/contact_tags.gtpl
@@ -11,7 +11,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmcontacts/testdata/tmpl/rotation_tags.gtpl
+++ b/internal/service/ssmcontacts/testdata/tmpl/rotation_tags.gtpl
@@ -35,7 +35,7 @@ resource "aws_ssmcontacts_contact" "test" {
 
 resource "aws_ssmincidents_replication_set" "test" {
   region {
-    name = data.aws_region.current.name
+    name = data.aws_region.current.region
   }
 }
 

--- a/internal/service/ssmquicksetup/configuration_manager_test.go
+++ b/internal/service/ssmquicksetup/configuration_manager_test.go
@@ -380,7 +380,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : local.patch_policy_name,
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -389,7 +389,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "RateControlErrorThreshold" : "2%%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }
@@ -414,7 +414,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : local.patch_policy_name,
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -423,7 +423,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "RateControlErrorThreshold" : "2%%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }
@@ -452,7 +452,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : local.patch_policy_name,
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -461,7 +461,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "RateControlErrorThreshold" : "2%%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }
@@ -485,7 +485,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : local.patch_policy_name,
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -494,7 +494,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "RateControlErrorThreshold" : "2%%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }
@@ -522,7 +522,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : local.patch_policy_name,
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -531,7 +531,7 @@ resource "aws_ssmquicksetup_configuration_manager" "test" {
       "RateControlErrorThreshold" : "2%%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }

--- a/internal/service/transfer/server_data_source_test.go
+++ b/internal/service/transfer/server_data_source_test.go
@@ -260,7 +260,7 @@ data "aws_region" "current" {}
 
 resource "aws_transfer_server" "test" {
   identity_provider_type = "API_GATEWAY"
-  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.${data.aws_region.current.name}.amazonaws.com${aws_api_gateway_resource.test.path}"
+  url                    = "https://${aws_api_gateway_rest_api.test.id}.execute-api.${data.aws_region.current.region}.amazonaws.com${aws_api_gateway_resource.test.path}"
   invocation_role        = aws_iam_role.test.arn
   logging_role           = aws_iam_role.test.arn
 }

--- a/internal/service/workspaces/directory_data_source_test.go
+++ b/internal/service/workspaces/directory_data_source_test.go
@@ -104,7 +104,7 @@ resource "aws_workspaces_directory" "test" {
 
   certificate_based_auth_properties {
     status                    = "ENABLED"
-    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate-authority/12345678-1234-1234-1234-123456789012"
+    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:certificate-authority/12345678-1234-1234-1234-123456789012"
   }
 
   saml_properties {

--- a/internal/service/workspaces/directory_test.go
+++ b/internal/service/workspaces/directory_test.go
@@ -646,7 +646,7 @@ locals {
     "us-east-1" = formatlist("use1-az%%d", [2, 4, 6])
   }
 
-  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.region, data.aws_availability_zones.available.zone_ids)
 }
 
 resource "aws_vpc" "main" {
@@ -795,7 +795,7 @@ resource "aws_workspaces_directory" "main" {
 
   certificate_based_auth_properties {
     status                    = "ENABLED"
-    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate-authority/%[3]s"
+    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:certificate-authority/%[3]s"
   }
 
   saml_properties {
@@ -847,7 +847,7 @@ resource "aws_workspaces_directory" "main" {
 
   certificate_based_auth_properties {
     status                    = "DISABLED"
-    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:certificate-authority/%[3]s"
+    certificate_authority_arn = "arn:${data.aws_partition.current.partition}:acm-pca:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:certificate-authority/%[3]s"
   }
 
   saml_properties {
@@ -1306,7 +1306,7 @@ locals {
     "us-east-1" = formatlist("use1-az%%d", [2, 4, 6])
   }
 
-  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.name, data.aws_availability_zones.available.zone_ids)
+  workspaces_az_ids = lookup(local.region_workspaces_az_ids, data.aws_region.current.region, data.aws_availability_zones.available.zone_ids)
 }
 
 resource "aws_vpc" "main" {

--- a/website/docs/cdktf/python/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/cdktf/python/r/api_gateway_rest_api.html.markdown
@@ -107,7 +107,7 @@ resource "aws_vpc_endpoint" "example" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.example.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.example.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.example.id

--- a/website/docs/cdktf/typescript/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/cdktf/typescript/r/api_gateway_rest_api.html.markdown
@@ -107,7 +107,7 @@ resource "aws_vpc_endpoint" "example" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.example.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.example.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.example.id

--- a/website/docs/d/ec2_managed_prefix_list.html.markdown
+++ b/website/docs/d/ec2_managed_prefix_list.html.markdown
@@ -19,7 +19,7 @@ customer-managed prefix list in the current region.
 data "aws_region" "current" {}
 
 data "aws_ec2_managed_prefix_list" "example" {
-  name = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  name = "com.amazonaws.${data.aws_region.current.region}.dynamodb"
 }
 ```
 

--- a/website/docs/d/lambda_invocation.html.markdown
+++ b/website/docs/d/lambda_invocation.html.markdown
@@ -45,7 +45,7 @@ data "aws_lambda_invocation" "resource_config" {
 
   input = jsonencode({
     environment = var.environment
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     service     = "api"
   })
 }

--- a/website/docs/d/route53_traffic_policy_document.html.markdown
+++ b/website/docs/d/route53_traffic_policy_document.html.markdown
@@ -24,12 +24,12 @@ data "aws_route53_traffic_policy_document" "example" {
   endpoint {
     id    = "my_elb"
     type  = "elastic-load-balancer"
-    value = "elb-111111.${data.aws_region.current.name}.elb.amazonaws.com"
+    value = "elb-111111.${data.aws_region.current.region}.elb.amazonaws.com"
   }
   endpoint {
     id     = "site_down_banner"
     type   = "s3-website"
-    region = data.aws_region.current.name
+    region = data.aws_region.current.region
     value  = "www.example.com"
   }
 

--- a/website/docs/d/service.html.markdown
+++ b/website/docs/d/service.html.markdown
@@ -18,7 +18,7 @@ Use this data source to compose and decompose AWS service DNS names.
 data "aws_region" "current" {}
 
 data "aws_service" "test" {
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
   service_id = "ec2"
 }
 ```

--- a/website/docs/ephemeral-resources/lambda_invocation.html.markdown
+++ b/website/docs/ephemeral-resources/lambda_invocation.html.markdown
@@ -69,7 +69,7 @@ ephemeral "aws_lambda_invocation" "resource_calculator" {
   payload = jsonencode({
     workload_type = var.workload_type
     expected_load = var.expected_requests_per_second
-    region        = data.aws_region.current.name
+    region        = data.aws_region.current.region
   })
 }
 

--- a/website/docs/r/api_gateway_rest_api.html.markdown
+++ b/website/docs/r/api_gateway_rest_api.html.markdown
@@ -105,7 +105,7 @@ resource "aws_vpc_endpoint" "example" {
 
   private_dns_enabled = false
   security_group_ids  = [aws_default_security_group.example.id]
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.execute-api"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.execute-api"
   subnet_ids          = [aws_subnet.example.id]
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.example.id

--- a/website/docs/r/appsync_graphql_api.html.markdown
+++ b/website/docs/r/appsync_graphql_api.html.markdown
@@ -38,7 +38,7 @@ resource "aws_appsync_graphql_api" "example" {
   name                = "example"
 
   user_pool_config {
-    aws_region     = data.aws_region.current.name
+    aws_region     = data.aws_region.current.region
     default_action = "DENY"
     user_pool_id   = aws_cognito_user_pool.example.id
   }

--- a/website/docs/r/bedrockagent_agent.html.markdown
+++ b/website/docs/r/bedrockagent_agent.html.markdown
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "example_agent_trust" {
     }
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:agent/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent/*"]
       variable = "AWS:SourceArn"
     }
   }
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "example_agent_permissions" {
   statement {
     actions = ["bedrock:InvokeModel"]
     resources = [
-      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-v2",
+      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/anthropic.claude-v2",
     ]
   }
 }

--- a/website/docs/r/bedrockagent_agent_alias.html.markdown
+++ b/website/docs/r/bedrockagent_agent_alias.html.markdown
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "example_agent_trust" {
     }
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:agent/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent/*"]
       variable = "AWS:SourceArn"
     }
   }
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "example_agent_permissions" {
   statement {
     actions = ["bedrock:InvokeModel"]
     resources = [
-      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-v2",
+      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/anthropic.claude-v2",
     ]
   }
 }

--- a/website/docs/r/bedrockagent_agent_collaborator.html.markdown
+++ b/website/docs/r/bedrockagent_agent_collaborator.html.markdown
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "example_agent_trust" {
     }
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:agent/*"]
+      values   = ["arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent/*"]
       variable = "AWS:SourceArn"
     }
   }
@@ -44,14 +44,14 @@ data "aws_iam_policy_document" "example_agent_permissions" {
   statement {
     actions = ["bedrock:InvokeModel"]
     resources = [
-      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
+      "arn:${data.aws_partition.current.partition}:bedrock:${data.aws_region.current.region}::foundation-model/anthropic.claude-3-5-sonnet-20241022-v2:0",
     ]
   }
   statement {
     actions = ["bedrock:GetAgentAlias", "bedrock:InvokeAgent"]
     resources = [
-      "arn:${data.aws_partition.current_agent.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:agent/*",
-      "arn:${data.aws_partition.current_agent.partition}:bedrock:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:agent-alias/*"
+      "arn:${data.aws_partition.current_agent.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent/*",
+      "arn:${data.aws_partition.current_agent.partition}:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent-alias/*"
     ]
   }
 }

--- a/website/docs/r/cloudtrail.html.markdown
+++ b/website/docs/r/cloudtrail.html.markdown
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "example" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/example"]
+      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/example"]
     }
   }
 
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "example" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:trail/example"]
+      values   = ["arn:${data.aws_partition.current.partition}:cloudtrail:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:trail/example"]
     }
   }
 }

--- a/website/docs/r/connect_bot_association.html.markdown
+++ b/website/docs/r/connect_bot_association.html.markdown
@@ -71,7 +71,7 @@ resource "aws_lex_bot" "example" {
 resource "aws_connect_bot_association" "example" {
   instance_id = aws_connect_instance.example.id
   lex_bot {
-    lex_region = data.aws_region.current.name
+    lex_region = data.aws_region.current.region
     name       = aws_lex_bot.example.name
   }
 }

--- a/website/docs/r/controltower_control.html.markdown
+++ b/website/docs/r/controltower_control.html.markdown
@@ -23,7 +23,7 @@ data "aws_organizations_organizational_units" "example" {
 }
 
 resource "aws_controltower_control" "example" {
-  control_identifier = "arn:aws:controltower:${data.aws_region.current.name}::control/AWS-GR_EC2_VOLUME_INUSE_CHECK"
+  control_identifier = "arn:aws:controltower:${data.aws_region.current.region}::control/AWS-GR_EC2_VOLUME_INUSE_CHECK"
   target_identifier = [
     for x in data.aws_organizations_organizational_units.example.children :
     x.arn if x.name == "Infrastructure"

--- a/website/docs/r/datasync_agent.html.markdown
+++ b/website/docs/r/datasync_agent.html.markdown
@@ -36,7 +36,7 @@ resource "aws_datasync_agent" "example" {
 data "aws_region" "current" {}
 
 resource "aws_vpc_endpoint" "example" {
-  service_name       = "com.amazonaws.${data.aws_region.current.name}.datasync"
+  service_name       = "com.amazonaws.${data.aws_region.current.region}.datasync"
   vpc_id             = aws_vpc.example.id
   security_group_ids = [aws_security_group.example.id]
   subnet_ids         = [aws_subnet.example.id]

--- a/website/docs/r/dynamodb_table.html.markdown
+++ b/website/docs/r/dynamodb_table.html.markdown
@@ -159,7 +159,7 @@ resource "aws_dynamodb_table" "example" {
 }
 
 resource "aws_dynamodb_tag" "example" {
-  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.name, data.aws_region.alternate.name)
+  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.alternate.name)
   key          = "Architect"
   value        = "Gigi"
 }

--- a/website/docs/r/dynamodb_tag.html.markdown
+++ b/website/docs/r/dynamodb_tag.html.markdown
@@ -43,7 +43,7 @@ resource "aws_dynamodb_table" "example" {
 resource "aws_dynamodb_tag" "test" {
   provider = aws.replica
 
-  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.name, data.aws_region.replica.name)
+  resource_arn = replace(aws_dynamodb_table.example.arn, data.aws_region.current.region, data.aws_region.replica.name)
   key          = "testkey"
   value        = "testvalue"
 }

--- a/website/docs/r/ecr_registry_policy.html.markdown
+++ b/website/docs/r/ecr_registry_policy.html.markdown
@@ -35,7 +35,7 @@ resource "aws_ecr_registry_policy" "example" {
           "ecr:ReplicateImage"
         ],
         Resource = [
-          "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:repository/*"
+          "arn:${data.aws_partition.current.partition}:ecr:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:repository/*"
         ]
       }
     ]

--- a/website/docs/r/elasticsearch_domain.html.markdown
+++ b/website/docs/r/elasticsearch_domain.html.markdown
@@ -55,7 +55,7 @@ resource "aws_elasticsearch_domain" "example" {
       "Action": "es:*",
       "Principal": "*",
       "Effect": "Allow",
-      "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*",
+      "Resource": "arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*",
       "Condition": {
         "IpAddress": {"aws:SourceIp": ["66.193.100.22/32"]}
       }
@@ -187,7 +187,7 @@ resource "aws_elasticsearch_domain" "es" {
 			"Action": "es:*",
 			"Principal": "*",
 			"Effect": "Allow",
-			"Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
+			"Resource": "arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"
 		}
 	]
 }

--- a/website/docs/r/glue_resource_policy.html.markdown
+++ b/website/docs/r/glue_resource_policy.html.markdown
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "glue-example-policy" {
     actions = [
       "glue:CreateTable",
     ]
-    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+    resources = ["arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
     principals {
       identifiers = ["*"]
       type        = "AWS"

--- a/website/docs/r/guardduty_publishing_destination.html.markdown
+++ b/website/docs/r/guardduty_publishing_destination.html.markdown
@@ -59,7 +59,7 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "kms_pol" {
     ]
 
     resources = [
-      "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+      "arn:aws:kms:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:key/*"
     ]
 
     principals {

--- a/website/docs/r/imagebuilder_image_pipeline.html.markdown
+++ b/website/docs/r/imagebuilder_image_pipeline.html.markdown
@@ -57,7 +57,7 @@ resource "aws_imagebuilder_image_recipe" "example" {
   }
 
   name         = "example"
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 ```

--- a/website/docs/r/imagebuilder_image_recipe.html.markdown
+++ b/website/docs/r/imagebuilder_image_recipe.html.markdown
@@ -39,7 +39,7 @@ resource "aws_imagebuilder_image_recipe" "example" {
   }
 
   name         = "example"
-  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.name}:aws:image/amazon-linux-2-x86/x.x.x"
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/amazon-linux-2-x86/x.x.x"
   version      = "1.0.0"
 }
 ```

--- a/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
+++ b/website/docs/r/kinesis_firehose_delivery_stream.html.markdown
@@ -574,7 +574,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 
   iceberg_configuration {
     role_arn           = aws_iam_role.firehose_role.arn
-    catalog_arn        = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:catalog"
+    catalog_arn        = "arn:${data.aws_partition.current.partition}:glue:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:catalog"
     buffering_size     = 10
     buffering_interval = 400
 

--- a/website/docs/r/macie2_findings_filter.html.markdown
+++ b/website/docs/r/macie2_findings_filter.html.markdown
@@ -23,7 +23,7 @@ resource "aws_macie2_findings_filter" "test" {
   finding_criteria {
     criterion {
       field = "region"
-      eq    = [data.aws_region.current.name]
+      eq    = [data.aws_region.current.region]
     }
   }
   depends_on = [aws_macie2_account.test]

--- a/website/docs/r/media_store_container_policy.html.markdown
+++ b/website/docs/r/media_store_container_policy.html.markdown
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "example" {
     }
 
     actions   = ["mediastore:*"]
-    resources = ["arn:aws:mediastore:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:container/${aws_media_store_container.example.name}/*"]
+    resources = ["arn:aws:mediastore:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:container/${aws_media_store_container.example.name}/*"]
 
     condition {
       test     = "Bool"

--- a/website/docs/r/networkmanager_dx_gateway_attachment.html.markdown
+++ b/website/docs/r/networkmanager_dx_gateway_attachment.html.markdown
@@ -19,7 +19,7 @@ Use this resource to create and manage a Direct Connect Gateway attachment to a 
 resource "aws_networkmanager_dx_gateway_attachment" "test" {
   core_network_id            = aws_networkmanager_core_network_policy_attachment.test.core_network_id
   direct_connect_gateway_arn = "arn:aws:directconnect::${data.aws_caller_identity.current.account_id}:dx-gateway/${aws_dx_gateway.test.id}"
-  edge_locations             = [data.aws_region.current.name]
+  edge_locations             = [data.aws_region.current.region]
 }
 ```
 

--- a/website/docs/r/networkmanager_site_to_site_vpn_attachment.html.markdown
+++ b/website/docs/r/networkmanager_site_to_site_vpn_attachment.html.markdown
@@ -50,7 +50,7 @@ data "aws_networkmanager_core_network_policy_document" "test" {
     vpn_ecmp_support = false
     asn_ranges       = ["64512-64555"]
     edge_locations {
-      location = data.aws_region.current.name
+      location = data.aws_region.current.region
       asn      = 64512
     }
   }

--- a/website/docs/r/opensearch_domain.html.markdown
+++ b/website/docs/r/opensearch_domain.html.markdown
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "example" {
     }
 
     actions   = ["es:*"]
-    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"]
+    resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"]
 
     condition {
       test     = "IpAddress"
@@ -188,7 +188,7 @@ data "aws_iam_policy_document" "example" {
     }
 
     actions   = ["es:*"]
-    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"]
+    resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain}/*"]
   }
 }
 

--- a/website/docs/r/opensearch_inbound_connection_accepter.html.markdown
+++ b/website/docs/r/opensearch_inbound_connection_accepter.html.markdown
@@ -22,13 +22,13 @@ resource "aws_opensearch_outbound_connection" "foo" {
   connection_alias = "outbound_connection"
   local_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.local_domain.domain_name
   }
 
   remote_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.remote_domain.domain_name
   }
 }

--- a/website/docs/r/opensearch_outbound_connection.html.markdown
+++ b/website/docs/r/opensearch_outbound_connection.html.markdown
@@ -23,13 +23,13 @@ resource "aws_opensearch_outbound_connection" "foo" {
   connection_mode  = "DIRECT"
   local_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.local_domain.domain_name
   }
 
   remote_domain_info {
     owner_id    = data.aws_caller_identity.current.account_id
-    region      = data.aws_region.current.name
+    region      = data.aws_region.current.region
     domain_name = aws_opensearch_domain.remote_domain.domain_name
   }
 }

--- a/website/docs/r/osis_pipeline.html.markdown
+++ b/website/docs/r/osis_pipeline.html.markdown
@@ -45,7 +45,7 @@ resource "aws_osis_pipeline" "example" {
                 - s3:
                     aws:
                       sts_role_arn: "${aws_iam_role.example.arn}"
-                      region: "${data.aws_region.current.name}"
+                      region: "${data.aws_region.current.region}"
                     bucket: "example"
                     threshold:
                       event_collect_timeout: "60s"

--- a/website/docs/r/quicksight_data_source.html.markdown
+++ b/website/docs/r/quicksight_data_source.html.markdown
@@ -49,7 +49,7 @@ resource "aws_s3_object" "example" {
     fileLocations = [
       {
         URIPrefixes = [
-          "https://${aws_s3_bucket.example.id}.s3-${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+          "https://${aws_s3_bucket.example.id}.s3-${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
         ]
       }
     ]

--- a/website/docs/r/sagemaker_flow_definition.html.markdown
+++ b/website/docs/r/sagemaker_flow_definition.html.markdown
@@ -47,7 +47,7 @@ resource "aws_sagemaker_flow_definition" "example" {
     task_count                            = 1
     task_description                      = "example"
     task_title                            = "example"
-    workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.name}:394669845002:workteam/public-crowd/default"
+    workteam_arn                          = "arn:aws:sagemaker:${data.aws_region.current.region}:394669845002:workteam/public-crowd/default"
 
     public_workforce_task_price {
       amount_in_usd {

--- a/website/docs/r/security_group_rule.html.markdown
+++ b/website/docs/r/security_group_rule.html.markdown
@@ -65,7 +65,7 @@ or [`ec2_managed_prefix_list`](/docs/providers/aws/d/ec2_managed_prefix_list.htm
 data "aws_region" "current" {}
 
 data "aws_prefix_list" "s3" {
-  name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }
 
 resource "aws_security_group_rule" "s3_gateway_egress" {

--- a/website/docs/r/securityhub_product_subscription.html.markdown
+++ b/website/docs/r/securityhub_product_subscription.html.markdown
@@ -19,7 +19,7 @@ data "aws_region" "current" {}
 
 resource "aws_securityhub_product_subscription" "example" {
   depends_on  = [aws_securityhub_account.example]
-  product_arn = "arn:aws:securityhub:${data.aws_region.current.name}:733251395267:product/alertlogic/althreatmanagement"
+  product_arn = "arn:aws:securityhub:${data.aws_region.current.region}:733251395267:product/alertlogic/althreatmanagement"
 }
 ```
 

--- a/website/docs/r/securityhub_standards_subscription.html.markdown
+++ b/website/docs/r/securityhub_standards_subscription.html.markdown
@@ -24,7 +24,7 @@ resource "aws_securityhub_standards_subscription" "cis" {
 
 resource "aws_securityhub_standards_subscription" "pci_321" {
   depends_on    = [aws_securityhub_account.example]
-  standards_arn = "arn:aws:securityhub:${data.aws_region.current.name}::standards/pci-dss/v/3.2.1"
+  standards_arn = "arn:aws:securityhub:${data.aws_region.current.region}::standards/pci-dss/v/3.2.1"
 }
 ```
 

--- a/website/docs/r/serverlessapplicationrepository_cloudformation_stack.html.markdown
+++ b/website/docs/r/serverlessapplicationrepository_cloudformation_stack.html.markdown
@@ -22,7 +22,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "postgres-ro
   ]
   parameters = {
     functionName = "func-postgres-rotator"
-    endpoint     = "secretsmanager.${data.aws_region.current.name}.${data.aws_partition.current.dns_suffix}"
+    endpoint     = "secretsmanager.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
   }
 }
 

--- a/website/docs/r/shield_drt_access_log_bucket_association.html.markdown
+++ b/website/docs/r/shield_drt_access_log_bucket_association.html.markdown
@@ -17,7 +17,7 @@ Up to 10 log buckets can be associated for DRT Access sharing with the Shield Re
 
 ```terraform
 resource "aws_shield_drt_access_role_arn_association" "test" {
-  role_arn = "arn:aws:iam:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${var.shield_drt_access_role_name}"
+  role_arn = "arn:aws:iam:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:${var.shield_drt_access_role_name}"
 }
 
 resource "aws_shield_drt_access_log_bucket_association" "test" {

--- a/website/docs/r/shield_protection.html.markdown
+++ b/website/docs/r/shield_protection.html.markdown
@@ -26,7 +26,7 @@ resource "aws_eip" "example" {
 
 resource "aws_shield_protection" "example" {
   name         = "example"
-  resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+  resource_arn = "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
 
   tags = {
     Environment = "Dev"

--- a/website/docs/r/shield_protection_group.html.markdown
+++ b/website/docs/r/shield_protection_group.html.markdown
@@ -36,7 +36,7 @@ resource "aws_eip" "example" {
 
 resource "aws_shield_protection" "example" {
   name         = "example"
-  resource_arn = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+  resource_arn = "arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
 }
 
 resource "aws_shield_protection_group" "example" {
@@ -45,7 +45,7 @@ resource "aws_shield_protection_group" "example" {
   protection_group_id = "example"
   aggregation         = "MEAN"
   pattern             = "ARBITRARY"
-  members             = ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"]
+  members             = ["arn:aws:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"]
 }
 ```
 

--- a/website/docs/r/shield_protection_health_check_association.html.markdown
+++ b/website/docs/r/shield_protection_health_check_association.html.markdown
@@ -31,7 +31,7 @@ resource "aws_eip" "example" {
 
 resource "aws_shield_protection" "example" {
   name         = "example-protection"
-  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
+  resource_arn = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:eip-allocation/${aws_eip.example.id}"
 }
 
 resource "aws_route53_health_check" "example" {

--- a/website/docs/r/ssmquicksetup_configuration_manager.html.markdown
+++ b/website/docs/r/ssmquicksetup_configuration_manager.html.markdown
@@ -47,7 +47,7 @@ resource "aws_ssmquicksetup_configuration_manager" "example" {
       "ConfigurationOptionsPatchOperation" : "Scan",
       "ConfigurationOptionsScanValue" : "cron(0 1 * * ? *)",
       "ConfigurationOptionsScanNextInterval" : "false",
-      "PatchBaselineRegion" : data.aws_region.current.name,
+      "PatchBaselineRegion" : data.aws_region.current.region,
       "PatchBaselineUseDefault" : "default",
       "PatchPolicyName" : "example",
       "SelectedPatchBaselines" : local.selected_patch_baselines,
@@ -56,7 +56,7 @@ resource "aws_ssmquicksetup_configuration_manager" "example" {
       "RateControlErrorThreshold" : "2%",
       "IsPolicyAttachAllowed" : "false",
       "TargetAccounts" : data.aws_caller_identity.current.account_id,
-      "TargetRegions" : data.aws_region.current.name,
+      "TargetRegions" : data.aws_region.current.region,
       "TargetType" : "*"
     }
   }

--- a/website/docs/r/vpc.html.markdown
+++ b/website/docs/r/vpc.html.markdown
@@ -40,14 +40,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "test" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "test" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.test.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "test" {

--- a/website/docs/r/vpc_ipam.html.markdown
+++ b/website/docs/r/vpc_ipam.html.markdown
@@ -20,7 +20,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam" "main" {
   description = "My IPAM"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {
@@ -51,7 +51,7 @@ variable "ipam_regions" {
 
 locals {
   # ensure current provider region is an operating_regions entry
-  all_ipam_regions = distinct(concat([data.aws_region.current.name], var.ipam_regions))
+  all_ipam_regions = distinct(concat([data.aws_region.current.region], var.ipam_regions))
 }
 ```
 

--- a/website/docs/r/vpc_ipam_pool.html.markdown
+++ b/website/docs/r/vpc_ipam_pool.html.markdown
@@ -19,14 +19,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "example" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 ```
 
@@ -37,7 +37,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
@@ -54,7 +54,7 @@ resource "aws_vpc_ipam_pool_cidr" "parent_test" {
 resource "aws_vpc_ipam_pool" "child" {
   address_family      = "ipv4"
   ipam_scope_id       = aws_vpc_ipam.example.private_default_scope_id
-  locale              = data.aws_region.current.name
+  locale              = data.aws_region.current.region
   source_ipam_pool_id = aws_vpc_ipam_pool.parent.id
 }
 

--- a/website/docs/r/vpc_ipam_pool_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr.html.markdown
@@ -24,14 +24,14 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 
 resource "aws_vpc_ipam_pool" "example" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam_pool_cidr" "example" {
@@ -47,7 +47,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 

--- a/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
+++ b/website/docs/r/vpc_ipam_pool_cidr_allocation.html.markdown
@@ -33,12 +33,12 @@ resource "aws_vpc_ipam_pool_cidr" "example" {
 resource "aws_vpc_ipam_pool" "example" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 ```
@@ -69,12 +69,12 @@ resource "aws_vpc_ipam_pool_cidr" "example" {
 resource "aws_vpc_ipam_pool" "example" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 ```

--- a/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
+++ b/website/docs/r/vpc_ipam_preview_next_cidr.html.markdown
@@ -38,12 +38,12 @@ resource "aws_vpc_ipam_pool_cidr" "example" {
 resource "aws_vpc_ipam_pool" "example" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.example.private_default_scope_id
-  locale         = data.aws_region.current.name
+  locale         = data.aws_region.current.region
 }
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 ```

--- a/website/docs/r/vpc_ipam_resource_discovery.html.markdown
+++ b/website/docs/r/vpc_ipam_resource_discovery.html.markdown
@@ -20,7 +20,7 @@ data "aws_region" "current" {}
 resource "aws_vpc_ipam_resource_discovery" "main" {
   description = "My IPAM Resource Discovery"
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 
   tags = {

--- a/website/docs/r/vpc_ipam_scope.html.markdown
+++ b/website/docs/r/vpc_ipam_scope.html.markdown
@@ -19,7 +19,7 @@ data "aws_region" "current" {}
 
 resource "aws_vpc_ipam" "example" {
   operating_regions {
-    region_name = data.aws_region.current.name
+    region_name = data.aws_region.current.region
   }
 }
 

--- a/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
+++ b/website/docs/r/wafv2_web_acl_logging_configuration.html.markdown
@@ -100,7 +100,7 @@ data "aws_iam_policy_document" "example" {
     resources = ["${aws_cloudwatch_log_group.example.arn}:*"]
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:*"]
       variable = "aws:SourceArn"
     }
     condition {


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
None

### Description

The PR updates the existing references of `aws_region` datasource to reflect `region` attribute than `name` with the v6.0.0 deprecation.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
