### PR TITLE
aws_s3_bucket_policy overwrite behavior clarification #43060

### DIFF
--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 }
 ```
 
-> Only one `aws_s3_bucket_policy` resource should be defined per S3 bucket. Defining multiple `aws_s3_bucket_policy` resources with different Terraform names but the same `bucket` value may result in unexpected policy overwrites. Each resource uses the `PutBucketPolicy` API, which replaces the entire existing policy without error or warning. Because Terraform treats each resource independently, the policy applied last will silently override any previously applied policy.
+-> Only one `aws_s3_bucket_policy` resource should be defined per S3 bucket. Defining multiple `aws_s3_bucket_policy` resources with different Terraform names but the same `bucket` value may result in unexpected policy overwrites. Each resource uses the `PutBucketPolicy` API, which replaces the entire existing policy without error or warning. Because Terraform treats each resource independently, the policy applied last will silently override any previously applied policy.
 
 ## Argument Reference
 

--- a/website/docs/r/s3_bucket_policy.html.markdown
+++ b/website/docs/r/s3_bucket_policy.html.markdown
@@ -46,6 +46,8 @@ data "aws_iam_policy_document" "allow_access_from_another_account" {
 }
 ```
 
+> Only one `aws_s3_bucket_policy` resource should be defined per S3 bucket. Defining multiple `aws_s3_bucket_policy` resources with different Terraform names but the same `bucket` value may result in unexpected policy overwrites. Each resource uses the `PutBucketPolicy` API, which replaces the entire existing policy without error or warning. Because Terraform treats each resource independently, the policy applied last will silently override any previously applied policy.
+
 ## Argument Reference
 
 This resource supports the following arguments:


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security controls have been modified

### Description
- Updated the `website/docs/r/s3_bucket_policy.md` file
- Added a note warning users about the overwrite behavior when multiple policies are defined for the same bucket
- Emphasized the recommendation to manage only one policy per bucket


### Relations

Closes #43060  


### References
No Response


### Output from Acceptance Testing
No Response
