### PR TITLE
fix: in-place modification of DMS replication config by adding a wait

### DIFF
--- a/.changelog/43092.txt
+++ b/.changelog/43092.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_dms_replication_config: Fix `InvalidResourceStateFault: Replication for Replication Config: {resource_name} is in MODIFYING state and cannot start` error when modifying DMS Task config in-place.
+```

--- a/internal/service/dms/replication_config.go
+++ b/internal/service/dms/replication_config.go
@@ -298,6 +298,10 @@ func resourceReplicationConfigUpdate(ctx context.Context, d *schema.ResourceData
 			return sdkdiag.AppendErrorf(diags, "modifying DMS Replication Config (%s): %s", d.Id(), err)
 		}
 
+		if err := waitReplicationStopped(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "waiting for modifying DMS Serverless Replication (%s) stop: %s", d.Id(), err)
+		}
+
 		if d.Get("start_replication").(bool) {
 			if err := startReplication(ctx, conn, d.Id(), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return sdkdiag.AppendFromErr(diags, err)


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
DMS Serverless tasks, when modified in-place due to a config change in Terraform, will always fail in the Terraform Apply due to the change in DMS state to **Modifying** and then being attempted to changed immediately to **Start**. The Terraform Apply must wait for the **Modifying** state to end first.

### Relations
Closes [#35650](https://github.com/hashicorp/terraform-provider-aws/issues/35650)


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccDMSReplicationConfig_update PKG=dms

...
```
