### PR TITLE
`efs_mount_target` add support for ipv6 / dualstack EFS mount targets

### DIFF
--- a/.changelog/43151.txt
+++ b/.changelog/43151.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_efs_mount_target: Add `ip_address_type` and `ipv6_address` attributes to enable support for IPv6/Dualstack networking.
+```
+
+```release-note:enhancement
+data source/aws_efs_mount_target: Add`ipv6_address` attribute to enable support for IPv6/Dualstack networking.
+```

--- a/internal/service/efs/mount_target.go
+++ b/internal/service/efs/mount_target.go
@@ -75,6 +75,19 @@ func resourceMountTarget() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IsIPv4Address,
 			},
+			"ipv6_address": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsIPv6Address,
+			},
+			names.AttrIPAddressType: {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: enum.Validate[awstypes.IpAddressType](),
+			},
 			"mount_target_dns_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -131,6 +144,14 @@ func resourceMountTargetCreate(ctx context.Context, d *schema.ResourceData, meta
 		input.IpAddress = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("ipv6_address"); ok {
+		input.Ipv6Address = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk(names.AttrIPAddressType); ok {
+		input.IpAddressType = awstypes.IpAddressType(v.(string))
+	}
+
 	if v, ok := d.GetOk(names.AttrSecurityGroups); ok {
 		input.SecurityGroups = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
@@ -180,6 +201,7 @@ func resourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta a
 	d.Set("file_system_arn", fsARN)
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
+	d.Set("ipv6_address", mt.Ipv6Address)
 	d.Set("mount_target_dns_name", meta.(*conns.AWSClient).RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
 	d.Set(names.AttrNetworkInterfaceID, mt.NetworkInterfaceId)
 	d.Set(names.AttrOwnerID, mt.OwnerId)

--- a/internal/service/efs/mount_target_data_source.go
+++ b/internal/service/efs/mount_target_data_source.go
@@ -54,6 +54,10 @@ func dataSourceMountTarget() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"ipv6_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"mount_target_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -123,6 +127,7 @@ func dataSourceMountTargetRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("file_system_arn", fsARN)
 	d.Set(names.AttrFileSystemID, fsID)
 	d.Set(names.AttrIPAddress, mt.IpAddress)
+	d.Set("ipv6_address", mt.Ipv6Address)
 	d.Set("mount_target_dns_name", meta.(*conns.AWSClient).RegionalHostname(ctx, fmt.Sprintf("%s.%s.efs", aws.ToString(mt.AvailabilityZoneName), aws.ToString(mt.FileSystemId))))
 	d.Set("mount_target_id", mt.MountTargetId)
 	d.Set(names.AttrNetworkInterfaceID, mt.NetworkInterfaceId)

--- a/internal/service/efs/mount_target_data_source_test.go
+++ b/internal/service/efs/mount_target_data_source_test.go
@@ -30,6 +30,7 @@ func TestAccEFSMountTargetDataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrFileSystemID, resourceName, names.AttrFileSystemID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrIPAddress, resourceName, names.AttrIPAddress),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_address", resourceName, "ipv6_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSubnetID, resourceName, names.AttrSubnetID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrNetworkInterfaceID, resourceName, names.AttrNetworkInterfaceID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDNSName, resourceName, names.AttrDNSName),
@@ -61,6 +62,7 @@ func TestAccEFSMountTargetDataSource_byAccessPointID(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrFileSystemID, resourceName, names.AttrFileSystemID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrIPAddress, resourceName, names.AttrIPAddress),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_address", resourceName, "ipv6_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSubnetID, resourceName, names.AttrSubnetID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrNetworkInterfaceID, resourceName, names.AttrNetworkInterfaceID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDNSName, resourceName, names.AttrDNSName),
@@ -92,6 +94,7 @@ func TestAccEFSMountTargetDataSource_byFileSystemID(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "file_system_arn", resourceName, "file_system_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrFileSystemID, resourceName, names.AttrFileSystemID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrIPAddress, resourceName, names.AttrIPAddress),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_address", resourceName, "ipv6_address"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrSubnetID, resourceName, names.AttrSubnetID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrNetworkInterfaceID, resourceName, names.AttrNetworkInterfaceID),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrDNSName, resourceName, names.AttrDNSName),
@@ -107,7 +110,7 @@ func TestAccEFSMountTargetDataSource_byFileSystemID(t *testing.T) {
 }
 
 func testAccMountTargetDataSourceConfig_base(rName string) string {
-	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnets(rName, 1), fmt.Sprintf(`
+	return acctest.ConfigCompose(acctest.ConfigVPCWithSubnetsIPv6(rName, 1), fmt.Sprintf(`
 resource "aws_efs_file_system" "test" {
   creation_token = %[1]q
 
@@ -117,8 +120,9 @@ resource "aws_efs_file_system" "test" {
 }
 
 resource "aws_efs_mount_target" "test" {
-  file_system_id = aws_efs_file_system.test.id
-  subnet_id      = aws_subnet.test[0].id
+  file_system_id  = aws_efs_file_system.test.id
+  ip_address_type = "DUAL_STACK"
+  subnet_id       = aws_subnet.test[0].id
 }
 `, rName))
 }

