### PR TITLE
resource/aws_redshift_cluster: Update `node_type` to valid value

### DIFF
--- a/.changelog/43270.txt
+++ b/.changelog/43270.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_redshift_cluster: Correctly set `availability_zone_relocation_enabled`
+```

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3651,7 +3651,7 @@ resource "aws_redshift_cluster" "test" {
   cluster_type       = "single-node"
   encrypted          = true
 
-  skip_final_snapshot                 = true
+  skip_final_snapshot = true
 }
 
 data "aws_partition" "current" {}

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -3647,11 +3647,10 @@ resource "aws_redshift_cluster" "test" {
   database_name      = "mydb"
   master_username    = "foo"
   master_password    = "Mustbe8characters"
-  node_type          = "dc2.large"
+  node_type          = "ra3.large"
   cluster_type       = "single-node"
   encrypted          = true
 
-  automated_snapshot_retention_period = 0
   skip_final_snapshot                 = true
 }
 

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -1964,14 +1964,14 @@ resource "aws_cloudwatch_event_target" "test" {
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  cluster_subnet_group_name           = aws_redshift_subnet_group.test.name
-  database_name                       = "test"
-  master_username                     = "tfacctest"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier        = %[1]q
+  cluster_subnet_group_name = aws_redshift_subnet_group.test.name
+  database_name             = "test"
+  master_username           = "tfacctest"
+  master_password           = "Mustbe8characters"
+  node_type                 = "ra3.large"
+  allow_version_upgrade     = false
+  skip_final_snapshot       = true
 
   depends_on = [aws_internet_gateway.test]
 }

--- a/internal/service/events/target_test.go
+++ b/internal/service/events/target_test.go
@@ -1969,8 +1969,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "test"
   master_username                     = "tfacctest"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 

--- a/internal/service/firehose/delivery_stream_test.go
+++ b/internal/service/firehose/delivery_stream_test.go
@@ -4334,7 +4334,7 @@ resource "aws_redshift_cluster" "test" {
   database_name             = "test"
   master_username           = "testuser"
   master_password           = "T3stPass"
-  node_type                 = "dc2.large"
+  node_type                 = "ra3.large"
   cluster_type              = "single-node"
   skip_final_snapshot       = true
   cluster_subnet_group_name = aws_redshift_subnet_group.test.id

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -3183,13 +3183,13 @@ func testAccPipeConfig_basicSQSSourceRedshiftTarget(rName string) string {
 		testAccPipeConfig_baseSQSSource(rName),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "target" {
-  cluster_identifier                  = "%[1]s-target"
-  database_name                       = "test"
-  master_username                     = "tfacctest"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = "%[1]s-target"
+  database_name         = "test"
+  master_username       = "tfacctest"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 
 resource "aws_pipes_pipe" "test" {

--- a/internal/service/pipes/pipe_test.go
+++ b/internal/service/pipes/pipe_test.go
@@ -3187,8 +3187,7 @@ resource "aws_redshift_cluster" "target" {
   database_name                       = "test"
   master_username                     = "tfacctest"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }

--- a/internal/service/redshift/cluster_credentials_data_source_test.go
+++ b/internal/service/redshift/cluster_credentials_data_source_test.go
@@ -43,7 +43,7 @@ resource "aws_redshift_cluster" "test" {
   database_name       = "testdb"
   master_username     = "foo"
   master_password     = "Password1"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   cluster_type        = "single-node"
   skip_final_snapshot = true
 }

--- a/internal/service/redshift/cluster_data_source_test.go
+++ b/internal/service/redshift/cluster_data_source_test.go
@@ -157,7 +157,7 @@ resource "aws_redshift_cluster" "test" {
   database_name       = "testdb"
   master_username     = "foo"
   master_password     = "Password1"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   cluster_type        = "single-node"
   skip_final_snapshot = true
 }
@@ -190,7 +190,7 @@ resource "aws_redshift_cluster" "test" {
   database_name             = "testdb"
   master_username           = "foo"
   master_password           = "Password1"
-  node_type                 = "dc2.large"
+  node_type                 = "ra3.large"
   cluster_type              = "multi-node"
   number_of_nodes           = 2
   publicly_accessible       = false
@@ -247,7 +247,7 @@ resource "aws_redshift_cluster" "test" {
   database_name       = "testdb"
   master_password     = "Password1"
   master_username     = "foo"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   skip_final_snapshot = true
 }
 

--- a/internal/service/redshift/cluster_iam_roles_test.go
+++ b/internal/service/redshift/cluster_iam_roles_test.go
@@ -132,13 +132,13 @@ EOF
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 `, rName)
 }

