### PR TITLE
feat: Add kms_key_identifier arg to aws_cloudwatch_event_archive

### DIFF
--- a/.changelog/43139.txt
+++ b/.changelog/43139.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_cloudwatch_event_archive: Add `kms_key_identifier` argument
+```

--- a/internal/service/events/archive.go
+++ b/internal/service/events/archive.go
@@ -61,12 +61,6 @@ func resourceArchive() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: verify.ValidARN,
 			},
-			names.AttrName: {
-				Type:         schema.TypeString,
-				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validArchiveName,
-			},
 			"kms_key_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -74,6 +68,12 @@ func resourceArchive() *schema.Resource {
 					validation.StringLenBetween(0, 2048),
 					validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9_\-/:]*$`), ""),
 				),
+			},
+			names.AttrName: {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validArchiveName,
 			},
 			"retention_days": {
 				Type:     schema.TypeInt,

--- a/internal/service/events/archive.go
+++ b/internal/service/events/archive.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
 	"github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
@@ -66,6 +67,14 @@ func resourceArchive() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validArchiveName,
 			},
+			"kms_key_identifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.All(
+					validation.StringLenBetween(0, 2048),
+					validation.StringMatch(regexache.MustCompile(`^[a-zA-Z0-9_\-/:]*$`), ""),
+				),
+			},
 			"retention_days": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -95,6 +104,10 @@ func resourceArchiveCreate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		input.EventPattern = aws.String(v)
+	}
+
+	if v, ok := d.GetOk("kms_key_identifier"); ok {
+		input.KmsKeyIdentifier = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {
@@ -132,6 +145,7 @@ func resourceArchiveRead(ctx context.Context, d *schema.ResourceData, meta any) 
 	d.Set(names.AttrDescription, output.Description)
 	d.Set("event_pattern", output.EventPattern)
 	d.Set("event_source_arn", output.EventSourceArn)
+	d.Set("kms_key_identifier", output.KmsKeyIdentifier)
 	d.Set(names.AttrName, output.ArchiveName)
 	d.Set("retention_days", output.RetentionDays)
 
@@ -157,6 +171,10 @@ func resourceArchiveUpdate(ctx context.Context, d *schema.ResourceData, meta any
 		}
 
 		input.EventPattern = aws.String(v)
+	}
+
+	if v, ok := d.GetOk("kms_key_identifier"); ok {
+		input.KmsKeyIdentifier = aws.String(v.(string))
 	}
 
 	if v, ok := d.GetOk("retention_days"); ok {

--- a/internal/service/events/archive_test.go
+++ b/internal/service/events/archive_test.go
@@ -40,6 +40,7 @@ func TestAccEventsArchive_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "events", fmt.Sprintf("archive/%s", archiveName)),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
 					resource.TestCheckResourceAttr(resourceName, "event_pattern", ""),
+					resource.TestCheckResourceAttr(resourceName, "kms_key_identifier", ""),
 				),
 			},
 			{
@@ -106,6 +107,91 @@ func TestAccEventsArchive_disappears(t *testing.T) {
 	})
 }
 
