### PR TITLE
feat: Add active threat defense support to aws_networkfirewall_firewall_policy

### DIFF
--- a/.changelog/43137.txt
+++ b/.changelog/43137.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_networkfirewall_firewall_policy: Add `firewall_policy.stateful_rule_group_reference.deep_threat_inspection` argument
+```
+
+```release-note:enhancement
+data-source/aws_networkfirewall_firewall_policy: Add `firewall_policy.stateful_rule_group_reference.deep_threat_inspection` attribute
+```

--- a/internal/service/networkfirewall/firewall_policy.go
+++ b/internal/service/networkfirewall/firewall_policy.go
@@ -6,6 +6,7 @@ package networkfirewall
 import (
 	"context"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/YakDriver/regexache"
@@ -22,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -142,6 +144,12 @@ func resourceFirewallPolicy() *schema.Resource {
 								Optional: true,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										"deep_threat_inspection": {
+											Type:         nullable.TypeNullableBool,
+											Optional:     true,
+											Computed:     true,
+											ValidateFunc: nullable.ValidateTypeStringNullableBool,
+										},
 										"override": {
 											Type:     schema.TypeList,
 											MaxItems: 1,
@@ -493,6 +501,11 @@ func expandStatefulRuleGroupReferences(tfList []any) []awstypes.StatefulRuleGrou
 
 		apiObject := awstypes.StatefulRuleGroupReference{}
 
+		if v, ok := tfMap["deep_threat_inspection"]; ok {
+			if v, null, _ := nullable.Bool(v.(string)).ValueBool(); !null {
+				apiObject.DeepThreatInspection = aws.Bool(v)
+			}
+		}
 		if v, ok := tfMap["override"].([]any); ok && len(v) > 0 {
 			apiObject.Override = expandStatefulRuleGroupOverride(v)
 		}
@@ -678,6 +691,9 @@ func flattenPolicyStatefulRuleGroupReferences(apiObjects []awstypes.StatefulRule
 			names.AttrResourceARN: aws.ToString(apiObject.ResourceArn),
 		}
 
+		if apiObject.DeepThreatInspection != nil {
+			tfMap["deep_threat_inspection"] = strconv.FormatBool(aws.ToBool(apiObject.DeepThreatInspection))
+		}
 		if apiObject.Override != nil {
 			tfMap["override"] = flattenStatefulRuleGroupOverride(apiObject.Override)
 		}

--- a/internal/service/networkfirewall/firewall_policy_data_source.go
+++ b/internal/service/networkfirewall/firewall_policy_data_source.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
+	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -102,6 +103,10 @@ func dataSourceFirewallPolicy() *schema.Resource {
 								Computed: true,
 								Elem: &schema.Resource{
 									Schema: map[string]*schema.Schema{
+										"deep_threat_inspection": {
+											Type:     nullable.TypeNullableBool,
+											Computed: true,
+										},
 										"override": {
 											Type:     schema.TypeList,
 											Optional: true,

--- a/internal/service/networkfirewall/firewall_policy_test.go
+++ b/internal/service/networkfirewall/firewall_policy_test.go
@@ -406,6 +406,7 @@ func TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference(t *testing.
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_default_actions.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_engine_options.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", ""),
 					resource.TestCheckTypeSetElemAttrPair(resourceName, "firewall_policy.0.stateful_rule_group_reference.*.resource_arn", ruleGroupResourceName, names.AttrARN),
 				),
 			},
@@ -1088,6 +1089,113 @@ func TestAccNetworkFirewallFirewallPolicy_disappears(t *testing.T) {
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfnetworkfirewall.ResourceFirewallPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_actionOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyConfig_activeThreatDefense_actionOrder_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
+			},
+			{
+				Config: testAccFirewallPolicyConfig_activeThreatDefense_actionOrder(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
+			},
+			{
+				Config: testAccFirewallPolicyConfig_activeThreatDefense_actionOrder(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
+			},
+		},
+	})
+}
+
+func TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder(t *testing.T) {
+	ctx := acctest.Context(t)
+	var firewallPolicy networkfirewall.DescribeFirewallPolicyOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_networkfirewall_firewall_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkFirewallServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFirewallPolicyDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFirewallPolicyConfig_activeThreatDefense_strictOrder(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", acctest.CtFalse),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
+			},
+			{
+				Config: testAccFirewallPolicyConfig_activeThreatDefense_strictOrder(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFirewallPolicyExists(ctx, resourceName, &firewallPolicy),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "firewall_policy.0.stateful_rule_group_reference.0.deep_threat_inspection", acctest.CtTrue),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"firewall_policy.0.stateful_rule_group_reference.0.priority"},
 			},
 		},
 	})
@@ -1815,4 +1923,71 @@ resource "aws_networkfirewall_firewall_policy" "test" {
   }
 }
 `, rName)