--- a/internal/service/redshift/cluster_iam_roles_test.go
+++ b/internal/service/redshift/cluster_iam_roles_test.go
@@ -136,8 +136,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -385,7 +385,7 @@ func TestAccRedshiftCluster_updateNodeCount(t *testing.T) {
 					testAccCheckClusterExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, "number_of_nodes", "2"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "multi-node"),
-					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.large"),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "ra3.large"),
 				),
 			},
 		},
@@ -405,17 +405,17 @@ func TestAccRedshiftCluster_updateNodeType(t *testing.T) {
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccClusterConfig_updateNodeType(rName, "dc2.large"),
+				Config: testAccClusterConfig_updateNodeType(rName, "ra3.large"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.large"),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "ra3.large"),
 				),
 			},
 			{
-				Config: testAccClusterConfig_updateNodeType(rName, "dc2.8xlarge"),
+				Config: testAccClusterConfig_updateNodeType(rName, "ra3.xlplus"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckClusterExists(ctx, resourceName, &v),
-					resource.TestCheckResourceAttr(resourceName, "node_type", "dc2.8xlarge"),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "ra3.xlplus"),
 				),
 			},
 		},
@@ -1436,8 +1436,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   number_of_nodes                     = 2
   skip_final_snapshot                 = true
@@ -1454,7 +1453,6 @@ resource "aws_redshift_cluster" "test" {
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
   node_type                           = %[2]q
-  automated_snapshot_retention_period = 0
   allow_version_upgrade               = false
   number_of_nodes                     = 2
   skip_final_snapshot                 = true
@@ -1469,8 +1467,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
@@ -1502,13 +1499,15 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
   publicly_accessible                 = false
 
   encrypted = %[2]t
+
+  # required for v5.97.0
+  availability_zone_relocation_enabled = true
 }
 `, rName, encrypted)
 }
@@ -1520,8 +1519,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
   publicly_accessible                 = false
@@ -1537,8 +1535,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = false
   final_snapshot_identifier           = %[1]q
@@ -1577,8 +1574,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   kms_key_id                          = aws_kms_key.test.arn
   encrypted                           = true
@@ -1595,8 +1591,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   enhanced_vpc_routing                = true
   skip_final_snapshot                 = true
@@ -1612,8 +1607,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   enhanced_vpc_routing                = false
   skip_final_snapshot                 = true
@@ -1629,7 +1623,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
+  node_type                           = "ra3.large"
   automated_snapshot_retention_period = 7
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
@@ -1649,7 +1643,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
+  node_type                           = "ra3.large"
   automated_snapshot_retention_period = 7
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
@@ -1672,8 +1666,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   cluster_subnet_group_name           = aws_redshift_subnet_group.test.name
   publicly_accessible                 = %[2]t
@@ -1700,17 +1693,19 @@ func testAccClusterConfig_publiclyAccessible_default(rName string) string {
 resource "aws_redshift_cluster" "test" {
   cluster_identifier                  = %[1]q
   database_name                       = "mydb"
-  encrypted                           = true # required for v5.92.0
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 
   cluster_subnet_group_name = aws_redshift_subnet_group.test.name
 
   depends_on = [aws_internet_gateway.test]
+
+  # required for v5.92.0
+  encrypted                            = true
+  availability_zone_relocation_enabled = true
 }
 
 resource "aws_internet_gateway" "test" {
@@ -1780,8 +1775,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   iam_roles                           = [aws_iam_role.ec2.arn, aws_iam_role.lambda.arn]
   skip_final_snapshot                 = true
@@ -1845,8 +1839,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   iam_roles                           = [aws_iam_role.ec2.arn]
   skip_final_snapshot                 = true
@@ -1969,7 +1962,7 @@ resource "aws_redshift_cluster" "restored" {
   encrypted           = true
   master_username     = "foo_test"
   master_password     = "Mustbe8characters"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   skip_final_snapshot = true
 }
 `, rName))