+func TestAccEventsArchive_kmsKeyIdentifier(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1 eventbridge.DescribeArchiveOutput
+	archiveName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_archive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchiveConfig_kmsKeyIdentifier(archiveName, "${aws_kms_key.test_1.id}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test_1", names.AttrID),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccArchiveConfig_kmsKeyIdentifier(archiveName, "${aws_kms_key.test_2.arn}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_key.test_2", names.AttrARN),
+				),
+			},
+			{
+				Config: testAccArchiveConfig_kmsKeyIdentifier(archiveName, "${aws_kms_alias.test_1.name}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_alias.test_1", names.AttrName),
+				),
+			},
+			{
+				Config: testAccArchiveConfig_kmsKeyIdentifier(archiveName, "${aws_kms_alias.test_1.arn}"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
+					resource.TestCheckResourceAttrPair(resourceName, "kms_key_identifier", "aws_kms_alias.test_1", names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
+func TestAccEventsArchive_retentionSetOnCreation(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v1 eventbridge.DescribeArchiveOutput
+	archiveName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_cloudwatch_event_archive.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckArchiveDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArchiveConfig_retentionOnCreation(archiveName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckArchiveExists(ctx, resourceName, &v1),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
+					resource.TestCheckResourceAttr(resourceName, "retention_days", "1"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "events", fmt.Sprintf("archive/%s", archiveName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, "event_pattern", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckArchiveDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).EventsClient(ctx)
@@ -153,38 +239,6 @@ func testAccCheckArchiveExists(ctx context.Context, n string, v *eventbridge.Des
 	}
 }
 
-func TestAccEventsArchive_retentionSetOnCreation(t *testing.T) {
-	ctx := acctest.Context(t)
-	var v1 eventbridge.DescribeArchiveOutput
-	archiveName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	resourceName := "aws_cloudwatch_event_archive.test"
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
-		ErrorCheck:               acctest.ErrorCheck(t, names.EventsServiceID),
-		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckArchiveDestroy(ctx),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccArchiveConfig_retentionOnCreation(archiveName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckArchiveExists(ctx, resourceName, &v1),
-					resource.TestCheckResourceAttr(resourceName, names.AttrName, archiveName),
-					resource.TestCheckResourceAttr(resourceName, "retention_days", "1"),
-					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "events", fmt.Sprintf("archive/%s", archiveName)),
-					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
-					resource.TestCheckResourceAttr(resourceName, "event_pattern", ""),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func testAccArchiveConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_event_bus" "test" {
@@ -216,6 +270,130 @@ resource "aws_cloudwatch_event_archive" "test" {
 PATTERN
 }
 `, name)
+}
+
+func testAccArchiveConfig_kmsKeyIdentifier(name, kmsKeyIdentifier string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_cloudwatch_event_bus" "test" {
+  name = %[1]q
+}
+
+resource "aws_kms_key" "test_1" {
+  deletion_window_in_days = 7
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-example"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow describing of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow use of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt",
+          "kms:ReEncrypt*"
+        ],
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:EncryptionContext:aws:events:event-bus:arn" = aws_cloudwatch_event_bus.test.arn
+          }
+        }
+      }
+    ]
+  })
+  tags = {
+    EventBridgeApiDestinations = "true"
+  }
+}
+
+resource "aws_kms_alias" "test_1" {
+  name          = "alias/test-1"
+  target_key_id = aws_kms_key.test_1.key_id
+}
+
+resource "aws_kms_key" "test_2" {
+  deletion_window_in_days = 7
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-example"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow describing of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow use of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt",
+          "kms:ReEncrypt*"
+        ],
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:EncryptionContext:aws:events:event-bus:arn" = aws_cloudwatch_event_bus.test.arn
+          }
+        }
+      }
+    ]
+  })
+  tags = {
+    EventBridgeApiDestinations = "true"
+  }
+}
+
+resource "aws_cloudwatch_event_archive" "test" {
+  name               = %[1]q
+  event_source_arn   = aws_cloudwatch_event_bus.test.arn
+  kms_key_identifier = %[2]q
+}
+`, name, kmsKeyIdentifier)
 }
 
 func testAccArchiveConfig_retentionOnCreation(name string) string {

--- a/website/docs/r/cloudwatch_event_archive.html.markdown
+++ b/website/docs/r/cloudwatch_event_archive.html.markdown
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_event_archive" "order" {
 }
 ```
 
-## Example all optional arguments
+## Example Usage Optional Arguments
 
 ```terraform
 resource "aws_cloudwatch_event_bus" "order" {
@@ -43,22 +43,91 @@ resource "aws_cloudwatch_event_archive" "order" {
 }
 ```
 
+## Example Usage CMK Encryption
+
+```terraform
+data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_cloudwatch_event_bus" "example" {
+  name = "example"
+}
+
+resource "aws_kms_key" "example" {
+  deletion_window_in_days = 7
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-example"
+    Statement = [
+      {
+        Sid    = "Enable IAM User Permissions"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root"
+        },
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow describing of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:DescribeKey"
+        ],
+        Resource = "*"
+      },
+      {
+        Sid    = "Allow use of the key"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        },
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt",
+          "kms:ReEncrypt*"
+        ],
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:EncryptionContext:aws:events:event-bus:arn" = aws_cloudwatch_event_bus.example.arn
+          }
+        }
+      }
+    ]
+  })
+  tags = {
+    EventBridgeApiDestinations = "true"
+  }
+}
+
+resource "aws_cloudwatch_event_archive" "example" {
+  name               = "example"
+  event_source_arn   = aws_cloudwatch_event_bus.example.arn
+  kms_key_identifier = aws_kms_key.example.id
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `name` - (Required) The name of the new event archive. The archive name cannot exceed 48 characters.
-* `event_source_arn` - (Required) Event bus source ARN from where these events should be archived.
-* `description` - (Optional) The description of the new event archive.
-* `event_pattern` - (Optional) Instructs the new event archive to only capture events matched by this pattern. By default, it attempts to archive every event received in the `event_source_arn`.
+* `name` - (Required) Name of the archive. The archive name cannot exceed 48 characters.
+* `event_source_arn` - (Required) ARN of the event bus associated with the archive. Only events from this event bus are sent to the archive.
+* `description` - (Optional) Description for the archive.
+* `event_pattern` - (Optional) Event pattern to use to filter events sent to the archive. By default, it attempts to archive every event received in the `event_source_arn`.
+* `kms_key_identifier` - (Optional) Identifier of the AWS KMS customer managed key for EventBridge to use, if you choose to use a customer managed key to encrypt this archive. The identifier can be the key Amazon Resource Name (ARN), KeyId, key alias, or key alias ARN.
 * `retention_days` - (Optional) The maximum number of days to retain events in the new event archive. By default, it archives indefinitely.
 
 ## Attribute Reference
 
 This resource exports the following attributes in addition to the arguments above:
 
-* `arn` - The Amazon Resource Name (ARN) of the event archive.
+* `arn` - ARN of the archive.
 
 ## Import
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to add the `kms_key_identifier` argument to the `aws_cloudwatch_event_archive` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43050

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to [CreateArchive](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_CreateArchive.html) and [Archive](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_Archive.html) for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccEventsArchive_ PKG=events
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/events/... -v -count 1 -parallel 20 -run='TestAccEventsArchive_'  -timeout 360m -vet=off
2025/06/22 23:44:38 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/22 23:44:38 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEventsArchive_basic
=== PAUSE TestAccEventsArchive_basic
=== RUN   TestAccEventsArchive_update
=== PAUSE TestAccEventsArchive_update
=== RUN   TestAccEventsArchive_disappears
=== PAUSE TestAccEventsArchive_disappears
=== RUN   TestAccEventsArchive_kmsKeyIdentifier
=== PAUSE TestAccEventsArchive_kmsKeyIdentifier
=== RUN   TestAccEventsArchive_retentionSetOnCreation
=== PAUSE TestAccEventsArchive_retentionSetOnCreation
=== CONT  TestAccEventsArchive_basic
=== CONT  TestAccEventsArchive_kmsKeyIdentifier
=== CONT  TestAccEventsArchive_disappears
=== CONT  TestAccEventsArchive_retentionSetOnCreation
=== CONT  TestAccEventsArchive_update
--- PASS: TestAccEventsArchive_disappears (16.68s)
--- PASS: TestAccEventsArchive_retentionSetOnCreation (19.05s)
--- PASS: TestAccEventsArchive_basic (19.38s)
--- PASS: TestAccEventsArchive_update (25.56s)
--- PASS: TestAccEventsArchive_kmsKeyIdentifier (57.96s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/events     58.258s

$
```
