### PR TITLE
docs: Add extended threat detection for EKS info and example to aws_guardduty_detector_feature doc

### DIFF
--- a/website/docs/r/guardduty_detector_feature.html.markdown
+++ b/website/docs/r/guardduty_detector_feature.html.markdown
@@ -19,6 +19,28 @@ resource "aws_guardduty_detector" "example" {
   enable = true
 }
 
+resource "aws_guardduty_detector_feature" "s3_protection" {
+  detector_id = aws_guardduty_detector.example.id
+  name        = "S3_DATA_EVENTS"
+  status      = "ENABLED"
+}
+```
+
+## Extended Threat Detection for EKS
+
+To enable GuardDuty [Extended Threat Detection](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-extended-threat-detection.html) for EKS, you need at least one of these features enabled: [EKS Protection](https://docs.aws.amazon.com/guardduty/latest/ug/kubernetes-protection.html) or [Runtime Monitoring}(https://docs.aws.amazon.com/guardduty/latest/ug/runtime-monitoring-configuration.html). For maximum detection coverage, enabling both is recommended to enhance detection capabilities.
+
+```terraform
+resource "aws_guardduty_detector" "example" {
+  enable = true
+}
+
+resource "aws_guardduty_detector_feature" "eks_protection" {
+  detector_id = aws_guardduty_detector.example.id
+  name        = "EKS_AUDIT_LOGS"
+  status      = "ENABLED"
+}
+
 resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
   detector_id = aws_guardduty_detector.example.id
   name        = "EKS_RUNTIME_MONITORING"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR is to update the `aws_guardduty_detector` resource documentation with information about the extended threat detection for EKS feature and an example usage for it (which effectively amounts to enabling EKS protection and EKS runtime monitoring).

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43082

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->
Referred to the [announcement blog post](https://aws.amazon.com/blogs/aws/amazon-guardduty-expands-extended-threat-detection-coverage-to-amazon-eks-clusters/) and associated documentation for specs and wordings.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

n/a