### PR TITLE
`aws_instance`: fix `ipv6_addresses` / `ipv6_addresses_count` refresh

### DIFF
--- a/.changelog/43158.txt
+++ b/.changelog/43158.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_instance: Recompute `ipv6_addresses` when `ipv6_address_count` is updated
+```

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -477,7 +477,6 @@ func resourceInstance() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.IsIPv6Address,
@@ -978,6 +977,26 @@ func resourceInstance() *schema.Resource {
 					return false
 				}
 
+				return true
+			}),
+			customdiff.ComputedIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
+				return diff.HasChange("ipv6_address_count")
+			}),
+			//customdiff.ComputedIf("ipv6_address_count", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
+			//	return diff.HasChange("ipv6_addresses")
+			//}),
+			customdiff.ForceNewIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
+				if !diff.HasChange("ipv6_addresses") {
+					return false
+				}
+
+				// Don't force new if ipv6_address_count is also changing
+				// This indicates the ipv6_addresses change is computed, not user-driven
+				if diff.HasChange("ipv6_address_count") {
+					return false
+				}
+
+				// Force new only for explicit user changes to ipv6_addresses
 				return true
 			}),
 		),

--- a/internal/service/ec2/ec2_instance.go
+++ b/internal/service/ec2/ec2_instance.go
@@ -982,9 +982,6 @@ func resourceInstance() *schema.Resource {
 			customdiff.ComputedIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				return diff.HasChange("ipv6_address_count")
 			}),
-			//customdiff.ComputedIf("ipv6_address_count", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
-			//	return diff.HasChange("ipv6_addresses")
-			//}),
 			customdiff.ForceNewIf("ipv6_addresses", func(_ context.Context, diff *schema.ResourceDiff, meta any) bool {
 				if !diff.HasChange("ipv6_addresses") {
 					return false

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -7181,9 +7181,9 @@ func testAccInstance_ipv6AddressesExplicit(rName string, addressCount int) strin
 		testAccInstanceConfig_vpcIPv6Base(rName),
 		fmt.Sprintf(`
 resource "aws_instance" "test" {
-  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
-  instance_type = "t2.medium"
-  subnet_id     = aws_subnet.test.id
+  ami            = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type  = "t2.medium"
+  subnet_id      = aws_subnet.test.id
   ipv6_addresses = [for i in range(%[2]d) : cidrhost(aws_subnet.test.ipv6_cidr_block, i + 10)]
 
   tags = {

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1419,18 +1419,18 @@ func TestAccEC2Instance_IPv6AddressesExplicit(t *testing.T) {
 				Config: testAccInstance_ipv6AddressesExplicit(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
-					testAccCheckInstanceRecreated(&original, &updated), // Should recreate due to ForceNew
+					testAccCheckInstanceRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "3"), // This tests the recomputation
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "3"),
 				),
 			},
 			{
 				Config: testAccInstance_ipv6AddressesExplicit(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
-					testAccCheckInstanceRecreated(&original, &updated), // Should recreate again
+					testAccCheckInstanceRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"), // This tests the recomputation
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"),
 				),
 			},
 			{

--- a/internal/service/ec2/ec2_instance_test.go
+++ b/internal/service/ec2/ec2_instance_test.go
@@ -1228,7 +1228,7 @@ func TestAccEC2Instance_IPv6_supportAddressCount(t *testing.T) {
 	})
 }
 
-func TestAccEC2Instance_ipv6AddressCountAndSingleAddressCausesError(t *testing.T) {
+func TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError(t *testing.T) {
 	ctx := acctest.Context(t)
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 
@@ -1370,6 +1370,7 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(ctx, resourceName, &original),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", strconv.Itoa(originalCount)),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", strconv.Itoa(originalCount)),
 				),
 			},
 			{
@@ -1378,6 +1379,7 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", strconv.Itoa(updatedCount)),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", strconv.Itoa(updatedCount)),
 				),
 			},
 			{
@@ -1386,7 +1388,56 @@ func TestAccEC2Instance_IPv6AddressCount(t *testing.T) {
 					testAccCheckInstanceExists(ctx, resourceName, &updated),
 					testAccCheckInstanceNotRecreated(&original, &updated),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", strconv.Itoa(shrunkenCount)),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", strconv.Itoa(shrunkenCount)),
 				),
