### PR TITLE
docs: fix argument name in wafv2 web acl

### DIFF
--- a/website/docs/r/wafv2_web_acl.html.markdown
+++ b/website/docs/r/wafv2_web_acl.html.markdown
@@ -847,7 +847,7 @@ The `managed_rule_group_configs` block support the following arguments:
 ### `client_side_action_config` Block
 
 * `challenge` - (Required) Configuration for the use of the `AWSManagedRulesAntiDDoSRuleSet` rules `ChallengeAllDuringEvent` and `ChallengeDDoSRequests`.
-    * `exempt_uri_regular_expressions` - (Optional) Block for the list of the regular expressions to match against the web request URI, used to identify requests that can't handle a silent browser challenge.
+    * `exempt_uri_regular_expression` - (Optional) Block for the list of the regular expressions to match against the web request URI, used to identify requests that can't handle a silent browser challenge.
         * `regex_string` - (Optional) Regular expression string.
     * `sensitivity` - (Optional) Sensitivity that the rule group rule ChallengeDDoSRequests uses when matching against the DDoS suspicion labeling on a request. Valid values are `LOW`, `MEDIUM` and `HIGH` (Default).
     * `usage_of_action` - (Required) Configuration whether to use the `AWSManagedRulesAntiDDoSRuleSet` rules `ChallengeAllDuringEvent` and `ChallengeDDoSRequests` in the rule group evaluation. Valid values are `ENABLED` and `DISABLED`.


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security controls have been modified

### Description

See #43285. The [documentation of the resource `aws_wafv2_web_acl`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#exempt_uri_regular_expressions-1) refers to an argument as `exempt_uri_regular_expressions` instead of `exempt_uri_regular_expression`.

### Relations

Closes #43285

### References

- [Argument in source code](https://github.com/hashicorp/terraform-provider-aws/blob/9afe5b341c36f1324fe2b20411ea91d9a9ba30ba/internal/service/wafv2/schemas.go#L1293) showing the correct argument name

### Output from Acceptance Testing

Not applicable, only documentation is update.