### PR TITLE
Add possible `ARN` value for `function_name` in `aws_lambda_permission` resource

### DIFF
--- a/website/docs/r/lambda_permission.html.markdown
+++ b/website/docs/r/lambda_permission.html.markdown
@@ -215,7 +215,7 @@ resource "aws_lambda_permission" "logging" {
 The following arguments are required:
 
 * `action` - (Required) Lambda action to allow in this statement (e.g., `lambda:InvokeFunction`)
-* `function_name` - (Required) Name of the Lambda function
+* `function_name` - (Required) Name or ARN of the Lambda function
 * `principal` - (Required) AWS service or account that invokes the function (e.g., `s3.amazonaws.com`, `sns.amazonaws.com`, AWS account ID, or AWS IAM principal)
 
 The following arguments are optional:


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->


### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This PR improves the documentation for the `aws_lambda_permission` resource by specifying that the function ARN is also a possible value for the `function_name` argument, as seen [here](https://github.com/hashicorp/terraform-provider-aws/blob/229b588b9676522d110ebdf0accffa821aef6b51/website/docs/r/config_organization_custom_rule.html.markdown?plain=1#L22) for example.

