### PR TITLE
Go-VCR: support `elasticache`

### DIFF
--- a/internal/service/elasticache/cluster.go
+++ b/internal/service/elasticache/cluster.go
@@ -20,7 +20,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -769,21 +770,22 @@ func deleteCacheCluster(ctx context.Context, conn *elasticache.Client, cacheClus
 		input.FinalSnapshotIdentifier = aws.String(finalSnapshotID)
 	}
 
+	// TODO: Migrate to retry.Operation
 	log.Printf("[DEBUG] Deleting ElastiCache Cache Cluster: %s", cacheClusterID)
-	err := retry.RetryContext(ctx, 5*time.Minute, func() *retry.RetryError {
+	err := sdkretry.RetryContext(ctx, 5*time.Minute, func() *sdkretry.RetryError {
 		_, err := conn.DeleteCacheCluster(ctx, input)
 		if err != nil {
 			if errs.IsAErrorMessageContains[*awstypes.InvalidCacheClusterStateFault](err, "serving as primary") {
-				return retry.NonRetryableError(err)
+				return sdkretry.NonRetryableError(err)
 			}
 			if errs.IsAErrorMessageContains[*awstypes.InvalidCacheClusterStateFault](err, "only member of a replication group") {
-				return retry.NonRetryableError(err)
+				return sdkretry.NonRetryableError(err)
 			}
 			// The cluster may be just snapshotting, so we retry until it's ready for deletion
 			if errs.IsA[*awstypes.InvalidCacheClusterStateFault](err) {
-				return retry.RetryableError(err)
+				return sdkretry.RetryableError(err)
 			}
-			return retry.NonRetryableError(err)
+			return sdkretry.NonRetryableError(err)
 		}
 		return nil
 	})
@@ -831,8 +833,7 @@ func findCacheClusters(ctx context.Context, conn *elasticache.Client, input *ela
 
 		if errs.IsA[*awstypes.CacheClusterNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -850,11 +851,11 @@ func findCacheClusters(ctx context.Context, conn *elasticache.Client, input *ela
 	return output, nil
 }
 
-func statusCacheCluster(ctx context.Context, conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusCacheCluster(conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findCacheClusterByID(ctx, conn, cacheClusterID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -887,7 +888,7 @@ func waitCacheClusterAvailable(ctx context.Context, conn *elasticache.Client, ca
 			cacheClusterStatusRebootingClusterNodes,
 		},
 		Target:     []string{cacheClusterStatusAvailable},
-		Refresh:    statusCacheCluster(ctx, conn, cacheClusterID),
+		Refresh:    statusCacheCluster(conn, cacheClusterID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -914,7 +915,7 @@ func waitCacheClusterDeleted(ctx context.Context, conn *elasticache.Client, cach
 			cacheClusterStatusSnapshotting,
 		},
 		Target:     []string{},
-		Refresh:    statusCacheCluster(ctx, conn, cacheClusterID),
+		Refresh:    statusCacheCluster(conn, cacheClusterID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/cluster_data_source_test.go
+++ b/internal/service/elasticache/cluster_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -20,11 +19,11 @@ func TestAccElastiCacheClusterDataSource_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 	dataSourceName := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -54,10 +53,10 @@ func TestAccElastiCacheClusterDataSource_Engine_Redis_LogDeliveryConfigurations(
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/elasticache/cluster_test.go
+++ b/internal/service/elasticache/cluster_test.go
@@ -14,13 +14,11 @@ import (
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -41,19 +39,19 @@ func TestAccElastiCacheCluster_Engine_memcached(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineMemcached(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
@@ -80,19 +78,19 @@ func TestAccElastiCacheCluster_Engine_redis(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineRedis(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
@@ -124,19 +122,19 @@ func TestAccElastiCacheCluster_disappears(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineRedis(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceCluster(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -152,19 +150,19 @@ func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineRedisV5(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 					// Even though it is ignored, the API returns `true` in this case
@@ -185,13 +183,13 @@ func TestAccElastiCacheCluster_Engine_redis_v5(t *testing.T) {
 
 func TestAccElastiCacheCluster_Engine_None(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineNone(rName),
@@ -210,18 +208,18 @@ func TestAccElastiCacheCluster_PortRedis_default(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_redisDefaultPort(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, "aws_elasticache_cluster.test", &ec),
+					testAccCheckClusterExists(ctx, t, "aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_security_group_rule.test", "to_port", "6379"),
 					resource.TestCheckResourceAttr("aws_security_group_rule.test", "from_port", "6379"),
 				),
@@ -237,19 +235,19 @@ func TestAccElastiCacheCluster_ParameterGroupName_default(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_parameterGroupName(rName, "memcached", "1.4.34", "default.memcached1.4"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "memcached"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "1.4.34"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.34"),
@@ -275,19 +273,19 @@ func TestAccElastiCacheCluster_ipDiscovery(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_ipDiscovery(rName, "ipv6", "dual_stack"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "ip_discovery", "ipv6"),
 					resource.TestCheckResourceAttr(resourceName, "network_type", "dual_stack"),
 				),
@@ -312,19 +310,19 @@ func TestAccElastiCacheCluster_port(t *testing.T) {
 
 	var ec awstypes.CacheCluster
 	port := 11212
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_port(rName, port),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint"),
 					resource.TestCheckResourceAttrSet(resourceName, "cluster_address"),
@@ -351,18 +349,18 @@ func TestAccElastiCacheCluster_snapshotsWithUpdates(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_snapshots(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, "aws_elasticache_cluster.test", &ec),
+					testAccCheckClusterExists(ctx, t, "aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "05:00-09:00"),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_retention_limit", "3"),
 				),
@@ -370,7 +368,7 @@ func TestAccElastiCacheCluster_snapshotsWithUpdates(t *testing.T) {
 			{
 				Config: testAccClusterConfig_snapshotsUpdated(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, "aws_elasticache_cluster.test", &ec),
+					testAccCheckClusterExists(ctx, t, "aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_window", "07:00-09:00"),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", "snapshot_retention_limit", "7"),
 				),
@@ -386,26 +384,26 @@ func TestAccElastiCacheCluster_NumCacheNodes_decrease(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numCacheNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_numCacheNodes(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
 				),
 			},
@@ -420,26 +418,26 @@ func TestAccElastiCacheCluster_NumCacheNodes_increase(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numCacheNodes(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_numCacheNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
 				),
 			},
@@ -454,19 +452,19 @@ func TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZo
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_numCacheNodesPreferredAvailabilityZones(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "1"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_availability_zones.#", "1"),
 				),
@@ -474,7 +472,7 @@ func TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZo
 			{
 				Config: testAccClusterConfig_numCacheNodesPreferredAvailabilityZones(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_nodes", "3"),
 					resource.TestCheckResourceAttr(resourceName, "preferred_availability_zones.#", "3"),
 				),
@@ -491,19 +489,19 @@ func TestAccElastiCacheCluster_vpc(t *testing.T) {
 
 	var csg awstypes.CacheSubnetGroup
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_inVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, "aws_elasticache_subnet_group.test", &csg),
-					testAccCheckClusterExists(ctx, "aws_elasticache_cluster.test", &ec),
+					testAccCheckSubnetGroupExists(ctx, t, "aws_elasticache_subnet_group.test", &csg),
+					testAccCheckClusterExists(ctx, t, "aws_elasticache_cluster.test", &ec),
 					testAccCheckClusterAttributes(&ec),
 				),
 			},
@@ -519,19 +517,19 @@ func TestAccElastiCacheCluster_multiAZInVPC(t *testing.T) {
 
 	var csg awstypes.CacheSubnetGroup
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_multiAZInVPC(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, "aws_elasticache_subnet_group.test", &csg),
-					testAccCheckClusterExists(ctx, "aws_elasticache_cluster.test", &ec),
+					testAccCheckSubnetGroupExists(ctx, t, "aws_elasticache_subnet_group.test", &csg),
+					testAccCheckClusterExists(ctx, t, "aws_elasticache_cluster.test", &ec),
 					resource.TestCheckResourceAttr("aws_elasticache_cluster.test", names.AttrAvailabilityZone, "Multiple"),
 				),
 			},
@@ -546,14 +544,14 @@ func TestAccElastiCacheCluster_AZMode_memcached(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterConfig_azModeMemcached(rName, "unknown"),
@@ -566,7 +564,7 @@ func TestAccElastiCacheCluster_AZMode_memcached(t *testing.T) {
 			{
 				Config: testAccClusterConfig_azModeMemcached(rName, "single-az"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "az_mode", "single-az"),
 				),
 			},
@@ -585,14 +583,14 @@ func TestAccElastiCacheCluster_AZMode_redis(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterConfig_azModeRedis(rName, "unknown"),
@@ -605,7 +603,7 @@ func TestAccElastiCacheCluster_AZMode_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_azModeRedis(rName, "single-az"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, "az_mode", "single-az"),
 				),
 			},
@@ -620,19 +618,19 @@ func TestAccElastiCacheCluster_EngineVersion_memcached(t *testing.T) {
 	}
 
 	var pre, mid, post awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineVersionMemcached(rName, "1.4.33"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &pre),
+					testAccCheckClusterExists(ctx, t, resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "1.4.33"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.33"),
 				),
@@ -640,7 +638,7 @@ func TestAccElastiCacheCluster_EngineVersion_memcached(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionMemcached(rName, "1.4.24"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &mid),
+					testAccCheckClusterExists(ctx, t, resourceName, &mid),
 					testAccCheckClusterRecreated(&pre, &mid),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "1.4.24"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.24"),
@@ -649,7 +647,7 @@ func TestAccElastiCacheCluster_EngineVersion_memcached(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionMemcached(rName, "1.4.34"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &post),
+					testAccCheckClusterExists(ctx, t, resourceName, &post),
 					testAccCheckClusterNotRecreated(&mid, &post),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "1.4.34"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "1.4.34"),
@@ -666,19 +664,19 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 	}
 
 	var v1, v2, v3, v4, v5, v6 awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "4.0.10"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v1),
+					testAccCheckClusterExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "4.0.10"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "4.0.10"),
 				),
@@ -686,7 +684,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v2),
+					testAccCheckClusterExists(ctx, t, resourceName, &v2),
 					testAccCheckClusterNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
@@ -695,7 +693,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v3),
+					testAccCheckClusterExists(ctx, t, resourceName, &v3),
 					testAccCheckClusterNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.2"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
@@ -704,7 +702,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "5.0.6"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v4),
+					testAccCheckClusterExists(ctx, t, resourceName, &v4),
 					testAccCheckClusterRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
@@ -713,7 +711,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.x"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v5),
+					testAccCheckClusterExists(ctx, t, resourceName, &v5),
 					testAccCheckClusterNotRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
@@ -722,7 +720,7 @@ func TestAccElastiCacheCluster_EngineVersion_redis(t *testing.T) {
 			{
 				Config: testAccClusterConfig_engineVersionRedis(rName, "6.0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &v6),
+					testAccCheckClusterExists(ctx, t, resourceName, &v6),
 					testAccCheckClusterRecreated(&v5, &v6),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
@@ -739,26 +737,26 @@ func TestAccElastiCacheCluster_NodeTypeResize_memcached(t *testing.T) {
 	}
 
 	var pre, post awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_nodeTypeMemcached(rName, "cache.t3.small"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &pre),
+					testAccCheckClusterExists(ctx, t, resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_nodeTypeMemcached(rName, "cache.t3.medium"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &post),
+					testAccCheckClusterExists(ctx, t, resourceName, &post),
 					testAccCheckClusterRecreated(&pre, &post),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.medium"),
 				),
@@ -774,26 +772,26 @@ func TestAccElastiCacheCluster_NodeTypeResize_redis(t *testing.T) {
 	}
 
 	var pre, post awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_nodeTypeRedis(rName, "cache.t3.small"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &pre),
+					testAccCheckClusterExists(ctx, t, resourceName, &pre),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
 				),
 			},
 			{
 				Config: testAccClusterConfig_nodeTypeRedis(rName, "cache.t3.medium"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &post),
+					testAccCheckClusterExists(ctx, t, resourceName, &post),
 					testAccCheckClusterNotRecreated(&pre, &post),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.medium"),
 				),
@@ -804,13 +802,13 @@ func TestAccElastiCacheCluster_NodeTypeResize_redis(t *testing.T) {
 
 func TestAccElastiCacheCluster_NumCacheNodes_redis(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterConfig_numCacheNodesRedis(rName, 2),
@@ -828,21 +826,21 @@ func TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone(t *testing.T)
 
 	var cluster awstypes.CacheCluster
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	clusterResourceName := "aws_elasticache_cluster.test"
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_replicationGroupIDAvailabilityZone(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, replicationGroupResourceName, &replicationGroup),
-					testAccCheckClusterExists(ctx, clusterResourceName, &cluster),
+					testAccCheckReplicationGroupExists(ctx, t, replicationGroupResourceName, &replicationGroup),
+					testAccCheckClusterExists(ctx, t, clusterResourceName, &cluster),
 					testAccCheckClusterReplicationGroupIDAttribute(&cluster, &replicationGroup),
 				),
 			},
@@ -858,21 +856,21 @@ func TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption(t *testing.T
 
 	var cluster awstypes.CacheCluster
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	clusterResourceName := "aws_elasticache_cluster.test"
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_replicationGroupIDTransitEncryption(rName, true),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, replicationGroupResourceName, &replicationGroup),
-					testAccCheckClusterExists(ctx, clusterResourceName, &cluster),
+					testAccCheckReplicationGroupExists(ctx, t, replicationGroupResourceName, &replicationGroup),
+					testAccCheckClusterExists(ctx, t, clusterResourceName, &cluster),
 					testAccCheckClusterReplicationGroupIDAttribute(&cluster, &replicationGroup),
 					resource.TestCheckResourceAttr(clusterResourceName, "transit_encryption_enabled", acctest.CtTrue),
 				),
@@ -889,21 +887,21 @@ func TestAccElastiCacheCluster_ReplicationGroupID_singleReplica(t *testing.T) {
 
 	var cluster awstypes.CacheCluster
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	clusterResourceName := "aws_elasticache_cluster.test.0"
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_replicationGroupIDReplica(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, replicationGroupResourceName, &replicationGroup),
-					testAccCheckClusterExists(ctx, clusterResourceName, &cluster),
+					testAccCheckReplicationGroupExists(ctx, t, replicationGroupResourceName, &replicationGroup),
+					testAccCheckClusterExists(ctx, t, clusterResourceName, &cluster),
 					testAccCheckClusterReplicationGroupIDAttribute(&cluster, &replicationGroup),
 					resource.TestCheckResourceAttr(clusterResourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(clusterResourceName, "node_type", "cache.t3.medium"),
@@ -922,29 +920,29 @@ func TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica(t *testing.T) 
 
 	var cluster1, cluster2 awstypes.CacheCluster
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	clusterResourceName1 := "aws_elasticache_cluster.test.0"
 	clusterResourceName2 := "aws_elasticache_cluster.test.1"
 	replicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_replicationGroupIDReplica(rName, 2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, replicationGroupResourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, replicationGroupResourceName, &replicationGroup),
 
-					testAccCheckClusterExists(ctx, clusterResourceName1, &cluster1),
+					testAccCheckClusterExists(ctx, t, clusterResourceName1, &cluster1),
 					testAccCheckClusterReplicationGroupIDAttribute(&cluster1, &replicationGroup),
 					resource.TestCheckResourceAttr(clusterResourceName1, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(clusterResourceName1, "node_type", "cache.t3.medium"),
 					resource.TestCheckResourceAttr(clusterResourceName1, names.AttrPort, "6379"),
 
-					testAccCheckClusterExists(ctx, clusterResourceName2, &cluster2),
+					testAccCheckClusterExists(ctx, t, clusterResourceName2, &cluster2),
 					testAccCheckClusterReplicationGroupIDAttribute(&cluster2, &replicationGroup),
 					resource.TestCheckResourceAttr(clusterResourceName2, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(clusterResourceName2, "node_type", "cache.t3.medium"),
@@ -957,13 +955,13 @@ func TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica(t *testing.T) 
 
 func TestAccElastiCacheCluster_Memcached_finalSnapshot(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterConfig_memcachedFinalSnapshot(rName),
@@ -980,19 +978,19 @@ func TestAccElastiCacheCluster_Redis_finalSnapshot(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_redisFinalSnapshot(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrFinalSnapshotIdentifier, rName),
 				),
 			},
@@ -1007,19 +1005,19 @@ func TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_redisAutoMinorVersionUpgrade(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
 				),
 			},
@@ -1034,7 +1032,7 @@ func TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade(t *testing.T) {
 			{
 				Config: testAccClusterConfig_redisAutoMinorVersionUpgrade(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 				),
 			},
@@ -1049,19 +1047,19 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, awstypes.DestinationTypeCloudWatchLogs, awstypes.LogFormatText, true, awstypes.DestinationTypeCloudWatchLogs, awstypes.LogFormatText),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "cloudwatch-logs"),
@@ -1082,7 +1080,7 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, awstypes.DestinationTypeKinesisFirehose, awstypes.LogFormatJson, true, awstypes.DestinationTypeKinesisFirehose, awstypes.LogFormatJson),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "kinesis-firehose"),
@@ -1103,7 +1101,7 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, awstypes.DestinationTypeCloudWatchLogs, awstypes.LogFormatText, true, awstypes.DestinationTypeKinesisFirehose, awstypes.LogFormatJson),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "cloudwatch-logs"),
@@ -1118,7 +1116,7 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, awstypes.DestinationTypeKinesisFirehose, awstypes.LogFormatJson, true, awstypes.DestinationTypeCloudWatchLogs, awstypes.LogFormatText),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "cloudwatch-logs"),
@@ -1133,7 +1131,7 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, false, "", "", false, "", ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination"),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination_type"),
@@ -1148,7 +1146,7 @@ func TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations(t *testing
 			{
 				Config: testAccClusterConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, awstypes.DestinationTypeKinesisFirehose, awstypes.LogFormatJson, false, "", ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "kinesis-firehose"),
@@ -1177,19 +1175,19 @@ func TestAccElastiCacheCluster_tags(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "1"),
@@ -1205,7 +1203,7 @@ func TestAccElastiCacheCluster_tags(t *testing.T) {
 			{
 				Config: testAccClusterConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -1217,7 +1215,7 @@ func TestAccElastiCacheCluster_tags(t *testing.T) {
 			{
 				Config: testAccClusterConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsAllPercent, "1"),
@@ -1235,19 +1233,19 @@ func TestAccElastiCacheCluster_tagWithOtherModification(t *testing.T) {
 	}
 
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_versionAndTag(rName, "6.0", acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -1258,7 +1256,7 @@ func TestAccElastiCacheCluster_tagWithOtherModification(t *testing.T) {
 			{
 				Config: testAccClusterConfig_versionAndTag(rName, "6.2", acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -1276,14 +1274,14 @@ func TestAccElastiCacheCluster_TransitEncryption(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 	var cluster awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccClusterConfig_transitEncryption(rName, "memcached", "1.6.6"),
@@ -1296,7 +1294,7 @@ func TestAccElastiCacheCluster_TransitEncryption(t *testing.T) {
 			{
 				Config: testAccClusterConfig_transitEncryption(rName, "memcached", "1.6.12"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &cluster),
+					testAccCheckClusterExists(ctx, t, resourceName, &cluster),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "memcached"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "1.6.12"),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
@@ -1313,19 +1311,19 @@ func TestAccElastiCacheCluster_outpost_memcached(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_outpost_memcached(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_nodes.0.outpost_arn"),
 					resource.TestCheckResourceAttrSet(resourceName, "configuration_endpoint"),
@@ -1353,19 +1351,19 @@ func TestAccElastiCacheCluster_outpost_redis(t *testing.T) {
 	}
 
 	var ec awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_outpost_redis(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &ec),
+					testAccCheckClusterExists(ctx, t, resourceName, &ec),
 					resource.TestCheckResourceAttr(resourceName, "cache_nodes.0.id", "0001"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_nodes.0.outpost_arn"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -1393,25 +1391,25 @@ func TestAccElastiCacheCluster_outpostID_memcached(t *testing.T) {
 	}
 
 	var pre, post awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_outpost_memcached(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &pre),
+					testAccCheckClusterExists(ctx, t, resourceName, &pre),
 				),
 			},
 			{
 				Config: testAccClusterConfig_outpost_memcached(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &post),
+					testAccCheckClusterExists(ctx, t, resourceName, &post),
 					testAccCheckClusterRecreated(&pre, &post),
 				),
 			},
@@ -1426,25 +1424,25 @@ func TestAccElastiCacheCluster_outpostID_redis(t *testing.T) {
 	}
 
 	var pre, post awstypes.CacheCluster
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckOutpostsOutposts(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccClusterConfig_outpost_redis(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &pre),
+					testAccCheckClusterExists(ctx, t, resourceName, &pre),
 				),
 			},
 			{
 				Config: testAccClusterConfig_outpost_redis(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckClusterExists(ctx, resourceName, &post),
+					testAccCheckClusterExists(ctx, t, resourceName, &post),
 					testAccCheckClusterNotRecreated(&pre, &post),
 				),
 			},
@@ -1500,9 +1498,9 @@ func testAccCheckClusterRecreated(i, j *awstypes.CacheCluster) resource.TestChec
 	}
 }
 
-func testAccCheckClusterDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckClusterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_cluster" {
@@ -1511,7 +1509,7 @@ func testAccCheckClusterDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tfelasticache.FindCacheClusterByID(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -1525,7 +1523,7 @@ func testAccCheckClusterDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckClusterExists(ctx context.Context, n string, v *awstypes.CacheCluster) resource.TestCheckFunc {
+func testAccCheckClusterExists(ctx context.Context, t *testing.T, n string, v *awstypes.CacheCluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -1536,7 +1534,7 @@ func testAccCheckClusterExists(ctx context.Context, n string, v *awstypes.CacheC
 			return fmt.Errorf("No ElastiCache Cluster ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindCacheClusterByID(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/elasticache/global_replication_group.go
+++ b/internal/service/elasticache/global_replication_group.go
@@ -20,12 +20,12 @@ import (
 	gversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -376,7 +376,7 @@ func resourceGlobalReplicationGroupRead(ctx context.Context, d *schema.ResourceD
 
 	globalReplicationGroup, err := findGlobalReplicationGroupByID(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Global Replication Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -658,8 +658,7 @@ func findGlobalReplicationGroups(ctx context.Context, conn *elasticache.Client, 
 
 		if errs.IsA[*awstypes.GlobalReplicationGroupNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -677,11 +676,11 @@ func findGlobalReplicationGroups(ctx context.Context, conn *elasticache.Client, 
 	return output, nil
 }
 
-func statusGlobalReplicationGroup(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusGlobalReplicationGroup(conn *elasticache.Client, globalReplicationGroupID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findGlobalReplicationGroupByID(ctx, conn, globalReplicationGroupID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -712,7 +711,7 @@ func waitGlobalReplicationGroupAvailable(ctx context.Context, conn *elasticache.
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{globalReplicationGroupStatusCreating, globalReplicationGroupStatusModifying},
 		Target:     []string{globalReplicationGroupStatusAvailable, globalReplicationGroupStatusPrimaryOnly},
-		Refresh:    statusGlobalReplicationGroup(ctx, conn, globalReplicationGroupID),
+		Refresh:    statusGlobalReplicationGroup(conn, globalReplicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -736,7 +735,7 @@ func waitGlobalReplicationGroupDeleted(ctx context.Context, conn *elasticache.Cl
 			globalReplicationGroupStatusDeleting,
 		},
 		Target:     []string{},
-		Refresh:    statusGlobalReplicationGroup(ctx, conn, globalReplicationGroupID),
+		Refresh:    statusGlobalReplicationGroup(conn, globalReplicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -773,11 +772,11 @@ func findGlobalReplicationGroupMemberByID(ctx context.Context, conn *elasticache
 	}
 }
 
-func statusGlobalReplicationGroupMember(ctx context.Context, conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusGlobalReplicationGroupMember(conn *elasticache.Client, globalReplicationGroupID, replicationGroupID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findGlobalReplicationGroupMemberByID(ctx, conn, globalReplicationGroupID, replicationGroupID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -797,7 +796,7 @@ func waitGlobalReplicationGroupMemberDetached(ctx context.Context, conn *elastic
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{globalReplicationGroupMemberStatusAssociated},
 		Target:     []string{},
-		Refresh:    statusGlobalReplicationGroupMember(ctx, conn, globalReplicationGroupID, replicationGroupID),
+		Refresh:    statusGlobalReplicationGroupMember(conn, globalReplicationGroupID, replicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/global_replication_group_test.go
+++ b/internal/service/elasticache/global_replication_group_test.go
@@ -18,10 +18,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -34,25 +33,25 @@ func TestAccElastiCacheGlobalReplicationGroup_Redis_basic(t *testing.T) {
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckGlobalReplicationGroupDestroy(ctx),
+			testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_basic(rName, primaryReplicationGroupId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "elasticache", regexache.MustCompile(`globalreplicationgroup:`+tfelasticache.GlobalReplicationGroupRegionPrefixFormat+rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "at_rest_encryption_enabled", primaryReplicationGroupResourceName, "at_rest_encryption_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_enabled", acctest.CtFalse),
@@ -88,25 +87,25 @@ func TestAccElastiCacheGlobalReplicationGroup_Valkey_basic(t *testing.T) {
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckGlobalReplicationGroupDestroy(ctx),
+			testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Valkey_basic(rName, primaryReplicationGroupId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					acctest.MatchResourceAttrGlobalARN(ctx, resourceName, names.AttrARN, "elasticache", regexache.MustCompile(`globalreplicationgroup:`+tfelasticache.GlobalReplicationGroupRegionPrefixFormat+rName)),
 					resource.TestCheckResourceAttrPair(resourceName, "at_rest_encryption_enabled", primaryReplicationGroupResourceName, "at_rest_encryption_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_enabled", acctest.CtFalse),
@@ -140,20 +139,20 @@ func TestAccElastiCacheGlobalReplicationGroup_disappears(t *testing.T) {
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_basic(rName, primaryReplicationGroupId),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceGlobalReplicationGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -169,22 +168,22 @@ func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	description1 := sdkacctest.RandString(10)
 	description2 := sdkacctest.RandString(10)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_description(rName, primaryReplicationGroupId, description1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", description1),
 				),
 			},
@@ -196,7 +195,7 @@ func TestAccElastiCacheGlobalReplicationGroup_description(t *testing.T) {
 			{
 				Config: testAccGlobalReplicationGroupConfig_description(rName, primaryReplicationGroupId, description2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "global_replication_group_description", description2),
 				),
 			},
@@ -211,21 +210,21 @@ func TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange(t *testing
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	nodeType := "cache.m5.large"
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_nodeType_createNoChange(rName, primaryReplicationGroupId, nodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_type", nodeType),
 				),
 			},
@@ -245,22 +244,22 @@ func TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange(t *testi
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	nodeType := "cache.m5.large"
 	globalNodeType := "cache.m5.xlarge"
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_nodeType_createWithChange(rName, primaryReplicationGroupId, nodeType, globalNodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_type", globalNodeType),
 				),
 			},
@@ -280,29 +279,29 @@ func TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange(t *testing.T)
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	nodeType := "cache.m5.large"
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_basic_nodeType(rName, primaryReplicationGroupId, nodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "cache_node_type", primaryReplicationGroupResourceName, "node_type"),
 				),
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_nodeType_createNoChange(rName, primaryReplicationGroupId, nodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_type", nodeType),
 				),
 			},
@@ -322,29 +321,29 @@ func TestAccElastiCacheGlobalReplicationGroup_nodeType_update(t *testing.T) {
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	nodeType := "cache.m5.large"
 	updatedNodeType := "cache.m5.xlarge"
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_nodeType_createNoChange(rName, primaryReplicationGroupId, nodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_type", nodeType),
 				),
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_nodeType_update(rName, primaryReplicationGroupId, updatedNodeType),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_type", updatedNodeType),
 				),
 			},
@@ -364,20 +363,20 @@ func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createNoChange(t
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, acctest.CtTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
 				),
 			},
@@ -397,20 +396,20 @@ func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createWithChange
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createWithChange(rName, primaryReplicationGroupId, acctest.CtFalse, acctest.CtTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
 				),
 			},
@@ -430,28 +429,28 @@ func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_setNoChange(t *t
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_basic_automaticFailover(rName, primaryReplicationGroupId, acctest.CtFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
 				),
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, acctest.CtFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtFalse),
 				),
 			},
@@ -471,27 +470,27 @@ func TestAccElastiCacheGlobalReplicationGroup_automaticFailover_update(t *testin
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_automaticFailover_createNoChange(rName, primaryReplicationGroupId, acctest.CtTrue),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
 				),
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_automaticFailover_update(rName, primaryReplicationGroupId, acctest.CtFalse),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtFalse),
 				),
 			},
@@ -511,22 +510,22 @@ func TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries(t *testing.T) 
 	}
 
 	var globalReplcationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 3)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3),
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_multipleSecondaries(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplcationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplcationGroup),
 				),
 			},
 		},
@@ -540,28 +539,28 @@ func TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion(t
 	}
 
 	var globalReplcationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 3)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 3),
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_replaceSecondaryDifferentRegionSetup(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplcationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplcationGroup),
 				),
 			},
 			{
 				Config: testAccGlobalReplicationGroupConfig_replaceSecondaryDifferentRegionMove(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplcationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplcationGroup),
 				),
 			},
 		},
@@ -577,22 +576,22 @@ func TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic(t *testing.T) {
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_clusterMode(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "automatic_failover_enabled", primaryReplicationGroupResourceName, "automatic_failover_enabled"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttrPair(resourceName, "global_node_groups.#", primaryReplicationGroupResourceName, "num_node_groups"),
@@ -617,22 +616,22 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange(
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
@@ -657,22 +656,22 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase(
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "3"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -706,22 +705,22 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease(
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 3, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "1"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -750,22 +749,22 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase(
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups_inherit(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "2"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -781,8 +780,8 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase(
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "3"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -816,22 +815,22 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease(
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var primaryReplicationGroup awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups_inherit(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "2"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -847,8 +846,8 @@ func TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease(
 			{
 				Config: testAccGlobalReplicationGroupConfig_numNodeGroups(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &primaryReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &primaryReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "global_node_groups.#", "1"),
 					resource.TestMatchTypeSetElemNestedAttrs(resourceName, "global_node_groups.*", map[string]*regexp.Regexp{
@@ -875,20 +874,20 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.2", "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -908,20 +907,20 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.2", "6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -942,20 +941,20 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "5.0.6", "5.0.6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
 			},
@@ -975,20 +974,20 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Valkey_engineVersion(rName, primaryReplicationGroupId, "7.2", "7.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^7\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1010,24 +1009,24 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgr
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var rg awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.0", "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &rg),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &rg),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
-					testAccMatchReplicationGroupActualVersion(ctx, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
+					testAccMatchReplicationGroupActualVersion(ctx, t, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -1048,24 +1047,24 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgr
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var rg awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.0", "6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &rg),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &rg),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
-					testAccMatchReplicationGroupActualVersion(ctx, &rg, regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
+					testAccMatchReplicationGroupActualVersion(ctx, t, &rg, regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
 			},
 		},
@@ -1081,24 +1080,24 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgr
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var rg awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &rg),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &rg),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
-					testAccMatchReplicationGroupActualVersion(ctx, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
+					testAccMatchReplicationGroupActualVersion(ctx, t, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -1120,24 +1119,24 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgr
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 	var rg awstypes.ReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
-					testAccCheckReplicationGroupExists(ctx, primaryReplicationGroupResourceName, &rg),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, primaryReplicationGroupResourceName, &rg),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
-					testAccMatchReplicationGroupActualVersion(ctx, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
+					testAccMatchReplicationGroupActualVersion(ctx, t, &rg, regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
 			{
@@ -1156,14 +1155,14 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDown
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.2", "6.0"),
@@ -1175,14 +1174,14 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDown
 
 func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_param(rName, primaryReplicationGroupId, "6.2", "default.redis6.x"),
@@ -1194,14 +1193,14 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersio
 
 func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "6.0", "6.2", "default.redis6.x"),
@@ -1218,21 +1217,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgr
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
@@ -1240,7 +1239,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgr
 			{
 				Config: testAccGlobalReplicationGroupConfig_Redis_engineVersion(rName, primaryReplicationGroupId, "6.0", "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1255,21 +1254,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgr
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
@@ -1301,21 +1300,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDown
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
@@ -1348,21 +1347,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgr
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "5.0.6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
@@ -1375,7 +1374,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgr
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1390,21 +1389,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgr
 	}
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_global_replication_group.test"
 	primaryReplicationGroupResourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "5.0.6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestCheckResourceAttrPair(resourceName, "engine_version_actual", primaryReplicationGroupResourceName, "engine_version_actual"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
 				),
@@ -1417,7 +1416,7 @@ func TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgr
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "5.0.6", "6.x", "default.redis6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1433,21 +1432,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersio
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1467,21 +1466,21 @@ func TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpg
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionInherit(rName, primaryReplicationGroupId, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
 				),
 			},
@@ -1501,22 +1500,22 @@ func TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName(t *testin
 
 	var globalReplicationGroup awstypes.GlobalReplicationGroup
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	primaryReplicationGroupId := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	parameterGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	primaryReplicationGroupId := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	parameterGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_global_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckGlobalReplicationGroup(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckGlobalReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGlobalReplicationGroupConfig_engineVersionParam(rName, primaryReplicationGroupId, "5.0.6", "6.2", "default.redis6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckGlobalReplicationGroupExists(ctx, resourceName, &globalReplicationGroup),
+					testAccCheckGlobalReplicationGroupExists(ctx, t, resourceName, &globalReplicationGroup),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
 				),
 			},
@@ -1528,7 +1527,7 @@ func TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName(t *testin
 	})
 }
 
-func testAccCheckGlobalReplicationGroupExists(ctx context.Context, resourceName string, v *awstypes.GlobalReplicationGroup) resource.TestCheckFunc {
+func testAccCheckGlobalReplicationGroupExists(ctx context.Context, t *testing.T, resourceName string, v *awstypes.GlobalReplicationGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -1539,7 +1538,7 @@ func testAccCheckGlobalReplicationGroupExists(ctx context.Context, resourceName 
 			return fmt.Errorf("No ElastiCache Global Replication Group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 		grg, err := tfelasticache.FindGlobalReplicationGroupByID(ctx, conn, rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("retrieving ElastiCache Global Replication Group (%s): %w", rs.Primary.ID, err)
@@ -1555,9 +1554,9 @@ func testAccCheckGlobalReplicationGroupExists(ctx context.Context, resourceName 
 	}
 }
 
-func testAccCheckGlobalReplicationGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckGlobalReplicationGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_global_replication_group" {
@@ -1565,7 +1564,7 @@ func testAccCheckGlobalReplicationGroupDestroy(ctx context.Context) resource.Tes
 			}
 
 			_, err := tfelasticache.FindGlobalReplicationGroupByID(ctx, conn, rs.Primary.ID)
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 			if err != nil {
@@ -1579,7 +1578,7 @@ func testAccCheckGlobalReplicationGroupDestroy(ctx context.Context) resource.Tes
 }
 
 func testAccPreCheckGlobalReplicationGroup(ctx context.Context, t *testing.T) {
-	conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+	conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 	input := &elasticache.DescribeGlobalReplicationGroupsInput{}
 	_, err := conn.DescribeGlobalReplicationGroups(ctx, input)
@@ -1594,9 +1593,9 @@ func testAccPreCheckGlobalReplicationGroup(ctx context.Context, t *testing.T) {
 	}
 }
 
-func testAccMatchReplicationGroupActualVersion(ctx context.Context, j *awstypes.ReplicationGroup, r *regexp.Regexp) resource.TestCheckFunc {
+func testAccMatchReplicationGroupActualVersion(ctx context.Context, t *testing.T, j *awstypes.ReplicationGroup, r *regexp.Regexp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		cacheCluster := j.NodeGroups[0].NodeGroupMembers[0]
 		cluster, err := tfelasticache.FindCacheClusterByID(ctx, conn, aws.ToString(cacheCluster.CacheClusterId))

--- a/internal/service/elasticache/parameter_group.go
+++ b/internal/service/elasticache/parameter_group.go
@@ -15,11 +15,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -125,7 +126,7 @@ func resourceParameterGroupRead(ctx context.Context, d *schema.ResourceData, met
 
 	parameterGroup, err := findCacheParameterGroupByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Parameter Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -193,7 +194,7 @@ func resourceParameterGroupUpdate(ctx context.Context, d *schema.ResourceData, m
 			// above, which may become out of date, here we add logic to
 			// workaround this API behavior
 
-			if tfresource.TimedOut(err) || errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "Parameter reserved-memory doesn't exist") {
+			if retry.TimedOut(err) || errs.IsAErrorMessageContains[*awstypes.InvalidParameterValueException](err, "Parameter reserved-memory doesn't exist") {
 				for i, paramToModify := range paramsToModify {
 					if aws.ToString(paramToModify.ParameterName) != "reserved-memory" {
 						continue
@@ -359,13 +360,15 @@ func resourceResetParameterGroup(ctx context.Context, conn *elasticache.Client, 
 		CacheParameterGroupName: aws.String(name),
 		ParameterNameValues:     tfslices.Values(parameters),
 	}
-	return retry.RetryContext(ctx, 30*time.Second, func() *retry.RetryError {
+
+	// TODO: Migrate to retry.Operation
+	return sdkretry.RetryContext(ctx, 30*time.Second, func() *sdkretry.RetryError {
 		_, err := conn.ResetCacheParameterGroup(ctx, &input)
 		if err != nil {
 			if errs.IsAErrorMessageContains[*awstypes.InvalidCacheParameterGroupStateFault](err, " has pending changes") {
-				return retry.RetryableError(err)
+				return sdkretry.RetryableError(err)
 			}
-			return retry.NonRetryableError(err)
+			return sdkretry.NonRetryableError(err)
 		}
 		return nil
 	})
@@ -408,8 +411,7 @@ func findCacheParameterGroups(ctx context.Context, conn *elasticache.Client, inp
 
 		if errs.IsA[*awstypes.CacheParameterGroupNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 

--- a/internal/service/elasticache/parameter_group_test.go
+++ b/internal/service/elasticache/parameter_group_test.go
@@ -12,13 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -26,18 +24,18 @@ func TestAccElastiCacheParameterGroup_Redis_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_Redis_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Managed by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrFamily, "redis2.8"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -57,18 +55,18 @@ func TestAccElastiCacheParameterGroup_Valkey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_Valkey_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Managed by Terraform"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrFamily, "valkey7"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
@@ -88,18 +86,18 @@ func TestAccElastiCacheParameterGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_Redis_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceParameterGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -112,18 +110,18 @@ func TestAccElastiCacheParameterGroup_addParameter(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis2.8", "appendonly", "yes"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "appendonly",
@@ -139,7 +137,7 @@ func TestAccElastiCacheParameterGroup_addParameter(t *testing.T) {
 			{
 				Config: testAccParameterGroupConfig_2(rName, "redis2.8", "appendonly", "yes", "appendfsync", "always"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "appendonly",
@@ -160,18 +158,18 @@ func TestAccElastiCacheParameterGroup_removeAllParameters(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_2(rName, "redis2.8", "appendonly", "yes", "appendfsync", "always"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "appendonly",
@@ -186,7 +184,7 @@ func TestAccElastiCacheParameterGroup_removeAllParameters(t *testing.T) {
 			{
 				Config: testAccParameterGroupConfig_Redis_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
 				),
 			},
@@ -200,18 +198,18 @@ func TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_allParameter
 	ctx := acctest.Context(t)
 	var cacheParameterGroup1 awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis3.2", "reserved-memory", "0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory",
@@ -222,7 +220,7 @@ func TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_allParameter
 			{
 				Config: testAccParameterGroupConfig_Redis_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "0"),
 				),
 			},
@@ -241,18 +239,18 @@ func TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_remainingPar
 	ctx := acctest.Context(t)
 	var cacheParameterGroup1 awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_2(rName, "redis3.2", "reserved-memory", "0", "tcp-keepalive", "360"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "2"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory",
@@ -267,7 +265,7 @@ func TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_remainingPar
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis3.2", "tcp-keepalive", "360"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "tcp-keepalive",
@@ -290,18 +288,18 @@ func TestAccElastiCacheParameterGroup_switchReservedMemoryParameter(t *testing.T
 	ctx := acctest.Context(t)
 	var cacheParameterGroup1 awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis3.2", "reserved-memory", "0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory",
@@ -312,7 +310,7 @@ func TestAccElastiCacheParameterGroup_switchReservedMemoryParameter(t *testing.T
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis3.2", "reserved-memory-percent", "25"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory-percent",
@@ -335,18 +333,18 @@ func TestAccElastiCacheParameterGroup_updateReservedMemoryParameter(t *testing.T
 	ctx := acctest.Context(t)
 	var cacheParameterGroup1 awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis2.8", "reserved-memory", "0"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory",
@@ -357,7 +355,7 @@ func TestAccElastiCacheParameterGroup_updateReservedMemoryParameter(t *testing.T
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis2.8", "reserved-memory", "1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, "parameter.#", "1"),
 					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "parameter.*", map[string]string{
 						names.AttrName:  "reserved-memory",
@@ -378,19 +376,19 @@ func TestAccElastiCacheParameterGroup_uppercaseName(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rInt := sdkacctest.RandInt()
+	rInt := acctest.RandInt(t)
 	rName := fmt.Sprintf("TF-ELASTIPG-%d", rInt)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_1(rName, "redis2.8", "appendonly", "yes"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, fmt.Sprintf("tf-elastipg-%d", rInt)),
 				),
 			},
@@ -407,18 +405,18 @@ func TestAccElastiCacheParameterGroup_description(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_description(rName, "description1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &v),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "description1"),
 				),
 			},
@@ -435,18 +433,18 @@ func TestAccElastiCacheParameterGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var cacheParameterGroup1 awstypes.CacheParameterGroup
 	resourceName := "aws_elasticache_parameter_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckParameterGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccParameterGroupConfig_tags1(rName, "redis2.8", acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -454,7 +452,7 @@ func TestAccElastiCacheParameterGroup_tags(t *testing.T) {
 			{
 				Config: testAccParameterGroupConfig_tags2(rName, "redis2.8", acctest.CtKey1, "updatedvalue1", acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, "updatedvalue1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -463,7 +461,7 @@ func TestAccElastiCacheParameterGroup_tags(t *testing.T) {
 			{
 				Config: testAccParameterGroupConfig_Redis_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckParameterGroupExists(ctx, resourceName, &cacheParameterGroup1),
+					testAccCheckParameterGroupExists(ctx, t, resourceName, &cacheParameterGroup1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 				),
 			},
@@ -476,9 +474,9 @@ func TestAccElastiCacheParameterGroup_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckParameterGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckParameterGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_parameter_group" {
@@ -487,7 +485,7 @@ func testAccCheckParameterGroupDestroy(ctx context.Context) resource.TestCheckFu
 
 			_, err := tfelasticache.FindCacheParameterGroupByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -502,7 +500,7 @@ func testAccCheckParameterGroupDestroy(ctx context.Context) resource.TestCheckFu
 	}
 }
 
-func testAccCheckParameterGroupExists(ctx context.Context, n string, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
+func testAccCheckParameterGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -513,7 +511,7 @@ func testAccCheckParameterGroupExists(ctx context.Context, n string, v *awstypes
 			return fmt.Errorf("No ElastiCache Parameter Group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindCacheParameterGroupByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/elasticache/replication_group.go
+++ b/internal/service/elasticache/replication_group.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/go-cty/cty/gocty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -30,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2/types/nullable"
 	"github.com/hashicorp/terraform-provider-aws/internal/semver"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
@@ -662,7 +662,7 @@ func resourceReplicationGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 	rgp, err := findReplicationGroupByID(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Replication Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -1305,8 +1305,7 @@ func findReplicationGroups(ctx context.Context, conn *elasticache.Client, input 
 
 		if errs.IsA[*awstypes.ReplicationGroupNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -1324,11 +1323,11 @@ func findReplicationGroups(ctx context.Context, conn *elasticache.Client, input 
 	return output, nil
 }
 
-func statusReplicationGroup(ctx context.Context, conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusReplicationGroup(conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findReplicationGroupByID(ctx, conn, replicationGroupID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -1357,7 +1356,7 @@ func waitReplicationGroupAvailable(ctx context.Context, conn *elasticache.Client
 			replicationGroupStatusSnapshotting,
 		},
 		Target:     []string{replicationGroupStatusAvailable},
-		Refresh:    statusReplicationGroup(ctx, conn, replicationGroupID),
+		Refresh:    statusReplicationGroup(conn, replicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      delay,
@@ -1380,7 +1379,7 @@ func waitReplicationGroupDeleted(ctx context.Context, conn *elasticache.Client, 
 			replicationGroupStatusDeleting,
 		},
 		Target:     []string{},
-		Refresh:    statusReplicationGroup(ctx, conn, replicationGroupID),
+		Refresh:    statusReplicationGroup(conn, replicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -1419,11 +1418,11 @@ func findReplicationGroupMemberClustersByID(ctx context.Context, conn *elasticac
 
 // statusReplicationGroupMemberClusters fetches the Replication Group's Member Clusters and either "available" or the first non-"available" status.
 // NOTE: This function assumes that the intended end-state is to have all member clusters in "available" status.
-func statusReplicationGroupMemberClusters(ctx context.Context, conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusReplicationGroupMemberClusters(conn *elasticache.Client, replicationGroupID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findReplicationGroupMemberClustersByID(ctx, conn, replicationGroupID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -1452,7 +1451,7 @@ func waitReplicationGroupMemberClustersAvailable(ctx context.Context, conn *elas
 			cacheClusterStatusSnapshotting,
 		},
 		Target:     []string{cacheClusterStatusAvailable},
-		Refresh:    statusReplicationGroupMemberClusters(ctx, conn, replicationGroupID),
+		Refresh:    statusReplicationGroupMemberClusters(conn, replicationGroupID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/replication_group_data_source_test.go
+++ b/internal/service/elasticache/replication_group_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -20,11 +19,11 @@ func TestAccElastiCacheReplicationGroupDataSource_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -58,11 +57,11 @@ func TestAccElastiCacheReplicationGroupDataSource_clusterMode(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -92,11 +91,11 @@ func TestAccElastiCacheReplicationGroupDataSource_multiAZ(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	dataSourceName := "data.aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -118,10 +117,10 @@ func TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfig
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	dataSourceName := "data.aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/elasticache/replication_group_test.go
+++ b/internal/service/elasticache/replication_group_test.go
@@ -24,10 +24,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -38,19 +37,19 @@ func TestAccElastiCacheReplicationGroup_Redis_basic(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "elasticache", fmt.Sprintf("replicationgroup:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
@@ -60,7 +59,7 @@ func TestAccElastiCacheReplicationGroup_Redis_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
-					testCheckEngineStuffRedisDefault(ctx, resourceName),
+					testCheckEngineStuffRedisDefault(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
@@ -85,19 +84,19 @@ func TestAccElastiCacheReplicationGroup_Redis_basic_v5(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_Redis_v5(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
@@ -125,19 +124,19 @@ func TestAccElastiCacheReplicationGroup_Valkey_basic(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "valkey"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "elasticache", fmt.Sprintf("replicationgroup:%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
@@ -147,7 +146,7 @@ func TestAccElastiCacheReplicationGroup_Valkey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "0"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
-					testCheckEngineStuffValkeyDefault(ctx, resourceName),
+					testCheckEngineStuffValkeyDefault(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "data_tiering_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtTrue),
@@ -172,19 +171,19 @@ func TestAccElastiCacheReplicationGroup_uppercase(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_uppercase(strings.ToUpper(rName)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "replication_group_id", rName),
 				),
 			},
@@ -205,19 +204,19 @@ func TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_v7(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "7.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^7\.[[:digit:]]+\.[[:digit:]]+$`)),
@@ -240,26 +239,26 @@ func TestAccElastiCacheReplicationGroup_OutOfBandUpgrade(t *testing.T) {
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_v6(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.x"),
 				),
 			},
 			{
 				PreConfig: func() {
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 					engineVersion := "7.1"
 
@@ -270,7 +269,7 @@ func TestAccElastiCacheReplicationGroup_OutOfBandUpgrade(t *testing.T) {
 				},
 				RefreshState: true,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "7.x"),
 				),
 				ExpectNonEmptyPlan: true,
@@ -278,7 +277,7 @@ func TestAccElastiCacheReplicationGroup_OutOfBandUpgrade(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_v7_upgraded(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "7.1"),
 				),
@@ -301,19 +300,19 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 	}
 
 	var v1, v2, v3, v4, v5, v6 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "4.0.10"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "4.0.10"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "4.0.10"),
 				),
@@ -321,7 +320,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v2),
 					testAccCheckReplicationGroupNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
@@ -330,7 +329,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v3),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v3),
 					testAccCheckReplicationGroupNotRecreated(&v2, &v3),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.2"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
@@ -345,7 +344,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "5.0.6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v4),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v4),
 					testAccCheckReplicationGroupRecreated(&v3, &v4),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "5.0.6"),
 					resource.TestCheckResourceAttr(resourceName, "engine_version_actual", "5.0.6"),
@@ -354,7 +353,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v5),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v5),
 					testAccCheckReplicationGroupNotRecreated(&v4, &v5),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
@@ -363,7 +362,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_update(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.0"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v6),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v6),
 					testAccCheckReplicationGroupRecreated(&v5, &v6),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.0\.[[:digit:]]+$`)),
@@ -380,19 +379,19 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion(t *testing
 	}
 
 	var v1, v2 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.x"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.x"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.[[:digit:]]+\.[[:digit:]]+$`)),
 				),
@@ -402,7 +401,7 @@ func TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion(t *testing
 				// If we create an `aws_elasticache_engine_versions` data source, we can use that to get the expected version
 				Config: testAccReplicationGroupConfig_engineVersion(rName, "6.2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v2),
 					testAccCheckReplicationGroupNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.2"),
 					resource.TestMatchResourceAttr(resourceName, "engine_version_actual", regexache.MustCompile(`^6\.2\.[[:digit:]]+$`)),
@@ -419,19 +418,19 @@ func TestAccElastiCacheReplicationGroup_Engine_RedisToValkey(t *testing.T) {
 	}
 
 	var v1, v2 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
@@ -443,7 +442,7 @@ func TestAccElastiCacheReplicationGroup_Engine_RedisToValkey(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_update_Valkey(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &v2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &v2),
 					testAccCheckReplicationGroupNotRecreated(&v1, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
@@ -460,19 +459,19 @@ func TestAccElastiCacheReplicationGroup_disappears(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceReplicationGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -493,19 +492,19 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test description"),
 				),
@@ -519,7 +518,7 @@ func TestAccElastiCacheReplicationGroup_updateDescription(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_updatedDescription(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "updated description"),
 				),
@@ -535,19 +534,19 @@ func TestAccElastiCacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "tue:06:30-tue:07:30"),
 				),
 			},
@@ -560,7 +559,7 @@ func TestAccElastiCacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_updatedMaintenanceWindow(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "maintenance_window", "wed:03:00-wed:06:00"),
 				),
 			},
@@ -575,22 +574,22 @@ func TestAccElastiCacheReplicationGroup_updateUserGroups(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	userGroup := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	userGroup := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_user(rName, userGroup, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					testAccCheckReplicationGroupUserGroup(ctx, resourceName, fmt.Sprintf("%s-%d", userGroup, 0)),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					testAccCheckReplicationGroupUserGroup(ctx, t, resourceName, fmt.Sprintf("%s-%d", userGroup, 0)),
 					resource.TestCheckTypeSetElemAttr(resourceName, "user_group_ids.*", fmt.Sprintf("%s-%d", userGroup, 0)),
 				),
 			},
@@ -603,8 +602,8 @@ func TestAccElastiCacheReplicationGroup_updateUserGroups(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_user(rName, userGroup, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					testAccCheckReplicationGroupUserGroup(ctx, resourceName, fmt.Sprintf("%s-%d", userGroup, 1)),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					testAccCheckReplicationGroupUserGroup(ctx, t, resourceName, fmt.Sprintf("%s-%d", userGroup, 1)),
 					resource.TestCheckTypeSetElemAttr(resourceName, "user_group_ids.*", fmt.Sprintf("%s-%d", userGroup, 1)),
 				),
 			},
@@ -619,19 +618,19 @@ func TestAccElastiCacheReplicationGroup_updateNodeSize(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
 				),
@@ -645,7 +644,7 @@ func TestAccElastiCacheReplicationGroup_updateNodeSize(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_updatedNodeSize(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "1"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.medium"),
 				),
@@ -665,18 +664,18 @@ func TestAccElastiCacheReplicationGroup_updateParameterGroup(t *testing.T) {
 	parameterGroupResourceName1 := "aws_elasticache_parameter_group.test.0"
 	parameterGroupResourceName2 := "aws_elasticache_parameter_group.test.1"
 	resourceName := "aws_elasticache_replication_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_parameterName(rName, 0),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, parameterGroupResourceName1, names.AttrName),
 				),
 			},
@@ -693,7 +692,7 @@ func TestAccElastiCacheReplicationGroup_updateParameterGroup(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_parameterName(rName, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrParameterGroupName, parameterGroupResourceName2, names.AttrName),
 				),
 			},
@@ -708,21 +707,21 @@ func TestAccElastiCacheReplicationGroup_authToken(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	token1 := sdkacctest.RandString(16)
 	token2 := sdkacctest.RandString(16)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_authTokenSetup(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 			},
 			{
@@ -736,7 +735,7 @@ func TestAccElastiCacheReplicationGroup_authToken(t *testing.T) {
 				// group, the SET strategy can be used.
 				Config: testAccReplicationGroupConfig_authToken(rName, token1, string(awstypes.AuthTokenUpdateStrategyTypeSet)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "auth_token", token1),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_update_strategy", string(awstypes.AuthTokenUpdateStrategyTypeSet)),
@@ -745,7 +744,7 @@ func TestAccElastiCacheReplicationGroup_authToken(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_authToken(rName, token2, string(awstypes.AuthTokenUpdateStrategyTypeRotate)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "auth_token", token2),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_update_strategy", string(awstypes.AuthTokenUpdateStrategyTypeRotate)),
@@ -758,7 +757,7 @@ func TestAccElastiCacheReplicationGroup_authToken(t *testing.T) {
 				// Ref: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html#auth-modifyng-token
 				Config: testAccReplicationGroupConfig_authToken(rName, token2, string(awstypes.AuthTokenUpdateStrategyTypeSet)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "auth_token", token2),
 					resource.TestCheckResourceAttr(resourceName, "auth_token_update_strategy", string(awstypes.AuthTokenUpdateStrategyTypeSet)),
@@ -775,13 +774,13 @@ func TestAccElastiCacheReplicationGroup_upgrade_6_0_0(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ElastiCacheServiceID),
-		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -792,14 +791,14 @@ func TestAccElastiCacheReplicationGroup_upgrade_6_0_0(t *testing.T) {
 				},
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -819,13 +818,13 @@ func TestAccElastiCacheReplicationGroup_upgrade_5_27_0(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ElastiCacheServiceID),
-		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -836,14 +835,14 @@ func TestAccElastiCacheReplicationGroup_upgrade_5_27_0(t *testing.T) {
 				},
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -863,13 +862,13 @@ func TestAccElastiCacheReplicationGroup_upgrade_4_68_0(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ElastiCacheServiceID),
-		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy: testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
@@ -880,14 +879,14 @@ func TestAccElastiCacheReplicationGroup_upgrade_4_68_0(t *testing.T) {
 				},
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 			},
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 				Config:                   testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -907,13 +906,13 @@ func TestAccElastiCacheReplicationGroup_vpc(t *testing.T) {
 
 	var rg awstypes.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_inVPC(rName),
@@ -929,7 +928,7 @@ func TestAccElastiCacheReplicationGroup_vpc(t *testing.T) {
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New("security_group_names"), knownvalue.SetSizeExact(0)),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 				),
 			},
 			{
@@ -953,19 +952,19 @@ func TestAccElastiCacheReplicationGroup_multiAzNotInVPC(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_multiAZNotInVPCPreferredCacheClusterAZsNotRepeated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
@@ -991,19 +990,19 @@ func TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_multiAZNotInVPCPreferredCacheClusterAZsRepeated(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
@@ -1031,19 +1030,19 @@ func TestAccElastiCacheReplicationGroup_multiAzInVPC(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_multiAZInVPC(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
@@ -1076,19 +1075,19 @@ func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_multiAZInVPC(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
@@ -1116,13 +1115,13 @@ func TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
 
 func TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_multiAZNoAutomaticFailover(rName),
@@ -1140,18 +1139,18 @@ func TestAccElastiCacheReplicationGroup_ipDiscovery(t *testing.T) {
 
 	var rg awstypes.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_ipDiscovery(rName, "ipv6"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "6379"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
@@ -1181,18 +1180,18 @@ func TestAccElastiCacheReplicationGroup_networkType(t *testing.T) {
 
 	var rg awstypes.ReplicationGroup
 	resourceName := "aws_elasticache_replication_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_networkType(rName, "ipv6", "dual_stack"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPort, "6379"),
 					resource.TestCheckResourceAttr(resourceName, "node_type", "cache.t3.small"),
@@ -1222,19 +1221,19 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_basic(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
@@ -1244,7 +1243,7 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
@@ -1264,19 +1263,19 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup(t
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisClusterNonClusteredParameter(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.redis6.x"),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
@@ -1308,20 +1307,20 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp(t
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
@@ -1329,13 +1328,13 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp(t
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 4, []kvp{
 						{names.AttrKey, names.AttrValue},
 					}),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 3, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
@@ -1344,7 +1343,7 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp(t
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 6, []kvp{
 						{names.AttrKey, names.AttrValue},
 					}),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 		},
@@ -1358,37 +1357,37 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 3, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "6"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "6"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 		},
@@ -1402,49 +1401,49 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup(t
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "3"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "8"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "8"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "6"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "6"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 		},
@@ -1458,37 +1457,37 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 3, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "9"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "9"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 		},
@@ -1502,37 +1501,37 @@ func TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplica
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 3, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "3"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "2"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "9"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "9"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisCluster(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
-					testCheckEngineStuffClusterEnabledDefault(ctx, resourceName),
+					testCheckEngineStuffClusterEnabledDefault(ctx, t, resourceName),
 				),
 			},
 		},
@@ -1546,19 +1545,19 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_singleNode(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_nativeRedisClusterSingleNode(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.redis6.x.cluster.on"),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
@@ -1590,19 +1589,19 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatibl
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled(rName, "disabled", false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode", "disabled"),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
@@ -1614,7 +1613,7 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatibl
 			{
 				Config: testAccReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled(rName, "compatible", true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode", "compatible"),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
@@ -1626,7 +1625,7 @@ func TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatibl
 			{
 				Config: testAccReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled(rName, names.AttrEnabled, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "cluster_mode", names.AttrEnabled),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "1"),
@@ -1645,13 +1644,13 @@ func TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNod
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_cacheClustersConflictsWithReplicasPerNodeGroup(rName),
@@ -1663,13 +1662,13 @@ func TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNod
 
 func TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_nativeRedisClusterError(rName),
@@ -1686,19 +1685,19 @@ func TestAccElastiCacheReplicationGroup_enableSnapshotting(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_basic_engine(rName, "redis"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "0"),
 				),
 			},
@@ -1711,7 +1710,7 @@ func TestAccElastiCacheReplicationGroup_enableSnapshotting(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_enableSnapshotting(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "snapshot_retention_limit", "2"),
 				),
 			},
@@ -1726,20 +1725,20 @@ func TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken(t *testin
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	authToken := sdkacctest.RandString(16)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_transitEncryptionWithAuthToken(rName, authToken),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "auth_token", authToken),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
@@ -1762,19 +1761,19 @@ func TestAccElastiCacheReplicationGroup_transitEncryption5x(t *testing.T) {
 	}
 
 	var rg1, rg2 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_transitEncryptionEnabled5x(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg1),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
 				),
@@ -1790,7 +1789,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption5x(t *testing.T) {
 				// during cluster creation. Modifying the argument should force a replacement.
 				Config: testAccReplicationGroupConfig_transitEncryptionDisabled5x(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg2),
 					testAccCheckReplicationGroupRecreated(&rg1, &rg2),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
@@ -1807,19 +1806,19 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_basic(t *testing.T) 
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_transitEncryption7x(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
 				),
@@ -1841,19 +1840,19 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable(t *testing.T)
 	}
 
 	var rg1, rg2, rg3 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_transitEncryptionDisabled7x(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg1),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
 				),
@@ -1868,7 +1867,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable(t *testing.T)
 				// Before enabling transit encryption, mode must be set to "preferred" first.
 				Config: testAccReplicationGroupConfig_transitEncryptionEnabled7x(rName, string(awstypes.TransitEncryptionModePreferred)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg2),
 					testAccCheckReplicationGroupNotRecreated(&rg1, &rg2),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModePreferred)),
@@ -1884,7 +1883,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable(t *testing.T)
 				// Before disabling transit encryption, mode must be transitioned back to "preferred" first.
 				Config: testAccReplicationGroupConfig_transitEncryptionEnabled7x(rName, string(awstypes.TransitEncryptionModeRequired)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg3),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg3),
 					testAccCheckReplicationGroupNotRecreated(&rg2, &rg3),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
@@ -1907,19 +1906,19 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable(t *testing.T
 	}
 
 	var rg1, rg2, rg3 awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_transitEncryptionEnabled7x(rName, string(awstypes.TransitEncryptionModeRequired)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg1),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModeRequired)),
 				),
@@ -1934,7 +1933,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable(t *testing.T
 				// With Redis engine versions >= 7.0.5, transit_encryption_mode can be modified in-place.
 				Config: testAccReplicationGroupConfig_transitEncryptionEnabled7x(rName, string(awstypes.TransitEncryptionModePreferred)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg2),
 					testAccCheckReplicationGroupNotRecreated(&rg1, &rg2),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", string(awstypes.TransitEncryptionModePreferred)),
@@ -1950,7 +1949,7 @@ func TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable(t *testing.T
 				// With Redis engine versions >= 7.0.5, transit_encryption_enabled can be modified in-place.
 				Config: testAccReplicationGroupConfig_transitEncryptionDisabled7x(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg3),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg3),
 					testAccCheckReplicationGroupNotRecreated(&rg2, &rg3),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "transit_encryption_mode", ""),
@@ -1973,19 +1972,19 @@ func TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption(t *testing.
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_Redis_enableAtRestEncryption(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtTrue),
 				),
 			},
@@ -2006,19 +2005,19 @@ func TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption(t *testin
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_Valkey_disableAtRestEncryption(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "at_rest_encryption_enabled", acctest.CtFalse),
 				),
 			},
@@ -2039,18 +2038,18 @@ func TestAccElastiCacheReplicationGroup_useCMKKMSKeyID(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_useCMKKMSKeyID(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrKMSKeyID),
 				),
 			},
@@ -2065,20 +2064,20 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
@@ -2097,7 +2096,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
@@ -2110,7 +2109,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic(t *testing.T) 
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
@@ -2131,22 +2130,22 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
 	autoFailoverEnabled := false
 	multiAZEnabled := false
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 3, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
@@ -2162,7 +2161,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
 			{
 				PreConfig: func() {
 					// Ensure that primary is on the node we are trying to delete
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					if err := resourceReplicationGroupSetPrimaryClusterID(ctx, conn, rName, formatReplicationGroupClusterID(rName, 3), timeout); err != nil {
@@ -2171,7 +2170,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
 				},
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 2, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
@@ -2189,22 +2188,22 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled(
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
 	autoFailoverEnabled := true
 	multiAZEnabled := false
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 3, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
@@ -2214,7 +2213,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled(
 			{
 				PreConfig: func() {
 					// Ensure that primary is on the node we are trying to delete
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					// Must disable automatic failover first
@@ -2234,7 +2233,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled(
 				},
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 2, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
@@ -2251,18 +2250,18 @@ func TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheC
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	const (
 		autoFailoverEnabled = true
 		multiAZDisabled     = false
 	)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_failoverMultiAZ(rName, 1, autoFailoverEnabled, multiAZDisabled),
@@ -2279,22 +2278,22 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled(t *te
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
 	autoFailoverEnabled := true
 	multiAZEnabled := true
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 3, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
@@ -2304,7 +2303,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled(t *te
 			{
 				PreConfig: func() {
 					// Ensure that primary is on the node we are trying to delete
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					// Must disable automatic failover first
@@ -2324,7 +2323,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled(t *te
 				},
 				Config: testAccReplicationGroupConfig_failoverMultiAZ(rName, 2, autoFailoverEnabled, multiAZEnabled),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", strconv.FormatBool(autoFailoverEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "multi_az_enabled", strconv.FormatBool(multiAZEnabled)),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
@@ -2342,19 +2341,19 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
@@ -2362,7 +2361,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 			{
 				PreConfig: func() {
 					// Remove one of the Cache Clusters
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					cacheClusterID := formatReplicationGroupClusterID(rName, 2)
@@ -2377,7 +2376,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				},
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
@@ -2393,19 +2392,19 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
@@ -2413,7 +2412,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 			{
 				PreConfig: func() {
 					// Remove one of the Cache Clusters
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					cacheClusterID := formatReplicationGroupClusterID(rName, 2)
@@ -2428,7 +2427,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				},
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 				),
@@ -2444,19 +2443,19 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "3"),
 				),
@@ -2464,7 +2463,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 			{
 				PreConfig: func() {
 					// Remove one of the Cache Clusters
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					cacheClusterID := formatReplicationGroupClusterID(rName, 2)
@@ -2479,7 +2478,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				},
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
@@ -2495,19 +2494,19 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 	}
 
 	var replicationGroup awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 4),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "4"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "4"),
 				),
@@ -2515,7 +2514,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 			{
 				PreConfig: func() {
 					// Remove one of the Cache Clusters
-					conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+					conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 					timeout := 40 * time.Minute
 
 					cacheClusterID := formatReplicationGroupClusterID(rName, 2)
@@ -2530,7 +2529,7 @@ func TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappea
 				},
 				Config: testAccReplicationGroupConfig_numberCacheClusters(rName, 2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &replicationGroup),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &replicationGroup),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					resource.TestCheckResourceAttr(resourceName, "member_clusters.#", "2"),
 				),
@@ -2546,20 +2545,20 @@ func TestAccElastiCacheReplicationGroup_tags(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey1, acctest.CtValue1},
 					}),
@@ -2574,7 +2573,7 @@ func TestAccElastiCacheReplicationGroup_tags(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey1, acctest.CtValue1Updated},
 						{acctest.CtKey2, acctest.CtValue2},
@@ -2584,7 +2583,7 @@ func TestAccElastiCacheReplicationGroup_tags(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey2, acctest.CtValue2},
 					}),
@@ -2601,20 +2600,20 @@ func TestAccElastiCacheReplicationGroup_TagWithOtherModification_version(t *test
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_tagAndVersion(rName, "6.0", acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.0"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey1, acctest.CtValue1},
@@ -2624,7 +2623,7 @@ func TestAccElastiCacheReplicationGroup_TagWithOtherModification_version(t *test
 			{
 				Config: testAccReplicationGroupConfig_tagAndVersion(rName, "6.2", acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, "6.2"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey1, acctest.CtValue1Updated},
@@ -2642,20 +2641,20 @@ func TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheCluster
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	clusterDataSourcePrefix := "data.aws_elasticache_cluster.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_tagAndNumCacheClusters(rName, 2, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "2"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 2, []kvp{
 						{acctest.CtKey1, acctest.CtValue1},
@@ -2665,7 +2664,7 @@ func TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheCluster
 			{
 				Config: testAccReplicationGroupConfig_tagAndNumCacheClusters(rName, 3, acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", "3"),
 					testAccReplicationGroupCheckMemberClusterTags(resourceName, clusterDataSourcePrefix, 3, []kvp{
 						{acctest.CtKey1, acctest.CtValue1Updated},
@@ -2683,19 +2682,19 @@ func TestAccElastiCacheReplicationGroup_finalSnapshot(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_finalSnapshot(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrFinalSnapshotIdentifier, rName),
 				),
 			},
@@ -2710,19 +2709,19 @@ func TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade(t *testing.T) {
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckClusterDestroy(ctx),
+		CheckDestroy:             testAccCheckClusterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_autoMinorVersionUpgrade(rName, false),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtFalse),
 				),
 			},
@@ -2735,7 +2734,7 @@ func TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade(t *testing.T) {
 			{
 				Config: testAccReplicationGroupConfig_autoMinorVersionUpgrade(rName, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrAutoMinorVersionUpgrade, acctest.CtTrue),
 				),
 			},
@@ -2745,16 +2744,16 @@ func TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade(t *testing.T) {
 
 func TestAccElastiCacheReplicationGroup_Validation_noNodeType(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_validationNoNodeType(rName),
@@ -2770,16 +2769,16 @@ func TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNo
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_validationGlobalIdAndNodeType(rName),
@@ -2797,11 +2796,11 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic(t *testin
 
 	var rg awstypes.ReplicationGroup
 	var pg awstypes.CacheParameterGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	primaryGroupResourceName := "aws_elasticache_replication_group.primary"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
@@ -2809,15 +2808,15 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic(t *testin
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckReplicationGroupDestroy(ctx),
-			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, &pg),
+			testAccCheckReplicationGroupDestroy(ctx, t),
+			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, t, &pg),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_globalIDBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					testAccCheckReplicationGroupParameterGroupExists(ctx, &rg, &pg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					testAccCheckReplicationGroupParameterGroupExists(ctx, t, &rg, &pg),
 					resource.TestCheckResourceAttrPair(resourceName, "global_replication_group_id", "aws_elasticache_global_replication_group.test", "global_replication_group_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "node_type", primaryGroupResourceName, "node_type"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngine, primaryGroupResourceName, names.AttrEngine),
@@ -2846,14 +2845,14 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 
 	var rg1, rg2 awstypes.ReplicationGroup
 	var pg1, pg2 awstypes.CacheParameterGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	primaryGroupResourceName := "aws_elasticache_replication_group.primary"
 
 	initialNumCacheClusters := 2
 	updatedNumCacheClusters := 3
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
@@ -2861,16 +2860,16 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckReplicationGroupDestroy(ctx),
-			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, &pg1),
-			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, &pg2),
+			testAccCheckReplicationGroupDestroy(ctx, t),
+			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, t, &pg1),
+			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, t, &pg2),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_globalIDFull(rName, initialNumCacheClusters),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
-					testAccCheckReplicationGroupParameterGroupExists(ctx, &rg1, &pg1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg1),
+					testAccCheckReplicationGroupParameterGroupExists(ctx, t, &rg1, &pg1),
 					resource.TestCheckResourceAttrPair(resourceName, "global_replication_group_id", "aws_elasticache_global_replication_group.test", "global_replication_group_id"),
 					resource.TestCheckResourceAttrPair(resourceName, "node_type", primaryGroupResourceName, "node_type"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrEngine, primaryGroupResourceName, names.AttrEngine),
@@ -2897,8 +2896,8 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full(t *testing
 			{
 				Config: testAccReplicationGroupConfig_globalIDFull(rName, updatedNumCacheClusters),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
-					testAccCheckReplicationGroupParameterGroupExists(ctx, &rg2, &pg2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg2),
+					testAccCheckReplicationGroupParameterGroupExists(ctx, t, &rg2, &pg2),
 					resource.TestCheckResourceAttr(resourceName, "num_cache_clusters", strconv.Itoa(updatedNumCacheClusters)),
 				),
 			},
@@ -2915,22 +2914,22 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears(t *t
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_globalIDBasic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceReplicationGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -2947,11 +2946,11 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 
 	var rg1, rg2 awstypes.ReplicationGroup
 	var pg1, pg2 awstypes.CacheParameterGroup
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 	primaryGroupResourceName := "aws_elasticache_replication_group.primary"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
@@ -2959,16 +2958,16 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckReplicationGroupDestroy(ctx),
-			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, &pg1),
-			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, &pg2),
+			testAccCheckReplicationGroupDestroy(ctx, t),
+			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, t, &pg1),
+			testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx, t, &pg2),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_globalIDClusterMode(rName, 2, 1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg1),
-					testAccCheckReplicationGroupParameterGroupExists(ctx, &rg1, &pg1),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg1),
+					testAccCheckReplicationGroupParameterGroupExists(ctx, t, &rg1, &pg1),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "1"),
 					resource.TestCheckResourceAttr(resourceName, "automatic_failover_enabled", acctest.CtTrue),
@@ -2988,8 +2987,8 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basi
 			{
 				Config: testAccReplicationGroupConfig_globalIDClusterMode(rName, 1, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg2),
-					testAccCheckReplicationGroupParameterGroupExists(ctx, &rg2, &pg2),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg2),
+					testAccCheckReplicationGroupParameterGroupExists(ctx, t, &rg2, &pg2),
 					resource.TestCheckResourceAttr(resourceName, "num_node_groups", "2"),
 					resource.TestCheckResourceAttr(resourceName, "replicas_per_node_group", "3"),
 
@@ -3007,16 +3006,16 @@ func TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValid
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckMultipleRegion(t, 2)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5FactoriesMultipleRegions(ctx, t, 2),
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccReplicationGroupConfig_globalIDClusterModeNumNodeOnSecondary(rName),
@@ -3036,20 +3035,20 @@ func TestAccElastiCacheReplicationGroup_dataTiering(t *testing.T) {
 		rg      awstypes.ReplicationGroup
 		version awstypes.CacheEngineVersion
 	)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_dataTiering(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
-					testCheckEngineVersionLatest(ctx, "redis", &version),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
+					testCheckEngineVersionLatest(ctx, t, "redis", &version),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					func(s *terraform.State) error {
 						return resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, *version.EngineVersion)(s)
@@ -3074,19 +3073,19 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, false, true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText), true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
@@ -3112,7 +3111,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, false, true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText), true, string(awstypes.DestinationTypeKinesisFirehose), string(awstypes.LogFormatJson)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
@@ -3128,7 +3127,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, false, true, string(awstypes.DestinationTypeKinesisFirehose), string(awstypes.LogFormatJson), false, "", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination", rName),
 					resource.TestCheckResourceAttr(resourceName, "log_delivery_configuration.0.destination_type", "kinesis-firehose"),
@@ -3143,7 +3142,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, false, false, "", "", false, "", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtFalse),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination"),
@@ -3177,19 +3176,19 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 	}
 
 	var rg awstypes.ReplicationGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc-test")
+	rName := acctest.RandomWithPrefix(t, "tf-acc-test")
 	resourceName := "aws_elasticache_replication_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckReplicationGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText), true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.redis6.x.cluster.on"),
@@ -3216,7 +3215,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, true, string(awstypes.DestinationTypeCloudWatchLogs), string(awstypes.LogFormatText), true, string(awstypes.DestinationTypeKinesisFirehose), string(awstypes.LogFormatJson)),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.redis6.x.cluster.on"),
@@ -3233,7 +3232,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, true, string(awstypes.DestinationTypeKinesisFirehose), string(awstypes.LogFormatJson), false, "", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, names.AttrParameterGroupName, "default.redis6.x.cluster.on"),
@@ -3250,7 +3249,7 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 			{
 				Config: testAccReplicationGroupConfig_dataSourceEngineRedisLogDeliveryConfigurations(rName, true, false, "", "", false, "", ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckReplicationGroupExists(ctx, resourceName, &rg),
+					testAccCheckReplicationGroupExists(ctx, t, resourceName, &rg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_enabled", acctest.CtTrue),
 					resource.TestCheckNoResourceAttr(resourceName, "log_delivery_configuration.0.destination"),
@@ -3277,14 +3276,14 @@ func TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_C
 	})
 }
 
-func testAccCheckReplicationGroupExists(ctx context.Context, n string, v *awstypes.ReplicationGroup) resource.TestCheckFunc {
+func testAccCheckReplicationGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.ReplicationGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindReplicationGroupByID(ctx, conn, rs.Primary.ID)
 
@@ -3298,9 +3297,9 @@ func testAccCheckReplicationGroupExists(ctx context.Context, n string, v *awstyp
 	}
 }
 
-func testAccCheckReplicationGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckReplicationGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_replication_group" {
@@ -3309,7 +3308,7 @@ func testAccCheckReplicationGroupDestroy(ctx context.Context) resource.TestCheck
 
 			_, err := tfelasticache.FindReplicationGroupByID(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -3323,9 +3322,9 @@ func testAccCheckReplicationGroupDestroy(ctx context.Context) resource.TestCheck
 	}
 }
 
-func testAccCheckReplicationGroupParameterGroupExists(ctx context.Context, rg *awstypes.ReplicationGroup, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
+func testAccCheckReplicationGroupParameterGroupExists(ctx context.Context, t *testing.T, rg *awstypes.ReplicationGroup, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		cacheClusterID := aws.ToString(rg.NodeGroups[0].NodeGroupMembers[0].CacheClusterId)
 		cluster, err := tfelasticache.FindCacheClusterByID(ctx, conn, cacheClusterID)
@@ -3347,14 +3346,14 @@ func testAccCheckReplicationGroupParameterGroupExists(ctx context.Context, rg *a
 	}
 }
 
-func testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx context.Context, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
+func testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx context.Context, t *testing.T, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		name := aws.ToString(v.CacheParameterGroupName)
 		_, err := tfelasticache.FindCacheParameterGroupByName(ctx, conn, name)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil
 		}
 
@@ -3366,14 +3365,14 @@ func testAccCheckGlobalReplicationGroupMemberParameterGroupDestroy(ctx context.C
 	}
 }
 
-func testAccCheckReplicationGroupUserGroup(ctx context.Context, n, userGroupID string) resource.TestCheckFunc {
+func testAccCheckReplicationGroupUserGroup(ctx context.Context, t *testing.T, n, userGroupID string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		id := rs.Primary.ID
 		output, err := tfelasticache.FindReplicationGroupByID(ctx, conn, id)
@@ -3414,15 +3413,15 @@ func testAccCheckReplicationGroupNotRecreated(i, j *awstypes.ReplicationGroup) r
 	}
 }
 
-func testCheckEngineStuffRedisDefault(ctx context.Context, resourceName string) resource.TestCheckFunc {
+func testCheckEngineStuffRedisDefault(ctx context.Context, t *testing.T, resourceName string) resource.TestCheckFunc {
 	var (
 		version        awstypes.CacheEngineVersion
 		parameterGroup awstypes.CacheParameterGroup
 	)
 
 	checks := []resource.TestCheckFunc{
-		testCheckEngineVersionLatest(ctx, "redis", &version),
-		testCheckParameterGroupDefault(ctx, &version, &parameterGroup),
+		testCheckEngineVersionLatest(ctx, t, "redis", &version),
+		testCheckParameterGroupDefault(ctx, t, &version, &parameterGroup),
 		func(s *terraform.State) error {
 			return resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, *version.EngineVersion)(s)
 		},
@@ -3437,15 +3436,15 @@ func testCheckEngineStuffRedisDefault(ctx context.Context, resourceName string) 
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func testCheckEngineStuffValkeyDefault(ctx context.Context, resourceName string) resource.TestCheckFunc {
+func testCheckEngineStuffValkeyDefault(ctx context.Context, t *testing.T, resourceName string) resource.TestCheckFunc {
 	var (
 		version        awstypes.CacheEngineVersion
 		parameterGroup awstypes.CacheParameterGroup
 	)
 
 	checks := []resource.TestCheckFunc{
-		testCheckEngineVersionLatest(ctx, "valkey", &version),
-		testCheckParameterGroupDefault(ctx, &version, &parameterGroup),
+		testCheckEngineVersionLatest(ctx, t, "valkey", &version),
+		testCheckParameterGroupDefault(ctx, t, &version, &parameterGroup),
 		func(s *terraform.State) error {
 			return resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, *version.EngineVersion)(s)
 		},
@@ -3460,9 +3459,9 @@ func testCheckEngineStuffValkeyDefault(ctx context.Context, resourceName string)
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func testCheckEngineVersionLatest(ctx context.Context, engine string, v *awstypes.CacheEngineVersion) resource.TestCheckFunc {
+func testCheckEngineVersionLatest(ctx context.Context, t *testing.T, engine string, v *awstypes.CacheEngineVersion) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		versions, err := conn.DescribeCacheEngineVersions(ctx, &elasticache.DescribeCacheEngineVersionsInput{
 			Engine:      aws.String(engine),
@@ -3484,9 +3483,9 @@ func testCheckEngineVersionLatest(ctx context.Context, engine string, v *awstype
 	}
 }
 
-func testCheckParameterGroupDefault(ctx context.Context, version *awstypes.CacheEngineVersion, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
+func testCheckParameterGroupDefault(ctx context.Context, t *testing.T, version *awstypes.CacheEngineVersion, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindCacheParameterGroup(ctx, conn, &elasticache.DescribeCacheParameterGroupsInput{}, tfslices.PredicateAnd(
 			func(v *awstypes.CacheParameterGroup) bool {
@@ -3508,15 +3507,15 @@ func testCheckParameterGroupDefault(ctx context.Context, version *awstypes.Cache
 	}
 }
 
-func testCheckEngineStuffClusterEnabledDefault(ctx context.Context, resourceName string) resource.TestCheckFunc {
+func testCheckEngineStuffClusterEnabledDefault(ctx context.Context, t *testing.T, resourceName string) resource.TestCheckFunc {
 	var (
 		version        awstypes.CacheEngineVersion
 		parameterGroup awstypes.CacheParameterGroup
 	)
 
 	checks := []resource.TestCheckFunc{
-		testCheckEngineVersionLatest(ctx, "redis", &version),
-		testCheckRedisParameterGroupClusterEnabledDefault(ctx, &version, &parameterGroup),
+		testCheckEngineVersionLatest(ctx, t, "redis", &version),
+		testCheckRedisParameterGroupClusterEnabledDefault(ctx, t, &version, &parameterGroup),
 		func(s *terraform.State) error {
 			return resource.TestCheckResourceAttr(resourceName, names.AttrEngineVersion, *version.EngineVersion)(s)
 		},
@@ -3531,9 +3530,9 @@ func testCheckEngineStuffClusterEnabledDefault(ctx context.Context, resourceName
 	return resource.ComposeAggregateTestCheckFunc(checks...)
 }
 
-func testCheckRedisParameterGroupClusterEnabledDefault(ctx context.Context, version *awstypes.CacheEngineVersion, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
+func testCheckRedisParameterGroupClusterEnabledDefault(ctx context.Context, t *testing.T, version *awstypes.CacheEngineVersion, v *awstypes.CacheParameterGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindCacheParameterGroup(ctx, conn, &elasticache.DescribeCacheParameterGroupsInput{}, tfslices.PredicateAnd(
 			func(v *awstypes.CacheParameterGroup) bool {

--- a/internal/service/elasticache/reserved_cache_node_offering_data_source_test.go
+++ b/internal/service/elasticache/reserved_cache_node_offering_data_source_test.go
@@ -15,7 +15,7 @@ func TestAccElastiCacheReservedNodeOffering_Redis_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_elasticache_reserved_cache_node_offering.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -40,7 +40,7 @@ func TestAccElastiCacheReservedNodeOffering_Valkey_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_elasticache_reserved_cache_node_offering.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,

--- a/internal/service/elasticache/reserved_cache_node_test.go
+++ b/internal/service/elasticache/reserved_cache_node_test.go
@@ -11,14 +11,12 @@ import (
 
 	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -33,7 +31,7 @@ func TestAccElastiCacheReservedCacheNode_Redis_basic(t *testing.T) {
 	resourceName := "aws_elasticache_reserved_cache_node.test"
 	dataSourceName := "data.aws_elasticache_reserved_cache_node_offering.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -42,7 +40,7 @@ func TestAccElastiCacheReservedCacheNode_Redis_basic(t *testing.T) {
 			{
 				Config: testAccReservedInstanceConfig_Redis_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccReservedInstanceExists(ctx, resourceName, &reservation),
+					testAccReservedInstanceExists(ctx, t, resourceName, &reservation),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "elasticache", regexache.MustCompile(`reserved-instance:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_count", "1"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cache_node_type", resourceName, "cache_node_type"),
@@ -76,7 +74,7 @@ func TestAccElastiCacheReservedCacheNode_Valkey_basic(t *testing.T) {
 	resourceName := "aws_elasticache_reserved_cache_node.test"
 	dataSourceName := "data.aws_elasticache_reserved_cache_node_offering.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -85,7 +83,7 @@ func TestAccElastiCacheReservedCacheNode_Valkey_basic(t *testing.T) {
 			{
 				Config: testAccReservedInstanceConfig_Valkey_basic(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccReservedInstanceExists(ctx, resourceName, &reservation),
+					testAccReservedInstanceExists(ctx, t, resourceName, &reservation),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "elasticache", regexache.MustCompile(`reserved-instance:.+`)),
 					resource.TestCheckResourceAttr(resourceName, "cache_node_count", "1"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "cache_node_type", resourceName, "cache_node_type"),
@@ -116,10 +114,10 @@ func TestAccElastiCacheReservedCacheNode_ID(t *testing.T) {
 	}
 
 	var reservation awstypes.ReservedCacheNode
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_reserved_cache_node.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy:             nil,
@@ -128,7 +126,7 @@ func TestAccElastiCacheReservedCacheNode_ID(t *testing.T) {
 			{
 				Config: testAccReservedInstanceConfig_ID(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccReservedInstanceExists(ctx, resourceName, &reservation),
+					testAccReservedInstanceExists(ctx, t, resourceName, &reservation),
 					resource.TestCheckResourceAttr(resourceName, names.AttrID, rName),
 					resource.TestCheckResourceAttrSet(resourceName, "usage_price"),
 				),
@@ -137,9 +135,9 @@ func TestAccElastiCacheReservedCacheNode_ID(t *testing.T) {
 	})
 }
 
-func testAccReservedInstanceExists(ctx context.Context, n string, reservation *awstypes.ReservedCacheNode) resource.TestCheckFunc {
+func testAccReservedInstanceExists(ctx context.Context, t *testing.T, n string, reservation *awstypes.ReservedCacheNode) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -25,12 +25,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -302,7 +302,7 @@ func (r *serverlessCacheResource) Read(ctx context.Context, request resource.Rea
 
 	output, err := findServerlessCacheByID(ctx, conn, data.ID.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 		return
@@ -443,8 +443,7 @@ func findServerlessCaches(ctx context.Context, conn *elasticache.Client, input *
 
 		if errs.IsA[*awstypes.ServerlessCacheNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -466,11 +465,11 @@ func findServerlessCacheByID(ctx context.Context, conn *elasticache.Client, id s
 	return findServerlessCache(ctx, conn, input)
 }
 
-func statusServerlessCache(ctx context.Context, conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusServerlessCache(conn *elasticache.Client, cacheClusterID string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findServerlessCacheByID(ctx, conn, cacheClusterID)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 		if err != nil {
@@ -496,7 +495,7 @@ func waitServerlessCacheAvailable(ctx context.Context, conn *elasticache.Client,
 			serverlessCacheStatusModifying,
 		},
 		Target:     []string{serverlessCacheStatusAvailable},
-		Refresh:    statusServerlessCache(ctx, conn, cacheClusterID),
+		Refresh:    statusServerlessCache(conn, cacheClusterID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -519,7 +518,7 @@ func waitServerlessCacheDeleted(ctx context.Context, conn *elasticache.Client, c
 			serverlessCacheStatusModifying,
 		},
 		Target:     []string{},
-		Refresh:    statusServerlessCache(ctx, conn, cacheClusterID),
+		Refresh:    statusServerlessCache(conn, cacheClusterID),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/serverless_cache_data_source_test.go
+++ b/internal/service/elasticache/serverless_cache_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -19,11 +18,11 @@ func TestAccElastiCacheServerlessCacheDataSource_Redis_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	dataSourceName := "data.aws_elasticache_serverless_cache.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)
@@ -65,11 +64,11 @@ func TestAccElastiCacheServerlessCacheDataSource_Valkey_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	dataSourceName := "data.aws_elasticache_serverless_cache.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckPartitionHasService(t, names.ElastiCacheEndpointID)

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -9,14 +9,12 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -26,22 +24,22 @@ func TestAccElastiCacheServerlessCache_basicRedis(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_basicRedis(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -71,22 +69,22 @@ func TestAccElastiCacheServerlessCache_basicValkey(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_basicValkey(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -115,22 +113,22 @@ func TestAccElastiCacheServerlessCache_full(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_full(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttr(resourceName, "cache_usage_limits.0.data_storage.0.maximum", "10"),
@@ -163,22 +161,22 @@ func TestAccElastiCacheServerlessCache_fullRedis(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_fullRedis(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -206,22 +204,22 @@ func TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_redisUpdateWithUserGroup(rName, "test description"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test description"),
@@ -230,7 +228,7 @@ func TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_redisUpdateWithUserGroup(rName, "test description updated"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "test description updated"),
@@ -246,22 +244,22 @@ func TestAccElastiCacheServerlessCache_fullValkey(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_fullValkey(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -289,24 +287,24 @@ func TestAccElastiCacheServerlessCache_description(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	descriptionOld := "Memcached Serverless Cluster"
 	descriptionNew := "Memcached Serverless Cluster updated"
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_description(rName, descriptionOld),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -328,7 +326,7 @@ func TestAccElastiCacheServerlessCache_description(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_description(rName, descriptionNew),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -357,24 +355,24 @@ func TestAccElastiCacheServerlessCache_cacheUsageLimits(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	descriptionOld := "Memcached Serverless Cluster"
 	descriptionNew := "Memcached Serverless Cluster updated"
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var v awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionOld, 1, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -401,7 +399,7 @@ func TestAccElastiCacheServerlessCache_cacheUsageLimits(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionOld, 2, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -423,7 +421,7 @@ func TestAccElastiCacheServerlessCache_cacheUsageLimits(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionNew, 2, 1000),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -445,7 +443,7 @@ func TestAccElastiCacheServerlessCache_cacheUsageLimits(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_cacheUsageLimits(rName, descriptionNew, 2, 1010),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "serverlesscache:{name}"),
 					resource.TestCheckResourceAttrSet(resourceName, "cache_usage_limits.#"),
 					resource.TestCheckResourceAttrSet(resourceName, names.AttrCreateTime),
@@ -474,22 +472,22 @@ func TestAccElastiCacheServerlessCache_engine(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var v awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_engine(rName, tfelasticache.EngineRedis),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, tfelasticache.EngineRedis),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -501,7 +499,7 @@ func TestAccElastiCacheServerlessCache_engine(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_engine(rName, tfelasticache.EngineValkey),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, tfelasticache.EngineValkey),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -513,7 +511,7 @@ func TestAccElastiCacheServerlessCache_engine(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_engine(rName, tfelasticache.EngineRedis),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &v),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, tfelasticache.EngineRedis),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
@@ -532,21 +530,21 @@ func TestAccElastiCacheServerlessCache_disappears(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckServerlessCacheDestroy(ctx),
+		CheckDestroy:             testAccCheckServerlessCacheDestroy(ctx, t),
 
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceServerlessCache, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -566,7 +564,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_serverless_cache.test"
 	var serverlessElasticCache awstypes.ServerlessCache
 
@@ -586,18 +584,18 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
     key2 = "value2"
   }
 `
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
-			testAccCheckServerlessCacheDestroy(ctx),
+			testAccCheckServerlessCacheDestroy(ctx, t),
 		),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServerlessCacheConfig_tags(rName, tags1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -605,7 +603,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_tags(rName, tags2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -614,7 +612,7 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 			{
 				Config: testAccServerlessCacheConfig_tags(rName, tags3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerlessCacheExists(ctx, resourceName, &serverlessElasticCache),
+					testAccCheckServerlessCacheExists(ctx, t, resourceName, &serverlessElasticCache),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
@@ -623,14 +621,14 @@ func TestAccElastiCacheServerlessCache_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckServerlessCacheExists(ctx context.Context, n string, v *awstypes.ServerlessCache) resource.TestCheckFunc {
+func testAccCheckServerlessCacheExists(ctx context.Context, t *testing.T, n string, v *awstypes.ServerlessCache) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindServerlessCacheByID(ctx, conn, rs.Primary.ID)
 
@@ -644,9 +642,9 @@ func testAccCheckServerlessCacheExists(ctx context.Context, n string, v *awstype
 	}
 }
 
-func testAccCheckServerlessCacheDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckServerlessCacheDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_serverless_cache" {
@@ -654,7 +652,7 @@ func testAccCheckServerlessCacheDestroy(ctx context.Context) resource.TestCheckF
 			}
 
 			_, err := tfelasticache.FindServerlessCacheByID(ctx, conn, rs.Primary.ID)
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 			if err != nil {

--- a/internal/service/elasticache/subnet_group.go
+++ b/internal/service/elasticache/subnet_group.go
@@ -13,12 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -131,7 +131,7 @@ func resourceSubnetGroupRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	group, err := findCacheSubnetGroupByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache Subnet Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -235,8 +235,7 @@ func findCacheSubnetGroups(ctx context.Context, conn *elasticache.Client, input 
 
 		if errs.IsA[*awstypes.CacheSubnetGroupNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 

--- a/internal/service/elasticache/subnet_group_data_source_test.go
+++ b/internal/service/elasticache/subnet_group_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -20,11 +19,11 @@ func testAccPreCheck(t *testing.T) {
 
 func TestAccElastiCacheSubnetGroupDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_subnet_group.test"
 	dataSourceName := "data.aws_elasticache_subnet_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheck(t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/elasticache/subnet_group_test.go
+++ b/internal/service/elasticache/subnet_group_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -23,18 +21,18 @@ func TestAccElastiCacheSubnetGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var csg awstypes.CacheSubnetGroup
 	resourceName := "aws_elasticache_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetGroupConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					acctest.CheckResourceAttrRegionalARNFormat(ctx, resourceName, names.AttrARN, "elasticache", "subnetgroup:{name}"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Managed by Terraform"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, resourceName, names.AttrName),
@@ -57,18 +55,18 @@ func TestAccElastiCacheSubnetGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var csg awstypes.CacheSubnetGroup
 	resourceName := "aws_elasticache_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceSubnetGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -81,18 +79,18 @@ func TestAccElastiCacheSubnetGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var csg awstypes.CacheSubnetGroup
 	resourceName := "aws_elasticache_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetGroupConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -105,7 +103,7 @@ func TestAccElastiCacheSubnetGroup_tags(t *testing.T) {
 			{
 				Config: testAccSubnetGroupConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -114,7 +112,7 @@ func TestAccElastiCacheSubnetGroup_tags(t *testing.T) {
 			{
 				Config: testAccSubnetGroupConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
@@ -127,18 +125,18 @@ func TestAccElastiCacheSubnetGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var csg awstypes.CacheSubnetGroup
 	resourceName := "aws_elasticache_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckSubnetGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubnetGroupConfig_updatePre(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Description1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "1"),
@@ -153,7 +151,7 @@ func TestAccElastiCacheSubnetGroup_update(t *testing.T) {
 			{
 				Config: testAccSubnetGroupConfig_updatePost(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubnetGroupExists(ctx, resourceName, &csg),
+					testAccCheckSubnetGroupExists(ctx, t, resourceName, &csg),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, "Description2"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "subnet_ids.#", "2"),
@@ -164,9 +162,9 @@ func TestAccElastiCacheSubnetGroup_update(t *testing.T) {
 	})
 }
 
-func testAccCheckSubnetGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckSubnetGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_subnet_group" {
@@ -175,7 +173,7 @@ func testAccCheckSubnetGroupDestroy(ctx context.Context) resource.TestCheckFunc 
 
 			_, err := tfelasticache.FindCacheSubnetGroupByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -190,7 +188,7 @@ func testAccCheckSubnetGroupDestroy(ctx context.Context) resource.TestCheckFunc 
 	}
 }
 
-func testAccCheckSubnetGroupExists(ctx context.Context, n string, v *awstypes.CacheSubnetGroup) resource.TestCheckFunc {
+func testAccCheckSubnetGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.CacheSubnetGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -201,7 +199,7 @@ func testAccCheckSubnetGroupExists(ctx context.Context, n string, v *awstypes.Ca
 			return fmt.Errorf("No ElastiCache Subnet Group ID is set")
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindCacheSubnetGroupByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/elasticache/user.go
+++ b/internal/service/elasticache/user.go
@@ -12,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -20,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -192,7 +192,7 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 	// https://github.com/hashicorp/terraform-provider-aws/issues/34002.
 	user, err := waitUserUpdated(ctx, conn, d.Id(), d.Timeout(schema.TimeoutRead))
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache User (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -321,8 +321,7 @@ func findUsers(ctx context.Context, conn *elasticache.Client, input *elasticache
 
 		if errs.IsA[*awstypes.UserNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -340,11 +339,11 @@ func findUsers(ctx context.Context, conn *elasticache.Client, input *elasticache
 	return output, nil
 }
 
-func statusUser(ctx context.Context, conn *elasticache.Client, id string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusUser(conn *elasticache.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findUserByID(ctx, conn, id)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -367,7 +366,7 @@ func waitUserCreated(ctx context.Context, conn *elasticache.Client, id string, t
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusCreating},
 		Target:  []string{userStatusActive},
-		Refresh: statusUser(ctx, conn, id),
+		Refresh: statusUser(conn, id),
 		Timeout: timeout,
 	}
 
@@ -384,7 +383,7 @@ func waitUserUpdated(ctx context.Context, conn *elasticache.Client, id string, t
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusModifying},
 		Target:  []string{userStatusActive},
-		Refresh: statusUser(ctx, conn, id),
+		Refresh: statusUser(conn, id),
 		Timeout: timeout,
 	}
 
@@ -401,7 +400,7 @@ func waitUserDeleted(ctx context.Context, conn *elasticache.Client, id string, t
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{userStatusDeleting},
 		Target:  []string{},
-		Refresh: statusUser(ctx, conn, id),
+		Refresh: statusUser(conn, id),
 		Timeout: timeout,
 	}
 

--- a/internal/service/elasticache/user_data_source_test.go
+++ b/internal/service/elasticache/user_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -17,9 +16,9 @@ func TestAccElastiCacheUserDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_elasticache_user.test-basic"
 	dataSourceName := "data.aws_elasticache_user.test-basic"
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),

--- a/internal/service/elasticache/user_group.go
+++ b/internal/service/elasticache/user_group.go
@@ -12,13 +12,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
@@ -128,7 +128,7 @@ func resourceUserGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 
 	userGroup, err := findUserGroupByID(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache User Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -237,8 +237,7 @@ func findUserGroups(ctx context.Context, conn *elasticache.Client, input *elasti
 
 		if errs.IsA[*awstypes.UserGroupNotFoundFault](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 
@@ -256,11 +255,11 @@ func findUserGroups(ctx context.Context, conn *elasticache.Client, input *elasti
 	return output, nil
 }
 
-func statusUserGroup(ctx context.Context, conn *elasticache.Client, id string) retry.StateRefreshFunc {
-	return func() (any, string, error) {
+func statusUserGroup(conn *elasticache.Client, id string) retry.StateRefreshFunc {
+	return func(ctx context.Context) (any, string, error) {
 		output, err := findUserGroupByID(ctx, conn, id)
 
-		if tfresource.NotFound(err) {
+		if retry.NotFound(err) {
 			return nil, "", nil
 		}
 
@@ -283,7 +282,7 @@ func waitUserGroupCreated(ctx context.Context, conn *elasticache.Client, id stri
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{userGroupStatusCreating, userGroupStatusModifying},
 		Target:     []string{userGroupStatusActive},
-		Refresh:    statusUserGroup(ctx, conn, id),
+		Refresh:    statusUserGroup(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -302,7 +301,7 @@ func waitUserGroupUpdated(ctx context.Context, conn *elasticache.Client, id stri
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{userGroupStatusModifying},
 		Target:     []string{userGroupStatusActive},
-		Refresh:    statusUserGroup(ctx, conn, id),
+		Refresh:    statusUserGroup(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,
@@ -321,7 +320,7 @@ func waitUserGroupDeleted(ctx context.Context, conn *elasticache.Client, id stri
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{userGroupStatusDeleting},
 		Target:     []string{},
-		Refresh:    statusUserGroup(ctx, conn, id),
+		Refresh:    statusUserGroup(conn, id),
 		Timeout:    timeout,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second,

--- a/internal/service/elasticache/user_group_association.go
+++ b/internal/service/elasticache/user_group_association.go
@@ -13,12 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -99,7 +99,7 @@ func resourceUserGroupAssociationRead(ctx context.Context, d *schema.ResourceDat
 
 	err = findUserGroupAssociationByTwoPartKey(ctx, conn, userGroupID, userID)
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] ElastiCache User Group Association (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/elasticache/user_group_association_test.go
+++ b/internal/service/elasticache/user_group_association_test.go
@@ -8,13 +8,11 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -24,19 +22,19 @@ func TestAccElastiCacheUserGroupAssociation_basic(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_user_group_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupAssociationExists(ctx, resourceName),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 				),
@@ -56,19 +54,19 @@ func TestAccElastiCacheUserGroupAssociation_update(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_user_group_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupAssociationConfig_preUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupAssociationExists(ctx, resourceName),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-2", rName)),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 				),
@@ -76,7 +74,7 @@ func TestAccElastiCacheUserGroupAssociation_update(t *testing.T) {
 			{
 				Config: testAccUserGroupAssociationConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupAssociationExists(ctx, resourceName),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "user_id", fmt.Sprintf("%s-3", rName)),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 				),
@@ -87,19 +85,19 @@ func TestAccElastiCacheUserGroupAssociation_update(t *testing.T) {
 
 func TestAccElastiCacheUserGroupAssociation_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_elasticache_user_group_association.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupAssociationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupAssociationExists(ctx, resourceName),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceUserGroupAssociation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -114,15 +112,15 @@ func TestAccElastiCacheUserGroupAssociation_multiple(t *testing.T) {
 		t.Skip("skipping long-running test in short mode")
 	}
 
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName1 := "aws_elasticache_user_group_association.test1"
 	resourceName2 := "aws_elasticache_user_group_association.test2"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupAssociationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupAssociationConfig_preMultiple(rName),
@@ -130,17 +128,17 @@ func TestAccElastiCacheUserGroupAssociation_multiple(t *testing.T) {
 			{
 				Config: testAccUserGroupAssociationConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupAssociationExists(ctx, resourceName1),
-					testAccCheckUserGroupAssociationExists(ctx, resourceName2),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName1),
+					testAccCheckUserGroupAssociationExists(ctx, t, resourceName2),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckUserGroupAssociationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserGroupAssociationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_user_group_association" {
@@ -149,7 +147,7 @@ func testAccCheckUserGroupAssociationDestroy(ctx context.Context) resource.TestC
 
 			err := tfelasticache.FindUserGroupAssociationByTwoPartKey(ctx, conn, rs.Primary.Attributes["user_group_id"], rs.Primary.Attributes["user_id"])
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -164,14 +162,14 @@ func testAccCheckUserGroupAssociationDestroy(ctx context.Context) resource.TestC
 	}
 }
 
-func testAccCheckUserGroupAssociationExists(ctx context.Context, n string) resource.TestCheckFunc {
+func testAccCheckUserGroupAssociationExists(ctx context.Context, t *testing.T, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		err := tfelasticache.FindUserGroupAssociationByTwoPartKey(ctx, conn, rs.Primary.Attributes["user_group_id"], rs.Primary.Attributes["user_id"])
 

--- a/internal/service/elasticache/user_group_test.go
+++ b/internal/service/elasticache/user_group_test.go
@@ -9,32 +9,30 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccElastiCacheUserGroup_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -52,19 +50,19 @@ func TestAccElastiCacheUserGroup_basic(t *testing.T) {
 func TestAccElastiCacheUserGroup_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -73,7 +71,7 @@ func TestAccElastiCacheUserGroup_update(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_multiple(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -82,7 +80,7 @@ func TestAccElastiCacheUserGroup_update(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -91,7 +89,7 @@ func TestAccElastiCacheUserGroup_update(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_engineValkey(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
@@ -100,7 +98,7 @@ func TestAccElastiCacheUserGroup_update(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, "user_ids.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "user_group_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -113,19 +111,19 @@ func TestAccElastiCacheUserGroup_update(t *testing.T) {
 func TestAccElastiCacheUserGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -133,7 +131,7 @@ func TestAccElastiCacheUserGroup_tags(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "2"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
@@ -142,7 +140,7 @@ func TestAccElastiCacheUserGroup_tags(t *testing.T) {
 			{
 				Config: testAccUserGroupConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey2, acctest.CtValue2),
 				),
@@ -154,19 +152,19 @@ func TestAccElastiCacheUserGroup_tags(t *testing.T) {
 func TestAccElastiCacheUserGroup_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var userGroup awstypes.UserGroup
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserGroupDestroy(ctx),
+		CheckDestroy:             testAccCheckUserGroupDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserGroupConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserGroupExists(ctx, resourceName, &userGroup),
+					testAccCheckUserGroupExists(ctx, t, resourceName, &userGroup),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceUserGroup(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -175,9 +173,9 @@ func TestAccElastiCacheUserGroup_disappears(t *testing.T) {
 	})
 }
 
-func testAccCheckUserGroupDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserGroupDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_user_group" {
@@ -186,7 +184,7 @@ func testAccCheckUserGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tfelasticache.FindUserGroupByID(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -201,14 +199,14 @@ func testAccCheckUserGroupDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckUserGroupExists(ctx context.Context, n string, v *awstypes.UserGroup) resource.TestCheckFunc {
+func testAccCheckUserGroupExists(ctx context.Context, t *testing.T, n string, v *awstypes.UserGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindUserGroupByID(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/elasticache/user_test.go
+++ b/internal/service/elasticache/user_test.go
@@ -11,32 +11,30 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccElastiCacheUser_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "no_password_required", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
@@ -59,19 +57,19 @@ func TestAccElastiCacheUser_basic(t *testing.T) {
 func TestAccElastiCacheUser_passwordAuthMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfigWithPasswordAuthMode_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -98,19 +96,19 @@ func TestAccElastiCacheUser_passwordAuthMode(t *testing.T) {
 func TestAccElastiCacheUser_iamAuthMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfigWithIAMAuthMode_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, rName),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
@@ -132,25 +130,25 @@ func TestAccElastiCacheUser_iamAuthMode(t *testing.T) {
 func TestAccElastiCacheUser_update(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 				),
 			},
 			{
 				Config: testAccUserConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "access_string", "on ~* +@all"),
 				),
 			},
@@ -170,26 +168,26 @@ func TestAccElastiCacheUser_update(t *testing.T) {
 func TestAccElastiCacheUser_updateEngine(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfigWithEngine(rName, "valkey"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "valkey"),
 				),
 			},
 			{
 				Config: testAccUserConfigWithEngine(rName, "redis"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, names.AttrEngine, "redis"),
 				),
 			},
@@ -209,19 +207,19 @@ func TestAccElastiCacheUser_updateEngine(t *testing.T) {
 func TestAccElastiCacheUser_updatePasswordAuthMode(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfigWithPasswordAuthMode_twoPasswords(rName, "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
 				),
 			},
@@ -237,7 +235,7 @@ func TestAccElastiCacheUser_updatePasswordAuthMode(t *testing.T) {
 			{
 				Config: testAccUserConfigWithPasswordAuthMode_onePassword(rName, "aaaaaaaaaaaaaaaa"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "1"),
 				),
 			},
@@ -253,7 +251,7 @@ func TestAccElastiCacheUser_updatePasswordAuthMode(t *testing.T) {
 			{
 				Config: testAccUserConfigWithPasswordAuthMode_twoPasswords(rName, "cccccccccccccccc", "dddddddddddddddd"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode.0.password_count", "2"),
 				),
 			},
@@ -273,19 +271,19 @@ func TestAccElastiCacheUser_updatePasswordAuthMode(t *testing.T) {
 func TestAccElastiCacheUser_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_tags(rName, "tagKey", "tagVal"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "no_password_required", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
@@ -297,7 +295,7 @@ func TestAccElastiCacheUser_tags(t *testing.T) {
 			{
 				Config: testAccUserConfig_tags(rName, "tagKey", "tagVal2"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "no_password_required", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
@@ -309,7 +307,7 @@ func TestAccElastiCacheUser_tags(t *testing.T) {
 			{
 				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "user_id", rName),
 					resource.TestCheckResourceAttr(resourceName, "no_password_required", acctest.CtFalse),
 					resource.TestCheckResourceAttr(resourceName, names.AttrUserName, "username1"),
@@ -324,19 +322,19 @@ func TestAccElastiCacheUser_tags(t *testing.T) {
 func TestAccElastiCacheUser_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfelasticache.ResourceUser(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -349,19 +347,19 @@ func TestAccElastiCacheUser_disappears(t *testing.T) {
 func TestAccElastiCacheUser_oobModify(t *testing.T) {
 	ctx := acctest.Context(t)
 	var user awstypes.User
-	rName := sdkacctest.RandomWithPrefix("tf-acc")
+	rName := acctest.RandomWithPrefix(t, "tf-acc")
 	resourceName := "aws_elasticache_user.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckUserDestroy(ctx),
+		CheckDestroy:             testAccCheckUserDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccUserConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
 				),
@@ -370,7 +368,7 @@ func TestAccElastiCacheUser_oobModify(t *testing.T) {
 			{
 				Config: testAccUserConfig_tags(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserUpdateOOB(ctx, &user),
+					testAccCheckUserUpdateOOB(ctx, t, &user),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -378,7 +376,7 @@ func TestAccElastiCacheUser_oobModify(t *testing.T) {
 			{
 				Config: testAccUserConfig_tags(rName, acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUserExists(ctx, resourceName, &user),
+					testAccCheckUserExists(ctx, t, resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
 				),
@@ -387,9 +385,9 @@ func TestAccElastiCacheUser_oobModify(t *testing.T) {
 	})
 }
 
-func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckUserDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_elasticache_user" {
@@ -398,7 +396,7 @@ func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tfelasticache.FindUserByID(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -413,14 +411,14 @@ func testAccCheckUserDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckUserExists(ctx context.Context, n string, v *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserExists(ctx context.Context, t *testing.T, n string, v *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		output, err := tfelasticache.FindUserByID(ctx, conn, rs.Primary.ID)
 
@@ -434,9 +432,9 @@ func testAccCheckUserExists(ctx context.Context, n string, v *awstypes.User) res
 	}
 }
 
-func testAccCheckUserUpdateOOB(ctx context.Context, v *awstypes.User) resource.TestCheckFunc {
+func testAccCheckUserUpdateOOB(ctx context.Context, t *testing.T, v *awstypes.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).ElastiCacheClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).ElastiCacheClient(ctx)
 
 		_, err := conn.ModifyUser(ctx, &elasticache.ModifyUserInput{
 			AccessString: aws.String("on ~* +@all"),

--- a/internal/vcr/.semgrep-vcr.yml
+++ b/internal/vcr/.semgrep-vcr.yml
@@ -175,6 +175,36 @@ rules:
       include:
         - "**/*.go"
 
+  - id: internal-retry-staterefreshfunc-remove-parent-context
+    languages: [go]
+    message: "The parent function returning an internal retry.StateRefreshFunc no longer needs a context argument"
+    severity: WARNING
+    pattern: |
+      func $F(ctx context.Context, $...ARGS) retry.StateRefreshFunc {
+        $...BODY
+      }
+    fix: |
+      func $F($...ARGS) retry.StateRefreshFunc {
+        $...BODY
+      }
+    paths:
+      include:
+        - "**/*.go"
+
+  - id: internal-retry-statechangeconf-refresh-remove-context
+    languages: [go]
+    message: "The internal retry.StateRefreshConf.Refresh function no longer needs a context argument"
+    severity: WARNING
+    patterns:
+      - pattern-inside: "retry.StateChangeConf{ ... }"
+      - pattern: |
+          Refresh: $F(ctx, $...ARGS)
+    fix: |
+      Refresh: $F($...ARGS)
+    paths:
+      include:
+        - "**/*.go"
+
   - id: internal-retry-notfounderror-drop-lastrequest
     languages: [go]
     message: "The internal retry.NotFoundError struct drops the LastRequest argument"


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables Go-VCR in the `elasticache` service.

```console
% VCR_MODE=REPLAY_ONLY VCR_PATH=/Users/jaredbaker/development/_worktrees/td-vcr-elasticache/testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_Engine_redis
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_Engine_redis'  -timeout 360m -vet=off
2025/06/26 15:19:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/26 15:19:45 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (10.12s)
--- PASS: TestAccElastiCacheCluster_Engine_redis (10.15s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        15.943s
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #25602



### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->


```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheCluster_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheCluster_'  -timeout 360m -vet=off
2025/07/08 15:37:27 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/08 15:37:27 Initializing Terraform AWS Provider (SDKv2-style)...

=== NAME  TestAccElastiCacheCluster_outpostID_redis
    cluster_test.go:1431: skipping since no Outposts found
    panic.go:636: persisting randomness seed
--- SKIP: TestAccElastiCacheCluster_outpostID_redis (0.98s)
=== CONT  TestAccElastiCacheCluster_vpc
=== NAME  TestAccElastiCacheCluster_outpost_redis
    cluster_test.go:1358: skipping since no Outposts found
    panic.go:636: persisting randomness seed
--- SKIP: TestAccElastiCacheCluster_outpost_redis (0.98s)
=== CONT  TestAccElastiCacheCluster_multiAZInVPC
=== NAME  TestAccElastiCacheCluster_outpostID_memcached
    cluster_test.go:1398: skipping since no Outposts found
    panic.go:636: persisting randomness seed
--- SKIP: TestAccElastiCacheCluster_outpostID_memcached (1.00s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones
=== NAME  TestAccElastiCacheCluster_outpost_memcached
    cluster_test.go:1318: skipping since no Outposts found
    panic.go:636: persisting randomness seed
--- SKIP: TestAccElastiCacheCluster_outpost_memcached (1.03s)
=== CONT  TestAccElastiCacheCluster_PortRedis_default
=== NAME  TestAccElastiCacheCluster_Memcached_finalSnapshot
    cluster_test.go:960: stopping VCR recorder
    cluster_test.go:960: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Memcached_finalSnapshot (13.18s)
=== CONT  TestAccElastiCacheCluster_snapshotsWithUpdates
=== NAME  TestAccElastiCacheCluster_NumCacheNodes_redis
    cluster_test.go:807: stopping VCR recorder
    cluster_test.go:807: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_redis (13.20s)
=== CONT  TestAccElastiCacheCluster_port
=== NAME  TestAccElastiCacheCluster_PortRedis_default
    cluster_test.go:213: stopping VCR recorder
    cluster_test.go:213: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_PortRedis_default (517.75s)
=== CONT  TestAccElastiCacheCluster_ipDiscovery
=== NAME  TestAccElastiCacheCluster_port
    cluster_test.go:316: stopping VCR recorder
    cluster_test.go:316: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_port (550.29s)
=== CONT  TestAccElastiCacheCluster_ParameterGroupName_default
=== NAME  TestAccElastiCacheCluster_Engine_memcached
    cluster_test.go:45: stopping VCR recorder
    cluster_test.go:45: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Engine_memcached (591.26s)
=== CONT  TestAccElastiCacheCluster_EngineVersion_memcached
=== NAME  TestAccElastiCacheCluster_tags
    cluster_test.go:1181: stopping VCR recorder
    cluster_test.go:1181: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_tags (594.60s)
=== CONT  TestAccElastiCacheCluster_EngineVersion_redis
=== NAME  TestAccElastiCacheCluster_TransitEncryption
    cluster_test.go:1280: stopping VCR recorder
    cluster_test.go:1280: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_TransitEncryption (614.84s)
=== CONT  TestAccElastiCacheCluster_NumCacheNodes_increase
=== NAME  TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade
    cluster_test.go:1011: stopping VCR recorder
    cluster_test.go:1011: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Redis_autoMinorVersionUpgrade (637.42s)
=== CONT  TestAccElastiCacheCluster_AZMode_redis
=== NAME  TestAccElastiCacheCluster_vpc
    cluster_test.go:494: stopping VCR recorder
    cluster_test.go:494: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_vpc (638.37s)
=== CONT  TestAccElastiCacheCluster_Engine_redis_v5
=== NAME  TestAccElastiCacheCluster_snapshotsWithUpdates
    cluster_test.go:354: stopping VCR recorder
    cluster_test.go:354: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_snapshotsWithUpdates (645.99s)
=== CONT  TestAccElastiCacheCluster_Engine_None
    cluster_test.go:188: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Engine_None (0.82s)
=== CONT  TestAccElastiCacheCluster_disappears
=== NAME  TestAccElastiCacheCluster_multiAZInVPC
    cluster_test.go:522: stopping VCR recorder
    cluster_test.go:522: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_multiAZInVPC (719.10s)
=== CONT  TestAccElastiCacheCluster_Engine_redis
=== NAME  TestAccElastiCacheCluster_Redis_finalSnapshot
    cluster_test.go:984: stopping VCR recorder
    cluster_test.go:984: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Redis_finalSnapshot (813.79s)
=== CONT  TestAccElastiCacheCluster_AZMode_memcached
=== NAME  TestAccElastiCacheCluster_NumCacheNodes_decrease
    cluster_test.go:390: stopping VCR recorder
    cluster_test.go:390: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_decrease (858.55s)
=== NAME  TestAccElastiCacheCluster_ipDiscovery
    cluster_test.go:279: stopping VCR recorder
    cluster_test.go:279: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ipDiscovery (579.06s)
=== NAME  TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones
    cluster_test.go:458: stopping VCR recorder
    cluster_test.go:458: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increaseWithPreferredAvailabilityZones (1103.40s)
=== NAME  TestAccElastiCacheCluster_NodeTypeResize_memcached
    cluster_test.go:743: stopping VCR recorder
    cluster_test.go:743: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_memcached (1112.89s)
=== NAME  TestAccElastiCacheCluster_ParameterGroupName_default
    cluster_test.go:241: stopping VCR recorder
    cluster_test.go:241: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ParameterGroupName_default (551.02s)
=== NAME  TestAccElastiCacheCluster_disappears
    cluster_test.go:128: stopping VCR recorder
    cluster_test.go:128: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_disappears (558.86s)
=== NAME  TestAccElastiCacheCluster_Engine_redis_v5
    cluster_test.go:156: stopping VCR recorder
    cluster_test.go:156: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Engine_redis_v5 (580.03s)
=== NAME  TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations
    cluster_test.go:1053: stopping VCR recorder
    cluster_test.go:1053: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Engine_Redis_LogDeliveryConfigurations (1221.29s)
=== NAME  TestAccElastiCacheCluster_AZMode_redis
    cluster_test.go:589: stopping VCR recorder
    cluster_test.go:589: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_AZMode_redis (599.53s)
=== NAME  TestAccElastiCacheCluster_Engine_redis
    cluster_test.go:84: stopping VCR recorder
    cluster_test.go:84: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_Engine_redis (600.26s)
=== NAME  TestAccElastiCacheCluster_AZMode_memcached
    cluster_test.go:550: stopping VCR recorder
    cluster_test.go:550: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_AZMode_memcached (571.64s)
=== NAME  TestAccElastiCacheCluster_NodeTypeResize_redis
    cluster_test.go:778: stopping VCR recorder
    cluster_test.go:778: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NodeTypeResize_redis (1407.00s)
=== NAME  TestAccElastiCacheCluster_tagWithOtherModification
    cluster_test.go:1239: stopping VCR recorder
    cluster_test.go:1239: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_tagWithOtherModification (1569.37s)
=== NAME  TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone
    cluster_test.go:833: stopping VCR recorder
    cluster_test.go:833: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_availabilityZone (1629.02s)
=== NAME  TestAccElastiCacheCluster_NumCacheNodes_increase
    cluster_test.go:424: stopping VCR recorder
    cluster_test.go:424: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_NumCacheNodes_increase (1143.92s)
=== NAME  TestAccElastiCacheCluster_EngineVersion_memcached
    cluster_test.go:624: stopping VCR recorder
    cluster_test.go:624: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_EngineVersion_memcached (1262.76s)
=== NAME  TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption
    cluster_test.go:863: stopping VCR recorder
    cluster_test.go:863: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_transitEncryption (2083.96s)
=== NAME  TestAccElastiCacheCluster_ReplicationGroupID_singleReplica
    cluster_test.go:894: stopping VCR recorder
    cluster_test.go:894: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_singleReplica (2104.09s)
=== NAME  TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica
    cluster_test.go:928: stopping VCR recorder
    cluster_test.go:928: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_ReplicationGroupID_multipleReplica (2786.01s)
=== NAME  TestAccElastiCacheCluster_EngineVersion_redis
    cluster_test.go:670: stopping VCR recorder
    cluster_test.go:670: persisting randomness seed
--- PASS: TestAccElastiCacheCluster_EngineVersion_redis (4967.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        5568.624s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheGlobalReplicationGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheGlobalReplicationGroup_'  -timeout 360m -vet=off
2025/07/08 15:37:19 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/08 15:37:19 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_NoVersion (11.14s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_Redis_basic (1493.70s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6 (1554.18s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade_6x (1556.17s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_MinorUpgrade (1593.21s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorDowngrade (1878.04s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade_6x (1918.51s)
=== CONT  TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries
    global_replication_group_test.go:516: Step 1/1 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-4010222397834554489): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 756c7c8f-5123-4f6a-89a4-01399968f90a, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-4010222397834554489 already exists.

          with aws_elasticache_subnet_group.primary,
          on terraform_plugin_test.tf line 53, in resource "aws_elasticache_subnet_group" "primary":
          53: resource "aws_elasticache_subnet_group" "primary" {


        Error: creating ElastiCache Subnet Group (tf-acc-test-4010222397834554489): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: c4aa0e8f-e99e-45d1-a0e5-95a46b196ec5, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-4010222397834554489 already exists.

          with aws_elasticache_subnet_group.third,
          on terraform_plugin_test.tf line 121, in resource "aws_elasticache_subnet_group" "third":
         121: resource "aws_elasticache_subnet_group" "third" {

--- FAIL: TestAccElastiCacheGlobalReplicationGroup_multipleSecondaries (16.67s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnUpdate_NoVersion (2157.06s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorDowngrade (2237.82s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetParameterGroupOnCreate_MinorUpgrade (2300.77s)

=== NAME  TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion
    global_replication_group_test.go:545: Step 1/2 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-2955163367753537304): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 69771291-4349-4706-adba-051dab7f61d0, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-2955163367753537304 already exists.

          with aws_elasticache_subnet_group.secondary,
          on terraform_plugin_test.tf line 87, in resource "aws_elasticache_subnet_group" "secondary":
          87: resource "aws_elasticache_subnet_group" "secondary" {


        Error: creating ElastiCache Subnet Group (tf-acc-test-2955163367753537304): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 6d0ec658-61e0-4ee1-9c7e-1e0cf4889d0e, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-2955163367753537304 already exists.

          with aws_elasticache_subnet_group.third,
          on terraform_plugin_test.tf line 121, in resource "aws_elasticache_subnet_group" "third":
         121: resource "aws_elasticache_subnet_group" "third" {

--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_setNoChange (2838.29s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Valkey_v7 (2917.63s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade (3008.82s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_UpdateParameterGroupName (3312.17s)
--- FAIL: TestAccElastiCacheGlobalReplicationGroup_ReplaceSecondary_differentRegion (1541.41s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade (3473.42s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MinorUpgrade (3478.31s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MinorUpgrade (3715.47s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_NoChange (2164.66s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnUpdate_MajorUpgrade_6x (3744.13s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_MajorUpgrade_6x (3765.48s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Decrease (3867.73s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_clusterMode_basic (2338.90s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v5 (1860.75s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_update (2417.51s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createWithChange (2114.99s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_automaticFailover_createNoChange (1598.15s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Increase (2997.27s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_setNoChange (1585.32s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetEngineVersionOnCreate_NoChange_Redis_v6x (1159.76s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnUpdate_Increase (4890.29s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createNoChange (1586.75s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_description (1714.64s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_SetNumNodeGroupsOnCreate_Decrease (3614.45s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_disappears (1716.64s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_createWithChange (3026.22s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_Valkey_basic (1821.93s)
--- PASS: TestAccElastiCacheGlobalReplicationGroup_nodeType_update (2752.87s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        5676.475s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheParameterGroup_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheParameterGroup_'  -timeout 360m -vet=off
2025/07/09 09:28:18 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/09 09:28:18 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheParameterGroup_disappears (24.82s)
=== NAME  TestAccElastiCacheParameterGroup_description
    parameter_group_test.go:410: stopping VCR recorder
    parameter_group_test.go:410: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_description (26.59s)
=== NAME  TestAccElastiCacheParameterGroup_Valkey_basic
    parameter_group_test.go:60: stopping VCR recorder
    parameter_group_test.go:60: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_Valkey_basic (27.14s)
=== NAME  TestAccElastiCacheParameterGroup_Redis_basic
    parameter_group_test.go:29: stopping VCR recorder
    parameter_group_test.go:29: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_Redis_basic (28.20s)
=== NAME  TestAccElastiCacheParameterGroup_uppercaseName
    parameter_group_test.go:382: stopping VCR recorder
    parameter_group_test.go:382: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_uppercaseName (28.51s)
=== NAME  TestAccElastiCacheParameterGroup_removeAllParameters
    parameter_group_test.go:163: stopping VCR recorder
    parameter_group_test.go:163: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_removeAllParameters (38.11s)
=== NAME  TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_allParameters
    parameter_group_test.go:203: stopping VCR recorder
    parameter_group_test.go:203: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_allParameters (47.04s)
=== NAME  TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_remainingParameters
    parameter_group_test.go:244: stopping VCR recorder
    parameter_group_test.go:244: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_RemoveReservedMemoryParameter_remainingParameters (47.81s)
=== NAME  TestAccElastiCacheParameterGroup_addParameter
    parameter_group_test.go:115: stopping VCR recorder
    parameter_group_test.go:115: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_addParameter (48.06s)
=== NAME  TestAccElastiCacheParameterGroup_updateReservedMemoryParameter
    parameter_group_test.go:338: stopping VCR recorder
    parameter_group_test.go:338: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_updateReservedMemoryParameter (48.21s)
=== NAME  TestAccElastiCacheParameterGroup_switchReservedMemoryParameter
    parameter_group_test.go:293: stopping VCR recorder
    parameter_group_test.go:293: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_switchReservedMemoryParameter (48.54s)
=== NAME  TestAccElastiCacheParameterGroup_tags
    parameter_group_test.go:438: stopping VCR recorder
    parameter_group_test.go:438: persisting randomness seed
--- PASS: TestAccElastiCacheParameterGroup_tags (55.44s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        61.319s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheReplicationGroup
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheReplicationGroup'  -timeout 360m -vet=off
2025/07/09 09:28:47 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/09 09:28:47 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheReplicationGroup_autoMinorVersionUpgrade (735.64s)
=== CONT  TestAccElastiCacheReplicationGroup_updateDescription
=== NAME  TestAccElastiCacheReplicationGroup_updateMaintenanceWindow
    replication_group_test.go:540: stopping VCR recorder
    replication_group_test.go:540: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_updateMaintenanceWindow (756.70s)
=== CONT  TestAccElastiCacheReplicationGroup_disappears
=== NAME  TestAccElastiCacheReplicationGroup_multiAzNotInVPC
    replication_group_test.go:958: stopping VCR recorder
    replication_group_test.go:958: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC (903.12s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
=== NAME  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary
    replication_group_test.go:3011: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-2287454968440298446): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 291e3d6e-9ba7-43dc-a399-4cd2fbdbfa0b, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-2287454968440298446 already exists.

          with aws_elasticache_subnet_group.test,
          on terraform_plugin_test.tf line 46, in resource "aws_elasticache_subnet_group" "test":
          46: resource "aws_elasticache_subnet_group" "test" {

=== NAME  TestAccElastiCacheReplicationGroup_ClusterMode_singleNode
    replication_group_test.go:1551: stopping VCR recorder
    replication_group_test.go:1551: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_singleNode (1072.52s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
=== NAME  TestAccElastiCacheReplicationGroup_updateUserGroups
    replication_group_test.go:582: stopping VCR recorder
    replication_group_test.go:582: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_updateUserGroups (1301.74s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
=== NAME  TestAccElastiCacheReplicationGroupDataSource_basic
    replication_group_data_source_test.go:26: stopping VCR recorder
    replication_group_data_source_test.go:26: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroupDataSource_basic (1304.90s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
=== NAME  TestAccElastiCacheReplicationGroup_ipDiscovery
    replication_group_test.go:1144: stopping VCR recorder
    replication_group_test.go:1144: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ipDiscovery (1425.01s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_basic
=== NAME  TestAccElastiCacheReplicationGroup_upgrade_5_27_0
    replication_group_test.go:824: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_5_27_0 (1521.98s)
=== CONT  TestAccElastiCacheReplicationGroup_networkType
=== NAME  TestAccElastiCacheReplicationGroup_disappears
    replication_group_test.go:465: stopping VCR recorder
    replication_group_test.go:465: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_disappears (896.21s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
=== NAME  TestAccElastiCacheReplicationGroup_updateNodeSize
    replication_group_test.go:624: stopping VCR recorder
    replication_group_test.go:624: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_updateNodeSize (1660.33s)
=== CONT  TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters
    replication_group_test.go:2260: stopping VCR recorder
    replication_group_test.go:2260: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_autoFailoverEnabled_validateNumberCacheClusters (1.79s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
--- FAIL: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterModeValidation_numNodeGroupsOnSecondary (1771.56s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
=== NAME  TestAccElastiCacheReplicationGroup_dataTiering
    replication_group_test.go:3041: stopping VCR recorder
    replication_group_test.go:3041: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_dataTiering (2006.98s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
=== NAME  TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup
    replication_group_test.go:1269: stopping VCR recorder
    replication_group_test.go:1269: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_nonClusteredParameterGroup (705.02s)
=== CONT  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
=== NAME  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled
    replication_group_test.go:3182: stopping VCR recorder
    replication_group_test.go:3182: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Enabled (2060.59s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
=== NAME  TestAccElastiCacheReplicationGroup_updateParameterGroup
    replication_group_test.go:669: stopping VCR recorder
    replication_group_test.go:669: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_updateParameterGroup (2156.94s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled
    replication_group_test.go:2287: stopping VCR recorder
    replication_group_test.go:2287: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_multiAZEnabled (2361.97s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic_v5
=== NAME  TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup
    replication_group_test.go:1407: stopping VCR recorder
    replication_group_test.go:1407: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateReplicasPerNodeGroup (1514.75s)
=== CONT  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
=== NAME  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown
    replication_group_test.go:1507: stopping VCR recorder
    replication_group_test.go:1507: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleDown (2527.63s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
=== NAME  TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled
    replication_group_test.go:3079: stopping VCR recorder
    replication_group_test.go:3079: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Engine_Redis_LogDeliveryConfigurations_ClusterMode_Disabled (2610.51s)
=== CONT  TestAccElastiCacheReplicationGroup_uppercase
=== NAME  TestAccElastiCacheReplicationGroup_upgrade_6_0_0
    replication_group_test.go:780: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_6_0_0 (2631.07s)
=== CONT  TestAccElastiCacheReplicationGroup_Valkey_basic
=== NAME  TestAccElastiCacheReplicationGroup_ClusterMode_basic
    replication_group_test.go:1227: stopping VCR recorder
    replication_group_test.go:1227: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_basic (1286.02s)
=== CONT  TestAccElastiCacheReplicationGroup_tags
=== NAME  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp
    replication_group_test.go:1463: stopping VCR recorder
    replication_group_test.go:1463: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroupsAndReplicasPerNodeGroup_scaleUp (2714.14s)
=== CONT  TestAccElastiCacheReplicationGroup_finalSnapshot
=== NAME  TestAccElastiCacheReplicationGroup_useCMKKMSKeyID
    replication_group_test.go:2043: stopping VCR recorder
    replication_group_test.go:2043: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_useCMKKMSKeyID (855.90s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
=== NAME  TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption
    replication_group_test.go:2011: stopping VCR recorder
    replication_group_test.go:2011: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_disableAtRestEncryption (928.19s)
=== CONT  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
=== NAME  TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption
    replication_group_test.go:1978: stopping VCR recorder
    replication_group_test.go:1978: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Redis_enableAtRestEncryption (836.67s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled
    replication_group_test.go:2197: stopping VCR recorder
    replication_group_test.go:2197: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverEnabled (1468.77s)
=== CONT  TestAccElastiCacheReplicationGroup_Redis_basic
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled
    replication_group_test.go:2139: stopping VCR recorder
    replication_group_test.go:2139: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_autoFailoverDisabled (1360.72s)
=== CONT  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
=== NAME  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown
    replication_group_test.go:1363: stopping VCR recorder
    replication_group_test.go:1363: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleDown (2089.63s)
=== CONT  TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover
    replication_group_test.go:1120: stopping VCR recorder
    replication_group_test.go:1120: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ValidationMultiAz_noAutomaticFailover (1.34s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
=== NAME  TestAccElastiCacheReplicationGroup_Redis_basic_v5
    replication_group_test.go:90: stopping VCR recorder
    replication_group_test.go:90: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic_v5 (939.18s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
=== NAME  TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7
    replication_group_test.go:210: stopping VCR recorder
    replication_group_test.go:210: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Redis_EngineVersion_v7 (838.35s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzInVPC
=== NAME  TestAccElastiCacheReplicationGroup_networkType
    replication_group_test.go:1185: stopping VCR recorder
    replication_group_test.go:1185: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_networkType (2109.02s)
=== CONT  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic
    replication_group_test.go:2071: stopping VCR recorder
    replication_group_test.go:2071: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClusters_basic (1627.69s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption5x
=== NAME  TestAccElastiCacheReplicationGroup_Valkey_basic
    replication_group_test.go:130: stopping VCR recorder
    replication_group_test.go:130: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Valkey_basic (1021.54s)
=== CONT  TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError
    replication_group_test.go:1667: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_clusteringAndCacheNodesCausesError (0.81s)
=== CONT  TestAccElastiCacheReplicationGroup_enableSnapshotting
=== NAME  TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp
    replication_group_test.go:1314: stopping VCR recorder
    replication_group_test.go:1314: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterModeUpdateNumNodeGroups_scaleUp (2415.98s)
=== CONT  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
=== NAME  TestAccElastiCacheReplicationGroup_authToken
    replication_group_test.go:715: stopping VCR recorder
    replication_group_test.go:715: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_authToken (3745.69s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
=== NAME  TestAccElastiCacheReplicationGroup_tags
    replication_group_test.go:2552: stopping VCR recorder
    replication_group_test.go:2552: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_tags (1152.63s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
=== NAME  TestAccElastiCacheReplicationGroup_finalSnapshot
    replication_group_test.go:2688: stopping VCR recorder
    replication_group_test.go:2688: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_finalSnapshot (1281.01s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
=== NAME  TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken
    replication_group_test.go:1732: stopping VCR recorder
    replication_group_test.go:1732: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryptionWithAuthToken (875.89s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic
    replication_group_test.go:2953: Step 1/3 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-9077136730301318423): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: fd3a2659-fbc4-47ba-8dca-18e02a40e367, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-9077136730301318423 already exists.

          with aws_elasticache_subnet_group.primary,
          on terraform_plugin_test.tf line 80, in resource "aws_elasticache_subnet_group" "primary":
          80: resource "aws_elasticache_subnet_group" "primary" {

--- FAIL: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupIDClusterMode_basic (13.81s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
=== NAME  TestAccElastiCacheReplicationGroup_OutOfBandUpgrade
    replication_group_test.go:245: stopping VCR recorder
    replication_group_test.go:245: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_OutOfBandUpgrade (1774.68s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
=== NAME  TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations
    replication_group_data_source_test.go:123: stopping VCR recorder
    replication_group_data_source_test.go:123: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroupDataSource_Engine_Redis_LogDeliveryConfigurations (1201.40s)
=== CONT  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
=== NAME  TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType
    replication_group_test.go:2774: Step 1/1, expected an error with pattern, no match on: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-4605420723343027215): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 88c4e8fd-9d3e-4e3c-aba1-b00c2683cca6, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-4605420723343027215 already exists.

          with aws_elasticache_subnet_group.primary,
          on terraform_plugin_test.tf line 80, in resource "aws_elasticache_subnet_group" "primary":
          80: resource "aws_elasticache_subnet_group" "primary" {

=== NAME  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic
    replication_group_test.go:2803: Step 1/2 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-4734562522060374921): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: 0f767c01-eff0-4e8a-a37e-adf3c66d2f8c, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-4734562522060374921 already exists.

          with aws_elasticache_subnet_group.primary,
          on terraform_plugin_test.tf line 80, in resource "aws_elasticache_subnet_group" "primary":
          80: resource "aws_elasticache_subnet_group" "primary" {

--- FAIL: TestAccElastiCacheReplicationGroup_Validation_globalReplicationGroupIdAndNodeType (13.49s)
=== CONT  TestAccElastiCacheReplicationGroup_Validation_noNodeType
--- FAIL: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_basic (13.60s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
=== NAME  TestAccElastiCacheReplicationGroup_updateDescription
    replication_group_test.go:498: stopping VCR recorder
    replication_group_test.go:498: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_updateDescription (3476.28s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_multiAZ
=== NAME  TestAccElastiCacheReplicationGroup_Validation_noNodeType
    replication_group_test.go:2749: stopping VCR recorder
    replication_group_test.go:2749: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Validation_noNodeType (6.01s)
=== CONT  TestAccElastiCacheReplicationGroup_vpc
=== NAME  TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable
    replication_group_test.go:1912: stopping VCR recorder
    replication_group_test.go:1912: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Disable (2849.71s)
=== CONT  TestAccElastiCacheReplicationGroupDataSource_clusterMode
=== NAME  TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC
    replication_group_test.go:1081: stopping VCR recorder
    replication_group_test.go:1081: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_deprecatedAvailabilityZones_multiAzInVPC (1394.44s)
=== CONT  TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup
    replication_group_test.go:1649: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_cacheClustersConflictsWithReplicasPerNodeGroup (0.85s)
=== CONT  TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
=== NAME  TestAccElastiCacheReplicationGroup_enableSnapshotting
    replication_group_test.go:1691: stopping VCR recorder
    replication_group_test.go:1691: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_enableSnapshotting (904.82s)
=== CONT  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
=== NAME  TestAccElastiCacheReplicationGroup_uppercase
    replication_group_test.go:177: stopping VCR recorder
    replication_group_test.go:177: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_uppercase (2074.75s)
=== CONT  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
=== NAME  TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters
    replication_group_test.go:2648: stopping VCR recorder
    replication_group_test.go:2648: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_numCacheClusters (1926.48s)
=== CONT  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
=== NAME  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full
    replication_group_test.go:2855: Step 1/3 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-1733046726881432402): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: fb99e03e-77d1-413d-99f4-48ea8571f160, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-1733046726881432402 already exists.

          with aws_elasticache_subnet_group.test,
          on terraform_plugin_test.tf line 46, in resource "aws_elasticache_subnet_group" "test":
          46: resource "aws_elasticache_subnet_group" "test" {

=== NAME  TestAccElastiCacheReplicationGroup_TagWithOtherModification_version
    replication_group_test.go:2607: stopping VCR recorder
    replication_group_test.go:2607: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_TagWithOtherModification_version (1952.87s)
=== CONT  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
=== NAME  TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears
    replication_group_test.go:2920: Step 1/1 error: Error running apply: exit status 1

        Error: creating ElastiCache Subnet Group (tf-acc-test-4123877423847223083): operation error ElastiCache: CreateCacheSubnetGroup, https response error StatusCode: 400, RequestID: e3f3bf14-7940-4336-803b-99cc6971fb70, CacheSubnetGroupAlreadyExists: Cache subnet group tf-acc-test-4123877423847223083 already exists.

          with aws_elasticache_subnet_group.test,
          on terraform_plugin_test.tf line 46, in resource "aws_elasticache_subnet_group" "test":
          46: resource "aws_elasticache_subnet_group" "test" {

=== NAME  TestAccElastiCacheReplicationGroupDataSource_multiAZ
    replication_group_data_source_test.go:98: stopping VCR recorder
    replication_group_data_source_test.go:98: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroupDataSource_multiAZ (813.99s)
=== NAME  TestAccElastiCacheReplicationGroup_multiAzInVPC
    replication_group_test.go:1036: stopping VCR recorder
    replication_group_test.go:1036: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_multiAzInVPC (1728.66s)
=== NAME  TestAccElastiCacheReplicationGroup_vpc
    replication_group_test.go:911: stopping VCR recorder
    replication_group_test.go:911: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_vpc (1028.58s)
=== NAME  TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable
    replication_group_test.go:1846: stopping VCR recorder
    replication_group_test.go:1846: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_Enable (2021.79s)
=== NAME  TestAccElastiCacheReplicationGroup_Redis_basic
    replication_group_test.go:43: stopping VCR recorder
    replication_group_test.go:43: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Redis_basic (2269.56s)
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown
    replication_group_test.go:2500: stopping VCR recorder
    replication_group_test.go:2500: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_scaleDown (1547.20s)
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize
    replication_group_test.go:2449: stopping VCR recorder
    replication_group_test.go:2449: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappearsRemoveMemberCluster_atTargetSize (1677.13s)
=== NAME  TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion
    replication_group_test.go:385: stopping VCR recorder
    replication_group_test.go:385: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_6xToRealVersion (1775.54s)
=== NAME  TestAccElastiCacheReplicationGroup_upgrade_4_68_0
    replication_group_test.go:868: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_upgrade_4_68_0 (907.19s)
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster
    replication_group_test.go:2398: stopping VCR recorder
    replication_group_test.go:2398: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_addMemberCluster (1408.39s)
--- FAIL: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_disappears (1599.91s)
=== NAME  TestAccElastiCacheReplicationGroupDataSource_clusterMode
    replication_group_data_source_test.go:64: stopping VCR recorder
    replication_group_data_source_test.go:64: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroupDataSource_clusterMode (1189.96s)
--- FAIL: TestAccElastiCacheReplicationGroup_GlobalReplicationGroupID_full (1775.08s)
=== NAME  TestAccElastiCacheReplicationGroup_transitEncryption5x
    replication_group_test.go:1767: stopping VCR recorder
    replication_group_test.go:1767: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption5x (2249.61s)
=== NAME  TestAccElastiCacheReplicationGroup_transitEncryption7x_basic
    replication_group_test.go:1812: stopping VCR recorder
    replication_group_test.go:1812: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_transitEncryption7x_basic (967.14s)
=== NAME  TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated
    replication_group_test.go:996: stopping VCR recorder
    replication_group_test.go:996: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_multiAzNotInVPC_repeated (2424.08s)
=== NAME  TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange
    replication_group_test.go:2347: stopping VCR recorder
    replication_group_test.go:2347: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_NumberCacheClustersMemberClusterDisappears_noChange (1841.18s)
=== NAME  TestAccElastiCacheReplicationGroup_EngineVersion_update
    replication_group_test.go:306: stopping VCR recorder
    replication_group_test.go:306: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_EngineVersion_update (6555.46s)
=== NAME  TestAccElastiCacheReplicationGroup_Engine_RedisToValkey
    replication_group_test.go:424: stopping VCR recorder
    replication_group_test.go:424: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_Engine_RedisToValkey (2117.61s)
=== NAME  TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled
    replication_group_test.go:1595: stopping VCR recorder
    replication_group_test.go:1595: persisting randomness seed
--- PASS: TestAccElastiCacheReplicationGroup_ClusterMode_updateFromDisabled_Compatible_Enabled (3417.15s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        7950.893s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheServerlessCache
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheServerlessCache'  -timeout 360m -vet=off
2025/07/09 09:34:06 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/09 09:34:06 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheServerlessCacheDataSource_Redis_basic (314.47s)
=== CONT  TestAccElastiCacheServerlessCache_full
=== NAME  TestAccElastiCacheServerlessCache_tags
    serverless_cache_test.go:587: stopping VCR recorder
    serverless_cache_test.go:587: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_tags (348.61s)
=== CONT  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
=== NAME  TestAccElastiCacheServerlessCache_fullValkey
    serverless_cache_test.go:251: stopping VCR recorder
    serverless_cache_test.go:251: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_fullValkey (428.63s)
=== CONT  TestAccElastiCacheServerlessCache_fullRedis
=== NAME  TestAccElastiCacheServerlessCache_cacheUsageLimits
    serverless_cache_test.go:364: stopping VCR recorder
    serverless_cache_test.go:364: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_cacheUsageLimits (647.18s)
=== CONT  TestAccElastiCacheServerlessCache_basicRedis
=== NAME  TestAccElastiCacheServerlessCache_full
    serverless_cache_test.go:120: stopping VCR recorder
    serverless_cache_test.go:120: persisting randomness seed
=== CONT  TestAccElastiCacheServerlessCache_basicValkey
--- PASS: TestAccElastiCacheServerlessCache_full (346.08s)
=== NAME  TestAccElastiCacheServerlessCache_fullRedis
    serverless_cache_test.go:168: stopping VCR recorder
    serverless_cache_test.go:168: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_fullRedis (346.81s)
=== CONT  TestAccElastiCacheServerlessCache_disappears
=== NAME  TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup
    serverless_cache_test.go:211: stopping VCR recorder
    serverless_cache_test.go:211: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_redisUpdateWithUserGroup (459.83s)
=== CONT  TestAccElastiCacheServerlessCache_description
=== NAME  TestAccElastiCacheServerlessCache_basicRedis
    serverless_cache_test.go:31: stopping VCR recorder
    serverless_cache_test.go:31: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_basicRedis (315.05s)
=== CONT  TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
=== NAME  TestAccElastiCacheServerlessCache_basicValkey
    serverless_cache_test.go:76: stopping VCR recorder
    serverless_cache_test.go:76: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_basicValkey (335.87s)
=== NAME  TestAccElastiCacheServerlessCache_disappears
    serverless_cache_test.go:537: Step 1/1 error: Post-apply refresh plan check(s) failed:
        'aws_elasticache_serverless_cache.test' - expected Create, got action(s): [delete create]
--- FAIL: TestAccElastiCacheServerlessCache_disappears (313.53s)
=== NAME  TestAccElastiCacheServerlessCache_engine
    serverless_cache_test.go:479: stopping VCR recorder
    serverless_cache_test.go:479: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_engine (1111.71s)
=== NAME  TestAccElastiCacheServerlessCache_description
    serverless_cache_test.go:296: stopping VCR recorder
    serverless_cache_test.go:296: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCache_description (353.02s)
=== NAME  TestAccElastiCacheServerlessCacheDataSource_Valkey_basic
    serverless_cache_data_source_test.go:71: stopping VCR recorder
    serverless_cache_data_source_test.go:71: persisting randomness seed
--- PASS: TestAccElastiCacheServerlessCacheDataSource_Valkey_basic (373.61s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        1341.660s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheSubnetGroup
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheSubnetGroup'  -timeout 360m -vet=off
2025/07/09 09:35:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/09 09:35:23 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheSubnetGroupDataSource_basic (20.23s)
=== NAME  TestAccElastiCacheSubnetGroup_disappears
    subnet_group_test.go:60: stopping VCR recorder
    subnet_group_test.go:60: persisting randomness seed
--- PASS: TestAccElastiCacheSubnetGroup_disappears (21.22s)
=== NAME  TestAccElastiCacheSubnetGroup_basic
    subnet_group_test.go:26: stopping VCR recorder
    subnet_group_test.go:26: persisting randomness seed
--- PASS: TestAccElastiCacheSubnetGroup_basic (22.34s)
=== NAME  TestAccElastiCacheSubnetGroup_update
    subnet_group_test.go:130: stopping VCR recorder
    subnet_group_test.go:130: persisting randomness seed
--- PASS: TestAccElastiCacheSubnetGroup_update (32.69s)
=== NAME  TestAccElastiCacheSubnetGroup_tags
    subnet_group_test.go:84: stopping VCR recorder
    subnet_group_test.go:84: persisting randomness seed
--- PASS: TestAccElastiCacheSubnetGroup_tags (42.41s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        48.451s
```

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=elasticache TESTS=TestAccElastiCacheUser
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/elasticache/... -v -count 1 -parallel 20 -run='TestAccElastiCacheUser'  -timeout 360m -vet=off
2025/07/09 09:36:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/09 09:36:56 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccElastiCacheUser_basic (64.23s)
=== NAME  TestAccElastiCacheUserDataSource_basic
    user_data_source_test.go:21: stopping VCR recorder
    user_data_source_test.go:21: persisting randomness seed
--- PASS: TestAccElastiCacheUserDataSource_basic (65.30s)
=== NAME  TestAccElastiCacheUser_passwordAuthMode
    user_test.go:63: stopping VCR recorder
    user_test.go:63: persisting randomness seed
--- PASS: TestAccElastiCacheUser_passwordAuthMode (67.46s)
=== NAME  TestAccElastiCacheUser_updateEngine
    user_test.go:174: stopping VCR recorder
    user_test.go:174: persisting randomness seed
--- PASS: TestAccElastiCacheUser_updateEngine (71.99s)
=== NAME  TestAccElastiCacheUser_tags
    user_test.go:277: stopping VCR recorder
    user_test.go:277: persisting randomness seed
--- PASS: TestAccElastiCacheUser_tags (78.51s)
=== NAME  TestAccElastiCacheUser_iamAuthMode
    user_test.go:102: stopping VCR recorder
    user_test.go:102: persisting randomness seed
--- PASS: TestAccElastiCacheUser_iamAuthMode (78.72s)
=== NAME  TestAccElastiCacheUser_update
    user_test.go:136: stopping VCR recorder
    user_test.go:136: persisting randomness seed
--- PASS: TestAccElastiCacheUser_update (128.50s)
=== NAME  TestAccElastiCacheUserGroup_basic
    user_group_test.go:26: stopping VCR recorder
    user_group_test.go:26: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroup_basic (188.33s)
=== NAME  TestAccElastiCacheUser_updatePasswordAuthMode
    user_test.go:213: stopping VCR recorder
    user_test.go:213: persisting randomness seed
--- PASS: TestAccElastiCacheUser_updatePasswordAuthMode (191.35s)
=== NAME  TestAccElastiCacheUserGroup_tags
    user_group_test.go:117: stopping VCR recorder
    user_group_test.go:117: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroup_tags (192.04s)
=== NAME  TestAccElastiCacheUserGroup_disappears
    user_group_test.go:158: stopping VCR recorder
    user_group_test.go:158: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroup_disappears (194.57s)
=== NAME  TestAccElastiCacheUser_oobModify
    user_test.go:353: stopping VCR recorder
    user_test.go:353: persisting randomness seed
--- PASS: TestAccElastiCacheUser_oobModify (197.23s)
=== NAME  TestAccElastiCacheUser_disappears
    user_test.go:328: stopping VCR recorder
    user_test.go:328: persisting randomness seed
--- PASS: TestAccElastiCacheUser_disappears (231.57s)
=== NAME  TestAccElastiCacheUserGroupAssociation_disappears
    user_group_association_test.go:91: stopping VCR recorder
    user_group_association_test.go:91: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroupAssociation_disappears (315.02s)
=== NAME  TestAccElastiCacheUserGroupAssociation_basic
    user_group_association_test.go:28: stopping VCR recorder
    user_group_association_test.go:28: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroupAssociation_basic (317.35s)
=== NAME  TestAccElastiCacheUserGroup_update
    user_group_test.go:56: stopping VCR recorder
    user_group_test.go:56: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroup_update (381.19s)
=== NAME  TestAccElastiCacheUserGroupAssociation_update
    user_group_association_test.go:60: stopping VCR recorder
    user_group_association_test.go:60: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroupAssociation_update (436.51s)
=== NAME  TestAccElastiCacheUserGroupAssociation_multiple
    user_group_association_test.go:119: stopping VCR recorder
    user_group_association_test.go:119: persisting randomness seed
--- PASS: TestAccElastiCacheUserGroupAssociation_multiple (442.03s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elasticache        447.888s
```