### PR TITLE
Fix: add ARN support in log_group_names for aws_cloudwatch_query_definition

### DIFF
--- a/.changelog/43183.txt
+++ b/.changelog/43183.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cloudwatch_query_definition: add ARN support in log_group_names for aws_cloudwatch_query_definition
+```

--- a/.changelog/43183.txt
+++ b/.changelog/43183.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cloudwatch_query_definition: add ARN support in log_group_names for aws_cloudwatch_query_definition
+resource/aws_cloudwatch_query_definition: Support ARNs as valid values for `log_group_names`
 ```

--- a/internal/service/logs/query_definition.go
+++ b/internal/service/logs/query_definition.go
@@ -51,8 +51,11 @@ func resourceQueryDefinition() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validLogGroupName,
+					Type: schema.TypeString,
+					ValidateFunc: validation.Any(
+						validLogGroupName,
+						verify.ValidARN,
+					),
 				},
 			},
 			"query_definition_id": {

--- a/internal/service/logs/query_definition_test.go
+++ b/internal/service/logs/query_definition_test.go
@@ -60,20 +60,6 @@ func TestAccLogsQueryDefinition_basic(t *testing.T) {
 	})
 }
 
-func testAccQueryDefinitionImportStateID(ctx context.Context, v *types.QueryDefinition) resource.ImportStateIdFunc {
-	return func(*terraform.State) (string, error) {
-		id := arn.ARN{
-			AccountID: acctest.AccountID(ctx),
-			Partition: acctest.Partition(),
-			Region:    acctest.Region(),
-			Service:   "logs",
-			Resource:  fmt.Sprintf("query-definition:%s", aws.ToString(v.QueryDefinitionId)),
-		}
-
-		return id.String(), nil
-	}
-}
-
 func TestAccLogsQueryDefinition_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.QueryDefinition
@@ -206,6 +192,20 @@ func TestAccLogsQueryDefinition_logGroupARNs(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccQueryDefinitionImportStateID(ctx context.Context, v *types.QueryDefinition) resource.ImportStateIdFunc {
+	return func(*terraform.State) (string, error) {
+		id := arn.ARN{
+			AccountID: acctest.AccountID(ctx),
+			Partition: acctest.Partition(),
+			Region:    acctest.Region(),
+			Service:   "logs",
+			Resource:  fmt.Sprintf("query-definition:%s", aws.ToString(v.QueryDefinitionId)),
+		}
+
+		return id.String(), nil
+	}
 }
 
 func testAccCheckQueryDefinitionExists(ctx context.Context, n string, v *types.QueryDefinition) resource.TestCheckFunc {


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

N/A

### Description
This pull request enhances the `aws_cloudwatch_query_definition` resource by adding support for specifying log group ARNs in addition to log group names. It also introduces a new acceptance test to validate this functionality.



### Enhancements to `aws_cloudwatch_query_definition` resource:

* Updated the `log_group_names` schema to allow validation of both log group names and ARNs using `validation.Any`. This ensures compatibility with ARNs while maintaining support for log group names. (`internal/service/logs/query_definition.go`, [internal/service/logs/query_definition.goL55-R58](diffhunk://#diff-484ed3d559befc5b790fbc050763e6473a4996c4003cd21259534379c672895aL55-R58))

### Testing improvements:

* Added a new acceptance test, `TestAccLogsQueryDefinition_logGroupARNs`, to verify the functionality of using log group ARNs in the `log_group_names` attribute. This test includes resource creation, attribute checks, and import state verification. (`internal/service/logs/query_definition_test.go`, [internal/service/logs/query_definition_test.goR179-R210](diffhunk://#diff-2bf76ff1196bcd3a127c6f502d9a00db759a1307547353e224a8dc279b05de7dR179-R210))
* Introduced a helper function, `testAccQueryDefinitionConfig_logGroupARNs`, to generate test configurations for log group ARNs. This function creates multiple log groups and references their ARNs in the query definition. (`internal/service/logs/query_definition_test.go`, [internal/service/logs/query_definition_test.goR293-R317](diffhunk://#diff-2bf76ff1196bcd3a127c6f502d9a00db759a1307547353e224a8dc279b05de7dR293-R317))


### Relations

Closes #37986


### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing

```console
% make testacc TESTS=TestAccLogsQueryDefinition_logGroupARNs PKG=logs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/logs/... -v -count 1 -parallel 1 -run='TestAccLogsQueryDefinition_logGroupARNs'  -timeout 360m -vet=off
2025/06/25 18:29:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/25 18:29:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLogsQueryDefinition_logGroupARNs
=== PAUSE TestAccLogsQueryDefinition_logGroupARNs
=== CONT  TestAccLogsQueryDefinition_logGroupARNs
--- PASS: TestAccLogsQueryDefinition_logGroupARNs (25.53s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       25.725s

...
```
