### PR TITLE
feat: add application_configuration as an optional argument

### DIFF
--- a/website/docs/r/emrserverless_application.html.markdown
+++ b/website/docs/r/emrserverless_application.html.markdown
@@ -59,11 +59,39 @@ resource "aws_emrserverless_application" "example" {
 }
 ```
 
+### Application Configuration Usage
+
+```terraform
+resource "aws_emrserverless_application" "example" {
+  name          = "example"
+  release_label = "emr-6.8.0"
+  type          = "spark"
+
+  application_configuration {
+    classification = "spark-executor-log4j2"
+    properties = {
+      "rootLogger.level"                       = "error"
+      "logger.IdentifierForClass.name"         = "classpathForSettingLogger"
+      "logger.IdentifierForClass.level"        = "info"
+    }
+  }
+
+  application_configuration {
+    classification = "spark-defaults"
+    properties = {
+      "spark.executor.memory" = "1g"
+      "spark.executor.cores" = "1"
+    }
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
+* `application_configuration` - (Optional) A configuration specification to be used when provisioning an application. A configuration consists of a classification, properties, and optional nested configurations. A classification refers to an application-specific configuration file. Properties are the settings you want to change in that file.
 * `architecture` - (Optional) The CPU architecture of an application. Valid values are `ARM64` or `X86_64`. Default value is `X86_64`.
 * `auto_start_configuration` - (Optional) The configuration for an application to automatically start on job submission.
 * `auto_stop_configuration` - (Optional) The configuration for an application to automatically stop after a certain amount of time being idle.
@@ -85,6 +113,11 @@ This resource supports the following arguments:
 
 * `enabled` - (Optional) Enables the application to automatically stop after a certain amount of time being idle. Defaults to `true`.
 * `idle_timeout_minutes` - (Optional) The amount of idle time in minutes after which your application will automatically stop. Defaults to `15` minutes.
+
+### application_configuration Arguments
+
+* `classification` - (Required) The classification within a configuration.
+* `properties` - (Optional) A set of properties specified within a configuration classification.
 
 ### initial_capacity Arguments
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Changes to Security Controls

N/A

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This adds optional application configurations to emr serverless applications which allows defaults to be set at application rather than passed in on job run, this helps keep the runtime configuration more lightweight.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->
Relates #36622
Relates #41288
Relates #34631
Closes #41289 

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/default-configs.html#default-configs-override

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console

% make testacc PKG=emrserverless
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/emrserverless/... -v -count 1 -parallel 20   -timeout 360m -vet=off
2025/07/08 16:22:43 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/08 16:22:43 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccEMRServerlessApplication_basic
=== PAUSE TestAccEMRServerlessApplication_basic
=== RUN   TestAccEMRServerlessApplication_arch
=== PAUSE TestAccEMRServerlessApplication_arch
=== RUN   TestAccEMRServerlessApplication_releaseLabel
=== PAUSE TestAccEMRServerlessApplication_releaseLabel
=== RUN   TestAccEMRServerlessApplication_initialCapacity
=== PAUSE TestAccEMRServerlessApplication_initialCapacity
=== RUN   TestAccEMRServerlessApplication_imageConfiguration
=== PAUSE TestAccEMRServerlessApplication_imageConfiguration
=== RUN   TestAccEMRServerlessApplication_interactiveConfiguration
=== PAUSE TestAccEMRServerlessApplication_interactiveConfiguration
=== RUN   TestAccEMRServerlessApplication_maxCapacity
=== PAUSE TestAccEMRServerlessApplication_maxCapacity
=== RUN   TestAccEMRServerlessApplication_network
=== PAUSE TestAccEMRServerlessApplication_network
=== RUN   TestAccEMRServerlessApplication_disappears
=== PAUSE TestAccEMRServerlessApplication_disappears
=== RUN   TestAccEMRServerlessApplication_tags
=== PAUSE TestAccEMRServerlessApplication_tags
=== RUN   TestAccEMRServerlessApplication_applicationConfiguration
=== PAUSE TestAccEMRServerlessApplication_applicationConfiguration
=== RUN   TestEndpointConfiguration
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file_overrides_base_config_file
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/use_fips_config
=== RUN   TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config
=== RUN   TestEndpointConfiguration/no_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar
=== RUN   TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file
=== RUN   TestEndpointConfiguration/package_name_endpoint_config
=== RUN   TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar
=== RUN   TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file
=== RUN   TestEndpointConfiguration/service_config_file
=== RUN   TestEndpointConfiguration/base_endpoint_config_file
--- PASS: TestEndpointConfiguration (0.30s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_service_config_file (0.03s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_config_file (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_config_file_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config (0.01s)
    --- PASS: TestEndpointConfiguration/use_fips_config_with_package_name_endpoint_config (0.02s)
    --- PASS: TestEndpointConfiguration/no_config (0.01s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_aws_service_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_base_envvar (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_envvar_overrides_base_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config (0.02s)
    --- PASS: TestEndpointConfiguration/package_name_endpoint_config_overrides_base_envvar (0.02s)
    --- PASS: TestEndpointConfiguration/service_aws_envvar_overrides_service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/service_config_file (0.01s)
    --- PASS: TestEndpointConfiguration/base_endpoint_config_file (0.01s)
=== CONT  TestAccEMRServerlessApplication_basic
=== CONT  TestAccEMRServerlessApplication_maxCapacity
=== CONT  TestAccEMRServerlessApplication_initialCapacity
=== CONT  TestAccEMRServerlessApplication_releaseLabel
=== CONT  TestAccEMRServerlessApplication_arch
=== CONT  TestAccEMRServerlessApplication_interactiveConfiguration
=== CONT  TestAccEMRServerlessApplication_tags
=== CONT  TestAccEMRServerlessApplication_applicationConfiguration
=== CONT  TestAccEMRServerlessApplication_disappears
=== CONT  TestAccEMRServerlessApplication_imageConfiguration
=== CONT  TestAccEMRServerlessApplication_network
--- PASS: TestAccEMRServerlessApplication_basic (83.65s)
--- PASS: TestAccEMRServerlessApplication_network (86.66s)
--- PASS: TestAccEMRServerlessApplication_maxCapacity (90.62s)
--- PASS: TestAccEMRServerlessApplication_releaseLabel (91.86s)
--- PASS: TestAccEMRServerlessApplication_arch (92.04s)
--- PASS: TestAccEMRServerlessApplication_applicationConfiguration (92.24s)
--- PASS: TestAccEMRServerlessApplication_initialCapacity (94.72s)
--- PASS: TestAccEMRServerlessApplication_tags (98.73s)
--- PASS: TestAccEMRServerlessApplication_interactiveConfiguration (105.04s)
--- PASS: TestAccEMRServerlessApplication_disappears (140.07s)
--- PASS: TestAccEMRServerlessApplication_imageConfiguration (558.56s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/emrserverless      563.151s
...
```
