### PR TITLE
[Enhancement] aws_rum_app_monitor: Support enabling unminification of JavaScript error stack traces

### DIFF
--- a/.changelog/43299.txt
+++ b/.changelog/43299.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/aws_rum_app_monitor: Add `deobfuscation_configuration` block to support enabling unminification of JavaScript error stack traces.
+resource/aws_rum_app_monitor: Add `deobfuscation_configuration` configuration block to support enabling unminification of JavaScript error stack traces.
 ```

--- a/.changelog/43299.txt
+++ b/.changelog/43299.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_rum_app_monitor: Add `deobfuscation_configuration` block to support enabling unminification of JavaScript error stack traces.
+```

--- a/internal/service/rum/app_monitor.go
+++ b/internal/service/rum/app_monitor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"log"
 
+	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/rum"
@@ -132,6 +133,38 @@ func resourceAppMonitor() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"deobfuscation_configuration": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"javascript_source_maps": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									names.AttrStatus: {
+										Type:             schema.TypeString,
+										Required:         true,
+										ValidateDiagFunc: enum.Validate[awstypes.DeobfuscationStatus](),
+									},
+									"s3_uri": {
+										Type:     schema.TypeString,
+										Optional: true,
+										ValidateFunc: validation.All(
+											validation.StringLenBetween(1, 1024),
+											validation.StringMatch(regexache.MustCompile(`^s3://[a-z0-9][-.a-z0-9]{1,61}(?:/[-!_*'().a-z0-9A-Z]+(?:/[-!_*'().a-z0-9A-Z]+)*)?/?`), "must be a valid S3 URI"),
+										),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 			names.AttrDomain: {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -177,6 +210,10 @@ func resourceAppMonitorCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	if v, ok := d.GetOk("custom_events"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
 		input.CustomEvents = expandCustomEvents(v.([]any)[0].(map[string]any))
+	}
+
+	if v, ok := d.GetOk("deobfuscation_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+		input.DeobfuscationConfiguration = expandDeobfuscationConfiguration(v.([]any)[0].(map[string]any))
 	}
 
 	if v, ok := d.GetOk(names.AttrDomain); ok {
@@ -234,6 +271,7 @@ func resourceAppMonitorRead(ctx context.Context, d *schema.ResourceData, meta an
 	d.Set(names.AttrARN, arn)
 	d.Set("cw_log_enabled", appMon.DataStorage.CwLog.CwLogEnabled)
 	d.Set("cw_log_group", appMon.DataStorage.CwLog.CwLogGroup)
+	d.Set("deobfuscation_configuration", flattenDeobfuscationConfiguration(appMon.DeobfuscationConfiguration))
 	d.Set(names.AttrDomain, appMon.Domain)
 	d.Set("domain_list", appMon.DomainList)
 	d.Set(names.AttrName, name)
@@ -262,6 +300,12 @@ func resourceAppMonitorUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 		if d.HasChange("cw_log_enabled") {
 			input.CwLogEnabled = aws.Bool(d.Get("cw_log_enabled").(bool))
+		}
+
+		if d.HasChange("deobfuscation_configuration") {
+			if v, ok := d.GetOk("deobfuscation_configuration"); ok && len(v.([]any)) > 0 && v.([]any)[0] != nil {
+				input.DeobfuscationConfiguration = expandDeobfuscationConfiguration(d.Get("deobfuscation_configuration").([]any)[0].(map[string]any))
+			}
 		}
 
 		if d.HasChange(names.AttrDomain) {
@@ -445,4 +489,50 @@ func flattenCustomEvents(apiObject *awstypes.CustomEvents) map[string]any {
 	}
 
 	return tfMap
+}
+
+func expandDeobfuscationConfiguration(tfMap map[string]any) *awstypes.DeobfuscationConfiguration {
+	if tfMap == nil {
+		return nil
+	}
+
+	config := &awstypes.DeobfuscationConfiguration{}
+
+	if v, ok := tfMap["javascript_source_maps"].([]any); ok && len(v) > 0 && v[0] != nil {
+		sourceMap := v[0].(map[string]any)
+		config.JavaScriptSourceMaps = &awstypes.JavaScriptSourceMaps{
+			Status: awstypes.DeobfuscationStatus(sourceMap[names.AttrStatus].(string)),
+		}
+
+		if s3URI, ok := sourceMap["s3_uri"].(string); ok && s3URI != "" {
+			config.JavaScriptSourceMaps.S3Uri = aws.String(s3URI)
+		}
+	}
+
+	return config
+}
+
+func flattenDeobfuscationConfiguration(apiObject *awstypes.DeobfuscationConfiguration) []any {
+	if apiObject == nil {
+		return nil
+	}
+
+	tfList := []any{}
+	tfMap := map[string]any{}
+
+	if apiObject.JavaScriptSourceMaps != nil {
+		jsSourceMaps := map[string]any{
+			names.AttrStatus: apiObject.JavaScriptSourceMaps.Status,
+		}
+
+		if s3URI := apiObject.JavaScriptSourceMaps.S3Uri; s3URI != nil {
+			jsSourceMaps["s3_uri"] = aws.ToString(s3URI)
+		}
+
+		tfMap["javascript_source_maps"] = []any{jsSourceMaps}
+	}
+
+	tfList = append(tfList, tfMap)
+
+	return tfList
 }

--- a/internal/service/rum/app_monitor_test.go
+++ b/internal/service/rum/app_monitor_test.go
@@ -443,6 +443,7 @@ func testAccAppMonitorConfig_deobfuscationConfiguration(rName, status string) st
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 resource "aws_s3_bucket" "test" {
   bucket = %[1]q
@@ -477,7 +478,7 @@ data "aws_iam_policy_document" "test" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:rum:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:appmonitor/%[1]s"]
+      values   = ["arn:${data.aws_partition.current.partition}:rum:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:appmonitor/%[1]s"]
     }
   }
 }

--- a/internal/service/rum/app_monitor_test.go
+++ b/internal/service/rum/app_monitor_test.go
@@ -41,6 +41,9 @@ func TestAccRUMAppMonitor_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "app_monitor_id"),
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rum", fmt.Sprintf("appmonitor/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "cw_log_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.0.status", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomain, "localhost"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "custom_events.#", "1"),
@@ -62,6 +65,9 @@ func TestAccRUMAppMonitor_basic(t *testing.T) {
 					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rum", fmt.Sprintf("appmonitor/%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "cw_log_enabled", acctest.CtTrue),
 					resource.TestCheckResourceAttrSet(resourceName, "cw_log_group"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.0.status", "DISABLED"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrDomain, "localhost"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttr(resourceName, "custom_events.#", "1"),
@@ -235,6 +241,64 @@ func TestAccRUMAppMonitor_tags(t *testing.T) {
 	})
 }
 