@@ -1991,7 +1984,7 @@ resource "aws_redshift_cluster" "restored" {
   encrypted           = true
   master_username     = "foo_test"
   master_password     = "Mustbe8characters"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   skip_final_snapshot = true
 }
 `, rName))
@@ -2012,7 +2005,7 @@ resource "aws_redshift_cluster" "restored" {
   database_name       = "mydb"
   master_username     = "foo_test"
   master_password     = "Mustbe8characters"
-  node_type           = "dc2.large"
+  node_type           = "ra3.large"
   skip_final_snapshot = true
 
   encrypted = %[2]t
@@ -2028,8 +2021,7 @@ resource "aws_redshift_cluster" "test" {
   encrypted                           = true
   master_username                     = "foo_test"
   manage_master_password              = true
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
@@ -2094,8 +2086,7 @@ resource "aws_redshift_cluster" "test" {
   master_password_wo                  = %[2]q
   master_password_wo_version          = %[3]d
   multi_az                            = false
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }
@@ -2111,8 +2102,7 @@ resource "aws_redshift_cluster" "test" {
   master_username                     = %[2]q
   master_password                     = "Mustbe8characters"
   multi_az                            = false
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }

--- a/internal/service/redshift/cluster_test.go
+++ b/internal/service/redshift/cluster_test.go
@@ -1431,15 +1431,15 @@ func testAccCheckClusterMasterUsername(c *awstypes.Cluster, value string) resour
 func testAccClusterConfig_updateNodeCount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  number_of_nodes                     = 2
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  number_of_nodes       = 2
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1447,15 +1447,15 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_updateNodeType(rName, nodeType string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = %[2]q
-  allow_version_upgrade               = false
-  number_of_nodes                     = 2
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = %[2]q
+  allow_version_upgrade = false
+  number_of_nodes       = 2
+  skip_final_snapshot   = true
 }
 `, rName, nodeType)
 }
@@ -1463,13 +1463,13 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1495,14 +1495,14 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_encrypted(rName string, encrypted bool) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
-  publicly_accessible                 = false
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
+  publicly_accessible   = false
 
   encrypted = %[2]t
 
@@ -1515,14 +1515,14 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_encrypted_default(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
-  publicly_accessible                 = false
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
+  publicly_accessible   = false
 }
 `, rName)
 }
@@ -1530,15 +1530,15 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_finalSnapshot(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = false
-  final_snapshot_identifier           = %[1]q
+  cluster_identifier        = %[1]q
+  database_name             = "mydb"
+  encrypted                 = true
+  master_username           = "foo_test"
+  master_password           = "Mustbe8characters"
+  node_type                 = "ra3.large"
+  allow_version_upgrade     = false
+  skip_final_snapshot       = false
+  final_snapshot_identifier = %[1]q
 }
 `, rName)
 }
@@ -1570,15 +1570,15 @@ POLICY
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  kms_key_id                          = aws_kms_key.test.arn
-  encrypted                           = true
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  kms_key_id            = aws_kms_key.test.arn
+  encrypted             = true
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1586,15 +1586,15 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_enhancedVPCRoutingEnabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  enhanced_vpc_routing                = true
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  enhanced_vpc_routing  = true
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1602,15 +1602,15 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_enhancedVPCRoutingDisabled(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  enhanced_vpc_routing                = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  enhanced_vpc_routing  = false
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1661,16 +1661,16 @@ func testAccClusterConfig_publiclyAccessible(rName string, publiclyAccessible bo
 		acctest.ConfigVPCWithSubnets(rName, 3),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  cluster_subnet_group_name           = aws_redshift_subnet_group.test.name
-  publicly_accessible                 = %[2]t
-  skip_final_snapshot                 = true
+  cluster_identifier        = %[1]q
+  database_name             = "mydb"
+  encrypted                 = true
+  master_username           = "foo"
+  master_password           = "Mustbe8characters"
+  node_type                 = "ra3.large"
+  allow_version_upgrade     = false
+  cluster_subnet_group_name = aws_redshift_subnet_group.test.name
+  publicly_accessible       = %[2]t
+  skip_final_snapshot       = true
 
   depends_on = [aws_internet_gateway.test]
 }
@@ -1691,13 +1691,13 @@ func testAccClusterConfig_publiclyAccessible_default(rName string) string {
 		acctest.ConfigVPCWithSubnets(rName, 3),
 		fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 
   cluster_subnet_group_name = aws_redshift_subnet_group.test.name
 
@@ -1770,15 +1770,15 @@ EOF
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  iam_roles                           = [aws_iam_role.ec2.arn, aws_iam_role.lambda.arn]
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  iam_roles             = [aws_iam_role.ec2.arn, aws_iam_role.lambda.arn]
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -1834,15 +1834,15 @@ EOF
 }
 
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  iam_roles                           = [aws_iam_role.ec2.arn]
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  iam_roles             = [aws_iam_role.ec2.arn]
+  skip_final_snapshot   = true
 }
 `, rName)
 }
@@ -2016,14 +2016,14 @@ resource "aws_redshift_cluster" "restored" {
 func testAccClusterConfig_manageMasterPassword(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  manage_master_password              = true
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier     = %[1]q
+  database_name          = "mydb"
+  encrypted              = true
+  master_username        = "foo_test"
+  manage_master_password = true
+  node_type              = "ra3.large"
+  allow_version_upgrade  = false
+  skip_final_snapshot    = true
 }
 `, rName)
 }
