### PR TITLE
resource/aws_bcmdataexports_export: Fixes error when refreshing existing resource

### DIFF
--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -58,113 +58,8 @@ type exportResource struct {
 }
 
 func (r *exportResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	dataQueryLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[dataQueryData](ctx),
-		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
-				"query_statement": schema.StringAttribute{
-					Required: true,
-				},
-				"table_configurations": schema.MapAttribute{
-					// map[string]map[string]string
-					CustomType: fwtypes.NewMapTypeOf[fwtypes.MapValueOf[types.String]](ctx),
-					Optional:   true,
-					PlanModifiers: []planmodifier.Map{
-						mapplanmodifier.UseStateForUnknown(),
-						mapplanmodifier.RequiresReplace(),
-					},
-				},
-			},
-		},
-	}
-
-	s3OutputConfigurationsLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[s3OutputConfigurations](ctx),
-		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
-				"compression": schema.StringAttribute{
-					Required:   true,
-					CustomType: fwtypes.StringEnumType[awstypes.CompressionOption](),
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				names.AttrFormat: schema.StringAttribute{
-					Required:   true,
-					CustomType: fwtypes.StringEnumType[awstypes.FormatOption](),
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				"output_type": schema.StringAttribute{
-					Required:   true,
-					CustomType: fwtypes.StringEnumType[awstypes.S3OutputType](),
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				"overwrite": schema.StringAttribute{
-					Required:   true,
-					CustomType: fwtypes.StringEnumType[awstypes.OverwriteOption](),
-				},
-			},
-		},
-	}
-
-	s3DestinationLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[s3Destination](ctx),
-		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
-				names.AttrS3Bucket: schema.StringAttribute{
-					Required: true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				"s3_prefix": schema.StringAttribute{
-					Required: true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-				"s3_region": schema.StringAttribute{
-					Required: true,
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-			},
-			Blocks: map[string]schema.Block{
-				"s3_output_configurations": s3OutputConfigurationsLNB,
-			},
-		},
-	}
-
-	destinationConfigurationsLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[destinationConfigurationsData](ctx),
-		NestedObject: schema.NestedBlockObject{
-			Blocks: map[string]schema.Block{
-				"s3_destination": s3DestinationLNB,
-			},
-		},
-	}
-
-	refreshCadenceLNB := schema.ListNestedBlock{
-		CustomType: fwtypes.NewListNestedObjectTypeOf[refreshCadenceData](ctx),
-		NestedObject: schema.NestedBlockObject{
-			Attributes: map[string]schema.Attribute{
-				"frequency": schema.StringAttribute{
-					Required:   true,
-					CustomType: fwtypes.StringEnumType[awstypes.FrequencyOption](),
-					PlanModifiers: []planmodifier.String{
-						stringplanmodifier.RequiresReplace(),
-					},
-				},
-			},
-		},
-	}
-
 	resp.Schema = schema.Schema{
+		Version: 1,
 		Attributes: map[string]schema.Attribute{
 			names.AttrARN:     framework.ARNAttributeComputedOnly(),
 			names.AttrID:      framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
@@ -199,9 +94,9 @@ func (r *exportResource) Schema(ctx context.Context, req resource.SchemaRequest,
 						},
 					},
 					Blocks: map[string]schema.Block{
-						"data_query":                 dataQueryLNB,
-						"destination_configurations": destinationConfigurationsLNB,
-						"refresh_cadence":            refreshCadenceLNB,
+						"data_query":                 exportDataQuerySchema(ctx),
+						"destination_configurations": exportDestinationConfigurationsSchema(ctx),
+						"refresh_cadence":            exportRefreshCadenceSchema(ctx),
 					},
 				},
 			},
@@ -209,6 +104,122 @@ func (r *exportResource) Schema(ctx context.Context, req resource.SchemaRequest,
 				Create: true,
 				Update: true,
 			}),
