### PR TITLE
elbv2/lb: Check for duplicate name for same/different type of nlb

### DIFF
--- a/.changelog/43278.txt
+++ b/.changelog/43278.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_lb: Fix to enable creating load balancers with same name but different type, avoid creating a load balancer with same name and type as an existing load balancer
+```

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -379,17 +379,20 @@ func resourceLoadBalancerCreate(ctx context.Context, d *schema.ResourceData, met
 		Names: []string{name},
 	})
 
+	lbType := awstypes.LoadBalancerTypeEnum(d.Get("load_balancer_type").(string))
+
 	if err != nil && !tfresource.NotFound(err) {
 		return sdkdiag.AppendErrorf(diags, "reading ELBv2 Load Balancer (%s): %s", name, err)
 	}
 
 	if exist != nil {
-		return sdkdiag.AppendErrorf(diags, "ELBv2 Load Balancer (%s) already exists", name)
+		if exist.Type == lbType {
+			return sdkdiag.AppendErrorf(diags, "ELBv2 Load Balancer (%s) already exists", name)
+		}
 	}
 
 	d.Set(names.AttrName, name)
 
-	lbType := awstypes.LoadBalancerTypeEnum(d.Get("load_balancer_type").(string))
 	input := &elasticloadbalancingv2.CreateLoadBalancerInput{
 		Name: aws.String(name),
 		Tags: getTagsIn(ctx),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

The [elbv2/lb: Check for duplicate name #32941](https://github.com/hashicorp/terraform-provider-aws/pull/32941) avoid creating nlb with duplicated name. However, it is able to create nlbs with same name only if they are not in the same type.

![f3822bfd52d2d99185cd0b581a64a4d](https://github.com/user-attachments/assets/1a2a4e98-47a2-40a9-ab9e-206b66b6fea3)


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #32941

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T=TestAccELBV2LoadBalancer_duplicateName K=elbv2

2025/07/05 01:03:24 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/05 01:03:24 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccELBV2LoadBalancer_duplicateName
=== PAUSE TestAccELBV2LoadBalancer_duplicateName
=== CONT  TestAccELBV2LoadBalancer_duplicateName
--- PASS: TestAccELBV2LoadBalancer_duplicateName (421.52s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/elbv2      421.621s
...
```