@@ -2079,16 +2079,16 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_passwordWriteOnly(rName, password string, passwordVersion int) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = "foo_test"
-  master_password_wo                  = %[2]q
-  master_password_wo_version          = %[3]d
-  multi_az                            = false
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier         = %[1]q
+  database_name              = "mydb"
+  encrypted                  = true
+  master_username            = "foo_test"
+  master_password_wo         = %[2]q
+  master_password_wo_version = %[3]d
+  multi_az                   = false
+  node_type                  = "ra3.large"
+  allow_version_upgrade      = false
+  skip_final_snapshot        = true
 }
 `, rName, password, passwordVersion)
 }
@@ -2096,15 +2096,15 @@ resource "aws_redshift_cluster" "test" {
 func testAccClusterConfig_masterUsername(rName, username string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  encrypted                           = true
-  master_username                     = %[2]q
-  master_password                     = "Mustbe8characters"
-  multi_az                            = false
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  encrypted             = true
+  master_username       = %[2]q
+  master_password       = "Mustbe8characters"
+  multi_az              = false
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 `, rName, username)
 }

--- a/internal/service/redshift/logging_test.go
+++ b/internal/service/redshift/logging_test.go
@@ -223,14 +223,14 @@ func testAccCheckLoggingExists(ctx context.Context, name string, log *redshift.D
 func testAccLoggingConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  multi_az                            = false
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  multi_az              = false
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 `, rName)
 }

--- a/internal/service/redshift/logging_test.go
+++ b/internal/service/redshift/logging_test.go
@@ -228,8 +228,7 @@ resource "aws_redshift_cluster" "test" {
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
   multi_az                            = false
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }

--- a/internal/service/redshift/orderable_cluster_data_source_test.go
+++ b/internal/service/redshift/orderable_cluster_data_source_test.go
@@ -59,7 +59,7 @@ func TestAccRedshiftOrderableClusterDataSource_clusterVersion(t *testing.T) {
 func TestAccRedshiftOrderableClusterDataSource_nodeType(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_redshift_orderable_cluster.test"
-	nodeType := "dc2.8xlarge"
+	nodeType := "ra3.xlplus"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccOrderableClusterPreCheck(ctx, t) },
@@ -80,7 +80,7 @@ func TestAccRedshiftOrderableClusterDataSource_nodeType(t *testing.T) {
 func TestAccRedshiftOrderableClusterDataSource_preferredNodeTypes(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_redshift_orderable_cluster.test"
-	preferredNodeType := "dc2.8xlarge"
+	preferredNodeType := "ra3.xlplus"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccOrderableClusterPreCheck(ctx, t) },
@@ -120,7 +120,7 @@ func testAccOrderableClusterDataSourceConfig_type(clusterType string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   cluster_type         = %[1]q
-  preferred_node_types = ["dc2.large", "ds2.xlarge"]
+  preferred_node_types = ["ra3.large", "ds2.xlarge"]
 }
 `, clusterType)
 }