--- a/website/docs/d/efs_mount_target.html.markdown
+++ b/website/docs/d/efs_mount_target.html.markdown
@@ -39,6 +39,7 @@ This data source exports the following attributes in addition to the arguments a
 * `file_system_arn` - Amazon Resource Name of the file system for which the mount target is intended.
 * `subnet_id` - ID of the mount target's subnet.
 * `ip_address` - Address at which the file system may be mounted via the mount target.
+* `ipv6_address` - IPv6 address at which the file system may be mounted via the mount target.
 * `security_groups` - List of VPC security group IDs attached to the mount target.
 * `dns_name` - DNS name for the EFS file system.
 * `mount_target_dns_name` - The DNS name for the given subnet/AZ per [documented convention](http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html).

--- a/website/docs/r/efs_mount_target.html.markdown
+++ b/website/docs/r/efs_mount_target.html.markdown
@@ -38,6 +38,9 @@ This resource supports the following arguments:
 * `subnet_id` - (Required) The ID of the subnet to add the mount target in.
 * `ip_address` - (Optional) The address (within the address range of the specified subnet) at
 which the file system may be mounted via the mount target.
+* `ip_address_type` - (Optional) IP address type used by the mount target. Valid values are `IPV4_ONLY`, `IPV6_ONLY`, and `DUAL_STACK`. The IP address type of a mount target must be compatible with the subnet to which it belongs.
+* `ipv6_address` - (Optional) The IPv6 address (within the address range of the specified subnet) at
+which the file system may be mounted via the mount target.
 * `security_groups` - (Optional) A list of up to 5 VPC security group IDs (that must
 be for the same VPC as subnet specified) in effect for the mount target.
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

None

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

AWS recently [added IPv6 support](https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-efs-internet-protocol-version-6/) to EFS mount targets. This PR enables the use of IPv6 and dual stack configuration for EFS mount targets in terraform-provider-aws, by:

* adding two new attributes `ip_address_type` and `ipv6_address` to the `aws_efs_mount_target` resource, and
* adding the `ipv6_address` attribute to the `aws_efs_mount_target` data source

Unfortunately, the DescribeMountTargets API doesn't return the ip address type so we can't read it back.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

None that I could find.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

* [AWS announcement](https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-efs-internet-protocol-version-6/)
* [MountTargetDescription](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/efs@v1.36.2/types#MountTargetDescription) (godoc)
* [CreateMountTargetInput](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/efs@v1.36.2#CreateMountTargetInput) (godoc)

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

I don't have access to a VPC I can run acceptance tests against, however I have successfully tested a local build using `dev_overrides` and been able to provision dual-stack mount targets.