### PR TITLE
`aws_api_gateway_resource`: recompute `path` when `path_part` changes

### DIFF
--- a/.changelog/43215.txt
+++ b/.changelog/43215.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_api_gateway_resource: Recompute `path` when `path_part` is updated
+```

--- a/internal/service/apigateway/resource.go
+++ b/internal/service/apigateway/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/aws/aws-sdk-go-v2/service/apigateway/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -63,6 +64,12 @@ func resourceResource() *schema.Resource {
 				ForceNew: true,
 			},
 		},
+
+		CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf(names.AttrPath, func(ctx context.Context, diff *schema.ResourceDiff, meta any) bool {
+				return diff.HasChange("path_part")
+			}),
+		),
 	}
 }
 

--- a/internal/service/apigateway/resource_test.go
+++ b/internal/service/apigateway/resource_test.go
@@ -33,7 +33,7 @@ func TestAccAPIGatewayResource_basic(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceConfig_basic(rName),
+				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
@@ -63,7 +63,7 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceConfig_basic(rName),
+				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
@@ -77,11 +77,56 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccResourceConfig_updatePathPart(rName),
+				Config: testAccResourceConfig_basic(rName, "test_changed"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test_changed"),
 					resource.TestCheckResourceAttr(resourceName, "path_part", "test_changed"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAPIGatewayResource_recomputePath(t *testing.T) {
+	ctx := acctest.Context(t)
+	var conf apigateway.GetResourceOutput
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_api_gateway_resource.test"
+	copyName := "aws_api_gateway_resource.copy"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckAPIGatewayTypeEDGE(t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConfig_copy(rName, "test"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, copyName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
+					resource.TestCheckResourceAttr(resourceName, "path_part", "test"),
+					resource.TestCheckResourceAttr(copyName, names.AttrPath, "/test-copy"),
+					resource.TestCheckResourceAttr(copyName, "path_part", "test-copy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccResourceImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccResourceConfig_copy(rName, "test_changed"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(ctx, resourceName, &conf),
+					testAccCheckResourceExists(ctx, copyName, &conf),
+					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test_changed"),
+					resource.TestCheckResourceAttr(resourceName, "path_part", "test_changed"),
+					resource.TestCheckResourceAttr(copyName, names.AttrPath, "/test_changed-copy"),
+					resource.TestCheckResourceAttr(copyName, "path_part", "test_changed-copy"),
 				),
 			},
 		},
@@ -101,7 +146,7 @@ func TestAccAPIGatewayResource_disappears(t *testing.T) {
 		CheckDestroy:             testAccCheckResourceDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceConfig_basic(rName),
+				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &conf),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfapigateway.ResourceResource(), resourceName),
@@ -132,7 +177,7 @@ func TestAccAPIGatewayResource_withSleep(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceConfig_basic(rName),
+				Config: testAccResourceConfig_basic(rName, "test"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, names.AttrPath, "/test"),
@@ -209,22 +254,22 @@ resource "aws_api_gateway_rest_api" "test" {
 `, rName)
 }
 
-func testAccResourceConfig_basic(rName string) string {
-	return acctest.ConfigCompose(testAccResourceConfig_base(rName), `
+func testAccResourceConfig_basic(rName string, pathPart string) string {
+	return acctest.ConfigCompose(testAccResourceConfig_base(rName), fmt.Sprintf(`
 resource "aws_api_gateway_resource" "test" {
   rest_api_id = aws_api_gateway_rest_api.test.id
   parent_id   = aws_api_gateway_rest_api.test.root_resource_id
-  path_part   = "test"
+  path_part   = %[1]q
 }
-`)
+`, pathPart))
 }
 
-func testAccResourceConfig_updatePathPart(rName string) string {
-	return acctest.ConfigCompose(testAccResourceConfig_base(rName), `
-resource "aws_api_gateway_resource" "test" {
+func testAccResourceConfig_copy(rName string, pathPart string) string {
+	return acctest.ConfigCompose(testAccResourceConfig_basic(rName, pathPart), `
+resource "aws_api_gateway_resource" "copy" {
   rest_api_id = aws_api_gateway_rest_api.test.id
   parent_id   = aws_api_gateway_rest_api.test.root_resource_id
-  path_part   = "test_changed"
+  path_part   = "${replace(aws_api_gateway_resource.test.path, "/", "")}-copy"
 }
 `)
 }

--- a/internal/service/apigateway/resource_test.go
+++ b/internal/service/apigateway/resource_test.go
@@ -88,6 +88,7 @@ func TestAccAPIGatewayResource_update(t *testing.T) {
 	})
 }
 
+// https://github.com/hashicorp/terraform-provider-aws/issues/42904
 func TestAccAPIGatewayResource_recomputePath(t *testing.T) {
 	ctx := acctest.Context(t)
 	var conf apigateway.GetResourceOutput


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes

### Description

Recomputes `path` when `path_part` is updated. Helps prevent situations where downstream resources are dependent on the `path` attribute requiring two applies.

### Relations

Closes #42904

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
$ make testacc TESTS=TestAccAPIGatewayResource_ PKG=apigateway
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/apigateway/... -v -count 1 -parallel 20 -run='TestAccAPIGatewayResource_'  -timeout 360m -vet=off
2025/06/27 11:08:35 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/27 11:08:35 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAPIGatewayResource_basic
=== PAUSE TestAccAPIGatewayResource_basic
=== RUN   TestAccAPIGatewayResource_update
=== PAUSE TestAccAPIGatewayResource_update
=== RUN   TestAccAPIGatewayResource_recomputePath
=== PAUSE TestAccAPIGatewayResource_recomputePath
=== RUN   TestAccAPIGatewayResource_disappears
=== PAUSE TestAccAPIGatewayResource_disappears
=== RUN   TestAccAPIGatewayResource_withSleep
=== PAUSE TestAccAPIGatewayResource_withSleep
=== CONT  TestAccAPIGatewayResource_basic
=== CONT  TestAccAPIGatewayResource_disappears
=== CONT  TestAccAPIGatewayResource_recomputePath
=== CONT  TestAccAPIGatewayResource_withSleep
=== CONT  TestAccAPIGatewayResource_update
--- PASS: TestAccAPIGatewayResource_disappears (15.67s)
--- PASS: TestAccAPIGatewayResource_recomputePath (27.26s)
--- PASS: TestAccAPIGatewayResource_basic (41.47s)
--- PASS: TestAccAPIGatewayResource_withSleep (83.65s)
--- PASS: TestAccAPIGatewayResource_update (118.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/apigateway	124.933s
```
