### PR TITLE
Fix EC2 fleet instance_pools_to_use_count

### DIFF
--- a/.changelog/43176.txt
+++ b/.changelog/43176.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_fleet: Fix `instance_pools_to_use_count` drift for non-lowestPrice allocation strategies
+```

--- a/internal/service/ec2/ec2_fleet.go
+++ b/internal/service/ec2/ec2_fleet.go
@@ -1534,11 +1534,14 @@ func flattenSpotOptions(apiObject *awstypes.SpotOptions) map[string]any {
 		tfMap["instance_interruption_behavior"] = v
 	}
 
-	if v := apiObject.InstancePoolsToUseCount; v != nil {
-		tfMap["instance_pools_to_use_count"] = aws.ToInt32(v)
-	} else if apiObject.AllocationStrategy == awstypes.SpotAllocationStrategyDiversified {
-		// API will omit InstancePoolsToUseCount if AllocationStrategy is diversified, which breaks our Default: 1
-		// Here we just reset it to 1 to prevent removing the Default and setting up a special DiffSuppressFunc.
+	if apiObject.AllocationStrategy == awstypes.SpotAllocationStrategy(spotAllocationStrategyLowestPrice) {
+		// InstancePoolsToUseCount is only valid for lowestPrice allocation strategy
+		if v := apiObject.InstancePoolsToUseCount; v != nil {
+			tfMap["instance_pools_to_use_count"] = aws.ToInt32(v)
+		}
+		// If AWS doesn't return the value for lowestPrice strategy, we don't set it and let the schema default apply
+	} else {
+		// For all other strategies, we always set it to 1 to not cause drift
 		tfMap["instance_pools_to_use_count"] = 1
 	}
 

--- a/internal/service/ec2/ec2_fleet_test.go
+++ b/internal/service/ec2/ec2_fleet_test.go
@@ -2689,6 +2689,38 @@ func TestAccEC2Fleet_SpotOptions_allocationStrategy(t *testing.T) {
 	})
 }
 
+func TestAccEC2Fleet_SpotOptions_allocationStrategyPriceCapacityOptimized(t *testing.T) {
+	ctx := acctest.Context(t)
+	var fleet1 awstypes.FleetData
+	resourceName := "aws_ec2_fleet.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckFleet(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_spotOptionsAllocationStrategy(rName, "price-capacity-optimized"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName, &fleet1),
+					resource.TestCheckResourceAttr(resourceName, "spot_options.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "spot_options.0.allocation_strategy", "price-capacity-optimized"),
+					// instance_pools_to_use_count should be set to 1 for price-capacity-optimized allocation strategy
+					resource.TestCheckResourceAttr(resourceName, "spot_options.0.instance_pools_to_use_count", "1"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"terminate_instances"},
+			},
+		},
+	})
+}
+
 func TestAccEC2Fleet_SpotOptions_capacityRebalance(t *testing.T) {
 	ctx := acctest.Context(t)
 	var fleet1 awstypes.FleetData


### PR DESCRIPTION
Sets instance_pools_to_use_count to 1 for all allocation strategies except lowest-price.

Closes #43176