+func TestAccRUMAppMonitor_deobfuscationConfiguration(t *testing.T) {
+	ctx := acctest.Context(t)
+	var appMon awstypes.AppMonitor
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_rum_app_monitor.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.RUMServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckAppMonitorDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppMonitorConfig_deobfuscationConfiguration(rName, "ENABLED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppMonitorExists(ctx, resourceName, &appMon),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "app_monitor_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_monitor_configuration.0.session_sample_rate", "0.1"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_monitor_id"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rum", fmt.Sprintf("appmonitor/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cw_log_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.0.status", "ENABLED"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.0.s3_uri", fmt.Sprintf("s3://%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomain, "localhost"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_events.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccAppMonitorConfig_deobfuscationConfiguration(rName, "DISABLED"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAppMonitorExists(ctx, resourceName, &appMon),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "app_monitor_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "app_monitor_configuration.0.session_sample_rate", "0.1"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_monitor_id"),
+					acctest.CheckResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "rum", fmt.Sprintf("appmonitor/%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "cw_log_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deobfuscation_configuration.0.javascript_source_maps.0.status", "DISABLED"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrDomain, "localhost"),
+					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
+					resource.TestCheckResourceAttr(resourceName, "custom_events.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccRUMAppMonitor_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var appMon awstypes.AppMonitor
@@ -373,4 +437,65 @@ resource "aws_rum_app_monitor" "test" {
   domain_list = ["localhost", "terraform.*"]
 }
 `, rName)
+}
+
+func testAccAppMonitorConfig_deobfuscationConfiguration(rName, status string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_object" "test" {
+  bucket  = aws_s3_bucket.test.bucket
+  key     = "example-source-map.js.map"
+  content = "dummy content for source map"
+}
+
+data "aws_iam_policy_document" "test" {
+  statement {
+    principals {
+      identifiers = ["rum.amazonaws.com"]
+      type        = "Service"
+    }
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.test.arn,
+      "${aws_s3_bucket.test.arn}/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:rum:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:appmonitor/%[1]s"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "test" {
+  bucket = aws_s3_bucket.test.id
+  policy = data.aws_iam_policy_document.test.json
+}
+
+resource "aws_rum_app_monitor" "test" {
+  name   = %[1]q
+  domain = "localhost"
+  deobfuscation_configuration {
+    javascript_source_maps {
+      status = %[2]q
+      s3_uri = "s3://${aws_s3_object.test.bucket}"
+    }
+  }
+}
+`, rName, status)
 }

--- a/website/docs/r/rum_app_monitor.html.markdown
+++ b/website/docs/r/rum_app_monitor.html.markdown
@@ -52,7 +52,6 @@ This resource supports the following arguments:
 ### deobfuscation_configuration
 
 * `javascript_source_maps` - (Optional) Configuration for how an app monitor can unminify JavaScript error stack traces using source maps.
-
     * `status` - (Required) Whether JavaScript error stack traces should be unminified for this app monitor. Valid values are `DISABLED` and `ENABLED`.
     * `s3_uri` - (Optional) S3 URI of the bucket or folder that stores the source map files.
 

--- a/website/docs/r/rum_app_monitor.html.markdown
+++ b/website/docs/r/rum_app_monitor.html.markdown
@@ -28,6 +28,7 @@ This resource supports the following arguments:
 * `app_monitor_configuration` - (Optional) configuration data for the app monitor. See [app_monitor_configuration](#app_monitor_configuration) below.
 * `cw_log_enabled` - (Optional) Data collected by RUM is kept by RUM for 30 days and then deleted. This parameter specifies whether RUM sends a copy of this telemetry data to Amazon CloudWatch Logs in your account. This enables you to keep the telemetry data for more than 30 days, but it does incur Amazon CloudWatch Logs charges. Default value is `false`.
 * `custom_events` - (Optional) Specifies whether this app monitor allows the web client to define and send custom events. If you omit this parameter, custom events are `DISABLED`. See [custom_events](#custom_events) below.
+* `deobfuscation_configuration` - (Optional) Configuration for how an app monitor can deobfuscate stack traces. See [deobfuscation_configuration](#deobfuscation_configuration) below.
 * `tags` - (Optional) A map of tags to assign to the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 
 ### app_monitor_configuration
@@ -47,6 +48,13 @@ This resource supports the following arguments:
 ### custom_events
 
 * `status` - (Optional) Specifies whether this app monitor allows the web client to define and send custom events. The default is for custom events to be `DISABLED`. Valid values are `DISABLED` and `ENABLED`.
+
+### deobfuscation_configuration
+
+* `javascript_source_maps` - (Optional) Configuration for how an app monitor can unminify JavaScript error stack traces using source maps.
+
+    * `status` - (Required) Whether JavaScript error stack traces should be unminified for this app monitor. Valid values are `DISABLED` and `ENABLED`.
+    * `s3_uri` - (Optional) S3 URI of the bucket or folder that stores the source map files.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Added `deobfuscation_configuration` block to support enabling unminification of JavaScript error stack traces.

### Relations

Closes #43287 

### References
https://docs.aws.amazon.com/ja_jp/cloudwatchrum/latest/APIReference/API_AppMonitor.html
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-RUM-JavaScriptStackTraceSourceMaps.html

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccRUMAppMonitor_ PKG=rum     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/rum/... -v -count 1 -parallel 20 -run='TestAccRUMAppMonitor_'  -timeout 360m -vet=off
2025/07/08 11:50:37 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/08 11:50:37 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRUMAppMonitor_basic
=== PAUSE TestAccRUMAppMonitor_basic
=== RUN   TestAccRUMAppMonitor_customEvents
=== PAUSE TestAccRUMAppMonitor_customEvents
=== RUN   TestAccRUMAppMonitor_domainList
=== PAUSE TestAccRUMAppMonitor_domainList
=== RUN   TestAccRUMAppMonitor_tags
=== PAUSE TestAccRUMAppMonitor_tags
=== RUN   TestAccRUMAppMonitor_deobfuscationConfiguration
=== PAUSE TestAccRUMAppMonitor_deobfuscationConfiguration
=== RUN   TestAccRUMAppMonitor_disappears
=== PAUSE TestAccRUMAppMonitor_disappears
=== CONT  TestAccRUMAppMonitor_basic
=== CONT  TestAccRUMAppMonitor_disappears
=== CONT  TestAccRUMAppMonitor_tags
=== CONT  TestAccRUMAppMonitor_domainList
=== CONT  TestAccRUMAppMonitor_deobfuscationConfiguration
=== CONT  TestAccRUMAppMonitor_customEvents
--- PASS: TestAccRUMAppMonitor_disappears (20.57s)
--- PASS: TestAccRUMAppMonitor_basic (35.73s)
--- PASS: TestAccRUMAppMonitor_tags (45.87s)
--- PASS: TestAccRUMAppMonitor_customEvents (46.33s)
--- PASS: TestAccRUMAppMonitor_domainList (46.77s)
--- PASS: TestAccRUMAppMonitor_deobfuscationConfiguration (48.38s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/rum        52.027s
```
