### PR TITLE
 r/aws_cur_report_definition: Allow an empty (`""`) value for `s3_prefix`

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cur_report_definition: Allow an empty (`""`) value for `s3_prefix`. This fixes a regression introduced in [v6.0.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#600-june-18-2025)
+```

--- a/internal/service/cur/cur_test.go
+++ b/internal/service/cur/cur_test.go
@@ -24,6 +24,7 @@ func TestAccCUR_serial(t *testing.T) {
 			"athena":                testAccReportDefinition_athena,
 			"refresh":               testAccReportDefinition_refresh,
 			"overwrite":             testAccReportDefinition_overwrite,
+			"upgradeNoPrefixFromV5": testAccReportDefinition_upgradeNoPrefixFromV5,
 			"DataSource_basic":      testAccReportDefinitionDataSource_basic,
 			"DataSource_additional": testAccReportDefinitionDataSource_additional,
 		},

--- a/internal/service/cur/report_definition.go
+++ b/internal/service/cur/report_definition.go
@@ -101,8 +101,8 @@ func resourceReportDefinition() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.All(
-					validation.StringLenBetween(1, 256),
-					validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z!\-_.*\'()]+`), "The prefix can't include invalid characters (!-_.*'()/) or spaces."),
+					validation.StringLenBetween(0, 256),
+					validation.StringMatch(regexache.MustCompile(`[0-9A-Za-z!\-_.*'()]*`), ""),
 				),
 			},
 			"s3_region": {
@@ -110,14 +110,14 @@ func resourceReportDefinition() *schema.Resource {
 				Required:         true,
 				ValidateDiagFunc: enum.Validate[types.AWSRegion](),
 			},
+			names.AttrTags:    tftags.TagsSchema(),
+			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 			"time_unit": {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: enum.Validate[types.TimeUnit](),
 			},
-			names.AttrTags:    tftags.TagsSchema(),
-			names.AttrTagsAll: tftags.TagsSchemaComputed(),
 		},
 	}
 }

--- a/website/docs/r/cur_report_definition.html.markdown
+++ b/website/docs/r/cur_report_definition.html.markdown
@@ -38,7 +38,7 @@ This resource supports the following arguments:
 * `compression` - (Required) Compression format for report. Valid values are: `GZIP`, `ZIP`, `Parquet`. If `Parquet` is used, then format must also be `Parquet`.
 * `additional_schema_elements` - (Required) A list of schema elements. Valid values are: `RESOURCES`, `SPLIT_COST_ALLOCATION_DATA`, `MANUAL_DISCOUNT_COMPATIBILITY`.
 * `s3_bucket` - (Required) Name of the existing S3 bucket to hold generated reports.
-* `s3_prefix` - (Required) Report path prefix. Limited to 256 characters.
+* `s3_prefix` - (Required) Report path prefix. Limited to 256 characters. May be empty (`""`) but the resource can then not be modified via the AWS Console.
 * `s3_region` - (Required) Region of the existing S3 bucket to hold generated reports.
 * `additional_artifacts` - (Required) A list of additional artifacts. Valid values are: `REDSHIFT`, `QUICKSIGHT`, `ATHENA`. When ATHENA exists within additional_artifacts, no other artifact type can be declared and report_versioning must be `OVERWRITE_REPORT`.
 * `refresh_closed_reports` - (Optional) Set to true to update your reports after they have been finalized if AWS detects charges related to previous months.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

For backwards compatibility we must allow the empty string (`""`) as a valid value for the now _Required_ `s3_prefix` argument.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/43153.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
