### PR TITLE
Simplify Framework registration

### DIFF
--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -388,21 +388,21 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 		servicePackageName := sp.ServicePackageName()
 
 		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
-			p.dataSources = append(p.dataSources, func() datasource.DataSource {
+			p.dataSources = append(p.dataSources, func() datasource.DataSource { //nolint:contextcheck // must be a func()
 				return newWrappedDataSource(dataSourceSpec, servicePackageName)
 			})
 		}
 
 		if v, ok := sp.(conns.ServicePackageWithEphemeralResources); ok {
 			for _, ephemeralResourceSpec := range v.EphemeralResources(ctx) {
-				p.ephemeralResources = append(p.ephemeralResources, func() ephemeral.EphemeralResource {
+				p.ephemeralResources = append(p.ephemeralResources, func() ephemeral.EphemeralResource { //nolint:contextcheck // must be a func()
 					return newWrappedEphemeralResource(ephemeralResourceSpec, servicePackageName)
 				})
 			}
 		}
 
 		for _, resourceSpec := range sp.FrameworkResources(ctx) {
-			p.resources = append(p.resources, func() resource.Resource {
+			p.resources = append(p.resources, func() resource.Resource { //nolint:contextcheck // must be a func()
 				return newWrappedResource(resourceSpec, servicePackageName)
 			})
 		}

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -394,32 +394,8 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 		servicePackageName := sp.ServicePackageName()
 
 		for _, dataSourceSpec := range sp.FrameworkDataSources(ctx) {
-			var isRegionOverrideEnabled bool
-			if regionSpec := dataSourceSpec.Region; !tfunique.IsHandleNil(regionSpec) && regionSpec.Value().IsOverrideEnabled {
-				isRegionOverrideEnabled = true
-			}
-
-			var interceptors interceptorInvocations
-
-			if isRegionOverrideEnabled {
-				v := dataSourceSpec.Region.Value()
-
-				interceptors = append(interceptors, dataSourceInjectRegionAttribute())
-				if v.IsValidateOverrideInPartition {
-					interceptors = append(interceptors, dataSourceValidateRegion())
-				}
-				interceptors = append(interceptors, dataSourceSetRegionInState())
-			}
-
-			if !tfunique.IsHandleNil(dataSourceSpec.Tags) {
-				interceptors = append(interceptors, dataSourceTransparentTagging(dataSourceSpec.Tags))
-			}
-
-			opts := wrappedDataSourceOptions{
-				interceptors: interceptors,
-			}
-			p.dataSources = append(p.dataSources, func() datasource.DataSource {
-				return newWrappedDataSource(dataSourceSpec, servicePackageName, opts)
+			p.dataSources = append(p.dataSources, func() datasource.DataSource { //nolint:contextcheck // must be a func()
+				return newWrappedDataSource(dataSourceSpec, servicePackageName)
 			})
 		}
 

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -516,15 +516,13 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 			opts := wrappedResourceOptions{
 				interceptors:       interceptors,
 				servicePackageName: servicePackageName,
-				spec:               resourceSpec,
 			}
 			if len(resourceSpec.Identity.Attributes) > 0 {
 				opts.interceptors = append(opts.interceptors, newIdentityInterceptor(resourceSpec.Identity.Attributes))
-				opts.spec = resourceSpec
 			}
 
 			p.resources = append(p.resources, func() resource.Resource {
-				return newWrappedResource(inner, opts)
+				return newWrappedResource(resourceSpec, opts)
 			})
 		}
 	}

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -458,12 +458,8 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 		}
 
 		for _, resourceSpec := range sp.FrameworkResources(ctx) {
-			opts := wrappedResourceOptions{
-				servicePackageName: servicePackageName,
-			}
-
 			p.resources = append(p.resources, func() resource.Resource {
-				return newWrappedResource(resourceSpec, opts)
+				return newWrappedResource(resourceSpec, servicePackageName)
 			})
 		}
 	}

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -416,11 +416,10 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 			}
 
 			opts := wrappedDataSourceOptions{
-				interceptors:       interceptors,
-				servicePackageName: servicePackageName,
+				interceptors: interceptors,
 			}
 			p.dataSources = append(p.dataSources, func() datasource.DataSource {
-				return newWrappedDataSource(dataSourceSpec, opts)
+				return newWrappedDataSource(dataSourceSpec, servicePackageName, opts)
 			})
 		}
 

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -70,9 +70,7 @@ func NewProvider(ctx context.Context, primary interface{ Meta() any }) (provider
 		return nil, err
 	}
 
-	if err := provider.initialize(ctx); err != nil {
-		return nil, err
-	}
+	provider.initialize(ctx)
 
 	return provider, nil
 }
