### PR TITLE
ssoadmin: Update tests and documentation to use `arn` instead of `application_arn` for `aws_ssoadmin_application`

### DIFF
--- a/internal/service/ssoadmin/application_access_scope_test.go
+++ b/internal/service/ssoadmin/application_access_scope_test.go
@@ -41,7 +41,7 @@ func TestAccSSOAdminApplicationAccessScope_basic(t *testing.T) {
 				Config: testAccApplicationAccessScopeConfig_basic(rName, "sso:account:access"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationAccessScopeExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, names.AttrScope, "sso:account:access"),
 				),
 			},
@@ -138,8 +138,8 @@ resource "aws_ssoadmin_application" "test" {
 }
 
 resource "aws_ssoadmin_application_access_scope" "test" {
-  application_arn    = aws_ssoadmin_application.test.application_arn
-  authorized_targets = [aws_ssoadmin_application.test.application_arn]
+  application_arn    = aws_ssoadmin_application.test.arn
+  authorized_targets = [aws_ssoadmin_application.test.arn]
   scope              = %[3]q
 }
 `, rName, testAccApplicationProviderARN, scope)

--- a/internal/service/ssoadmin/application_assignment_test.go
+++ b/internal/service/ssoadmin/application_assignment_test.go
@@ -42,7 +42,7 @@ func TestAccSSOAdminApplicationAssignment_basic(t *testing.T) {
 				Config: testAccApplicationAssignmentConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationAssignmentExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "principal_id", userResourceName, "user_id"),
 					resource.TestCheckResourceAttr(resourceName, "principal_type", "USER"),
 				),
@@ -77,7 +77,7 @@ func TestAccSSOAdminApplicationAssignment_group(t *testing.T) {
 				Config: testAccApplicationAssignmentConfig_group(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckApplicationAssignmentExists(ctx, resourceName),
-					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(resourceName, "application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(resourceName, "principal_id", groupResourceName, "group_id"),
 					resource.TestCheckResourceAttr(resourceName, "principal_type", "GROUP"),
 				),
@@ -221,7 +221,7 @@ resource "aws_identitystore_user" "test" {
 }
 
 resource "aws_ssoadmin_application_assignment" "test" {
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
   principal_id    = aws_identitystore_user.test.user_id
   principal_type  = "USER"
 }
@@ -238,7 +238,7 @@ resource "aws_identitystore_group" "test" {
 }
 
 resource "aws_ssoadmin_application_assignment" "test" {
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
   principal_id    = aws_identitystore_group.test.group_id
   principal_type  = "GROUP"
 }

--- a/internal/service/ssoadmin/application_assignments_data_source_test.go
+++ b/internal/service/ssoadmin/application_assignments_data_source_test.go
@@ -33,9 +33,9 @@ func TestAccSSOAdminApplicationAssignmentsDataSource_basic(t *testing.T) {
 			{
 				Config: testAccApplicationAssignmentsDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(dataSourceName, "application_assignments.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.principal_id", userResourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "application_assignments.0.principal_type", "USER"),
 				),
@@ -67,7 +67,7 @@ resource "aws_identitystore_user" "test" {
 }
 
 resource "aws_ssoadmin_application_assignment" "test" {
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
   principal_id    = aws_identitystore_user.test.user_id
   principal_type  = "USER"
 }
@@ -81,7 +81,7 @@ func testAccApplicationAssignmentsDataSourceConfig_basic(rName string) string {
 data "aws_ssoadmin_application_assignments" "test" {
   depends_on = [aws_ssoadmin_application_assignment.test]
 
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
 }
 `)
 }

