### PR TITLE
Converts `ExistingResource` tests to `resource.ParallelTest`

### DIFF
--- a/internal/service/apigateway/domain_name_access_association_test.go
+++ b/internal/service/apigateway/domain_name_access_association_test.go
@@ -91,7 +91,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_Identity_ExistingResource(t *t
 	certificate := acctest.TLSRSAX509SelfSignedCertificatePEM(t, key, domainName)
 	resourceName := "aws_api_gateway_domain_name_access_association.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/batch/job_queue_test.go
+++ b/internal/service/batch/job_queue_test.go
@@ -387,7 +387,7 @@ func TestAccBatchJobQueue_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_batch_job_queue.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/bedrock/provisioned_model_throughput_test.go
+++ b/internal/service/bedrock/provisioned_model_throughput_test.go
@@ -81,7 +81,7 @@ func TestAccBedrockProvisionedModelThroughput_Identity_ExistingResource(t *testi
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_bedrock_provisioned_model_throughput.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeconnections/connection_test.go
+++ b/internal/service/codeconnections/connection_test.go
@@ -126,7 +126,7 @@ func TestAccCodeConnectionsConnection_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeconnections_connection.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/codeconnections/host_test.go
+++ b/internal/service/codeconnections/host_test.go
@@ -146,7 +146,7 @@ func TestAccCodeConnectionsHost_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_codeconnections_host.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/docdbelastic/cluster_test.go
+++ b/internal/service/docdbelastic/cluster_test.go
@@ -237,7 +237,7 @@ func TestAccDocDBElasticCluster_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_docdbelastic_cluster.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/dynamodb/resource_policy_test.go
+++ b/internal/service/dynamodb/resource_policy_test.go
@@ -118,7 +118,7 @@ func TestAccDynamoDBResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_dynamodb_resource_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/globalaccelerator/cross_account_attachment_test.go
+++ b/internal/service/globalaccelerator/cross_account_attachment_test.go
@@ -216,7 +216,7 @@ func TestAccGlobalAcceleratorCrossAccountAttachment_Identity_ExistingResource(t 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_globalaccelerator_cross_account_attachment.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/imagebuilder/lifecycle_policy_test.go
+++ b/internal/service/imagebuilder/lifecycle_policy_test.go
@@ -249,7 +249,7 @@ func TestAccImageBuilderLifecyclePolicy_Identity_ExistingResource(t *testing.T) 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_imagebuilder_lifecycle_policy.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/kinesis/resource_policy_test.go
+++ b/internal/service/kinesis/resource_policy_test.go
@@ -81,7 +81,7 @@ func TestAccKinesisResourcePolicy_Identity_ExistingResource(t *testing.T) {
 	resourceName := "aws_kinesis_resource_policy.test"
 	providers := make(map[string]*schema.Provider)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/networkfirewall/tls_inspection_configuration_test.go
+++ b/internal/service/networkfirewall/tls_inspection_configuration_test.go
@@ -332,7 +332,7 @@ func TestAccNetworkFirewallTLSInspectionConfiguration_Identity_ExistingResource(
 	commonName := acctest.RandomDomain()
 	certificateDomain := commonName.RandomSubdomain()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/paymentcryptography/key_test.go
+++ b/internal/service/paymentcryptography/key_test.go
@@ -76,86 +76,6 @@ func TestAccPaymentCryptographyKey_basic(t *testing.T) {
 	})
 }
 
-// func TestAccPaymentCryptographyKey_Identity_Basic(t *testing.T) {
-// 	ctx := acctest.Context(t)
-// 	if testing.Short() {
-// 		t.Skip("skipping long-running test in short mode")
-// 	}
-
-// 	var key paymentcryptography.GetKeyOutput
-// 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-// 	resourceName := "aws_paymentcryptography_key.test"
-
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.PreCheck(ctx, t)
-// 			testAccPreCheck(ctx, t)
-// 		},
-// 		ErrorCheck:               acctest.ErrorCheck(t, names.PaymentCryptographyServiceID),
-// 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-// 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccKeyConfig_basic(rName),
-// 				Check: resource.ComposeAggregateTestCheckFunc(
-// 					testAccCheckKeyExists(ctx, resourceName, &key),
-// 				),
-// 				ConfigStateChecks: []statecheck.StateCheck{
-// 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNRegexp("payment-cryptography", regexache.MustCompile(`key/[0-9a-z]{16}`))),
-// 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
-// 				},
-// 			},
-// 			{
-// 				ResourceName:            resourceName,
-// 				ImportState:             true,
-// 				ImportStateVerify:       true,
-// 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
-// 			},
-// 		},
-// 	})
-// }
-
-// func TestAccPaymentCryptographyKey_Identity_RegionOverride(t *testing.T) {
-// 	ctx := acctest.Context(t)
-// 	if testing.Short() {
-// 		t.Skip("skipping long-running test in short mode")
-// 	}
-
-// 	resourceName := "aws_paymentcryptography_key.test"
-
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck: func() {
-// 			acctest.PreCheck(ctx, t)
-// 			testAccPreCheck(ctx, t)
-// 		},
-// 		ErrorCheck:               acctest.ErrorCheck(t, names.PaymentCryptographyServiceID),
-// 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-// 		CheckDestroy:             acctest.CheckDestroyNoop,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config: testAccKeyConfig_regionOverride(),
-// 				ConfigStateChecks: []statecheck.StateCheck{
-// 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrARN), tfknownvalue.RegionalARNAlternateRegionRegexp("payment-cryptography", regexache.MustCompile(`key/[0-9a-z]{16}`))),
-// 					statecheck.CompareValuePairs(resourceName, tfjsonpath.New(names.AttrID), resourceName, tfjsonpath.New(names.AttrARN), compare.ValuesSame()),
-// 				},
-// 			},
-// 			{
-// 				ResourceName:            resourceName,
-// 				ImportState:             true,
-// 				ImportStateIdFunc:       acctest.CrossRegionImportStateIdFunc(resourceName),
-// 				ImportStateVerify:       true,
-// 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
-// 			},
-// 			{
-// 				ResourceName:            resourceName,
-// 				ImportState:             true,
-// 				ImportStateVerify:       true,
-// 				ImportStateVerifyIgnore: []string{"deletion_window_in_days"},
-// 			},
-// 		},
-// 	})
-// }
-
 func TestAccPaymentCryptographyKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	if testing.Short() {
@@ -372,7 +292,7 @@ func TestAccPaymentCryptographyKey_Identity_ExistingResource(t *testing.T) {
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_paymentcryptography_key.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},

--- a/internal/service/shield/application_layer_automatic_response_test.go
+++ b/internal/service/shield/application_layer_automatic_response_test.go
@@ -93,7 +93,7 @@ func TestAccShieldApplicationLayerAutomaticResponse_Identity_ExistingResource(t 
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_shield_application_layer_automatic_response.test"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
 			tfversion.SkipBelow(tfversion.Version1_12_0),
 		},


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Converts `ExistingResource` tests to `resource.ParallelTest`