@@ -379,10 +377,8 @@ func (p *frameworkProvider) Functions(_ context.Context) []func() function.Funct
 }
 
 // initialize is called from `New` to perform any Terraform Framework-style initialization.
-func (p *frameworkProvider) initialize(ctx context.Context) error {
+func (p *frameworkProvider) initialize(ctx context.Context) {
 	log.Printf("Initializing Terraform AWS Provider (Framework-style)...")
-
-	var errs []error
 
 	for sp := range p.servicePackages {
 		servicePackageName := sp.ServicePackageName()
@@ -407,8 +403,6 @@ func (p *frameworkProvider) initialize(ctx context.Context) error {
 			})
 		}
 	}
-
-	return errors.Join(errs...)
 }
 
 // validateResourceSchemas is called from `New` to validate Terraform Plugin Framework-style resource schemas.

--- a/internal/provider/framework/provider.go
+++ b/internal/provider/framework/provider.go
@@ -422,7 +422,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 			inner, err := dataSourceSpec.Factory(ctx)
 
 			if err != nil {
-				errs = append(errs, fmt.Errorf("creating data source (%s): %w", typeName, err))
+				errs = append(errs, fmt.Errorf("creating data source type (%s): %w", typeName, err))
 				continue
 			}
 
@@ -430,7 +430,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 			inner.Schema(ctx, datasource.SchemaRequest{}, &schemaResponse)
 
 			if err := validateSchemaRegionForDataSource(dataSourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("data source %q: %w", typeName, err))
+				errs = append(errs, fmt.Errorf("data source type %q: %w", typeName, err))
 				continue
 			}
 
@@ -446,7 +446,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 				inner, err := ephemeralResourceSpec.Factory(ctx)
 
 				if err != nil {
-					errs = append(errs, fmt.Errorf("creating ephemeral resource (%s): %w", typeName, err))
+					errs = append(errs, fmt.Errorf("creating ephemeral resource type (%s): %w", typeName, err))
 					continue
 				}
 
@@ -454,7 +454,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 				inner.Schema(ctx, ephemeral.SchemaRequest{}, &schemaResponse)
 
 				if err := validateSchemaRegionForEphemeralResource(ephemeralResourceSpec.Region, schemaResponse.Schema); err != nil {
-					errs = append(errs, fmt.Errorf("ephemeral resource %q: %w", typeName, err))
+					errs = append(errs, fmt.Errorf("ephemeral resource type %q: %w", typeName, err))
 					continue
 				}
 			}
@@ -465,7 +465,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 			inner, err := resourceSpec.Factory(ctx)
 
 			if err != nil {
-				errs = append(errs, fmt.Errorf("creating resource (%s): %w", typeName, err))
+				errs = append(errs, fmt.Errorf("creating resource type (%s): %w", typeName, err))
 				continue
 			}
 
@@ -473,7 +473,7 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 			inner.Schema(ctx, resource.SchemaRequest{}, &schemaResponse)
 
 			if err := validateSchemaRegionForResource(resourceSpec.Region, schemaResponse.Schema); err != nil {
-				errs = append(errs, fmt.Errorf("resource %q: %w", typeName, err))
+				errs = append(errs, fmt.Errorf("resource type %q: %w", typeName, err))
 				continue
 			}
 
