### PR TITLE
resource/aws_ssoadmin_application: Fix Resource Identity error

### DIFF
--- a/internal/generate/servicepackage/main.go
+++ b/internal/generate/servicepackage/main.go
@@ -186,6 +186,7 @@ type ResourceDatum struct {
 	ImportIDHandler                   string
 	SetIDAttribute                    bool
 	HasV6_0SDKv2Fix                   bool
+	HasIdentityFix                    bool
 }
 
 func (r ResourceDatum) IsARNFormatGlobal() bool {
@@ -481,6 +482,9 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 			// TODO: allow underscore?
 			case "V60SDKv2Fix":
 				d.HasV6_0SDKv2Fix = true
+
+			case "IdentityFix":
+				d.HasIdentityFix = true
 			}
 		}
 	}
@@ -635,7 +639,7 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 					v.sdkResources[typeName] = d
 				}
 
-			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix":
+			case "IdentityAttribute", "ArnIdentity", "ImportIDHandler", "MutableIdentity", "SingletonIdentity", "Region", "Tags", "WrappedImport", "V60SDKv2Fix", "IdentityFix":
 				// Handled above.
 			case "ArnFormat", "IdAttrFormat", "NoImport", "Testing":
 				// Ignored.

--- a/internal/generate/servicepackage/service_package_gen.go.gtpl
+++ b/internal/generate/servicepackage/service_package_gen.go.gtpl
@@ -128,26 +128,40 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 							{{- range $value.IdentityAttributes }}
 								{{ template "IdentifierAttribute" . }}
 							{{- end }}
-						}),
+						},
+						{{- if .HasIdentityFix }}
+							inttypes.WithIdentityFix(),
+						{{- end -}}
+						),
 					{{- else }}
 						Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
 							{{- range $value.IdentityAttributes }}
 								{{ template "IdentifierAttribute" . }}
 							{{- end }}
-						}),
+						},
+						{{- if .HasIdentityFix }}
+							inttypes.WithIdentityFix(),
+						{{- end -}}
+						),
 					{{- end }}
 				{{- else if gt (len $value.IdentityAttributes) 0 }}
 					{{- if or $.IsGlobal $value.IsGlobal }}
 						Identity: inttypes.GlobalSingleParameterIdentity(
 							{{- range $value.IdentityAttributes -}}
-								{{ .Name }}
+								{{ .Name }},
 							{{- end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- else }}
 						Identity: inttypes.RegionalSingleParameterIdentity(
 							{{- range $value.IdentityAttributes -}}
-								{{ .Name }}
+								{{ .Name }},
 							{{- end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- end }}
 				{{- else if $value.ARNIdentity }}
@@ -173,21 +187,30 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 						{{- end }}
 					{{- end }}
 						{{- if .HasIdentityDuplicateAttrs -}}
-							inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
+							inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }}),
 						{{- end -}}
+						{{- if .HasIdentityFix }}
+							inttypes.WithIdentityFix(),
+						{{- end }}
 						),
 				{{- else if $value.SingletonIdentity }}
 					{{- if or $.IsGlobal $value.IsGlobal }}
 						Identity: inttypes.GlobalSingletonIdentity(
 							{{- if .HasIdentityDuplicateAttrs -}}
-								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
+								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }}),
 							{{- end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{ else }}
 						Identity: inttypes.RegionalSingletonIdentity(
 							{{- if .HasIdentityDuplicateAttrs -}}
-								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }})
+								inttypes.WithIdentityDuplicateAttrs({{ range .IdentityDuplicateAttrs }}{{ . }}, {{ end }}),
 							{{- end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- end }}
 				{{- end }}
@@ -280,6 +303,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 						{{- if $value.HasV6_0SDKv2Fix }}
 							inttypes.WithV6_0SDKv2Fix(),
 						{{ end -}}
+						{{- if .HasIdentityFix }}
+							inttypes.WithIdentityFix(),
+						{{- end -}}
 						),
 					{{- else }}
 						Identity: inttypes.RegionalParameterizedIdentity([]inttypes.IdentityAttribute{
@@ -290,6 +316,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 						{{- if $value.HasV6_0SDKv2Fix }}
 							inttypes.WithV6_0SDKv2Fix(),
 						{{ end -}}
+						{{- if .HasIdentityFix }}
+							inttypes.WithIdentityFix(),
+						{{- end -}}
 						),
 					{{- end }}
 				{{- else if gt (len $value.IdentityAttributes) 0 }}
@@ -301,6 +330,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- else }}
 						Identity: inttypes.RegionalSingleParameterIdentity(
@@ -310,6 +342,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- end }}
 				{{- else if $value.ARNIdentity }}
@@ -320,6 +355,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 							),
 						{{- else }}
 							Identity: inttypes.GlobalARNIdentity(
@@ -327,6 +365,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 							),
 						{{- end }}
 					{{- else }}