+}
+
+func testAccFirewallPolicyConfig_activeThreatDefense_actionOrder_default(rName string) string {
+	return acctest.ConfigCompose(testAccFirewallPolicyConfig_baseStatelessRuleGroup(rName, 1), fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_networkfirewall_firewall_policy" "test" {
+  name = %[1]q
+
+  firewall_policy {
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+
+    stateful_rule_group_reference {
+      resource_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/AttackInfrastructureActionOrder"
+    }
+  }
+}
+`, rName))
+}
+
+func testAccFirewallPolicyConfig_activeThreatDefense_actionOrder(rName string, deepThreatInspection bool) string {
+	return acctest.ConfigCompose(testAccFirewallPolicyConfig_baseStatelessRuleGroup(rName, 1), fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_networkfirewall_firewall_policy" "test" {
+  name = %[1]q
+
+  firewall_policy {
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+
+    stateful_rule_group_reference {
+      deep_threat_inspection = %[2]t
+      resource_arn           = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/AttackInfrastructureActionOrder"
+    }
+  }
+}
+`, rName, deepThreatInspection))
+}
+
+func testAccFirewallPolicyConfig_activeThreatDefense_strictOrder(rName string, deepThreatInspection bool) string {
+	return acctest.ConfigCompose(testAccFirewallPolicyConfig_baseStatelessRuleGroup(rName, 1), fmt.Sprintf(`
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_networkfirewall_firewall_policy" "test" {
+  name = %[1]q
+
+  firewall_policy {
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+
+    stateful_rule_group_reference {
+      deep_threat_inspection = %[2]t
+      priority               = 1
+      resource_arn           = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/AttackInfrastructureStrictOrder"
+    }
+  }
+}
+`, rName, deepThreatInspection))
 }

--- a/website/docs/r/networkfirewall_firewall_policy.html.markdown
+++ b/website/docs/r/networkfirewall_firewall_policy.html.markdown
@@ -13,6 +13,10 @@ Provides an AWS Network Firewall Firewall Policy Resource
 ## Example Usage
 
 ```terraform
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
 resource "aws_networkfirewall_firewall_policy" "example" {
   name = "example"
 
@@ -23,7 +27,7 @@ resource "aws_networkfirewall_firewall_policy" "example" {
       priority     = 1
       resource_arn = aws_networkfirewall_rule_group.example.arn
     }
-    tls_inspection_configuration_arn = "arn:aws:network-firewall:REGION:ACCT:tls-configuration/example"
+    tls_inspection_configuration_arn = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:tls-configuration/example"
   }
 
   tags = {
@@ -66,7 +70,7 @@ resource "aws_networkfirewall_firewall_policy" "example" {
 ## Policy with a Custom Action for Stateless Inspection
 
 ```terraform
-resource "aws_networkfirewall_firewall_policy" "test" {
+resource "aws_networkfirewall_firewall_policy" "example" {
   name = "example"
 
   firewall_policy {
@@ -82,6 +86,53 @@ resource "aws_networkfirewall_firewall_policy" "test" {
         }
       }
       action_name = "ExampleCustomAction"
+    }
+  }
+}
+```
+
+## Policy with Active Threat Defense in Action Order
+
+```terraform
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_networkfirewall_firewall_policy" "example" {
+  name = "example"
+
+  firewall_policy {
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+
+    stateful_rule_group_reference {
+      deep_threat_inspection = true
+      resource_arn           = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/AttackInfrastructureActionOrder"
+    }
+  }
+}
+```
+
+## Policy with Active Threat Defense in Strict Order
+
+```terraform
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_networkfirewall_firewall_policy" "example" {
+  name = "example"
+
+  firewall_policy {
+    stateless_fragment_default_actions = ["aws:drop"]
+    stateless_default_actions          = ["aws:pass"]
+
+    stateful_engine_options {
+      rule_order = "STRICT_ORDER"
+    }
+
+    stateful_rule_group_reference {
+      deep_threat_inspection = false
+      priority               = 1
+      resource_arn           = "arn:${data.aws_partition.current.partition}:network-firewall:${data.aws_region.current.region}:aws-managed:stateful-rulegroup/AttackInfrastructureStrictOrder"
     }
   }
 }
@@ -165,6 +216,9 @@ The `flow_timeouts` block supports the following argument:
 
 The `stateful_rule_group_reference` block supports the following arguments:
 
