### PR TITLE
d/aws_apigatewayv2_stages: new data source

### DIFF
--- a/internal/service/apigatewayv2/service_package_gen.go
+++ b/internal/service/apigatewayv2/service_package_gen.go
@@ -19,7 +19,14 @@ import (
 type servicePackage struct{}
 
 func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.ServicePackageFrameworkDataSource {
-	return []*inttypes.ServicePackageFrameworkDataSource{}
+	return []*inttypes.ServicePackageFrameworkDataSource{
+		{
+			Factory:  newDataSourceStages,
+			TypeName: "aws_apigatewayv2_stages",
+			Name:     "Stages",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+	}
 }
 
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {

--- a/internal/service/apigatewayv2/stages_data_source.go
+++ b/internal/service/apigatewayv2/stages_data_source.go
@@ -1,0 +1,89 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkDataSource("aws_apigatewayv2_stages", name="Stages")
+func newDataSourceStages(context.Context) (datasource.DataSourceWithConfigure, error) {
+	return &dataSourceStages{}, nil
+}
+
+type dataSourceStages struct {
+	framework.DataSourceWithModel[dataSourceStagesModel]
+}
+
+func (d *dataSourceStages) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"api_id": schema.StringAttribute{
+				Optional: true,
+			},
+			names.AttrNames: schema.ListAttribute{
+				CustomType:  fwtypes.ListOfStringType,
+				ElementType: types.StringType,
+				Computed:    true,
+			},
+			names.AttrTags: tftags.TagsAttribute(),
+		},
+	}
+}
+
+func (d *dataSourceStages) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
+	var data dataSourceStagesModel
+
+	response.Diagnostics.Append(request.Config.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := d.Meta().APIGatewayV2Client(ctx)
+	input := apigatewayv2.GetStagesInput{
+		ApiId: flex.StringFromFramework(ctx, data.APIID),
+	}
+
+	stages, err := findStages(ctx, conn, &input)
+	if err != nil {
+		response.Diagnostics.AddError("reading API Gateway Stages", err.Error())
+		return
+	}
+
+	ignoreTagsConfig := d.Meta().IgnoreTagsConfig(ctx)
+	tagsToMatch := tftags.New(ctx, data.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig)
+
+	names := []string{}
+
+	for _, stage := range stages {
+
+		if len(tagsToMatch) > 0 && !keyValueTags(ctx, stage.Tags).IgnoreAWS().IgnoreConfig(ignoreTagsConfig).ContainsAll(tagsToMatch) {
+			continue
+		}
+
+		names = append(names, aws.ToString(stage.StageName))
+	}
+
+	data.Names = flex.FlattenFrameworkStringValueListOfString(ctx, names)
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+type dataSourceStagesModel struct {
+	framework.WithRegionModel
+	APIID types.String         `tfsdk:"api_id"`
+	Names fwtypes.ListOfString `tfsdk:"names"`
+	Tags  tftags.Map           `tfsdk:"tags"`
+}

--- a/internal/service/apigatewayv2/stages_data_source_test.go
+++ b/internal/service/apigatewayv2/stages_data_source_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package apigatewayv2_test
+
+import (
+	"fmt"
+	"testing"
+
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAPIGatewayV2StagesDataSource_id(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSource1Name := "data.aws_apigatewayv2_stages.test1"
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIStagesDataSourceConfig_id(rName1, rName2, rName3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSource1Name, "names.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayV2StagesDataSource_tags(t *testing.T) {
+	ctx := acctest.Context(t)
+	dataSource1Name := "data.aws_apigatewayv2_stages.test1"
+	dataSource2Name := "data.aws_apigatewayv2_stages.test2"
+	dataSource3Name := "data.aws_apigatewayv2_stages.test3"
+	rName1 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName2 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName3 := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAPIStagesDataSourceConfig_tags(rName1, rName2, rName3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSource1Name, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSource2Name, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSource3Name, "names.#", "1"),
+					resource.TestCheckResourceAttr(dataSource1Name, "names.0", rName1),
+					resource.TestCheckResourceAttr(dataSource2Name, "names.0", rName2),
+					resource.TestCheckResourceAttr(dataSource3Name, "names.0", rName3),
+				),
+			},
+		},
+	})
+}
+
+func testAccAPIStagesBaseDataSourceConfig(rName1, rName2, rName3 string) string {
+	apiName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	return fmt.Sprintf(`
+resource "aws_apigatewayv2_api" "api" {
+  name          = %[1]q
+  protocol_type = "HTTP"
+}
+  
+resource "aws_apigatewayv2_stage" "test1" {
+  api_id = aws_apigatewayv2_api.api.id
+  name   = %[2]q
+
+  tags = {
+    Name = %[2]q
+  }
+}
+
+resource "aws_apigatewayv2_stage" "test2" {
+  api_id = aws_apigatewayv2_api.api.id
+  name   = %[3]q
+
+  tags = {
+    Name = %[3]q
+  }
+}
+
+resource "aws_apigatewayv2_stage" "test3" {
+  api_id = aws_apigatewayv2_api.api.id
+  name   = %[4]q
+
+  tags = {
+    Name = %[4]q
+  }
+}
+
+`, apiName, rName1, rName2, rName3)
+}
+
+func testAccAPIStagesDataSourceConfig_id(rName1, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccAPIStagesBaseDataSourceConfig(rName1, rName2, rName3),
+		`
+data "aws_apigatewayv2_stages" "test1" {
+  api_id = aws_apigatewayv2_api.api.id
+
+  depends_on = [
+    aws_apigatewayv2_stage.test1,
+    aws_apigatewayv2_stage.test2,
+    aws_apigatewayv2_stage.test3,
+  ]
+}
+
+`)
+}
+
+func testAccAPIStagesDataSourceConfig_tags(rName1, rName2, rName3 string) string {
+	return acctest.ConfigCompose(
+		testAccAPIStagesBaseDataSourceConfig(rName1, rName2, rName3),
+		`
+data "aws_apigatewayv2_stages" "test1" {
+  # Force dependency on resources.
+  api_id = aws_apigatewayv2_api.api.id
+  tags = {
+    Name = element([aws_apigatewayv2_stage.test1.name, aws_apigatewayv2_stage.test2.name, aws_apigatewayv2_stage.test3.name], 0)
+  }
+}
+
+data "aws_apigatewayv2_stages" "test2" {
+  # Force dependency on resources.
+  api_id = aws_apigatewayv2_api.api.id
+  tags = {
+    Name = element([aws_apigatewayv2_stage.test1.name, aws_apigatewayv2_stage.test2.name, aws_apigatewayv2_stage.test3.name], 1)
+  }
+}
+
+data "aws_apigatewayv2_stages" "test3" {
+  # Force dependency on resources.
+  api_id = aws_apigatewayv2_api.api.id
+  tags = {
+    Name = element([aws_apigatewayv2_stage.test1.name, aws_apigatewayv2_stage.test2.name, aws_apigatewayv2_stage.test3.name], 2)
+  }
+}
+
+`)
+}