+			},
+		},
+	})
+}
+
+func TestAccEC2Instance_IPv6AddressesExplicit(t *testing.T) {
+	ctx := acctest.Context(t)
+	var original, updated awstypes.Instance
+	resourceName := "aws_instance.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstance_ipv6AddressesExplicit(rName, 1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &original),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "1"),
+				),
+			},
+			{
+				Config: testAccInstance_ipv6AddressesExplicit(rName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &updated),
+					testAccCheckInstanceRecreated(&original, &updated), // Should recreate due to ForceNew
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "3"), // This tests the recomputation
+				),
+			},
+			{
+				Config: testAccInstance_ipv6AddressesExplicit(rName, 2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists(ctx, resourceName, &updated),
+					testAccCheckInstanceRecreated(&original, &updated), // Should recreate again
+					resource.TestCheckResourceAttr(resourceName, "ipv6_addresses.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_address_count", "2"), // This tests the recomputation
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"user_data_replace_on_change"},
 			},
 		},
 	})
@@ -7122,6 +7173,24 @@ resource "aws_instance" "test" {
   }
 }
 `, rName, ipv6AddressCount))
+}
+
+func testAccInstance_ipv6AddressesExplicit(rName string, addressCount int) string {
+	return acctest.ConfigCompose(
+		acctest.ConfigLatestAmazonLinux2HVMEBSX8664AMI(),
+		testAccInstanceConfig_vpcIPv6Base(rName),
+		fmt.Sprintf(`
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amzn2-ami-minimal-hvm-ebs-x86_64.id
+  instance_type = "t2.medium"
+  subnet_id     = aws_subnet.test.id
+  ipv6_addresses = [for i in range(%[2]d) : cidrhost(aws_subnet.test.ipv6_cidr_block, i + 10)]
+
+  tags = {
+    Name = %[1]q
+  }
+}
+`, rName, addressCount))
 }
 
 func testAccInstanceConfig_ebsKMSKeyARN(rName string) string {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes

### Description

Updates `aws_instance` so that `ipv6_addresses` are recomputed when `ipv6_address_count` is updated.

In order to achieve this, I needed to remove `ForceNew` from `ipv6_addresses`, but reimplemented the functionality via `customdiff.ForceNewIf`.

The `TestAccEC2Instance_IPv6AddressesExplicit` test may be overkill -- since the instance is recreated when `ipv6_addresses` is explicitly changed, `ipv6_address_count` should inherently be recomputed since it's a new instance. I introduced it anyways, to make sure that the `customdiff.ForceNewIf` did what I was expecting.

I also updated the name of the `TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError` test function in order to make it more convenient to run with `TESTS=TestAccEC2Instance_IPv6`.

### Relations

Closes #43009

### Output from Acceptance Testing

```console
$ make testacc TESTS=TestAccEC2Instance_IPv6 PKG=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccEC2Instance_IPv6'  -timeout 360m -vet=off
2025/06/24 10:04:41 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/24 10:04:42 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEC2Instance_IPv6_supportAddressCount
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCount
=== RUN   TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError
=== PAUSE TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError
=== RUN   TestAccEC2Instance_IPv6_primaryEnable
=== PAUSE TestAccEC2Instance_IPv6_primaryEnable
=== RUN   TestAccEC2Instance_IPv6_primaryDisable
=== PAUSE TestAccEC2Instance_IPv6_primaryDisable
=== RUN   TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== PAUSE TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== RUN   TestAccEC2Instance_IPv6AddressCount
=== PAUSE TestAccEC2Instance_IPv6AddressCount
=== RUN   TestAccEC2Instance_IPv6AddressesExplicit
=== PAUSE TestAccEC2Instance_IPv6AddressesExplicit
=== CONT  TestAccEC2Instance_IPv6_supportAddressCount
=== CONT  TestAccEC2Instance_IPv6AddressesExplicit
=== CONT  TestAccEC2Instance_IPv6_primaryEnable
=== CONT  TestAccEC2Instance_IPv6_supportAddressCountWithIPv4
=== CONT  TestAccEC2Instance_IPv6_primaryDisable
=== CONT  TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError
=== CONT  TestAccEC2Instance_IPv6AddressCount
--- PASS: TestAccEC2Instance_IPv6AddressCountAndSingleAddressCausesError (2.23s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCountWithIPv4 (111.06s)
--- PASS: TestAccEC2Instance_IPv6_supportAddressCount (111.10s)
--- PASS: TestAccEC2Instance_IPv6_primaryEnable (147.70s)
--- PASS: TestAccEC2Instance_IPv6AddressCount (177.61s)
--- PASS: TestAccEC2Instance_IPv6_primaryDisable (177.66s)
--- PASS: TestAccEC2Instance_IPv6AddressesExplicit (354.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	361.486s
```
