### PR TITLE
Combine duplicate `region` arguments in `aws_region` data source documentation

### DIFF
--- a/website/docs/d/region.html.markdown
+++ b/website/docs/d/region.html.markdown
@@ -28,10 +28,9 @@ data "aws_region" "current" {}
 
 This data source supports the following arguments:
 
-* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `region` - (Optional) Full name of the region to select (e.g. `us-east-1`), and the region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `endpoint` - (Optional) EC2 endpoint of the region to select.
 * `name` - (Optional, **Deprecated**) Full name of the region to select. Use `region` instead.
-* `region` - (Optional) Full name of the region to select (e.g. `us-east-1`)
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes

### Description

Combines the duplicate `region` argument descriptions (one being the existing `region` argument, one being the `region` description that was added to all relevant items for the v6 enhanced region support)