--- a/internal/service/ssoadmin/application_data_source_test.go
+++ b/internal/service/ssoadmin/application_data_source_test.go
@@ -30,7 +30,7 @@ func TestAccSSOAdminApplicationDataSource_basic(t *testing.T) {
 			{
 				Config: testAccApplicationDataSourceConfig_basic(rName, testAccApplicationProviderARN),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, "application_provider_arn", applicationResourceName, "application_provider_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "instance_arn", applicationResourceName, "instance_arn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrName, applicationResourceName, names.AttrName),
@@ -45,7 +45,7 @@ func TestAccSSOAdminApplicationDataSource_basic(t *testing.T) {
 func testAccApplicationDataSourceConfig_basic(rName, applicationProviderARN string) string {
 	return acctest.ConfigCompose(testAccApplicationConfig_basic(rName, applicationProviderARN), `
 data "aws_ssoadmin_application" "test" {
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
 }
 `)
 }

--- a/internal/service/ssoadmin/principal_application_assignments_data_source_test.go
+++ b/internal/service/ssoadmin/principal_application_assignments_data_source_test.go
@@ -36,7 +36,7 @@ func TestAccSSOAdminPrincipalApplicationAssignmentsDataSource_basic(t *testing.T
 					resource.TestCheckResourceAttrPair(dataSourceName, "principal_id", userResourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "principal_type", "USER"),
 					resource.TestCheckResourceAttr(dataSourceName, "application_assignments.#", "1"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.application_arn", applicationResourceName, "application_arn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.application_arn", applicationResourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, "application_assignments.0.principal_id", userResourceName, "user_id"),
 					resource.TestCheckResourceAttr(dataSourceName, "application_assignments.0.principal_type", "USER"),
 				),
@@ -68,7 +68,7 @@ resource "aws_identitystore_user" "test" {
 }
 
 resource "aws_ssoadmin_application_assignment" "test" {
-  application_arn = aws_ssoadmin_application.test.application_arn
+  application_arn = aws_ssoadmin_application.test.arn
   principal_id    = aws_identitystore_user.test.user_id
   principal_type  = "USER"
 }

--- a/internal/service/ssoadmin/testdata/ApplicationAssignmentConfiguration/basic/main_gen.tf
+++ b/internal/service/ssoadmin/testdata/ApplicationAssignmentConfiguration/basic/main_gen.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 resource "aws_ssoadmin_application_assignment_configuration" "test" {
-  application_arn     = aws_ssoadmin_application.test.application_arn
+  application_arn     = aws_ssoadmin_application.test.arn
   assignment_required = true
 }
 

--- a/internal/service/ssoadmin/testdata/ApplicationAssignmentConfiguration/region_override/main_gen.tf
+++ b/internal/service/ssoadmin/testdata/ApplicationAssignmentConfiguration/region_override/main_gen.tf
@@ -4,7 +4,7 @@
 resource "aws_ssoadmin_application_assignment_configuration" "test" {
   region = var.region
 
-  application_arn     = aws_ssoadmin_application.test.application_arn
+  application_arn     = aws_ssoadmin_application.test.arn
   assignment_required = true
 }
 

--- a/internal/service/ssoadmin/testdata/tmpl/application_assignment_configuration_basic.gtpl
+++ b/internal/service/ssoadmin/testdata/tmpl/application_assignment_configuration_basic.gtpl
@@ -1,6 +1,6 @@
 resource "aws_ssoadmin_application_assignment_configuration" "test" {
 {{- template "region" }}
-  application_arn     = aws_ssoadmin_application.test.application_arn
+  application_arn     = aws_ssoadmin_application.test.arn
   assignment_required = true
 }
 

--- a/website/docs/d/ssoadmin_application_assignments.html.markdown
+++ b/website/docs/d/ssoadmin_application_assignments.html.markdown
@@ -16,7 +16,7 @@ Terraform data source for managing AWS SSO Admin Application Assignments.
 
 ```terraform
 data "aws_ssoadmin_application_assignments" "example" {
-  application_arn = aws_ssoadmin_application.example.application_arn
+  application_arn = aws_ssoadmin_application.example.arn
 }
 ```
 

--- a/website/docs/r/ssoadmin_application_access_scope.html.markdown
+++ b/website/docs/r/ssoadmin_application_access_scope.html.markdown
@@ -23,7 +23,7 @@ resource "aws_ssoadmin_application" "example" {
 }
 
 resource "aws_ssoadmin_application_access_scope" "example" {
-  application_arn    = aws_ssoadmin_application.example.application_arn
+  application_arn    = aws_ssoadmin_application.example.arn
   authorized_targets = ["arn:aws:sso::123456789012:application/ssoins-123456789012/apl-123456789012"]
   scope              = "sso:account:access"
 }

--- a/website/docs/r/ssoadmin_application_assignment.html.markdown
+++ b/website/docs/r/ssoadmin_application_assignment.html.markdown
@@ -15,7 +15,7 @@ Terraform resource for managing an AWS SSO Admin Application Assignment.
 
 ```terraform
 resource "aws_ssoadmin_application_assignment" "example" {
-  application_arn = aws_ssoadmin_application.example.application_arn
+  application_arn = aws_ssoadmin_application.example.arn
   principal_id    = aws_identitystore_user.example.user_id
   principal_type  = "USER"
 }
@@ -25,7 +25,7 @@ resource "aws_ssoadmin_application_assignment" "example" {
 
 ```terraform
 resource "aws_ssoadmin_application_assignment" "example" {
-  application_arn = aws_ssoadmin_application.example.application_arn
+  application_arn = aws_ssoadmin_application.example.arn
   principal_id    = aws_identitystore_group.example.group_id
   principal_type  = "GROUP"
 }

--- a/website/docs/r/ssoadmin_application_assignment_configuration.html.markdown
+++ b/website/docs/r/ssoadmin_application_assignment_configuration.html.markdown
@@ -20,7 +20,7 @@ This resource can be used to adjust this default behavior if necessary.
 
 ```terraform
 resource "aws_ssoadmin_application_assignment_configuration" "example" {
-  application_arn     = aws_ssoadmin_application.example.application_arn
+  application_arn     = aws_ssoadmin_application.example.arn
   assignment_required = true
 }
 ```


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Update tests and documentation to use `arn` instead of `application_arn` for `aws_ssoadmin_application`

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #43261
