### PR TITLE
Fix `runtime error: invalid memory address or nil pointer dereference` panics for numerous resource types when modifying `tags`

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+provider: Fix `runtime error: invalid memory address or nil pointer dereference` panics for numerous resource types when modifying `tags`
+```

--- a/internal/tags/map.go
+++ b/internal/tags/map.go
@@ -158,6 +158,10 @@ func (v Map) MapSemanticEquals(ctx context.Context, oValuable basetypes.MapValua
 	for k, v := range elements {
 		ov := oElements[k]
 
+		if ov == nil {
+			return false, diags
+		}
+
 		if v.IsNull() {
 			if !ov.IsUnknown() && !ov.IsNull() {
 				sv := ov.(types.String)

--- a/internal/tags/map_test.go
+++ b/internal/tags/map_test.go
@@ -75,7 +75,7 @@ func TestTagMapEquality(t *testing.T) {
 			semanticEquals: false,
 		},
 
-		"set-missing": {
+		"set-missing-different-lengths": {
 			val1: newMapValueMust(
 				map[string]attr.Value{
 					"key1": types.StringValue("value1"),
@@ -84,6 +84,23 @@ func TestTagMapEquality(t *testing.T) {
 			),
 			val2: newMapValueMust(
 				map[string]attr.Value{
+					"key2": types.StringValue("value2"),
+				},
+			),
+			equals:         false,
+			semanticEquals: false,
+		},
+
+		"set-missing-same-lengths": {
+			val1: newMapValueMust(
+				map[string]attr.Value{
+					"key1": types.StringValue("value1"),
+					"key3": types.StringValue("value3"),
+				},
+			),
+			val2: newMapValueMust(
+				map[string]attr.Value{
+					"key1": types.StringValue("value1"),
 					"key2": types.StringValue("value2"),
 				},
 			),

--- a/internal/tags/map_test.go
+++ b/internal/tags/map_test.go
@@ -4,7 +4,6 @@
 package tags
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -230,7 +229,7 @@ func TestTagMapEquality(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			equals := test.val1.Equal(test.val2)
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Prevents crash for `terraform-plugin-framework` resources when a `tags` key is not present in the new value.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/42954.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% go test -v -run=TestTagMapEquality ./internal/tags
=== RUN   TestTagMapEquality
=== PAUSE TestTagMapEquality
=== CONT  TestTagMapEquality
=== RUN   TestTagMapEquality/null-unset
=== PAUSE TestTagMapEquality/null-unset
=== RUN   TestTagMapEquality/unset-null
=== PAUSE TestTagMapEquality/unset-null
=== RUN   TestTagMapEquality/null-empty
=== PAUSE TestTagMapEquality/null-empty
=== RUN   TestTagMapEquality/not_equal
=== PAUSE TestTagMapEquality/not_equal
=== RUN   TestTagMapEquality/set-missing-different-lengths
=== PAUSE TestTagMapEquality/set-missing-different-lengths
=== RUN   TestTagMapEquality/null-set
=== PAUSE TestTagMapEquality/null-set
=== RUN   TestTagMapEquality/set-null
=== PAUSE TestTagMapEquality/set-null
=== RUN   TestTagMapEquality/empty-null
=== PAUSE TestTagMapEquality/empty-null
=== RUN   TestTagMapEquality/equal
=== PAUSE TestTagMapEquality/equal
=== RUN   TestTagMapEquality/missing-set
=== PAUSE TestTagMapEquality/missing-set
=== RUN   TestTagMapEquality/set-missing-same-lengths
=== PAUSE TestTagMapEquality/set-missing-same-lengths
=== RUN   TestTagMapEquality/null-null
=== PAUSE TestTagMapEquality/null-null
=== CONT  TestTagMapEquality/null-unset
=== CONT  TestTagMapEquality/missing-set
=== CONT  TestTagMapEquality/null-empty
=== CONT  TestTagMapEquality/null-null
=== CONT  TestTagMapEquality/set-null
=== CONT  TestTagMapEquality/set-missing-same-lengths
=== CONT  TestTagMapEquality/set-missing-different-lengths
=== CONT  TestTagMapEquality/empty-null
=== CONT  TestTagMapEquality/null-set
=== CONT  TestTagMapEquality/not_equal
=== CONT  TestTagMapEquality/unset-null
=== CONT  TestTagMapEquality/equal
--- PASS: TestTagMapEquality (0.00s)
    --- PASS: TestTagMapEquality/null-unset (0.00s)
    --- PASS: TestTagMapEquality/missing-set (0.00s)
    --- PASS: TestTagMapEquality/null-empty (0.00s)
    --- PASS: TestTagMapEquality/set-null (0.00s)
    --- PASS: TestTagMapEquality/set-missing-same-lengths (0.00s)
    --- PASS: TestTagMapEquality/null-null (0.00s)
    --- PASS: TestTagMapEquality/set-missing-different-lengths (0.00s)
    --- PASS: TestTagMapEquality/empty-null (0.00s)
    --- PASS: TestTagMapEquality/null-set (0.00s)
    --- PASS: TestTagMapEquality/not_equal (0.00s)
    --- PASS: TestTagMapEquality/unset-null (0.00s)
    --- PASS: TestTagMapEquality/equal (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/tags	0.567s
```

