### PR TITLE
Make agentsarns optional for aws_datasync_location_object_storage resource

### DIFF
--- a/.changelog/43241.txt
+++ b/.changelog/43241.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datasync_location_object_storage: Fix agent_arns being required
+```

--- a/internal/service/datasync/location_object_storage.go
+++ b/internal/service/datasync/location_object_storage.go
@@ -48,7 +48,7 @@ func resourceLocationObjectStorage() *schema.Resource {
 			},
 			"agent_arns": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidARN,

--- a/website/docs/r/datasync_location_object_storage.html.markdown
+++ b/website/docs/r/datasync_location_object_storage.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Manages a Object Storage Location within AWS DataSync.
 
-~> **NOTE:** The DataSync Agents must be available before creating this resource.
+~> **NOTE:** When using DataSync Agents, they must be available before creating this resource.
 
 ## Example Usage
 
@@ -27,7 +27,7 @@ resource "aws_datasync_location_object_storage" "example" {
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `agent_arns` - (Required) A list of DataSync Agent ARNs with which this location will be associated.
+* `agent_arns` - (Optional) A list of DataSync Agent ARNs with which this location will be associated.
 * `access_key` - (Optional) The access key is used if credentials are required to access the self-managed object storage server. If your object storage requires a user name and password to authenticate, use `access_key` and `secret_key` to provide the user name and password, respectively.
 * `bucket_name` - (Required) The bucket on the self-managed object storage server that is used to read data from.
 * `secret_key` - (Optional) The secret key is used if credentials are required to access the self-managed object storage server. If your object storage requires a user name and password to authenticate, use `access_key` and `secret_key` to provide the user name and password, respectively.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Makes the `AgentArns` argument for the `aws_datasync_location_object_storage` resource optional, matching the AWS API.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43243

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
