### PR TITLE
add note about what to do with an existing resource

### DIFF
--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -144,3 +144,8 @@ This resource exports the following attributes in addition to the arguments abov
 [Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
 
 - `create` - (Default `75m`)
+
+
+## Import
+
+You cannot import the ACM Certificate Validation resource. Running an apply will update the existing one, even if the plan shows a resource to add.

--- a/website/docs/r/acm_certificate_validation.html.markdown
+++ b/website/docs/r/acm_certificate_validation.html.markdown
@@ -145,7 +145,6 @@ This resource exports the following attributes in addition to the arguments abov
 
 - `create` - (Default `75m`)
 
-
 ## Import
 
 You cannot import the ACM Certificate Validation resource. Running an apply will update the existing one, even if the plan shows a resource to add.


### PR DESCRIPTION

### Description

I was just dealing with a plan that showed creation of an existing resource here, and I thought I would have to import it. However, there is no mention of the syntax for import on the [existing docs page](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation). This makes sense, since you don't need to import it. A `terraform apply` is enough to update the existing resource.

This commit adds that explicit note for future travellers.

### References

[docs page that led to this PR](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation)