### PR TITLE
Fixed task_definition import

### DIFF
--- a/internal/service/ecs/service.go
+++ b/internal/service/ecs/service.go
@@ -437,6 +437,9 @@ func resourceService() *schema.Resource {
 			"task_definition": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, oldValue, newValue string, d *schema.ResourceData) bool {
+					return oldValue == familyAndRevisionFromTaskDefinitionARN(newValue)
+				},
 			},
 			names.AttrTriggers: {
 				Type:     schema.TypeMap,
@@ -1409,12 +1412,7 @@ func resourceServiceRead(ctx context.Context, d *schema.ResourceData, meta inter
 	// you can specify only parameters that aren't controlled at the task set level
 	// hence TaskDefinition will not be set by aws sdk
 	if service.TaskDefinition != nil {
-		// Save task definition in the same format.
-		if arn.IsARN(d.Get("task_definition").(string)) {
-			d.Set("task_definition", service.TaskDefinition)
-		} else {
-			d.Set("task_definition", familyAndRevisionFromTaskDefinitionARN(aws.ToString(service.TaskDefinition)))
-		}
+		d.Set("task_definition", service.TaskDefinition)
 	}
 	d.Set(names.AttrTriggers, d.Get(names.AttrTriggers))
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

The AWS API returns a full Task Definition ARN for task_definition. The aws_ecs_service resource attempts to determine whether it should return the full ARN or the Task Definition name plus revision. This logic fails when importing, and always returns the name plus revision.

The returned value is the ARN and use a DiffSuppressFunc


### Relations

Relates #42731


### References

### Output from Acceptance Testing

Unfortunately I can't run acceptance tests
