### PR TITLE
pass timeouts through to updateInstanceState

### DIFF
--- a/internal/service/ec2/ec2_instance_state.go
+++ b/internal/service/ec2/ec2_instance_state.go
@@ -69,7 +69,7 @@ func resourceInstanceStateCreate(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "waiting for EC2 Instance (%s) ready: %s", instanceID, err)
 	}
 
-	if err := updateInstanceState(ctx, conn, instanceID, string(instance.State.Name), d.Get(names.AttrState).(string), d.Get("force").(bool)); err != nil {
+	if err := updateInstanceState(ctx, conn, instanceID, string(instance.State.Name), d.Get(names.AttrState).(string), d.Get("force").(bool), d.Timeout(schema.TimeoutCreate)); err != nil {
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
@@ -112,7 +112,7 @@ func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange(names.AttrState) {
 		o, n := d.GetChange(names.AttrState)
 
-		if err := updateInstanceState(ctx, conn, d.Id(), o.(string), n.(string), d.Get("force").(bool)); err != nil {
+		if err := updateInstanceState(ctx, conn, d.Id(), o.(string), n.(string), d.Get("force").(bool), d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return sdkdiag.AppendFromErr(diags, err)
 		}
 	}
@@ -120,19 +120,19 @@ func resourceInstanceStateUpdate(ctx context.Context, d *schema.ResourceData, me
 	return append(diags, resourceInstanceStateRead(ctx, d, meta)...)
 }
 
-func updateInstanceState(ctx context.Context, conn *ec2.Client, id string, currentState string, configuredState string, force bool) error {
+func updateInstanceState(ctx context.Context, conn *ec2.Client, id string, currentState string, configuredState string, force bool, timeout time.Duration ) error {
 	if currentState == configuredState {
 		return nil
 	}
 
 	if configuredState == "stopped" {
-		if err := stopInstance(ctx, conn, id, force, instanceStopTimeout); err != nil {
+		if err := stopInstance(ctx, conn, id, force, timeout); err != nil {
 			return err
 		}
 	}
 
 	if configuredState == "running" {
-		if err := startInstance(ctx, conn, id, false, instanceStartTimeout); err != nil {
+		if err := startInstance(ctx, conn, id, false, timeout); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

# WIP 🚧 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

This can be reverted trivially, no state changes will occur due to this.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No. 

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Currently it seems that there are 2 timeouts at play when updating the instance state of an EC2 instance. 

* the const `instance[Stop|Start]Timeout` which controls how long it waits for Update/Create operations (10 minutes)
* the configurable ones that only seem to control how long it waits for waitInstanceReady() to return.

This seems a bit odd to me for a couple of reasons

* If a resource allows me to set a timeout on an operation, I would expect that to be the maximum time taken to reconcile that resource's state. Currently the maximum time taken is the user-defined timeout + 10 minutes.
* If the user-defined timeout is passed into the `stopInstance`/`startInstance` functions, then the actual timeout is at least relative to the user-defined amount. 

This PR passes those user-defined timeouts through to the `start|stopInstance` calls. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #42569 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
No tf state changes occur from this PR, so no new acceptance tests. 