### PR TITLE
[New resource] Support for amp_query_logging_configuration

### DIFF
--- a/.changelog/43222.txt
+++ b/.changelog/43222.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_prometheus_query_logging_configuration
+```

--- a/internal/service/amp/exports_test.go
+++ b/internal/service/amp/exports_test.go
@@ -5,14 +5,16 @@ package amp
 
 // Exports for use in tests only.
 var (
-	ResourceAlertManagerDefinition = resourceAlertManagerDefinition
-	ResourceRuleGroupNamespace     = resourceRuleGroupNamespace
-	ResourceScraper                = newScraperResource
-	ResourceWorkspace              = resourceWorkspace
+	ResourceAlertManagerDefinition    = resourceAlertManagerDefinition
+	ResourceQueryLoggingConfiguration = newQueryLoggingConfigurationResource
+	ResourceRuleGroupNamespace        = resourceRuleGroupNamespace
+	ResourceScraper                   = newScraperResource
+	ResourceWorkspace                 = resourceWorkspace
 
-	FindAlertManagerDefinitionByID = findAlertManagerDefinitionByID
-	FindRuleGroupNamespaceByARN    = findRuleGroupNamespaceByARN
-	FindScraperByID                = findScraperByID
-	FindWorkspaceByID              = findWorkspaceByID
-	FindWorkspaceConfigurationByID = findWorkspaceConfigurationByID
+	FindAlertManagerDefinitionByID    = findAlertManagerDefinitionByID
+	FindQueryLoggingConfigurationByID = findQueryLoggingConfigurationByID
+	FindRuleGroupNamespaceByARN       = findRuleGroupNamespaceByARN
+	FindScraperByID                   = findScraperByID
+	FindWorkspaceByID                 = findWorkspaceByID
+	FindWorkspaceConfigurationByID    = findWorkspaceConfigurationByID
 )

--- a/internal/service/amp/query_logging_configuration.go
+++ b/internal/service/amp/query_logging_configuration.go
@@ -71,7 +71,7 @@ func (r *queryLoggingConfigurationResource) Schema(ctx context.Context, request 
 				},
 				NestedObject: schema.NestedBlockObject{
 					Blocks: map[string]schema.Block{
-						"cloudwatch_logs": schema.ListNestedBlock{
+						names.AttrCloudWatchLogs: schema.ListNestedBlock{
 							CustomType: fwtypes.NewListNestedObjectTypeOf[cloudwatchLogsModel](ctx),
 							Validators: []validator.List{
 								listvalidator.SizeAtLeast(1),
@@ -242,11 +242,11 @@ func (r *queryLoggingConfigurationResource) Delete(ctx context.Context, request 
 	conn := r.Meta().AMPClient(ctx)
 
 	workspaceID := fwflex.StringValueFromFramework(ctx, data.WorkspaceID)
-
-	_, err := conn.DeleteQueryLoggingConfiguration(ctx, &amp.DeleteQueryLoggingConfigurationInput{
+	input := amp.DeleteQueryLoggingConfigurationInput{
 		WorkspaceId: aws.String(workspaceID),
-	})
-
+		ClientToken: aws.String(sdkid.UniqueId()),
+	}
+	_, err := conn.DeleteQueryLoggingConfiguration(ctx, &input)
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return
 	}

--- a/internal/service/amp/query_logging_configuration.go
+++ b/internal/service/amp/query_logging_configuration.go
@@ -62,7 +62,7 @@ func (r *queryLoggingConfigurationResource) Schema(ctx context.Context, request 
 			},
 		},
 		Blocks: map[string]schema.Block{
-			"destination": schema.ListNestedBlock{
+			names.AttrDestination: schema.ListNestedBlock{
 				CustomType: fwtypes.NewListNestedObjectTypeOf[loggingDestinationModel](ctx),
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),

--- a/internal/service/amp/query_logging_configuration.go
+++ b/internal/service/amp/query_logging_configuration.go
@@ -1,0 +1,395 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package amp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/amp"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/amp/types"
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkid "github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/framework"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+// @FrameworkResource("aws_prometheus_query_logging_configuration", name="QueryLoggingConfiguration")
+// @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/amp/types;types.QueryLoggingConfigurationMetadata")
+func newQueryLoggingConfigurationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
+	r := &queryLoggingConfigurationResource{}
+
+	r.SetDefaultCreateTimeout(5 * time.Minute)
+	r.SetDefaultUpdateTimeout(5 * time.Minute)
+	r.SetDefaultDeleteTimeout(5 * time.Minute)
+
+	return r, nil
+}
+
+type queryLoggingConfigurationResource struct {
+	framework.ResourceWithModel[queryLoggingConfigurationResourceModel]
+	framework.WithTimeouts
+}
+
+func (r *queryLoggingConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			names.AttrID: framework.IDAttribute(),
+			"workspace_id": schema.StringAttribute{
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"destinations": schema.ListNestedBlock{
+				CustomType: fwtypes.NewListNestedObjectTypeOf[queryLoggingDestinationModel](ctx),
+				Validators: []validator.List{
+					listvalidator.SizeAtLeast(1),
+					listvalidator.IsRequired(),
+				},
+				NestedObject: schema.NestedBlockObject{
+					Blocks: map[string]schema.Block{
+						"cloudwatch_logs": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[cloudwatchLogsModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+								listvalidator.SizeAtMost(1),
+								listvalidator.IsRequired(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"log_group_arn": schema.StringAttribute{
+										CustomType: fwtypes.ARNType,
+										Required:   true,
+									},
+								},
+							},
+						},
+						"filters": schema.ListNestedBlock{
+							CustomType: fwtypes.NewListNestedObjectTypeOf[loggingFilterModel](ctx),
+							Validators: []validator.List{
+								listvalidator.SizeAtLeast(1),
+								listvalidator.SizeAtMost(1),
+								listvalidator.IsRequired(),
+							},
+							NestedObject: schema.NestedBlockObject{
+								Attributes: map[string]schema.Attribute{
+									"qsp_threshold": schema.Int64Attribute{
+										Required: true,
+										Validators: []validator.Int64{
+											int64validator.AtLeast(0),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			names.AttrTimeouts: timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				Update: true,
+				Delete: true,
+			}),
+		},
+	}
+}
+
+func (r *queryLoggingConfigurationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data queryLoggingConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().AMPClient(ctx)
+
+	workspaceID := fwflex.StringValueFromFramework(ctx, data.WorkspaceID)
+	var input amp.CreateQueryLoggingConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Additional fields.
+	input.ClientToken = aws.String(sdkid.UniqueId())
+
+	_, err := conn.CreateQueryLoggingConfiguration(ctx, &input)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("creating AMP Query Logging Configuration (%s)", workspaceID), err.Error())
+
+		return
+	}
+
+	// Set the ID to the workspace ID as per the documentation
+	data.ID = data.WorkspaceID
+
+	output, err := waitQueryLoggingConfigurationCreated(ctx, conn, workspaceID, r.CreateTimeout(ctx, data.Timeouts))
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for AMP Query Logging Configuration (%s) create", workspaceID), err.Error())
+
+		return
+	}
+
+	// Update data with any computed values from the API response
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
+}
+
+func (r *queryLoggingConfigurationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data queryLoggingConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().AMPClient(ctx)
+
+	out, err := findQueryLoggingConfigurationByID(ctx, conn, data.ID.ValueString())
+
+	if tfresource.NotFound(err) {
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("reading AMP Query Logging Configuration (%s)", data.ID.ValueString()), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(fwflex.Flatten(ctx, out, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
+}
+
+func (r *queryLoggingConfigurationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var new queryLoggingConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &new)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().AMPClient(ctx)
+
+	workspaceID := fwflex.StringValueFromFramework(ctx, new.WorkspaceID)
+	var input amp.UpdateQueryLoggingConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, new, &input)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Additional fields.
+	input.ClientToken = aws.String(sdkid.UniqueId())
+
+	_, err := conn.UpdateQueryLoggingConfiguration(ctx, &input)
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating AMP Query Logging Configuration (%s)", workspaceID), err.Error())
+
+		return
+	}
+
+	if _, err := waitQueryLoggingConfigurationUpdated(ctx, conn, workspaceID, r.UpdateTimeout(ctx, new.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for AMP Query Logging Configuration (%s) update", workspaceID), err.Error())
+
+		return
+	}
+
+	response.Diagnostics.Append(response.State.Set(ctx, new)...)
+}
+
+func (r *queryLoggingConfigurationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data queryLoggingConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	conn := r.Meta().AMPClient(ctx)
+
+	workspaceID := fwflex.StringValueFromFramework(ctx, data.WorkspaceID)
+
+	_, err := conn.DeleteQueryLoggingConfiguration(ctx, &amp.DeleteQueryLoggingConfigurationInput{
+		WorkspaceId: aws.String(workspaceID),
+	})
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return
+	}
+
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("deleting AMP Query Logging Configuration (%s)", workspaceID), err.Error())
+
+		return
+	}
+
+	if _, err := waitQueryLoggingConfigurationDeleted(ctx, conn, workspaceID, r.DeleteTimeout(ctx, data.Timeouts)); err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("waiting for AMP Query Logging Configuration (%s) delete", workspaceID), err.Error())
+
+		return
+	}
+}
+
+func (r *queryLoggingConfigurationResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("workspace_id"), request, response)
+	// Also set the ID to the workspace ID
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrID), request.ID)...)
+}
+
+func findQueryLoggingConfigurationByID(ctx context.Context, conn *amp.Client, id string) (*awstypes.QueryLoggingConfigurationMetadata, error) {
+	input := amp.DescribeQueryLoggingConfigurationInput{
+		WorkspaceId: aws.String(id),
+	}
+	output, err := conn.DescribeQueryLoggingConfiguration(ctx, &input)
+
+	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	if output == nil || output.QueryLoggingConfiguration == nil {
+		return nil, tfresource.NewEmptyResultError(input)
+	}
+
+	return output.QueryLoggingConfiguration, nil
+}
+
+func statusQueryLoggingConfiguration(ctx context.Context, conn *amp.Client, id string) retry.StateRefreshFunc {
+	return func() (any, string, error) {
+		output, err := findQueryLoggingConfigurationByID(ctx, conn, id)
+
+		if tfresource.NotFound(err) {
+			return nil, "", nil
+		}
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		return output, string(output.Status.StatusCode), nil
+	}
+}
+
+func waitQueryLoggingConfigurationCreated(ctx context.Context, conn *amp.Client, id string, timeout time.Duration) (*awstypes.QueryLoggingConfigurationMetadata, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.QueryLoggingConfigurationStatusCodeCreating),
+		Target:  enum.Slice(awstypes.QueryLoggingConfigurationStatusCodeActive),
+		Refresh: statusQueryLoggingConfiguration(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.QueryLoggingConfigurationMetadata); ok {
+		if output.Status != nil {
+			tfresource.SetLastError(err, errors.New(aws.ToString(output.Status.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitQueryLoggingConfigurationUpdated(ctx context.Context, conn *amp.Client, id string, timeout time.Duration) (*awstypes.QueryLoggingConfigurationMetadata, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.QueryLoggingConfigurationStatusCodeUpdating),
+		Target:  enum.Slice(awstypes.QueryLoggingConfigurationStatusCodeActive),
+		Refresh: statusQueryLoggingConfiguration(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.QueryLoggingConfigurationMetadata); ok {
+		if output.Status != nil {
+			tfresource.SetLastError(err, errors.New(aws.ToString(output.Status.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+func waitQueryLoggingConfigurationDeleted(ctx context.Context, conn *amp.Client, id string, timeout time.Duration) (*awstypes.QueryLoggingConfigurationMetadata, error) {
+	stateConf := &retry.StateChangeConf{
+		Pending: enum.Slice(awstypes.QueryLoggingConfigurationStatusCodeDeleting, awstypes.QueryLoggingConfigurationStatusCodeActive),
+		Target:  []string{},
+		Refresh: statusQueryLoggingConfiguration(ctx, conn, id),
+		Timeout: timeout,
+	}
+
+	outputRaw, err := stateConf.WaitForStateContext(ctx)
+
+	if output, ok := outputRaw.(*awstypes.QueryLoggingConfigurationMetadata); ok {
+		if output.Status != nil {
+			tfresource.SetLastError(err, errors.New(aws.ToString(output.Status.StatusReason)))
+		}
+
+		return output, err
+	}
+
+	return nil, err
+}
+
+type queryLoggingConfigurationResourceModel struct {
+	framework.WithRegionModel
+	Destinations fwtypes.ListNestedObjectValueOf[queryLoggingDestinationModel] `tfsdk:"destinations"`
+	ID           types.String                                                  `tfsdk:"id"`
+	Timeouts     timeouts.Value                                                `tfsdk:"timeouts"`
+	WorkspaceID  types.String                                                  `tfsdk:"workspace_id"`
+}
+
+type queryLoggingDestinationModel struct {
+	CloudwatchLogs fwtypes.ListNestedObjectValueOf[cloudwatchLogsModel] `tfsdk:"cloudwatch_logs"`
+	Filters        fwtypes.ListNestedObjectValueOf[loggingFilterModel]  `tfsdk:"filters"`
+}
+
+type cloudwatchLogsModel struct {
+	LogGroupArn fwtypes.ARN `tfsdk:"log_group_arn"`
+}
+
+type loggingFilterModel struct {
+	QspThreshold types.Int64 `tfsdk:"qsp_threshold"`
+}

--- a/internal/service/amp/query_logging_configuration.go
+++ b/internal/service/amp/query_logging_configuration.go
@@ -267,7 +267,7 @@ func (r *queryLoggingConfigurationResource) Delete(ctx context.Context, request 
 func (r *queryLoggingConfigurationResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("workspace_id"), request, response)
 	// Also set the ID to the workspace ID
-	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root(names.AttrID), request.ID)...)
+	resource.ImportStatePassthroughID(ctx, path.Root(names.AttrID), request, response)
 }
 
 func findQueryLoggingConfigurationByID(ctx context.Context, conn *amp.Client, id string) (*awstypes.QueryLoggingConfigurationMetadata, error) {

--- a/internal/service/amp/query_logging_configuration_test.go
+++ b/internal/service/amp/query_logging_configuration_test.go
@@ -37,10 +37,9 @@ func TestAccAMPQueryLoggingConfiguration_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryLoggingConfigurationConfig_basic(rName),
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
-					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, workspaceResourceName, names.AttrID),
 					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "destination.0.cloudwatch_logs.#", "1"),
 					resource.TestCheckResourceAttrSet(resourceName, "destination.0.cloudwatch_logs.0.log_group_arn"),
@@ -49,9 +48,11 @@ func TestAccAMPQueryLoggingConfiguration_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "workspace_id"),
+				ImportStateVerifyIdentifierAttribute: "workspace_id",
 			},
 		},
 	})
@@ -82,9 +83,11 @@ func TestAccAMPQueryLoggingConfiguration_withFilters(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateIdFunc:                    acctest.AttrImportStateIdFunc(resourceName, "workspace_id"),
+				ImportStateVerifyIdentifierAttribute: "workspace_id",
 			},
 		},
 	})
@@ -126,7 +129,7 @@ func testAccCheckQueryLoggingConfigurationDestroy(ctx context.Context) resource.
 				continue
 			}
 
-			_, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.ID)
+			_, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.Attributes["workspace_id"])
 
 			if tfresource.NotFound(err) {
 				continue
@@ -136,7 +139,7 @@ func testAccCheckQueryLoggingConfigurationDestroy(ctx context.Context) resource.
 				return err
 			}
 
-			return fmt.Errorf("Prometheus Query Logging Configuration %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Prometheus Query Logging Configuration %s still exists", rs.Primary.Attributes["workspace_id"])
 		}
 
 		return nil
@@ -152,7 +155,7 @@ func testAccCheckQueryLoggingConfigurationExists(ctx context.Context, n string, 
 
 		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPClient(ctx)
 
-		output, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.ID)
+		output, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.Attributes["workspace_id"])
 
 		if err != nil {
 			return err

--- a/internal/service/amp/query_logging_configuration_test.go
+++ b/internal/service/amp/query_logging_configuration_test.go
@@ -1,0 +1,217 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package amp_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/amp/types"
+	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	tfamp "github.com/hashicorp/terraform-provider-aws/internal/service/amp"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/names"
+)
+
+func TestAccAMPQueryLoggingConfiguration_basic(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.QueryLoggingConfigurationMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_prometheus_query_logging_configuration.test"
+	workspaceResourceName := "aws_prometheus_workspace.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueryLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryLoggingConfigurationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, workspaceResourceName, names.AttrID),
+					resource.TestCheckResourceAttr(resourceName, "destinations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destinations.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "destinations.0.cloudwatch_logs.0.log_group_arn"),
+					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.0.qsp_threshold", "500"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAMPQueryLoggingConfiguration_withFilters(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.QueryLoggingConfigurationMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_prometheus_query_logging_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueryLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryLoggingConfigurationConfig_withFilters(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
+					resource.TestCheckResourceAttr(resourceName, "destinations.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.0.qsp_threshold", "1000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAMPQueryLoggingConfiguration_disappears(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v types.QueryLoggingConfigurationMetadata
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_prometheus_query_logging_configuration.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.AMPEndpointID)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckQueryLoggingConfigurationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccQueryLoggingConfigurationConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
+					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tfamp.ResourceQueryLoggingConfiguration, resourceName),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckQueryLoggingConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPClient(ctx)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_prometheus_query_logging_configuration" {
+				continue
+			}
+
+			_, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.ID)
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("AMP Query Logging Configuration %s still exists", rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckQueryLoggingConfigurationExists(ctx context.Context, n string, v *types.QueryLoggingConfigurationMetadata) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).AMPClient(ctx)
+
+		output, err := tfamp.FindQueryLoggingConfigurationByID(ctx, conn, rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccQueryLoggingConfigurationConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {
+  alias = %[1]q
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = "/aws/prometheus/query-logs/%[1]s"
+}
+
+resource "aws_prometheus_query_logging_configuration" "test" {
+  workspace_id = aws_prometheus_workspace.test.id
+
+  destinations {
+    cloudwatch_logs {
+      log_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
+    }
+
+    filters {
+      qsp_threshold = 500
+    }
+  }
+}
+`, rName)
+}
+
+func testAccQueryLoggingConfigurationConfig_withFilters(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_prometheus_workspace" "test" {
+  alias = %[1]q
+}
+
+resource "aws_cloudwatch_log_group" "test" {
+  name = "/aws/prometheus/query-logs/%[1]s-custom"
+}
+
+resource "aws_prometheus_query_logging_configuration" "test" {
+  workspace_id = aws_prometheus_workspace.test.id
+
+  destinations {
+    cloudwatch_logs {
+      log_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
+    }
+
+    filters {
+      qsp_threshold = 1000
+    }
+  }
+}
+`, rName)
+}

--- a/internal/service/amp/query_logging_configuration_test.go
+++ b/internal/service/amp/query_logging_configuration_test.go
@@ -136,7 +136,7 @@ func testAccCheckQueryLoggingConfigurationDestroy(ctx context.Context) resource.
 				return err
 			}
 
-			return fmt.Errorf("AMP Query Logging Configuration %s still exists", rs.Primary.ID)
+			return fmt.Errorf("Prometheus Query Logging Configuration %s still exists", rs.Primary.ID)
 		}
 
 		return nil

--- a/internal/service/amp/query_logging_configuration_test.go
+++ b/internal/service/amp/query_logging_configuration_test.go
@@ -41,11 +41,11 @@ func TestAccAMPQueryLoggingConfiguration_basic(t *testing.T) {
 					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "workspace_id", workspaceResourceName, names.AttrID),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrID, workspaceResourceName, names.AttrID),
-					resource.TestCheckResourceAttr(resourceName, "destinations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "destinations.0.cloudwatch_logs.#", "1"),
-					resource.TestCheckResourceAttrSet(resourceName, "destinations.0.cloudwatch_logs.0.log_group_arn"),
-					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.0.qsp_threshold", "500"),
+					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.cloudwatch_logs.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "destination.0.cloudwatch_logs.0.log_group_arn"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.filters.0.qsp_threshold", "500"),
 				),
 			},
 			{
@@ -76,9 +76,9 @@ func TestAccAMPQueryLoggingConfiguration_withFilters(t *testing.T) {
 				Config: testAccQueryLoggingConfigurationConfig_withFilters(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckQueryLoggingConfigurationExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "destinations.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "destinations.0.filters.0.qsp_threshold", "1000"),
+					resource.TestCheckResourceAttr(resourceName, "destination.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.filters.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destination.0.filters.0.qsp_threshold", "1000"),
 				),
 			},
 			{
@@ -177,7 +177,7 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_prometheus_query_logging_configuration" "test" {
   workspace_id = aws_prometheus_workspace.test.id
 
-  destinations {
+  destination {
     cloudwatch_logs {
       log_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
     }
@@ -203,7 +203,7 @@ resource "aws_cloudwatch_log_group" "test" {
 resource "aws_prometheus_query_logging_configuration" "test" {
   workspace_id = aws_prometheus_workspace.test.id
 
-  destinations {
+  destination {
     cloudwatch_logs {
       log_group_arn = "${aws_cloudwatch_log_group.test.arn}:*"
     }

--- a/internal/service/amp/service_package_gen.go
+++ b/internal/service/amp/service_package_gen.go
@@ -32,6 +32,12 @@ func (p *servicePackage) FrameworkDataSources(ctx context.Context) []*inttypes.S
 func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.ServicePackageFrameworkResource {
 	return []*inttypes.ServicePackageFrameworkResource{
 		{
+			Factory:  newQueryLoggingConfigurationResource,
+			TypeName: "aws_prometheus_query_logging_configuration",
+			Name:     "QueryLoggingConfiguration",
+			Region:   unique.Make(inttypes.ResourceRegionDefault()),
+		},
+		{
 			Factory:  newScraperResource,
 			TypeName: "aws_prometheus_scraper",
 			Name:     "Scraper",

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_log_group" "example" {
 resource "aws_prometheus_query_logging_configuration" "example" {
   workspace_id = aws_prometheus_workspace.example.id
 
-  destinations {
+  destination {
     cloudwatch_logs {
       log_group_arn = "${aws_cloudwatch_log_group.example.arn}:*"
     }
@@ -40,14 +40,14 @@ resource "aws_prometheus_query_logging_configuration" "example" {
 
 This resource supports the following arguments:
 
+* `destination` - (Required) Configuration block for the logging destinations. See [`destinations`](#destinations).
 * `workspace_id` - (Required) The ID of the AMP workspace for which to configure query logging.
-* `destinations` - (Required) Configuration block for the logging destinations. See [`destinations`](#destinations).
 
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 
-### `destinations`
+### `destination`
 
 * `cloudwatch_logs` - (Required) Configuration block for CloudWatch Logs destination. See [`cloudwatch_logs`](#cloudwatch_logs).
 * `filters` - (Required) A list of filter configurations that specify which logs should be sent to the destination. See [`filters`](#filters).
@@ -62,9 +62,7 @@ The following arguments are optional:
 
 ## Attribute Reference
 
-This resource exports the following attributes in addition to the arguments above:
-
-* `id` - The ID of the Query Logging Configuration, which is the workspace ID.
+This resource exports no additional attributes.
 
 ## Import
 

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -38,21 +38,21 @@ resource "aws_prometheus_query_logging_configuration" "example" {
 
 ## Argument Reference
 
-The following arguments are required:
+This resource supports the following arguments:
 
 * `workspace_id` - (Required) The ID of the AMP workspace for which to configure query logging.
-* `destinations` - (Required) Configuration block for the logging destinations. Detailed below.
+* `destinations` - (Required) Configuration block for the logging destinations. See [`destinations`](#destinations).
 
-The `destinations` block supports the following:
+### `destinations`
 
-* `cloudwatch_logs` - (Required) Configuration block for CloudWatch Logs destination. Detailed below.
-* `filters` - (Optional) A list of filter configurations that specify which logs should be sent to the destination. Detailed below.
+* `cloudwatch_logs` - (Required) Configuration block for CloudWatch Logs destination. See [`cloudwatch_logs`](#cloudwatch_logs).
+* `filters` - (Required) A list of filter configurations that specify which logs should be sent to the destination. See [`filters`](#filters).
 
-The `cloudwatch_logs` block supports the following:
+#### `cloudwatch_logs`
 
 * `log_group_arn` - (Required) The ARN of the CloudWatch log group to which query logs will be sent.
 
-The `filters` block supports the following:
+### `filters`
 
 * `qsp_threshold` - (Required) The Query Samples Processed (QSP) threshold above which queries will be logged. Queries processing more samples than this threshold will be captured in logs.
 

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -43,6 +43,10 @@ This resource supports the following arguments:
 * `workspace_id` - (Required) The ID of the AMP workspace for which to configure query logging.
 * `destinations` - (Required) Configuration block for the logging destinations. See [`destinations`](#destinations).
 
+The following arguments are optional:
+
+* `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+
 ### `destinations`
 
 * `cloudwatch_logs` - (Required) Configuration block for CloudWatch Logs destination. See [`cloudwatch_logs`](#cloudwatch_logs).
@@ -52,7 +56,7 @@ This resource supports the following arguments:
 
 * `log_group_arn` - (Required) The ARN of the CloudWatch log group to which query logs will be sent.
 
-### `filters`
+#### `filters`
 
 * `qsp_threshold` - (Required) The Query Samples Processed (QSP) threshold above which queries will be logged. Queries processing more samples than this threshold will be captured in logs.
 

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Prometheus"
+subcategory: "AMP (Managed Prometheus)"
 layout: "aws"
 page_title: "AWS: aws_prometheus_query_logging_configuration"
 description: |-
@@ -28,7 +28,7 @@ resource "aws_prometheus_query_logging_configuration" "example" {
     cloudwatch_logs {
       log_group_arn = "${aws_cloudwatch_log_group.example.arn}:*"
     }
-    
+
     filters {
       qsp_threshold = 1000
     }

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -1,0 +1,79 @@
+---
+subcategory: "Prometheus"
+layout: "aws"
+page_title: "AWS: aws_prometheus_query_logging_configuration"
+description: |-
+  Manages an Amazon Managed Service for Prometheus (AMP) Query Logging Configuration.
+---
+
+# Resource: aws_prometheus_query_logging_configuration
+
+Manages an Amazon Managed Service for Prometheus (AMP) Query Logging Configuration.
+
+## Example Usage
+
+```terraform
+resource "aws_prometheus_workspace" "example" {
+  alias = "example"
+}
+
+resource "aws_cloudwatch_log_group" "example" {
+  name = "/aws/prometheus/query-logs/example"
+}
+
+resource "aws_prometheus_query_logging_configuration" "example" {
+  workspace_id = aws_prometheus_workspace.example.id
+
+  destinations {
+    cloudwatch_logs {
+      log_group_arn = "${aws_cloudwatch_log_group.example.arn}:*"
+    }
+    
+    filters {
+      qsp_threshold = 1000
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are required:
+
+* `workspace_id` - (Required) The ID of the AMP workspace for which to configure query logging.
+* `destinations` - (Required) Configuration block for the logging destinations. Detailed below.
+
+The `destinations` block supports the following:
+
+* `cloudwatch_logs` - (Required) Configuration block for CloudWatch Logs destination. Detailed below.
+* `filters` - (Optional) A list of filter configurations that specify which logs should be sent to the destination. Detailed below.
+
+The `cloudwatch_logs` block supports the following:
+
+* `log_group_arn` - (Required) The ARN of the CloudWatch log group to which query logs will be sent.
+
+The `filters` block supports the following:
+
+* `qsp_threshold` - (Required) The Query Samples Processed (QSP) threshold above which queries will be logged. Queries processing more samples than this threshold will be captured in logs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the Query Logging Configuration, which is the workspace ID.
+
+## Import
+
+AMP Query Logging Configuration can be imported using the workspace ID, e.g.,
+
+```
+$ terraform import aws_prometheus_query_logging_configuration.example ws-12345678-90ab-cdef-1234-567890abcdef
+```
+
+## Timeouts
+
+[Configuration options](https://developer.hashicorp.com/terraform/language/resources/syntax#operation-timeouts):
+
+- `create` - (Default `5m`)
+- `update` - (Default `5m`)
+- `delete` - (Default `5m`)

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -60,7 +60,7 @@ The following arguments are optional:
 
 * `qsp_threshold` - (Required) The Query Samples Processed (QSP) threshold above which queries will be logged. Queries processing more samples than this threshold will be captured in logs.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/website/docs/r/prometheus_query_logging_configuration.html.markdown
+++ b/website/docs/r/prometheus_query_logging_configuration.html.markdown
@@ -62,16 +62,19 @@ The following arguments are optional:
 
 ## Attribute Reference
 
-In addition to all arguments above, the following attributes are exported:
+This resource exports the following attributes in addition to the arguments above:
 
 * `id` - The ID of the Query Logging Configuration, which is the workspace ID.
 
 ## Import
 
-AMP Query Logging Configuration can be imported using the workspace ID, e.g.,
+In Terraform v1.5.0 and later, use an [`import` block](https://developer.hashicorp.com/terraform/language/import) to import the Query Logging Configuration using the workspace ID. For example:
 
-```
-$ terraform import aws_prometheus_query_logging_configuration.example ws-12345678-90ab-cdef-1234-567890abcdef
+```terraform
+import {
+  to = aws_prometheus_query_logging_configuration.example
+  id = "ws-12345678-90ab-cdef-1234-567890abcdef"
+}
 ```
 
 ## Timeouts


### PR DESCRIPTION

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This implement Terraform support for new AWS APIs including https://docs.aws.amazon.com/prometheus/latest/APIReference/API_CreateQueryLoggingConfiguration.html

### Relations


Closes https://github.com/hashicorp/terraform-provider-aws/issues/42776

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make build && make testacc TESTARGS='-run=TestAccAMPQueryLoggingConfiguration' PKG=amp ACCTEST_PARALLELISM=5
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Building provider...
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/amp/... -v -count 1 -parallel 5  -run=TestAccAMPQueryLoggingConfiguration -timeout 360m -vet=off
2025/06/29 16:49:53 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/29 16:49:53 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAMPQueryLoggingConfiguration_basic
=== PAUSE TestAccAMPQueryLoggingConfiguration_basic
=== RUN   TestAccAMPQueryLoggingConfiguration_withFilters
=== PAUSE TestAccAMPQueryLoggingConfiguration_withFilters
=== RUN   TestAccAMPQueryLoggingConfiguration_disappears
=== PAUSE TestAccAMPQueryLoggingConfiguration_disappears
=== CONT  TestAccAMPQueryLoggingConfiguration_basic
=== CONT  TestAccAMPQueryLoggingConfiguration_disappears
=== CONT  TestAccAMPQueryLoggingConfiguration_withFilters
--- PASS: TestAccAMPQueryLoggingConfiguration_disappears (34.18s)
--- PASS: TestAccAMPQueryLoggingConfiguration_withFilters (36.23s)
--- PASS: TestAccAMPQueryLoggingConfiguration_basic (38.09s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/amp	40.026s
...
```