@@ -129,7 +129,7 @@ func testAccOrderableClusterDataSourceConfig_version(clusterVersion string) stri
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   cluster_version      = %[1]q
-  preferred_node_types = ["dc2.8xlarge", "ds2.8xlarge"]
+  preferred_node_types = ["ra3.xlplus", "ra3.large"]
 }
 `, clusterVersion)
 }
@@ -138,7 +138,7 @@ func testAccOrderableClusterDataSourceConfig_nodeType(nodeType string) string {
 	return fmt.Sprintf(`
 data "aws_redshift_orderable_cluster" "test" {
   node_type            = %[1]q
-  preferred_node_types = ["dc2.8xlarge", "ds2.8xlarge"]
+  preferred_node_types = ["ra3.xlplus", "ra3.large"]
 }
 `, nodeType)
 }

--- a/internal/service/redshift/scheduled_action_test.go
+++ b/internal/service/redshift/scheduled_action_test.go
@@ -240,7 +240,7 @@ func TestAccRedshiftScheduledAction_resizeClusterWithOptions(t *testing.T) {
 		CheckDestroy:             testAccCheckScheduledActionDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScheduledActionConfig_resizeClusterFullOptions(rName, "cron(00 23 * * ? *)", true, "multi-node", "dc2.large", 2),
+				Config: testAccScheduledActionConfig_resizeClusterFullOptions(rName, "cron(00 23 * * ? *)", true, "multi-node", "ra3.large", 2),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckScheduledActionExists(ctx, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDescription, ""),
@@ -256,7 +256,7 @@ func TestAccRedshiftScheduledAction_resizeClusterWithOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.classic", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.cluster_identifier", "tf-test-identifier"),
 					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.cluster_type", "multi-node"),
-					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.node_type", "dc2.large"),
+					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.node_type", "ra3.large"),
 					resource.TestCheckResourceAttr(resourceName, "target_action.0.resize_cluster.0.number_of_nodes", "2"),
 				),
 			},

--- a/internal/service/redshift/snapshot_copy_test.go
+++ b/internal/service/redshift/snapshot_copy_test.go
@@ -225,8 +225,7 @@ resource "aws_redshift_cluster" "test" {
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
   multi_az                            = false
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }

--- a/internal/service/redshift/snapshot_copy_test.go
+++ b/internal/service/redshift/snapshot_copy_test.go
@@ -220,14 +220,14 @@ func testAccCheckSnapshotCopyExists(ctx context.Context, name string, snap *type
 func testAccSnapshotCopyConfigBase(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  multi_az                            = false
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  multi_az              = false
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 `, rName)
 }

--- a/internal/service/redshiftdata/statement_test.go
+++ b/internal/service/redshiftdata/statement_test.go
@@ -106,13 +106,13 @@ func testAccCheckStatementExists(ctx context.Context, n string, v *redshiftdata.
 func testAccStatementConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_redshift_cluster" "test" {
-  cluster_identifier                  = %[1]q
-  database_name                       = "mydb"
-  master_username                     = "foo_test"
-  master_password                     = "Mustbe8characters"
-  node_type                           = "ra3.large"
-  allow_version_upgrade               = false
-  skip_final_snapshot                 = true
+  cluster_identifier    = %[1]q
+  database_name         = "mydb"
+  master_username       = "foo_test"
+  master_password       = "Mustbe8characters"
+  node_type             = "ra3.large"
+  allow_version_upgrade = false
+  skip_final_snapshot   = true
 }
 
 resource "aws_redshiftdata_statement" "test" {

--- a/internal/service/redshiftdata/statement_test.go
+++ b/internal/service/redshiftdata/statement_test.go
@@ -110,8 +110,7 @@ resource "aws_redshift_cluster" "test" {
   database_name                       = "mydb"
   master_username                     = "foo_test"
   master_password                     = "Mustbe8characters"
-  node_type                           = "dc2.large"
-  automated_snapshot_retention_period = 0
+  node_type                           = "ra3.large"
   allow_version_upgrade               = false
   skip_final_snapshot                 = true
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Most acceptance tests using `aws_redshift_cluster` use a `node_type` of `dc2.*`, which is no longer available. Switch to `ra3.*`.

Also correctly sets `availability_zone_relocation_enabled` in API calls.

Some acceptance tests still fail due to `ra3.*` instances need completed snapshots, unlike `dc2.*` instances.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43268