@@ -336,6 +377,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 							),
 						{{- else }}
 							Identity: inttypes.RegionalARNIdentity(
@@ -343,6 +387,9 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 							),
 						{{- end }}
 					{{- end }}
@@ -352,12 +399,18 @@ func (p *servicePackage) SDKResources(ctx context.Context) []*inttypes.ServicePa
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- else }}
 						Identity: inttypes.RegionalSingletonIdentity(
 							{{- if $value.HasV6_0SDKv2Fix }}
 								inttypes.WithV6_0SDKv2Fix(),
 							{{ end -}}
+							{{- if .HasIdentityFix }}
+								inttypes.WithIdentityFix(),
+							{{- end }}
 						),
 					{{- end }}
 				{{- end }}

--- a/internal/provider/framework/wrap.go
+++ b/internal/provider/framework/wrap.go
@@ -304,6 +304,10 @@ func newWrappedResource(inner resource.ResourceWithConfigure, opts wrappedResour
 func (w *wrappedResource) Metadata(ctx context.Context, request resource.MetadataRequest, response *resource.MetadataResponse) {
 	// This method does not call down to the inner resource.
 	response.TypeName = w.opts.typeName
+
+	if w.opts.identity.IsMutable {
+		response.ResourceBehavior.MutableIdentity = true
+	}
 }
 
 func (w *wrappedResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {

--- a/internal/service/ssoadmin/application.go
+++ b/internal/service/ssoadmin/application.go
@@ -34,6 +34,7 @@ import (
 // @Tags
 // @ArnIdentity(identityDuplicateAttributes="id;application_arn")
 // @ArnFormat(global=true)
+// @IdentityFix
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/ssoadmin;ssoadmin.DescribeApplicationOutput")
 // @Testing(preCheckWithRegion="github.com/hashicorp/terraform-provider-aws/internal/acctest;acctest.PreCheckSSOAdminInstancesWithRegion")
 func newApplicationResource(_ context.Context) (resource.ResourceWithConfigure, error) {

--- a/internal/service/ssoadmin/service_package_gen.go
+++ b/internal/service/ssoadmin/service_package_gen.go
@@ -61,7 +61,9 @@ func (p *servicePackage) FrameworkResources(ctx context.Context) []*inttypes.Ser
 			Name:     "Application",
 			Tags:     unique.Make(inttypes.ServicePackageResourceTags{}),
 			Region:   unique.Make(inttypes.ResourceRegionDefault()),
-			Identity: inttypes.RegionalResourceWithGlobalARNFormat(inttypes.WithIdentityDuplicateAttrs(names.AttrID, "application_arn")),
+			Identity: inttypes.RegionalResourceWithGlobalARNFormat(inttypes.WithIdentityDuplicateAttrs(names.AttrID, "application_arn"),
+				inttypes.WithIdentityFix(),
+			),
 			Import: inttypes.FrameworkImport{
 				WrappedImport: true,
 			},

--- a/internal/types/service_package.go
+++ b/internal/types/service_package.go
@@ -336,7 +336,15 @@ func WithIdentityDuplicateAttrs(attrs ...string) IdentityOptsFunc {
 	}
 }
 
+// WithV6_0SDKv2Fix is for use ONLY for resource types affected by the v6.0 SDKv2 existing resource issue
 func WithV6_0SDKv2Fix() IdentityOptsFunc {
+	return func(opts *Identity) {
+		opts.IsMutable = true
+	}
+}
+
+// WithIdentityFix is for use ONLY for resource types that must be able to modify Resource Identity due to an error
+func WithIdentityFix() IdentityOptsFunc {
 	return func(opts *Identity) {
 		opts.IsMutable = true
 	}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

If a pre-existing `aws_ssoadmin_application` was refreshed using either v6.0 or v6.2, the Identity was incorrectly populated with a  `null` value for `arn`, because the `arn` attribute on the resource was also set to `null` (#43261)

The fix in #43273 addresses the resource attribute, but caused "Unexpected Identity Change" errors in the `ExstingResource` check added by #43273

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=ssoadmin TESTS=TestAccSSOAdminApplication_

--- SKIP: TestAccSSOAdminApplication_Identity_RegionOverride (0.99s)
--- PASS: TestAccSSOAdminApplication_disappears (19.34s)
--- PASS: TestAccSSOAdminApplication_basic (24.59s)
--- PASS: TestAccSSOAdminApplication_Identity_Basic (33.85s)
--- PASS: TestAccSSOAdminApplication_portalOptions (34.65s)
--- PASS: TestAccSSOAdminApplication_description (34.74s)
--- PASS: TestAccSSOAdminApplication_tags (43.99s)
--- PASS: TestAccSSOAdminApplication_status (44.06s)
--- PASS: TestAccSSOAdminApplication_Identity_ExistingResource (104.82s)
```
