### PR TITLE
aws_glue_catalog_database: when create_table_default_permission is present, but empty, create default LF permissions, not IAM_ALLOWED_PRINCIPALS (legacy/hybrid) permissions

### DIFF
--- a/.changelog/43226.txt
+++ b/.changelog/43226.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_glue_catalog_database: when create_table_default_permission is present, but empty, create default LF permissions, not IAM_ALLOWED_PRINCIPALS (legacy/hybrid) permissions
+```

--- a/internal/service/glue/catalog_database.go
+++ b/internal/service/glue/catalog_database.go
@@ -1,8 +1,6 @@
 // Copyright IBM Corp. 2014, 2026
 // SPDX-License-Identifier: MPL-2.0
 
-// DONOTCOPY: Copying old resources spreads bad habits. Use skaff instead.
-
 package glue
 
 import (
@@ -17,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/glue"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/glue/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	sdkretry "github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -43,6 +41,35 @@ func resourceCatalogDatabase() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, meta any) error {
+				// Handle the case where create_table_default_permission is configured as an empty block
+				// This is needed to enable Lake Formation-only permissions
+				old, new := diff.GetChange("create_table_default_permission")
+
+				// Check if we have an empty block in the new configuration
+				if new != nil {
+					if newList, ok := new.([]any); ok && len(newList) == 1 {
+						if newBlock, ok := newList[0].(map[string]any); ok {
+							if isEmptyPermissionBlock(newBlock) {
+								// This is an empty block, we need to ensure it's preserved in state
+								// even when AWS returns no permissions
+								return nil
+							}
+						}
+					}
+				}
+
+				// Check if we're removing the block entirely
+				if old != nil && len(old.([]any)) > 0 && (new == nil || len(new.([]any)) == 0) {
+					// Block was removed, this should trigger an update
+					return nil
+				}
+
+				return nil
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			names.AttrARN: {
@@ -185,7 +212,7 @@ func resourceCatalogDatabaseCreate(ctx context.Context, d *schema.ResourceData, 
 		dbInput.TargetDatabase = expandDatabaseTargetDatabase(v.([]any)[0].(map[string]any))
 	}
 
-	if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
+	if v, ok := d.GetOk("create_table_default_permission"); ok {
 		dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]any))
 	}
 
@@ -215,7 +242,7 @@ func resourceCatalogDatabaseRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	out, err := findDatabaseByName(ctx, conn, catalogID, name)
-	if !d.IsNewResource() && retry.NotFound(err) {
+	if !d.IsNewResource() && errs.IsA[*retry.NotFoundError](err) {
 		log.Printf("[WARN] Glue Catalog Database (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -298,8 +325,18 @@ func resourceCatalogDatabaseUpdate(ctx context.Context, d *schema.ResourceData, 
 			dbInput.FederatedDatabase = expandDatabaseFederatedDatabase(v.([]any)[0].(map[string]any))
 		}
 
-		if v, ok := d.GetOk("create_table_default_permission"); ok && len(v.([]any)) > 0 {
-			dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]any))
+		if d.HasChange("create_table_default_permission") {
+			// Check if the field is configured (even if empty) vs not configured at all
+			if raw := d.GetRawConfig().GetAttr("create_table_default_permission"); !raw.IsNull() {
+				// Field is configured (could be empty block or with values)
+				if v, ok := d.GetOk("create_table_default_permission"); ok {
+					dbInput.CreateTableDefaultPermissions = expandDatabasePrincipalPermissions(v.([]any))
+				} else {
+					// Empty configuration, send empty array
+					dbInput.CreateTableDefaultPermissions = []awstypes.PrincipalPermissions{}
+				}
+			}
+			// If raw.IsNull(), the field was removed entirely, so we don't set it
 		}
 
 		dbUpdateInput.DatabaseInput = dbInput
@@ -358,9 +395,8 @@ func findDatabaseByName(ctx context.Context, conn *glue.Client, catalogID, name 
 
 	output, err := conn.GetDatabase(ctx, input)
 	if errs.IsA[*awstypes.EntityNotFoundException](err) {
-		return nil, &sdkretry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+		return nil, &retry.NotFoundError{
+			LastError: err,
 		}
 	}
 
@@ -456,25 +492,43 @@ func flattenDatabaseTargetDatabase(apiObject *awstypes.DatabaseIdentifier) map[s
 }
 
 func expandDatabasePrincipalPermissions(tfList []any) []awstypes.PrincipalPermissions {
-	if len(tfList) == 0 {
+	// Always return an empty slice when tfList is not nil, even if it's empty
+	// This handles the case where an empty block {} is specified in config
+	if tfList == nil {
 		return nil
 	}
 
-	var apiObjects []awstypes.PrincipalPermissions
+	apiObjects := make([]awstypes.PrincipalPermissions, 0, len(tfList))
 
 	for _, tfMapRaw := range tfList {
 		tfMap, ok := tfMapRaw.(map[string]any)
-
 		if !ok {
 			continue
 		}
 
-		apiObject := expandDatabasePrincipalPermission(tfMap)
+		// Skip empty blocks (no permissions and no principal)
+		if isEmptyPermissionBlock(tfMap) {
+			continue
+		}
 
-		apiObjects = append(apiObjects, apiObject)
+		apiObjects = append(apiObjects, expandDatabasePrincipalPermission(tfMap))
 	}
 
 	return apiObjects
+}
+
+func isEmptyPermissionBlock(tfMap map[string]any) bool {
+	hasPermissions := false
+	if v, ok := tfMap[names.AttrPermissions].(*schema.Set); ok && v.Len() > 0 {
+		hasPermissions = true
+	}
+
+	hasPrincipal := false
+	if v, ok := tfMap[names.AttrPrincipal].([]any); ok && len(v) > 0 && v[0] != nil {
+		hasPrincipal = true
+	}
+
+	return !hasPermissions && !hasPrincipal
 }
 
 func expandDatabasePrincipalPermission(tfMap map[string]any) awstypes.PrincipalPermissions {
@@ -507,7 +561,12 @@ func expandDatabasePrincipal(tfMap map[string]any) *awstypes.DataLakePrincipal {
 
 func flattenDatabasePrincipalPermissions(apiObjects []awstypes.PrincipalPermissions) []any {
 	if len(apiObjects) == 0 {
-		return nil
+		// When AWS returns an empty array, preserve it as an empty block
+		// This handles the Lake Formation-only permissions use case
+		return []any{map[string]any{
+			names.AttrPermissions: []any{},
+			names.AttrPrincipal:   []any{},
+		}}
 	}
 
 	var tfList []any

--- a/website/docs/r/glue_catalog_database.html.markdown
+++ b/website/docs/r/glue_catalog_database.html.markdown
@@ -34,13 +34,26 @@ resource "aws_glue_catalog_database" "example" {
 }
 ```
 