+* `deep_threat_inspection` - (Optional) Whether to enable deep threat inspection, which allows AWS to analyze service logs of network traffic processed by these rule groups to identify threat indicators across customers. AWS will use these threat indicators to improve the active threat defense managed rule groups and protect the security of AWS customers and services. This only applies to active threat defense maanaged rule groups.
+
+  For details, refer to [AWS active threat defense for AWS Network Firewall](https://docs.aws.amazon.com/network-firewall/latest/developerguide/aws-managed-rule-groups-atd.html) in the AWS Network Firewall Developer Guide.
 * `priority` - (Optional) An integer setting that indicates the order in which to apply the stateful rule groups in a single policy. This argument must be specified if the policy has a `stateful_engine_options` block with a `rule_order` value of `STRICT_ORDER`. AWS Network Firewall applies each stateful rule group to a packet starting with the group that has the lowest priority setting.
 
 * `resource_arn` - (Required) The Amazon Resource Name (ARN) of the stateful rule group.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR is to add AWS active threat defense support to the `aws_networkfirewall_firewall_policy` resource and data source. The feature requires a new `deep_threat_inspection` argument/attribute in the `stateful_rule_group_reference` block, which can be set alongside the `resource_arn` for the `AttackInfrastructure` rule groups.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43080

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [StatefulRuleGroupReference](https://docs.aws.amazon.com/network-firewall/latest/APIReference/API_StatefulRuleGroupReference.html) for specs and wordings.

Also referred to some resource code for examples of using nullable boolean values, which seems appropriate for `deep_threat_inspection`.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS="TestAccNetworkFirewallFirewallPolicy" PKG=networkfirewall
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/networkfirewall/... -v -count 1 -parallel 20 -run='TestAccNetworkFirewallFirewallPolicy'  -timeout 360m -vet=off
2025/06/22 14:11:09 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/22 14:11:09 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_name
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_name
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== RUN   TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== PAUSE TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== RUN   TestAccNetworkFirewallFirewallPolicy_basic
=== PAUSE TestAccNetworkFirewallFirewallPolicy_basic
=== RUN   TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== PAUSE TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== RUN   TestAccNetworkFirewallFirewallPolicy_policyVariables
=== PAUSE TestAccNetworkFirewallFirewallPolicy_policyVariables
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsFlowTimeouts
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsFlowTimeouts
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
=== RUN   TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== PAUSE TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
=== RUN   TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== PAUSE TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
=== RUN   TestAccNetworkFirewallFirewallPolicy_tlsInspectionConfigurationARN
    firewall_policy_test.go:993: Environment variable AWS_NETWORKFIREWALL_TLS_INSPECTION_CONFIGURATION_ARN_1 is not set, skipping test
--- SKIP: TestAccNetworkFirewallFirewallPolicy_tlsInspectionConfigurationARN (0.00s)
=== RUN   TestAccNetworkFirewallFirewallPolicy_tags
=== PAUSE TestAccNetworkFirewallFirewallPolicy_tags
=== RUN   TestAccNetworkFirewallFirewallPolicy_disappears
=== PAUSE TestAccNetworkFirewallFirewallPolicy_disappears
=== RUN   TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_actionOrder
=== PAUSE TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_actionOrder
=== RUN   TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder
=== PAUSE TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_arn
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessCustomAction
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_basic
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicy_policyVariables
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsFlowTimeouts
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulEngineOption
=== CONT  TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulDefaultActions (139.48s)
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_name
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessCustomAction (140.52s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_tags
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_arn (143.31s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_activeThreatDefense (143.93s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_actionOrder
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withOverriddenManagedRuleGroup (145.54s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_disappears
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_withPolicyVariables (161.69s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReference (182.30s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOption (188.11s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions
--- PASS: TestAccNetworkFirewallFirewallPolicy_policyVariables (191.47s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceManaged (196.49s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupOverrideActionReference (197.21s)
=== CONT  TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupPriorityReference (207.43s)
=== CONT  TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsSingle (209.14s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupPriorityReference (213.67s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulRuleGroupReference (213.89s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulEngineOptionsFlowTimeouts (214.44s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_encryptionConfiguration (215.10s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatefulRuleGroupReferences (215.10s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_name (141.59s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_tags (140.69s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_disappears (151.55s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatefulEngineOption (306.80s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_actionOrder (171.13s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_activeThreatDefense_strictOrder (174.13s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_basic (333.51s)
--- PASS: TestAccNetworkFirewallFirewallPolicyDataSource_nameAndARN (141.07s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessRuleGroupReference (189.73s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessRuleGroupReferences (195.15s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statelessRuleGroupReference (201.91s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_multipleStatelessCustomActions (281.90s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_statefulRuleGroupReferenceAndCustomAction (348.69s)
--- PASS: TestAccNetworkFirewallFirewallPolicy_updateStatelessCustomAction (585.25s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/networkfirewall    782.056s

$
```