--- a/website/docs/d/apigatewayv2_stages.html.markdown
+++ b/website/docs/d/apigatewayv2_stages.html.markdown
@@ -1,0 +1,33 @@
+---
+subcategory: "API Gateway V2"
+layout: "aws"
+page_title: "AWS: aws_apigatewayv2_stages"
+description: |-
+  Provides details about stages in an Amazon API Gateway V2 API.
+---
+
+# Data Source: aws_apigatewayv2_stages
+
+Use this data source to get a list of stages in an Amazon API Gateway V2 API.
+
+## Example Usage
+
+```terraform
+data "aws_apigatewayv2_stages" "example" {
+  api_id = aws_apigatewayv2_api.example.id
+}
+```
+
+## Argument Reference
+
+This data source supports the following arguments:
+
+* `api_id` - (Required) ID of the associated API Gateway.
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match a pair on the desired stages.
+
+## Attribute Reference
+
+This data source exports the following attributes in addition to the arguments above:
+
+* `names` - Names of stages in the API Gateway.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

n/a

### Description

New data source to list stages on an API Gateway V2 API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

n/a

### References

Referred to [GetStages](https://docs.aws.amazon.com/apigateway/latest/api/API_GetStages.html) for naming.


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccAPIGatewayV2StagesDataSource PKG=apigatewayv2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/apigatewayv2/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayV2StagesDataSource'  -timeout 360m -vet=off
2025/06/25 07:16:13 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/25 07:16:13 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayV2StagesDataSource_id
=== PAUSE TestAccAPIGatewayV2StagesDataSource_id
=== RUN   TestAccAPIGatewayV2StagesDataSource_tags
=== PAUSE TestAccAPIGatewayV2StagesDataSource_tags
=== CONT  TestAccAPIGatewayV2StagesDataSource_id
=== CONT  TestAccAPIGatewayV2StagesDataSource_tags
--- PASS: TestAccAPIGatewayV2StagesDataSource_id (17.85s)
--- PASS: TestAccAPIGatewayV2StagesDataSource_tags (19.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigatewayv2	23.040s
```