+### Enable Lake Formation Permissions Only
+
+To enable Lake Formation permissions only (removing default IAM permissions), declare an empty `create_table_default_permission` block:
+
+```terraform
+resource "aws_glue_catalog_database" "example" {
+  name = "MyCatalogDatabase"
+
+  create_table_default_permission {
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `catalog_id` - (Optional) ID of the Glue Catalog to create the database in. If omitted, this defaults to the AWS Account ID.
-* `create_table_default_permission` - (Optional) Creates a set of default permissions on the table for principals. See [`create_table_default_permission`](#create_table_default_permission) below.
+* `create_table_default_permission` - (Optional) Creates a set of default permissions on the table for principals. See [`create_table_default_permission`](#create_table_default_permission) below. When this block is present but empty, it enables Lake Formation permissions only by removing default IAM permissions. When this block is absent entirely, default permissions (IAMAllowedPrincipals group) are used.
 * `description` - (Optional) Description of the database.
 * `federated_database` - (Optional) Configuration block that references an entity outside the AWS Glue Data Catalog. See [`federated_database`](#federated_database) below.
 * `location_uri` - (Optional) Location of the database (for example, an HDFS path).


### PR DESCRIPTION
### Description
As described in #27295, this resource would always create a glue database with IAM_ALLOWED_PRINCIPALS group in the permissions (i.e. IAM-only or Hybrid permissions, not Lake Formation permissions). 

This PR makes it possible to create a database with Lake Formation permissions. 

### Relations
Closes #27295

### References
https://docs.aws.amazon.com/glue/latest/webapi/API_DatabaseInput.html#Glue-Type-DatabaseInput-CreateTableDefaultPermissions

### Output from Acceptance Testing

```console TF_ACC=1 go test -v ./internal/service/glue -run TestAccGlueCatalogDatabase_createTablePermission -timeout 30m
 
2025/06/30 09:44:32 Creating Terraform AWS Provider (SDKv2-style)...
2025/06/30 09:46:08 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccGlueCatalogDatabase_full
=== PAUSE TestAccGlueCatalogDatabase_full
=== RUN   TestAccGlueCatalogDatabase_createTablePermissionTransition
=== PAUSE TestAccGlueCatalogDatabase_createTablePermissionTransition
=== RUN   TestAccGlueCatalogDatabase_createTablePermission
=== PAUSE TestAccGlueCatalogDatabase_createTablePermission
=== RUN   TestAccGlueCatalogDatabase_targetDatabase
=== PAUSE TestAccGlueCatalogDatabase_targetDatabase
=== RUN   TestAccGlueCatalogDatabase_targetDatabaseWithRegion
=== PAUSE TestAccGlueCatalogDatabase_targetDatabaseWithRegion
=== RUN   TestAccGlueCatalogDatabase_federatedDatabase
=== PAUSE TestAccGlueCatalogDatabase_federatedDatabase
=== RUN   TestAccGlueCatalogDatabase_tags
=== PAUSE TestAccGlueCatalogDatabase_tags
=== RUN   TestAccGlueCatalogDatabase_disappears
=== PAUSE TestAccGlueCatalogDatabase_disappears
=== CONT  TestAccGlueCatalogDatabase_full
=== CONT  TestAccGlueCatalogDatabase_targetDatabaseWithRegion
=== CONT  TestAccGlueCatalogDatabase_tags
=== CONT  TestAccGlueCatalogDatabase_createTablePermissionTransition
=== CONT  TestAccGlueCatalogDatabase_disappears
=== CONT  TestAccGlueCatalogDatabase_targetDatabase
=== CONT  TestAccGlueCatalogDatabase_createTablePermission
=== CONT  TestAccGlueCatalogDatabase_federatedDatabase
--- PASS: TestAccGlueCatalogDatabase_disappears (27.06s)
--- PASS: TestAccGlueCatalogDatabase_createTablePermissionTransition (37.98s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabaseWithRegion (42.18s)
--- PASS: TestAccGlueCatalogDatabase_createTablePermission (47.08s)
--- PASS: TestAccGlueCatalogDatabase_targetDatabase (49.45s)
--- PASS: TestAccGlueCatalogDatabase_full (61.77s)
--- PASS: TestAccGlueCatalogDatabase_tags (61.88s)
--- PASS: TestAccGlueCatalogDatabase_federatedDatabase (361.69s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/glue       365.925s

...
```
