### PR TITLE
Fix: Managed login version updates for custom Cognito domains

### DIFF
--- a/.changelog/43252.txt
+++ b/.changelog/43252.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_cognito_user_pool_domain: Fix managed login version updates for custom Cognito domains
+```

--- a/.changelog/43252.txt
+++ b/.changelog/43252.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_cognito_user_pool_domain: Fix managed login version updates for custom Cognito domains
+resource/aws_cognito_user_pool_domain: Correctly update `managed_login_version` for custom Cognito domains
 ```

--- a/internal/service/cognitoidp/user_pool_domain.go
+++ b/internal/service/cognitoidp/user_pool_domain.go
@@ -182,6 +182,14 @@ func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChange("managed_login_version") {
 		input.ManagedLoginVersion = aws.Int32(int32(d.Get("managed_login_version").(int)))
+
+		if v, ok := d.GetOk(names.AttrCertificateARN); ok {
+			// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains
+			input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
+				CertificateArn: aws.String(v.(string)),
+			}
+			timeout = 60 * time.Minute // Custom domains take more time to become active.
+		}
 	}
 
 	_, err := conn.UpdateUserPoolDomain(ctx, &input)

--- a/internal/service/cognitoidp/user_pool_domain.go
+++ b/internal/service/cognitoidp/user_pool_domain.go
@@ -184,11 +184,11 @@ func resourceUserPoolDomainUpdate(ctx context.Context, d *schema.ResourceData, m
 		input.ManagedLoginVersion = aws.Int32(int32(d.Get("managed_login_version").(int)))
 
 		if v, ok := d.GetOk(names.AttrCertificateARN); ok {
-			// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains
+			// If there is a certificate use it as part of the request, this is how AWS distinguishes between custom and prefix domains.
+			timeout = 60 * time.Minute // Custom domains take more time to become active.
 			input.CustomDomainConfig = &awstypes.CustomDomainConfigType{
 				CertificateArn: aws.String(v.(string)),
 			}
-			timeout = 60 * time.Minute // Custom domains take more time to become active.
 		}
 	}
 
@@ -235,11 +235,11 @@ func resourceUserPoolDomainDelete(ctx context.Context, d *schema.ResourceData, m
 }
 
 func findUserPoolDomain(ctx context.Context, conn *cognitoidentityprovider.Client, domain string) (*awstypes.DomainDescriptionType, error) {
-	input := &cognitoidentityprovider.DescribeUserPoolDomainInput{
+	input := cognitoidentityprovider.DescribeUserPoolDomainInput{
 		Domain: aws.String(domain),
 	}
 
-	output, err := conn.DescribeUserPoolDomain(ctx, input)
+	output, err := conn.DescribeUserPoolDomain(ctx, &input)
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{

--- a/internal/service/cognitoidp/user_pool_domain_test.go
+++ b/internal/service/cognitoidp/user_pool_domain_test.go
@@ -183,6 +183,43 @@ func TestAccCognitoIDPUserPoolDomain_managedLoginVersion(t *testing.T) {
 	})
 }
 
+func TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate(t *testing.T) {
+	ctx := acctest.Context(t)
+	rootDomain := acctest.ACMCertificateDomainFromEnv(t)
+	domain := acctest.ACMCertificateRandomSubDomain(rootDomain)
+	poolName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	acmCertResourceName := "aws_acm_certificate.test"
+	cognitoPoolResourceName := "aws_cognito_user_pool_domain.test"
+	fmt.Println("In test")
+	fmt.Println(rootDomain)
+	fmt.Println(poolName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckUserPoolDomainDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUserPoolDomainConfig_customCustomDomainManagedLoginVersionUpdate(rootDomain, domain, poolName, 1),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainExists(ctx, cognitoPoolResourceName),
+					resource.TestCheckResourceAttr(cognitoPoolResourceName, "managed_login_version", "1"),
+					resource.TestCheckResourceAttrPair(cognitoPoolResourceName, names.AttrCertificateARN, acmCertResourceName, names.AttrARN),
+				),
+			},
+			{
+				Config: testAccUserPoolDomainConfig_customCustomDomainManagedLoginVersionUpdate(rootDomain, domain, poolName, 2),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckUserPoolDomainCertMatches(ctx, cognitoPoolResourceName, acmCertResourceName),
+					resource.TestCheckResourceAttr(cognitoPoolResourceName, "managed_login_version", "2"),
+					resource.TestCheckResourceAttrPair(cognitoPoolResourceName, names.AttrCertificateARN, acmCertResourceName, names.AttrARN),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckUserPoolDomainExists(ctx context.Context, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -376,4 +413,44 @@ resource "aws_cognito_user_pool" "test" {
   name = %[1]q
 }
 `, rName, version)
+}
+
+func testAccUserPoolDomainConfig_customCustomDomainManagedLoginVersionUpdate(rootDomain, domain, poolName string, version int) string {
+	return fmt.Sprintf(`
+data "aws_route53_zone" "test" {
+  name         = %[1]q
+  private_zone = false
+}
+
+resource "aws_acm_certificate" "test" {
+  domain_name       = %[2]q
+  validation_method = "DNS"
+}
+
+resource "aws_route53_record" "test" {
+  allow_overwrite = true
+  name            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_name
+  records         = [tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_value]
+  ttl             = 60
+  type            = tolist(aws_acm_certificate.test.domain_validation_options)[0].resource_record_type
+  zone_id         = data.aws_route53_zone.test.zone_id
+}
+
+resource "aws_acm_certificate_validation" "test" {
+  certificate_arn         = aws_acm_certificate.test.arn
+  validation_record_fqdns = [aws_route53_record.test.fqdn]
+}
+
+resource "aws_cognito_user_pool" "test" {
+  name = %[3]q
+}
+
+resource "aws_cognito_user_pool_domain" "test" {
+  certificate_arn = aws_acm_certificate_validation.test.certificate_arn
+  domain          = aws_acm_certificate.test.domain_name
+  user_pool_id    = aws_cognito_user_pool.test.id
+
+  managed_login_version = %[4]d
+}
+`, rootDomain, domain, poolName, version)
 }

--- a/internal/service/cognitoidp/user_pool_domain_test.go
+++ b/internal/service/cognitoidp/user_pool_domain_test.go
@@ -190,9 +190,6 @@ func TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
 	poolName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	acmCertResourceName := "aws_acm_certificate.test"
 	cognitoPoolResourceName := "aws_cognito_user_pool_domain.test"
-	fmt.Println("In test")
-	fmt.Println(rootDomain)
-	fmt.Println(poolName)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); acctest.PreCheckRegion(t, endpoints.UsEast1RegionID) },


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description

The aim of this PR is to allow changes to the managed login version for custom Cognito domains.

Requests to update the managed login version for custom domains without a certificate arn fail with 
> An error occurred (InvalidParameterException) when calling the UpdateUserPoolDomain operation: Cannot convert custom domain to prefix domain.

This happens from terraform and the aws cli. This means the aws provider should send the certificate arn if it's a custom domain. 

### Relations

Closes #43248

### References

### Output from Acceptance Testing

Running only the new test for cost concerns.

```console
% make testacc TESTS=TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate PKG=cognitoidp

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/cognitoidp/... -v -count 1 -parallel 20 -run='TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate'  -timeout 360m -vet=off
2025/07/02 16:54:52 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/02 16:54:52 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
=== PAUSE TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
=== CONT  TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate
--- PASS: TestAccCognitoIDPUserPoolDomain_customCustomDomainManagedLoginVersionUpdate (830.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/cognitoidp 835.226s
...
```
