### PR TITLE
r/aws_sagemaker_image_version: Fix CodeQL `go/incorrect-integer-conversion` warnings

### DIFF
--- a/internal/service/sagemaker/status.go
+++ b/internal/service/sagemaker/status.go
@@ -76,7 +76,7 @@ func statusImageVersionByName(ctx context.Context, conn *sagemaker.Client, name 
 	}
 }
 
-func statusImageVersionByID(ctx context.Context, conn *sagemaker.Client, name string, version int) retry.StateRefreshFunc {
+func statusImageVersionByID(ctx context.Context, conn *sagemaker.Client, name string, version int32) retry.StateRefreshFunc {
 	return func() (any, string, error) {
 		output, err := findImageVersionByTwoPartKey(ctx, conn, name, version)
 

--- a/internal/service/sagemaker/wait.go
+++ b/internal/service/sagemaker/wait.go
@@ -234,7 +234,7 @@ func waitImageVersionCreated(ctx context.Context, conn *sagemaker.Client, name s
 	return nil, err
 }
 
-func waitImageVersionDeleted(ctx context.Context, conn *sagemaker.Client, name string, version int) (*sagemaker.DescribeImageVersionOutput, error) {
+func waitImageVersionDeleted(ctx context.Context, conn *sagemaker.Client, name string, version int32) (*sagemaker.DescribeImageVersionOutput, error) {
 	stateConf := &retry.StateChangeConf{
 		Pending: enum.Slice(awstypes.ImageVersionStatusDeleting),
 		Target:  []string{},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/475 and https://github.com/hashicorp/terraform-provider-aws/security/code-scanning/474.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% SAGEMAKER_IMAGE_VERSION_BASE_IMAGE=763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.5.1-cpu-py36-ubuntu16.04 make testacc TESTARGS='-run=TestAccSageMakerImageVersion_' PKG=sagemaker ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/sagemaker/... -v -count 1 -parallel 4  -run=TestAccSageMakerImageVersion_ -timeout 360m -vet=off
2025/07/07 18:02:23 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/07 18:02:23 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccSageMakerImageVersion_basic
=== PAUSE TestAccSageMakerImageVersion_basic
=== RUN   TestAccSageMakerImageVersion_update
=== PAUSE TestAccSageMakerImageVersion_update
=== RUN   TestAccSageMakerImageVersion_disappears
=== PAUSE TestAccSageMakerImageVersion_disappears
=== RUN   TestAccSageMakerImageVersion_Disappears_image
=== PAUSE TestAccSageMakerImageVersion_Disappears_image
=== RUN   TestAccSageMakerImageVersion_multiple
=== PAUSE TestAccSageMakerImageVersion_multiple
=== RUN   TestAccSageMakerImageVersion_aliases
=== PAUSE TestAccSageMakerImageVersion_aliases
=== RUN   TestAccSageMakerImageVersion_upgrade_V5_98_0
=== PAUSE TestAccSageMakerImageVersion_upgrade_V5_98_0
=== CONT  TestAccSageMakerImageVersion_basic
=== CONT  TestAccSageMakerImageVersion_multiple
=== CONT  TestAccSageMakerImageVersion_disappears
=== CONT  TestAccSageMakerImageVersion_Disappears_image
--- PASS: TestAccSageMakerImageVersion_Disappears_image (78.97s)
=== CONT  TestAccSageMakerImageVersion_upgrade_V5_98_0
--- PASS: TestAccSageMakerImageVersion_multiple (83.27s)
=== CONT  TestAccSageMakerImageVersion_update
--- PASS: TestAccSageMakerImageVersion_disappears (83.67s)
=== CONT  TestAccSageMakerImageVersion_aliases
--- PASS: TestAccSageMakerImageVersion_basic (86.47s)
--- PASS: TestAccSageMakerImageVersion_update (90.04s)
--- PASS: TestAccSageMakerImageVersion_aliases (101.03s)
--- PASS: TestAccSageMakerImageVersion_upgrade_V5_98_0 (111.97s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/sagemaker	196.058s
```
