### PR TITLE
Adds support for TargetRoleARN on `aws_pod_identity_association`

### DIFF
--- a/.changelog/43122.txt
+++ b/.changelog/43122.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_eks_pod_identity_association: Add `target_role_arn` argument.
+```

--- a/internal/service/eks/pod_identity_association.go
+++ b/internal/service/eks/pod_identity_association.go
@@ -47,6 +47,7 @@ type podIdentityAssociationResourceModel struct {
 	Namespace      types.String `tfsdk:"namespace"`
 	RoleARN        fwtypes.ARN  `tfsdk:"role_arn"`
 	ServiceAccount types.String `tfsdk:"service_account"`
+	TargetRoleARN  types.String `tfsdk:"target_role_arn"`
 	Tags           tftags.Map   `tfsdk:"tags"`
 	TagsAll        tftags.Map   `tfsdk:"tags_all"`
 }
@@ -97,6 +98,12 @@ func (r *podIdentityAssociationResource) Schema(ctx context.Context, req resourc
 			},
 			"service_account": schema.StringAttribute{
 				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			names.AttrTargetRoleARN: schema.StringAttribute{
+				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
@@ -198,7 +205,7 @@ func (r *podIdentityAssociationResource) Update(ctx context.Context, req resourc
 
 	conn := r.Meta().EKSClient(ctx)
 
-	if !new.RoleARN.Equal(old.RoleARN) {
+	if !new.RoleARN.Equal(old.RoleARN) || !new.TargetRoleARN.Equal(old.TargetRoleARN) {
 		input := &eks.UpdatePodIdentityAssociationInput{}
 		resp.Diagnostics.Append(fwflex.Expand(ctx, new, input)...)
 		if resp.Diagnostics.HasError() {

--- a/names/attr_consts_gen.go
+++ b/names/attr_consts_gen.go
@@ -165,6 +165,7 @@ const (
 	AttrRetentionPeriod            = "retention_period"
 	AttrRole                       = "role"
 	AttrRoleARN                    = "role_arn"
+	AttrTargetRoleARN              = "target_role_arn"
 	AttrRule                       = "rule"
 	AttrS3Bucket                   = "s3_bucket"
 	AttrS3BucketName               = "s3_bucket_name"

--- a/website/docs/r/eks_pod_identity_association.html.markdown
+++ b/website/docs/r/eks_pod_identity_association.html.markdown
@@ -70,6 +70,7 @@ The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `tags` - (Optional) Key-value map of resource tags. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
+* `target_role_arn` - (Optional) The Amazon Resource Name (ARN) of the target IAM role to associate with the service account. This role is assumed by using the EKS Pod Identity association role, then the credentials for this role are injected into the Pod.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
Added TargetRoleArn to `aws_eks_pod_identity_association` resource


### Relations
Closes #42991

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccEKSPodIdentityAssociation_ PKG=eks
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/eks/... -v -count 1 -parallel 20 -run='TestAccEKSPodIdentityAssociation_'  -timeout 360m -vet=off
2025/06/19 23:48:24 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/19 23:48:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEKSPodIdentityAssociation_basic
=== PAUSE TestAccEKSPodIdentityAssociation_basic
=== RUN   TestAccEKSPodIdentityAssociation_disappears
=== PAUSE TestAccEKSPodIdentityAssociation_disappears
=== RUN   TestAccEKSPodIdentityAssociation_tags
=== PAUSE TestAccEKSPodIdentityAssociation_tags
=== RUN   TestAccEKSPodIdentityAssociation_updateRoleARN
=== PAUSE TestAccEKSPodIdentityAssociation_updateRoleARN
=== CONT  TestAccEKSPodIdentityAssociation_basic
=== CONT  TestAccEKSPodIdentityAssociation_tags
=== CONT  TestAccEKSPodIdentityAssociation_disappears
=== CONT  TestAccEKSPodIdentityAssociation_updateRoleARN
--- PASS: TestAccEKSPodIdentityAssociation_basic (522.78s)
--- PASS: TestAccEKSPodIdentityAssociation_tags (549.28s)
--- PASS: TestAccEKSPodIdentityAssociation_disappears (556.17s)
--- PASS: TestAccEKSPodIdentityAssociation_updateRoleARN (617.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/eks	621.637s
```
