### PR TITLE
Fix/update tests data with spn data souce

### DIFF
--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1253,7 +1253,9 @@ func testAccCheckRolePolicyRemoveInlinePolicy(ctx context.Context, role *awstype
 
 func testAccRoleConfig_maxSessionDuration(rName string, maxSessionDuration int) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name                 = %[1]q
@@ -1265,7 +1267,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1277,7 +1279,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_permissionsBoundary(rName, permissionsBoundary string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   assume_role_policy = jsonencode({
@@ -1285,7 +1289,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1301,7 +1305,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_basic(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1312,7 +1318,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1421,7 +1427,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_description(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name        = %[1]q
@@ -1433,7 +1441,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1445,7 +1453,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_updatedDescription(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name        = %[1]q
@@ -1457,7 +1467,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1469,7 +1479,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_nameGenerated() string {
 	return `
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   path = "/"
@@ -1479,7 +1491,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1491,7 +1503,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_namePrefix(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name_prefix = %[1]q
@@ -1502,7 +1516,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1514,7 +1528,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_pre(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1525,7 +1541,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1564,7 +1580,9 @@ resource "aws_iam_instance_profile" "role_update_test" {
 
 func testAccRoleConfig_post(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1575,7 +1593,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1614,7 +1632,9 @@ resource "aws_iam_instance_profile" "role_update_test" {
 
 func testAccRoleConfig_badJSON(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1626,7 +1646,7 @@ resource "aws_iam_role" "test" {
   {
     "Action": "sts:AssumeRole",
     "Principal": {
-    "Service": "ec2.${data.aws_partition.current.dns_suffix}",
+    "Service": "${data.aws_service_principal.ec2.name}",
     },
     "Effect": "Allow",
     "Sid": ""
@@ -1640,7 +1660,9 @@ INTENTIONALLYBAD
 
 func testAccRoleConfig_forceDetachPolicies(rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role_policy" "test" {
   name = %[1]q
@@ -1696,7 +1718,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1708,7 +1730,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyInline(roleName, policyName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1718,7 +1742,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1749,7 +1773,9 @@ EOF
 
 func testAccRoleConfig_policyInlineUpdate(roleName, policyName2, policyName3 string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1759,7 +1785,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1809,7 +1835,9 @@ EOF
 
 func testAccRoleConfig_policyInlineUpdateDown(roleName, policyName3 string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1819,7 +1847,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1850,7 +1878,9 @@ EOF
 
 func testAccRoleConfig_policyInlineActionOrder(roleName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1860,7 +1890,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1890,7 +1920,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyInlineActionOrderActualDiff(roleName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1900,7 +1932,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1929,7 +1961,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyInlineActionNewOrder(roleName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1939,7 +1973,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -1969,7 +2003,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyInlineMalformed(roleName, policyName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -1979,7 +2015,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2004,7 +2040,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyManaged(roleName, policyName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_policy" "test" {
   name = %[1]q
@@ -2035,7 +2073,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2047,7 +2085,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyManagedUpdate(roleName, policyName1, policyName2, policyName3 string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_policy" "test" {
   name = %[1]q
@@ -2118,7 +2158,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2130,7 +2170,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyManagedUpdateDown(roleName, policyName1, policyName2, policyName3 string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_policy" "test" {
   name = %[1]q
@@ -2201,7 +2243,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2213,7 +2255,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyExtraManaged(roleName, policyName1, policyName2 string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_policy" "test" {
   name = %[1]q
@@ -2264,7 +2308,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2291,7 +2335,9 @@ func testAccRolePolicyExtraInlineConfig() string {
 
 func testAccRoleConfig_policyNoInline(roleName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2301,7 +2347,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2313,7 +2359,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyNoManaged(roleName, policyName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2323,7 +2371,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2355,7 +2403,9 @@ EOF
 
 func testAccRoleConfig_policyEmptyInline(roleName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2365,7 +2415,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""
@@ -2379,7 +2429,9 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_policyEmptyManaged(roleName, policyName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -2389,7 +2441,7 @@ resource "aws_iam_role" "test" {
     Statement = [{
       Action = "sts:AssumeRole",
       Principal = {
-        Service = "ec2.${data.aws_partition.current.dns_suffix}",
+        Service = "${data.aws_service_principal.ec2.name}",
       }
       Effect = "Allow"
       Sid    = ""

--- a/internal/service/iam/role_test.go
+++ b/internal/service/iam/role_test.go
@@ -1528,6 +1528,7 @@ resource "aws_iam_role" "test" {
 
 func testAccRoleConfig_pre(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
 data "aws_service_principal" "ec2" {
   service_name = "ec2"
 }
@@ -1580,6 +1581,7 @@ resource "aws_iam_instance_profile" "role_update_test" {
 
 func testAccRoleConfig_post(rName string) string {
 	return fmt.Sprintf(`
+data "aws_partition" "current" {}
 data "aws_service_principal" "ec2" {
   service_name = "ec2"
 }

--- a/internal/service/iam/roles_data_source_test.go
+++ b/internal/service/iam/roles_data_source_test.go
@@ -128,7 +128,9 @@ data "aws_iam_roles" "test" {}
 
 func testAccRolesDataSourceConfig_nameRegex(rCount, rName string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   count = %[1]s
@@ -141,7 +143,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.ec2.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -162,7 +164,9 @@ data "aws_iam_roles" "test" {
 
 func testAccRolesDataSourceConfig_pathPrefix(rCount, rName, rPathPrefix string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   count = %[1]s
@@ -175,7 +179,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.ec2.name}"
       },
       "Effect": "Allow",
       "Sid": ""
@@ -201,7 +205,9 @@ data "aws_iam_roles" "test" {
 
 func testAccRolesDataSourceConfig_nameRegexAndPathPrefix(rCount, rName, rPathPrefix, rIndex string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   count = %[1]s
@@ -214,7 +220,7 @@ resource "aws_iam_role" "test" {
     {
       "Action": "sts:AssumeRole",
       "Principal": {
-        "Service": "ec2.${data.aws_partition.current.dns_suffix}"
+        "Service": "${data.aws_service_principal.ec2.name}"
       },
       "Effect": "Allow",
       "Sid": ""

--- a/internal/service/iam/session_context_data_source_test.go
+++ b/internal/service/iam/session_context_data_source_test.go
@@ -216,6 +216,10 @@ func TestAccIAMSessionContextDataSource_notAssumedRoleUser(t *testing.T) {
 
 func testAccSessionContextDataSourceConfig_basic(rName, path, sessionID string) string {
 	return fmt.Sprintf(`
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
+
 resource "aws_iam_role" "test" {
   name = %[1]q
   path = %[2]q
@@ -226,7 +230,7 @@ resource "aws_iam_role" "test" {
     "Statement" = [{
       "Action" = "sts:AssumeRole"
       "Principal" = {
-        "Service" = "ec2.${data.aws_partition.current.dns_suffix}"
+        "Service" = "${data.aws_service_principal.ec2.name}"
       }
       "Effect" = "Allow"
     }]
@@ -244,7 +248,9 @@ data "aws_iam_session_context" "test" {
 
 func testAccSessionContextDataSourceConfig_notAssumed(rName, path string) string {
 	return fmt.Sprintf(`
-data "aws_partition" "current" {}
+data "aws_service_principal" "ec2" {
+  service_name = "ec2"
+}
 
 resource "aws_iam_role" "test" {
   name = %[1]q
@@ -256,7 +262,7 @@ resource "aws_iam_role" "test" {
     "Statement" = [{
       "Action" = "sts:AssumeRole"
       "Principal" = {
-        "Service" = "ec2.${data.aws_partition.current.dns_suffix}"
+        "Service" = "${data.aws_service_principal.ec2.name}"
       }
       "Effect" = "Allow"
     }]


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description

Updates all IAM tests to use the SPN Data Provider, so they do not fail when running in Partitions where the polocy suffix is not the regions domain.

### Relations

Relates #38693

### References

Previously done for S3 [here](https://github.com/hashicorp/terraform-provider-aws/pull/38693)


### Output from Acceptance Testing
```console
% make testacc TESTS=TestAccIAMRole PKG=iam
        
--- PASS: TestAccIAMRolePolicy_invalidJSON (5.83s)
--- PASS: TestAccIAMRolePoliciesExclusive_empty (54.63s)
--- PASS: TestAccIAMRoleDataSource_tags (58.37s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Role (59.09s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_basic (59.15s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_empty (60.38s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_disappears_Policy (67.47s)
--- PASS: TestAccIAMRolePolicyAttachment_disappears (68.68s)
--- PASS: TestAccIAMRolePolicyAttachment_Disappears_role (70.14s)
--- PASS: TestAccIAMRolePolicy_Policy_invalidResource (32.54s)
--- PASS: TestAccIAMRolePoliciesExclusive_outOfBandAddition (102.12s)
--- PASS: TestAccIAMRolePolicyAttachment_basic (113.78s)
--- PASS: TestAccIAMRolePoliciesExclusive_outOfBandRemoval (108.94s)
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToProviderOnly (115.69s)
--- PASS: TestAccIAMRolePolicy_unknownsInPolicy (55.43s)
--- PASS: TestAccIAMRole_badJSON (7.76s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace (124.93s)
--- PASS: TestAccIAMRole_maxSessionDuration (125.87s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_multiple (126.86s)
--- PASS: TestAccIAMRole_basic (70.10s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnCreate (143.96s)
--- PASS: TestAccIAMRole_tags_null (91.21s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnCreate (77.21s)
--- PASS: TestAccIAMRole_tags_EmptyMap (93.54s)
--- PASS: TestAccIAMRole_disappears (53.24s)
--- PASS: TestAccIAMRole_policiesForceDetach (67.09s)
--- PASS: TestAccIAMRole_tags_AddOnUpdate (113.67s)
--- PASS: TestAccIAMRole_tags_EmptyTag_OnUpdate_Add (177.15s)
--- PASS: TestAccIAMRole_tags_DefaultTags_overlapping (187.34s)
--- PASS: TestAccIAMRoleDataSource_basic (53.09s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nonOverlapping (200.05s)
--- PASS: TestAccIAMRole_namePrefix (66.07s)
--- PASS: TestAccIAMRole_nameGenerated (64.75s)
--- PASS: TestAccIAMRolePoliciesExclusive_disappears_Role (59.60s)
--- PASS: TestAccIAMRoleDataSource_tags_DefaultTags_nonOverlapping (57.74s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace (115.16s)
--- PASS: TestAccIAMRolePoliciesExclusive_basic (66.48s)
--- PASS: TestAccIAMRole_tags_ComputedTag_OnUpdate_Add (113.42s)
--- PASS: TestAccIAMRole_testNameChange (113.24s)
--- PASS: TestAccIAMRole_tags_DefaultTags_providerOnly (240.45s)
--- PASS: TestAccIAMRoleDataSource_tags_IgnoreTags_Overlap_ResourceTag (58.19s)
--- PASS: TestAccIAMRoleDataSource_tags_IgnoreTags_Overlap_DefaultTag (57.46s)
--- PASS: TestAccIAMRole_tags_IgnoreTags_Overlap_ResourceTag (148.20s)
--- PASS: TestAccIAMRolePoliciesExclusive_multiple (107.36s)
--- PASS: TestAccIAMRole_tags_IgnoreTags_Overlap_DefaultTag (139.53s)
--- PASS: TestAccIAMRolePolicy_disappears (58.71s)
--- PASS: TestAccIAMRole_Identity_Basic (95.43s)
--- PASS: TestAccIAMRolePolicy_namePrefix (67.83s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyProviderOnlyTag (70.27s)
--- PASS: TestAccIAMRole_tags (228.72s)
--- PASS: TestAccIAMRolePolicy_policyOrder (77.42s)
--- PASS: TestAccIAMRolePolicy_nameGenerated (66.59s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag (69.01s)
--- PASS: TestAccIAMRolesDataSource_nonExistentPathPrefix (47.90s)
--- PASS: TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag (72.38s)
--- PASS: TestAccIAMRolesDataSource_nameRegexAndPathPrefix (56.88s)
--- PASS: TestAccIAMRolePolicy_basic (67.96s)
--- PASS: TestAccIAMRolesDataSource_pathPrefix (54.24s)
--- PASS: TestAccIAMRole_tags_DefaultTags_emptyResourceTag (68.55s)
--- PASS: TestAccIAMRole_description (148.75s)
--- PASS: TestAccIAMRolesDataSource_basic (43.46s)
--- PASS: TestAccIAMRolesDataSource_nameRegex (57.57s)
--- PASS: TestAccIAMRole_diffsCondition (194.94s)
--- PASS: TestAccIAMRole_InlinePolicy_malformed (26.97s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandAddition (101.02s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemoved (95.82s)
--- PASS: TestAccIAMRoleDataSource_tags_EmptyMap (51.40s)
--- PASS: TestAccIAMRole_tags_DefaultTags_updateToResourceOnly (107.11s)
--- PASS: TestAccIAMRole_InlinePolicy_empty (47.56s)
--- PASS: TestAccIAMRoleDataSource_tags_NullMap (46.65s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionIgnored (84.73s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionRemovedEmpty (77.95s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemoved (79.00s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandAdditionRemovedEmpty (77.09s)
--- PASS: TestAccIAMRolePolicyAttachmentsExclusive_outOfBandRemoval (76.76s)
--- PASS: TestAccIAMRole_ManagedPolicy_outOfBandRemovalAddedBack (72.85s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandAdditionIgnored (100.64s)
--- PASS: TestAccIAMRole_InlinePolicy_outOfBandRemovalAddedBack (65.16s)
--- PASS: TestAccIAMRole_InlinePolicy_ignoreOrder (77.20s)
--- PASS: TestAccIAMRole_ManagedPolicy_basic (91.42s)
--- PASS: TestAccIAMRole_InlinePolicy_basic (86.76s)
--- PASS: TestAccIAMRole_permissionsBoundary (122.85s)
--- PASS: TestAccIAMRole_diffs (387.21s)
ok      github.com/hashicorp/terraform-provider-aws/internal/service/iam        519.176s
```