+		},
+	}
+}
+
+func exportDataQuerySchema(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[dataQueryData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"query_statement": schema.StringAttribute{
+					Required: true,
+				},
+				"table_configurations": schema.MapAttribute{
+					// map[string]map[string]string
+					CustomType: fwtypes.NewMapTypeOf[fwtypes.MapValueOf[types.String]](ctx),
+					Optional:   true,
+					PlanModifiers: []planmodifier.Map{
+						mapplanmodifier.UseStateForUnknown(),
+						mapplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func exportS3OutputConfigurationsSchema(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[s3OutputConfigurations](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"compression": schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.CompressionOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				names.AttrFormat: schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.FormatOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"output_type": schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.S3OutputType](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"overwrite": schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.OverwriteOption](),
+				},
+			},
+		},
+	}
+}
+
+func exportS3DestinationSchema(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[s3Destination](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				names.AttrS3Bucket: schema.StringAttribute{
+					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"s3_prefix": schema.StringAttribute{
+					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+				"s3_region": schema.StringAttribute{
+					Required: true,
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+			},
+			Blocks: map[string]schema.Block{
+				"s3_output_configurations": exportS3OutputConfigurationsSchema(ctx),
+			},
+		},
+	}
+}
+
+func exportDestinationConfigurationsSchema(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[destinationConfigurationsData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Blocks: map[string]schema.Block{
+				"s3_destination": exportS3DestinationSchema(ctx),
+			},
+		},
+	}
+}
+
+func exportRefreshCadenceSchema(ctx context.Context) schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		CustomType: fwtypes.NewListNestedObjectTypeOf[refreshCadenceData](ctx),
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"frequency": schema.StringAttribute{
+					Required:   true,
+					CustomType: fwtypes.StringEnumType[awstypes.FrequencyOption](),
+					PlanModifiers: []planmodifier.String{
+						stringplanmodifier.RequiresReplace(),
+					},
+				},
+			},
 		},
 	}
 }
@@ -378,6 +389,17 @@ func (r *exportResource) Delete(ctx context.Context, req resource.DeleteRequest,
 			err.Error(),
 		)
 		return
+	}
+}
+
+func (r *exportResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	schemaV0 := exportSchemaV0(ctx)
+
+	return map[int64]resource.StateUpgrader{
+		0: {
+			PriorSchema:   &schemaV0,
+			StateUpgrader: upgradeExportResourceStateFromV0,
+		},
 	}
 }
 

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -37,7 +37,6 @@ import (
 // @Tags(identifierAttribute="arn")
 // @ArnIdentity(identityDuplicateAttributes="id")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/bcmdataexports;bcmdataexports.GetExportOutput")
-// @Testing(preCheckRegion="us-east-1")
 // @Testing(skipEmptyTags=true, skipNullTags=true)
 func newExportResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &exportResource{}

--- a/internal/service/bcmdataexports/export_identity_gen_test.go
+++ b/internal/service/bcmdataexports/export_identity_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/bcmdataexports"
-	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-testing/compare"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -31,10 +30,7 @@ func TestAccBCMDataExportsExport_Identity_Basic(t *testing.T) {
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/bcmdataexports/export_migrate.go
+++ b/internal/service/bcmdataexports/export_migrate.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package bcmdataexports
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func exportSchemaV0(ctx context.Context) schema.Schema {
+	return schema.Schema{
+		Version: 0,
+		Attributes: map[string]schema.Attribute{
+			names.AttrID:      framework.IDAttributeDeprecatedWithAlternate(path.Root(names.AttrARN)),
+			names.AttrTags:    tftags.TagsAttribute(),
+			names.AttrTagsAll: tftags.TagsAttributeComputedOnly(),
+		},
+		Blocks: map[string]schema.Block{
+			"export": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[exportData](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtMost(1),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						names.AttrName: schema.StringAttribute{
+							Required: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						names.AttrDescription: schema.StringAttribute{
+							Optional: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.RequiresReplace(),
+							},
+						},
+						"export_arn": schema.StringAttribute{
+							Computed: true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
+						},
+					},
+					Blocks: map[string]schema.Block{
+						"data_query":                 exportDataQuerySchema(ctx),
+						"destination_configurations": exportDestinationConfigurationsSchema(ctx),
+						"refresh_cadence":            exportRefreshCadenceSchema(ctx),
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+			}),
+		},
+	}
+}
+
+type exportResourceModelV0 struct {
+	Export   fwtypes.ListNestedObjectValueOf[exportData] `tfsdk:"export"`
+	ID       types.String                                `tfsdk:"id"`
+	Tags     tftags.Map                                  `tfsdk:"tags"`
+	TagsAll  tftags.Map                                  `tfsdk:"tags_all"`
+	Timeouts timeouts.Value                              `tfsdk:"timeouts"`
+}
+
+func upgradeExportResourceStateFromV0(ctx context.Context, request resource.UpgradeStateRequest, response *resource.UpgradeStateResponse) {
+	var exportDataV0 exportResourceModelV0
+	response.Diagnostics.Append(request.State.Get(ctx, &exportDataV0)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	exportData := exportResourceModel{
+		ARN:      exportDataV0.ID,
+		Export:   exportDataV0.Export,
+		ID:       exportDataV0.ID,
+		Tags:     exportDataV0.Tags,
+		TagsAll:  exportDataV0.TagsAll,
+		Timeouts: exportDataV0.Timeouts,
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, exportData)...)
+}

