### PR TITLE
fix the type of parameters_declarations in the quicksight template schema

### DIFF
--- a/.changelog/43160.txt
+++ b/.changelog/43160.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_quicksight_template: Fix `definition.*.parameter_declarations` to correctly use the set type.
+```

--- a/internal/service/quicksight/schema/template.go
+++ b/internal/service/quicksight/schema/template.go
@@ -61,7 +61,7 @@ func TemplateDefinitionSchema() *schema.Schema {
 					},
 				},
 				"parameters_declarations": { // https://docs.aws.amazon.com/quicksight/latest/APIReference/API_ParameterDeclaration.html
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					MinItems: 1,
 					MaxItems: 200,
 					Optional: true,


### PR DESCRIPTION
### Description
Fixes the type of `parameters_declarations` on the Quicksight Template schema. The `ExpandTemplateDefinition` was changed to expect a TypeSet in https://github.com/hashicorp/terraform-provider-aws/pull/33120, however the type in the schema was left as TypeList. This results in ParameterDeclarations being set to null when mapping to the AWS SDK method input.


### Relations
Closes #32996