@@ -485,13 +485,13 @@ func (p *frameworkProvider) validateResourceSchemas(ctx context.Context) error {
 			if resourceSpec.Import.WrappedImport {
 				if resourceSpec.Import.SetIDAttr {
 					if _, ok := resourceSpec.Import.ImportID.(inttypes.FrameworkImportIDCreator); !ok {
-						errs = append(errs, fmt.Errorf("resource type %s: importer sets \"id\" attribute, but creator isn't configured", resourceSpec.TypeName))
+						errs = append(errs, fmt.Errorf("resource type %q: importer sets `%s` attribute, but creator isn't configured", resourceSpec.TypeName, names.AttrID))
 						continue
 					}
 				}
 
 				if _, ok := inner.(framework.ImportByIdentityer); !ok {
-					errs = append(errs, fmt.Errorf("resource type %s: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]()))
+					errs = append(errs, fmt.Errorf("resource type %q: cannot configure importer, does not implement %q", resourceSpec.TypeName, reflect.TypeFor[framework.ImportByIdentityer]()))
 					continue
 				}
 			}

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -30,9 +30,6 @@ import (
 // Implemented by (Config|Plan|State).GetAttribute().
 type getAttributeFunc func(context.Context, path.Path, any) diag.Diagnostics
 
-// contextFunc augments Context.
-type contextFunc func(context.Context, getAttributeFunc, *conns.AWSClient) (context.Context, diag.Diagnostics)
-
 // wrappedDataSource represents an interceptor dispatcher for a Plugin Framework data source.
 type wrappedDataSource struct {
 	inner              datasource.DataSourceWithConfigure

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -5,7 +5,6 @@ package framework
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -400,18 +399,11 @@ func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, serviceP
 	inner, _ := spec.Factory(context.TODO())
 
 	if spec.Import.WrappedImport {
-		if spec.Import.SetIDAttr {
-			if _, ok := spec.Import.ImportID.(inttypes.FrameworkImportIDCreator); !ok {
-				panic(fmt.Sprintf("resource type %s: importer sets \"id\" attribute, but creator isn't configured", spec.TypeName))
-			}
-		}
-		switch v := inner.(type) {
-		case framework.ImportByIdentityer:
+		if v, ok := inner.(framework.ImportByIdentityer); ok {
 			v.SetIdentitySpec(spec.Identity, spec.Import)
-
-		default:
-			panic(fmt.Sprintf("resource type %s: cannot configure importer", spec.TypeName))
 		}
+		// If the resource does not implement framework.ImportByIdentityer,
+		// it will be caught by `validateResourceSchemas`, so we can ignore it here.
 	}
 	return &wrappedResource{
 		inner:              inner,

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -310,20 +310,16 @@ func (w *wrappedEphemeralResource) ValidateConfig(ctx context.Context, request e
 	}
 }
 
-type wrappedResourceOptions struct {
-	servicePackageName string
-}
-
 // wrappedResource represents an interceptor dispatcher for a Plugin Framework resource.
 type wrappedResource struct {
-	inner        resource.ResourceWithConfigure
-	meta         *conns.AWSClient
-	opts         wrappedResourceOptions
-	spec         *inttypes.ServicePackageFrameworkResource
-	interceptors interceptorInvocations
+	inner              resource.ResourceWithConfigure
+	meta               *conns.AWSClient
+	servicePackageName string
+	spec               *inttypes.ServicePackageFrameworkResource
+	interceptors       interceptorInvocations
 }
 
-func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, opts wrappedResourceOptions) resource.ResourceWithConfigure {
+func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, servicePackageName string) resource.ResourceWithConfigure {
 	var isRegionOverrideEnabled bool
 	if v := spec.Region; !tfunique.IsHandleNil(v) && v.Value().IsOverrideEnabled {
 		isRegionOverrideEnabled = true
@@ -373,10 +369,10 @@ func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, opts wra
 		}
 	}
 	return &wrappedResource{
-		inner:        inner,
-		opts:         opts,
-		spec:         spec,
-		interceptors: interceptors,
+		inner:              inner,
+		servicePackageName: servicePackageName,
+		spec:               spec,
+		interceptors:       interceptors,
 	}
 }
 
@@ -400,7 +396,7 @@ func (w *wrappedResource) bootstrapContext(ctx context.Context, getAttribute get
 		overrideRegion = target.ValueString()
 	}
 
-	ctx = conns.NewResourceContext(ctx, w.opts.servicePackageName, w.spec.Name, overrideRegion)
+	ctx = conns.NewResourceContext(ctx, w.servicePackageName, w.spec.Name, overrideRegion)
 	if c != nil {
 		ctx = tftags.NewContext(ctx, c.DefaultTagsConfig(ctx), c.IgnoreTagsConfig(ctx))
 		ctx = c.RegisterLogger(ctx)

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -32,24 +32,25 @@ type getAttributeFunc func(context.Context, path.Path, any) diag.Diagnostics
 type contextFunc func(context.Context, getAttributeFunc, *conns.AWSClient) (context.Context, diag.Diagnostics)
 
 type wrappedDataSourceOptions struct {
-	interceptors       interceptorInvocations
-	servicePackageName string
+	interceptors interceptorInvocations
 }
 
 // wrappedDataSource represents an interceptor dispatcher for a Plugin Framework data source.
 type wrappedDataSource struct {
-	inner datasource.DataSourceWithConfigure
-	meta  *conns.AWSClient
-	opts  wrappedDataSourceOptions
-	spec  *inttypes.ServicePackageFrameworkDataSource
+	inner              datasource.DataSourceWithConfigure
+	meta               *conns.AWSClient
+	opts               wrappedDataSourceOptions
+	servicePackageName string
+	spec               *inttypes.ServicePackageFrameworkDataSource
 }
 
-func newWrappedDataSource(spec *inttypes.ServicePackageFrameworkDataSource, opts wrappedDataSourceOptions) datasource.DataSourceWithConfigure {
+func newWrappedDataSource(spec *inttypes.ServicePackageFrameworkDataSource, servicePackageName string, opts wrappedDataSourceOptions) datasource.DataSourceWithConfigure {
 	inner, _ := spec.Factory(context.TODO())
 	return &wrappedDataSource{
-		inner: inner,
-		opts:  opts,
-		spec:  spec,
+		inner:              inner,
+		opts:               opts,
+		servicePackageName: servicePackageName,
+		spec:               spec,
 	}
 }
 
@@ -73,7 +74,7 @@ func (w *wrappedDataSource) bootstrapContext(ctx context.Context, getAttribute g
 		overrideRegion = target.ValueString()
 	}
 
-	ctx = conns.NewResourceContext(ctx, w.opts.servicePackageName, w.spec.Name, overrideRegion)
+	ctx = conns.NewResourceContext(ctx, w.servicePackageName, w.spec.Name, overrideRegion)
 	if c != nil {
 		ctx = tftags.NewContext(ctx, c.DefaultTagsConfig(ctx), c.IgnoreTagsConfig(ctx))
 		ctx = c.RegisterLogger(ctx)

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -74,8 +74,8 @@ func newWrappedDataSource(spec *inttypes.ServicePackageFrameworkDataSource, serv
 	}
 }
 
-// bootstrapContext is run on all wrapped methods before any interceptors.
-func (w *wrappedDataSource) bootstrapContext(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
+// context is run on all wrapped methods before any interceptors.
+func (w *wrappedDataSource) context(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var overrideRegion string
 
@@ -110,7 +110,7 @@ func (w *wrappedDataSource) Metadata(ctx context.Context, request datasource.Met
 }
 
 func (w *wrappedDataSource) Schema(ctx context.Context, request datasource.SchemaRequest, response *datasource.SchemaResponse) {
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -134,7 +134,7 @@ func (w *wrappedDataSource) Schema(ctx context.Context, request datasource.Schem
 }
 
 func (w *wrappedDataSource) Read(ctx context.Context, request datasource.ReadRequest, response *datasource.ReadResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -148,7 +148,7 @@ func (w *wrappedDataSource) Configure(ctx context.Context, request datasource.Co
 		w.meta = v
 	}
 
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -159,7 +159,7 @@ func (w *wrappedDataSource) Configure(ctx context.Context, request datasource.Co
 
 func (w *wrappedDataSource) ConfigValidators(ctx context.Context) []datasource.ConfigValidator {
 	if v, ok := w.inner.(datasource.DataSourceWithConfigValidators); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		if diags.HasError() {
 			tflog.Warn(ctx, "wrapping ConfigValidators", map[string]any{
 				"data source":            w.spec.TypeName,
@@ -177,7 +177,7 @@ func (w *wrappedDataSource) ConfigValidators(ctx context.Context) []datasource.C
 
 func (w *wrappedDataSource) ValidateConfig(ctx context.Context, request datasource.ValidateConfigRequest, response *datasource.ValidateConfigResponse) {
 	if v, ok := w.inner.(datasource.DataSourceWithValidateConfig); ok {
-		ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+		ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 		response.Diagnostics.Append(diags...)
 		if response.Diagnostics.HasError() {
 			return
@@ -224,8 +224,8 @@ func newWrappedEphemeralResource(spec *inttypes.ServicePackageEphemeralResource,
 	}
 }
 
-// bootstrapContext is run on all wrapped methods before any interceptors.
-func (w *wrappedEphemeralResource) bootstrapContext(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
+// context is run on all wrapped methods before any interceptors.
+func (w *wrappedEphemeralResource) context(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var overrideRegion string
 
@@ -260,7 +260,7 @@ func (w *wrappedEphemeralResource) Metadata(ctx context.Context, request ephemer
 }
 
 func (w *wrappedEphemeralResource) Schema(ctx context.Context, request ephemeral.SchemaRequest, response *ephemeral.SchemaResponse) {
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -281,7 +281,7 @@ func (w *wrappedEphemeralResource) Schema(ctx context.Context, request ephemeral
 }
 
 func (w *wrappedEphemeralResource) Open(ctx context.Context, request ephemeral.OpenRequest, response *ephemeral.OpenResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -295,7 +295,7 @@ func (w *wrappedEphemeralResource) Configure(ctx context.Context, request epheme
 		w.meta = v
 	}
 
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -306,7 +306,7 @@ func (w *wrappedEphemeralResource) Configure(ctx context.Context, request epheme
 
 func (w *wrappedEphemeralResource) Renew(ctx context.Context, request ephemeral.RenewRequest, response *ephemeral.RenewResponse) {
 	if v, ok := w.inner.(ephemeral.EphemeralResourceWithRenew); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		response.Diagnostics.Append(diags...)
 		if response.Diagnostics.HasError() {
 			return
@@ -318,7 +318,7 @@ func (w *wrappedEphemeralResource) Renew(ctx context.Context, request ephemeral.
 
 func (w *wrappedEphemeralResource) Close(ctx context.Context, request ephemeral.CloseRequest, response *ephemeral.CloseResponse) {
 	if v, ok := w.inner.(ephemeral.EphemeralResourceWithClose); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		response.Diagnostics.Append(diags...)
 		if response.Diagnostics.HasError() {
 			return
@@ -330,7 +330,7 @@ func (w *wrappedEphemeralResource) Close(ctx context.Context, request ephemeral.
 
 func (w *wrappedEphemeralResource) ConfigValidators(ctx context.Context) []ephemeral.ConfigValidator {
 	if v, ok := w.inner.(ephemeral.EphemeralResourceWithConfigValidators); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		if diags.HasError() {
 			tflog.Warn(ctx, "wrapping ConfigValidators", map[string]any{
 				"ephemeral resource":     w.spec.TypeName,
@@ -348,7 +348,7 @@ func (w *wrappedEphemeralResource) ConfigValidators(ctx context.Context) []ephem
 
 func (w *wrappedEphemeralResource) ValidateConfig(ctx context.Context, request ephemeral.ValidateConfigRequest, response *ephemeral.ValidateConfigResponse) {
 	if v, ok := w.inner.(ephemeral.EphemeralResourceWithValidateConfig); ok {
-		ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+		ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 		response.Diagnostics.Append(diags...)
 		if response.Diagnostics.HasError() {
 			return
@@ -424,8 +424,8 @@ func newWrappedResource(spec *inttypes.ServicePackageFrameworkResource, serviceP
 	}
 }
 
-// bootstrapContext is run on all wrapped methods before any interceptors.
-func (w *wrappedResource) bootstrapContext(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
+// context is run on all wrapped methods before any interceptors.
+func (w *wrappedResource) context(ctx context.Context, getAttribute getAttributeFunc, c *conns.AWSClient) (context.Context, diag.Diagnostics) {
 	var diags diag.Diagnostics
 	var overrideRegion string
 
@@ -464,7 +464,7 @@ func (w *wrappedResource) Metadata(ctx context.Context, request resource.Metadat
 }
 
 func (w *wrappedResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -485,7 +485,7 @@ func (w *wrappedResource) Schema(ctx context.Context, request resource.SchemaReq
 }
 
 func (w *wrappedResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Plan.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Plan.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -495,7 +495,7 @@ func (w *wrappedResource) Create(ctx context.Context, request resource.CreateReq
 }
 
 func (w *wrappedResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.State.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.State.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -505,7 +505,7 @@ func (w *wrappedResource) Read(ctx context.Context, request resource.ReadRequest
 }
 
 func (w *wrappedResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Plan.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Plan.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -515,7 +515,7 @@ func (w *wrappedResource) Update(ctx context.Context, request resource.UpdateReq
 }
 
 func (w *wrappedResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.State.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.State.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -529,7 +529,7 @@ func (w *wrappedResource) Configure(ctx context.Context, request resource.Config
 		w.meta = v
 	}
 
-	ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+	ctx, diags := w.context(ctx, nil, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -540,7 +540,7 @@ func (w *wrappedResource) Configure(ctx context.Context, request resource.Config
 
 func (w *wrappedResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
 	if v, ok := w.inner.(resource.ResourceWithImportState); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		response.Diagnostics.Append(diags...)
 		if response.Diagnostics.HasError() {
 			return
@@ -559,7 +559,7 @@ func (w *wrappedResource) ImportState(ctx context.Context, request resource.Impo
 }
 
 func (w *wrappedResource) ModifyPlan(ctx context.Context, request resource.ModifyPlanRequest, response *resource.ModifyPlanResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -576,7 +576,7 @@ func (w *wrappedResource) ModifyPlan(ctx context.Context, request resource.Modif
 
 func (w *wrappedResource) ConfigValidators(ctx context.Context) []resource.ConfigValidator {
 	if v, ok := w.inner.(resource.ResourceWithConfigValidators); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		if diags.HasError() {
 			tflog.Warn(ctx, "wrapping ConfigValidators", map[string]any{
 				"resource":               w.spec.TypeName,
@@ -593,7 +593,7 @@ func (w *wrappedResource) ConfigValidators(ctx context.Context) []resource.Confi
 }
 
 func (w *wrappedResource) ValidateConfig(ctx context.Context, request resource.ValidateConfigRequest, response *resource.ValidateConfigResponse) {
-	ctx, diags := w.bootstrapContext(ctx, request.Config.GetAttribute, w.meta)
+	ctx, diags := w.context(ctx, request.Config.GetAttribute, w.meta)
 	response.Diagnostics.Append(diags...)
 	if response.Diagnostics.HasError() {
 		return
@@ -606,7 +606,7 @@ func (w *wrappedResource) ValidateConfig(ctx context.Context, request resource.V
 
 func (w *wrappedResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
 	if v, ok := w.inner.(resource.ResourceWithUpgradeState); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		if diags.HasError() {
 			tflog.Warn(ctx, "wrapping UpgradeState", map[string]any{
 				"resource":               w.spec.TypeName,
@@ -624,7 +624,7 @@ func (w *wrappedResource) UpgradeState(ctx context.Context) map[int64]resource.S
 
 func (w *wrappedResource) MoveState(ctx context.Context) []resource.StateMover {
 	if v, ok := w.inner.(resource.ResourceWithMoveState); ok {
-		ctx, diags := w.bootstrapContext(ctx, nil, w.meta)
+		ctx, diags := w.context(ctx, nil, w.meta)
 		if diags.HasError() {
 			tflog.Warn(ctx, "wrapping MoveState", map[string]any{
 				"resource":               w.spec.TypeName,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Uses `sync.Once` instead of mutex and boolean to ensure schema validation is called once. 

Simplifies Framework Data Source registration:

* Defers creating `inner` wrapped resource until wrapper is called
* Makes `boostrapContext` a method on wrappers instead of function pointer
* Encapsulates configuration of interceptors
