### PR TITLE
Resource Identity: Don't set Identity when removing resource

### DIFF
--- a/internal/provider/framework/identity_interceptor.go
+++ b/internal/provider/framework/identity_interceptor.go
@@ -70,6 +70,9 @@ func (r identityInterceptor) read(ctx context.Context, opts interceptorOptions[r
 
 	switch response, when := opts.response, opts.when; when {
 	case After:
+		if response.State.Raw.IsNull() {
+			break
+		}
 		identity := response.Identity
 		if identity == nil {
 			break

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -76,7 +76,7 @@ func getAttributeOk(d schemaResourceData, name string) (string, bool) {
 func newIdentityInterceptor(attributes []inttypes.IdentityAttribute) interceptorInvocation {
 	return interceptorInvocation{
 		when: After,
-		why:  Create, // TODO: probably need to do this after Read and Update as well
+		why:  Create | Read,
 		interceptor: identityInterceptor{
 			attributes: tfslices.ApplyToAll(attributes, func(v inttypes.IdentityAttribute) string {
 				return v.Name

--- a/internal/provider/sdkv2/identity_interceptor.go
+++ b/internal/provider/sdkv2/identity_interceptor.go
@@ -32,6 +32,9 @@ func (r identityInterceptor) run(ctx context.Context, opts crudInterceptorOption
 	case After:
 		switch why {
 		case Create, Read:
+			if d.Id() == "" {
+				break
+			}
 			identity, err := d.Identity()
 			if err != nil {
 				return sdkdiag.AppendFromErr(diags, err)


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

When removing a resource during Read because it is not found, the Identity must not be set for Framework-based resource types. Skips setting Identity for both SDKv2- and Framework-based types.