--- a/internal/service/bcmdataexports/export_tags_gen_test.go
+++ b/internal/service/bcmdataexports/export_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/bcmdataexports"
-	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -25,10 +24,7 @@ func TestAccBCMDataExportsExport_tags(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -212,10 +208,7 @@ func TestAccBCMDataExportsExport_tags_null(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -277,10 +270,7 @@ func TestAccBCMDataExportsExport_tags_EmptyMap(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -330,10 +320,7 @@ func TestAccBCMDataExportsExport_tags_AddOnUpdate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -415,10 +402,7 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnCreate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -510,10 +494,7 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -654,10 +635,7 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -747,10 +725,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_providerOnly(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -931,10 +906,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1094,10 +1066,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_overlapping(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1273,10 +1242,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_updateToProviderOnly(t *testin
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1366,10 +1332,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_updateToResourceOnly(t *testin
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1460,10 +1423,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1531,10 +1491,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1594,10 +1551,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nullOverlappingResourceTag(t *
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1668,10 +1622,7 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nullNonOverlappingResourceTag(
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1742,10 +1693,7 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnCreate(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1800,10 +1748,7 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1900,10 +1845,7 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -1990,10 +1932,7 @@ func TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{
@@ -2155,10 +2094,7 @@ func TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(ctx, t)
-			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID)
-		},
+		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
 		Steps: []resource.TestStep{

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -16,8 +16,13 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -371,6 +376,66 @@ func TestAccBCMDataExportsExport_updateTable(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "export.0.name", rName),
 					resource.TestCheckResourceAttr(resourceName, "export.0.data_query.0.query_statement", "SELECT identity_line_item_id, identity_time_interval, line_item_usage_amount, line_item_unblended_cost, cost_category FROM COST_AND_USAGE_REPORT"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccBCMDataExportsExport_upgradeFromV5(t *testing.T) {
+	ctx := acctest.Context(t)
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	var export bcmdataexports.GetExportOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_bcmdataexports_export.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionNot(t, endpoints.AwsUsGovPartitionID)
+		},
+		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
+		CheckDestroy: testAccCheckExportDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"aws": {
+						Source:            "hashicorp/aws",
+						VersionConstraint: "5.100.0",
+					},
+				},
+				Config: testAccExportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, resourceName, &export),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
+				},
+			},
+			{
+				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+				Config:                   testAccExportConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckExportExists(ctx, resourceName, &export),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+					PostApplyPostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
+				},
 			},
 		},
 	})

--- a/internal/service/bcmdataexports/export_test.go
+++ b/internal/service/bcmdataexports/export_test.go
@@ -16,13 +16,9 @@ import (
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	tfstatecheck "github.com/hashicorp/terraform-provider-aws/internal/acctest/statecheck"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
@@ -415,9 +411,6 @@ func TestAccBCMDataExportsExport_upgradeFromV5(t *testing.T) {
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionCreate),
 					},
 				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					tfstatecheck.ExpectNoValue(resourceName, tfjsonpath.New(names.AttrRegion)),
-				},
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -432,9 +425,6 @@ func TestAccBCMDataExportsExport_upgradeFromV5(t *testing.T) {
 					PostApplyPostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
 					},
-				},
-				ConfigStateChecks: []statecheck.StateCheck{
-					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrRegion), knownvalue.StringExact(acctest.Region())),
 				},
 			},
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Existing `aws_bcmdataexports_export` resources created before v6.0 are returning the following error when refreshing state