Previously:

```console
% go test -v -run=TestTagMapEquality ./internal/tags
=== RUN   TestTagMapEquality
=== PAUSE TestTagMapEquality
=== CONT  TestTagMapEquality
=== RUN   TestTagMapEquality/not_equal
=== PAUSE TestTagMapEquality/not_equal
=== RUN   TestTagMapEquality/missing-set
=== PAUSE TestTagMapEquality/missing-set
=== RUN   TestTagMapEquality/null-empty
=== PAUSE TestTagMapEquality/null-empty
=== RUN   TestTagMapEquality/empty-null
=== PAUSE TestTagMapEquality/empty-null
=== RUN   TestTagMapEquality/set-missing-different-lengths
=== PAUSE TestTagMapEquality/set-missing-different-lengths
=== RUN   TestTagMapEquality/set-missing-same-lengths
=== PAUSE TestTagMapEquality/set-missing-same-lengths
=== RUN   TestTagMapEquality/null-set
=== PAUSE TestTagMapEquality/null-set
=== RUN   TestTagMapEquality/set-null
=== PAUSE TestTagMapEquality/set-null
=== RUN   TestTagMapEquality/null-null
=== PAUSE TestTagMapEquality/null-null
=== RUN   TestTagMapEquality/null-unset
=== PAUSE TestTagMapEquality/null-unset
=== RUN   TestTagMapEquality/unset-null
=== PAUSE TestTagMapEquality/unset-null
=== RUN   TestTagMapEquality/equal
=== PAUSE TestTagMapEquality/equal
=== CONT  TestTagMapEquality/not_equal
=== CONT  TestTagMapEquality/null-set
=== CONT  TestTagMapEquality/equal
=== CONT  TestTagMapEquality/null-null
=== CONT  TestTagMapEquality/set-null
=== CONT  TestTagMapEquality/unset-null
=== CONT  TestTagMapEquality/null-empty
=== CONT  TestTagMapEquality/set-missing-same-lengths
=== CONT  TestTagMapEquality/null-unset
=== CONT  TestTagMapEquality/empty-null
=== CONT  TestTagMapEquality/missing-set
=== CONT  TestTagMapEquality/set-missing-different-lengths
--- FAIL: TestTagMapEquality (0.00s)
    --- PASS: TestTagMapEquality/not_equal (0.00s)
    --- PASS: TestTagMapEquality/null-set (0.00s)
    --- PASS: TestTagMapEquality/equal (0.00s)
    --- PASS: TestTagMapEquality/set-null (0.00s)
    --- PASS: TestTagMapEquality/unset-null (0.00s)
    --- PASS: TestTagMapEquality/null-null (0.00s)
    --- PASS: TestTagMapEquality/null-empty (0.00s)
    --- PASS: TestTagMapEquality/null-unset (0.00s)
    --- PASS: TestTagMapEquality/empty-null (0.00s)
    --- PASS: TestTagMapEquality/missing-set (0.00s)
    --- PASS: TestTagMapEquality/set-missing-different-lengths (0.00s)
    --- FAIL: TestTagMapEquality/set-missing-same-lengths (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x103040040]

goroutine 16 [running]:
testing.tRunner.func1.2({0x103174ac0, 0x103494f20})
	/Users/kewbank/sdk/go1.24.4/src/testing/testing.go:1734 +0x1ac
testing.tRunner.func1()
	/Users/kewbank/sdk/go1.24.4/src/testing/testing.go:1737 +0x334
panic({0x103174ac0?, 0x103494f20?})
	/Users/kewbank/sdk/go1.24.4/src/runtime/panic.go:792 +0x124
github.com/hashicorp/terraform-provider-aws/internal/tags.Map.MapSemanticEquals({{0x1400148a120?, {0x1031e7cb0?, 0x1034cdc20?}, 0xcc?}}, {0x1031e7d40?, 0x140005b6ef8?}, {0x1031e8690?, 0x140005b6ed8?})
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/tags/map.go:173 +0x3e0
github.com/hashicorp/terraform-provider-aws/internal/tags.TestTagMapEquality.func1(0x140004b5180)
	/Users/kewbank/altsrc.1/github.com/hashicorp/terraform-provider-aws/internal/tags/map_test.go:241 +0x190
testing.tRunner(0x140004b5180, 0x14000246d70)
	/Users/kewbank/sdk/go1.24.4/src/testing/testing.go:1792 +0xe4
created by testing.(*T).Run in goroutine 10
	/Users/kewbank/sdk/go1.24.4/src/testing/testing.go:1851 +0x374
FAIL	github.com/hashicorp/terraform-provider-aws/internal/tags	0.511s
FAIL
```