```
Error: setting AWS BCM Data Exports Export (<null>): operation error BCM Data Exports: GetExport, https response error StatusCode: 400, RequestID: 9638c0f7-34fb-4ac1-84d6-8bbc76d72454, ValidationException: 2 validation errors detected: Value '' at 'exportArn' failed to satisfy constraint: Member must have length greater than or equal to 20; Value '' at 'exportArn' failed to satisfy constraint: Member must satisfy regular expression pattern: arn:aws[-a-z0-9]*:(bcm-data-exports):[-a-z0-9]*:[0-9]{12}:[-a-zA-Z0-9/:_]+
        
          with aws_bcmdataexports_export.test,
          on terraform_plugin_test.tf line 43, in resource "aws_bcmdataexports_export" "test":
          43: resource "aws_bcmdataexports_export" "test" {
        
        operation error BCM Data Exports: GetExport, https response error StatusCode:
        400, RequestID: 9638c0f7-34fb-4ac1-84d6-8bbc76d72454, ValidationException: 2
        validation errors detected: Value '' at 'exportArn' failed to satisfy
        constraint: Member must have length greater than or equal to 20; Value '' at
        'exportArn' failed to satisfy constraint: Member must satisfy regular
        expression pattern:
        arn:aws[-a-z0-9]*:(bcm-data-exports):[-a-z0-9]*:[0-9]{12}:[-a-zA-Z0-9/:_]+
```

Adds state upgrader to copy `id` value to `arn`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43086

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=bcmdataexports TESTS=TestAccBCMDataExportsExport ACCTEST_PARALLELISM=5

--- PASS: TestAccBCMDataExportsExport_update (32.46s)
--- PASS: TestAccBCMDataExportsExport_updateTable (35.19s)
--- PASS: TestAccBCMDataExportsExport_Identity_Basic (39.31s)
--- PASS: TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Add (40.29s)
--- PASS: TestAccBCMDataExportsExport_upgradeFromV5 (49.59s)
--- PASS: TestAccBCMDataExportsExport_tags_ComputedTag_OnCreate (24.52s)
--- PASS: TestAccBCMDataExportsExport_tags_DefaultTags_updateToResourceOnly (36.06s)
--- PASS: TestAccBCMDataExportsExport_tags_DefaultTags_updateToProviderOnly (37.21s)
--- PASS: TestAccBCMDataExportsExport_tags_DefaultTags_nonOverlapping (57.37s)
--- PASS: TestAccBCMDataExportsExport_basic (19.99s)
--- FAIL: TestAccBCMDataExportsExport_disappears (15.24s)
--- PASS: TestAccBCMDataExportsExport_tags_DefaultTags_overlapping (57.32s)
--- PASS: TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_ResourceTag (47.52s)
--- PASS: TestAccBCMDataExportsExport_curSubset (15.64s)
--- PASS: TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_DefaultTag (44.11s)
--- PASS: TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Replace (37.56s)
--- PASS: TestAccBCMDataExportsExport_tags_AddOnUpdate (33.76s)
--- PASS: TestAccBCMDataExportsExport_tags_EmptyMap (21.13s)
--- PASS: TestAccBCMDataExportsExport_tags_DefaultTags_providerOnly (71.45s)
--- PASS: TestAccBCMDataExportsExport_tags (65.25s)
```

#43089 will address `TestAccBCMDataExportsExport_disappears`