### PR TITLE
Go-VCR: support `logs`

### DIFF
--- a/internal/service/logs/account_policy.go
+++ b/internal/service/logs/account_policy.go
@@ -13,13 +13,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -104,7 +104,7 @@ func resourceAccountPolicyRead(ctx context.Context, d *schema.ResourceData, meta
 
 	output, err := findAccountPolicyByTwoPartKey(ctx, conn, awstypes.PolicyType(d.Get("policy_type").(string)), d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Account Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -212,8 +212,7 @@ func findAccountPolicies(ctx context.Context, conn *cloudwatchlogs.Client, input
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/account_policy_test.go
+++ b/internal/service/logs/account_policy_test.go
@@ -9,32 +9,30 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccLogsAccountPolicy_basicSubscriptionFilter(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_account_policy.test"
 	var accountPolicy types.AccountPolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPolicyConfig_basicSubscriptionFilter(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPolicyExists(ctx, resourceName, &accountPolicy),
+					testAccCheckAccountPolicyExists(ctx, t, resourceName, &accountPolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					testAccCheckAccountHasSubscriptionFilterPolicy(ctx, resourceName, rName),
 				),
@@ -51,52 +49,52 @@ func TestAccLogsAccountPolicy_basicSubscriptionFilter(t *testing.T) {
 
 func TestAccLogsAccountPolicy_basicDataProtection(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_account_policy.test"
 	var accountPolicy types.AccountPolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPolicyConfig_basicDataProtection(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPolicyExists(ctx, resourceName, &accountPolicy),
+					testAccCheckAccountPolicyExists(ctx, t, resourceName, &accountPolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_type", "DATA_PROTECTION_POLICY"),
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", `
-{
-	"Name": "Test",
-	"Version": "2021-06-01",
-	"Statement": [
-		{
-			"Sid": "Audit",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Audit": {
-					"FindingsDestination": {}
-				}
-			}
-		},
-		{
-			"Sid": "Redact",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Deidentify": {
-					"MaskConfig": {}
-				}
-			}
-		}
-	]
-}
-`), //lintignore:AWSAT005
+ {
+ 	"Name": "Test",
+ 	"Version": "2021-06-01",
+ 	"Statement": [
+ 		{
+ 			"Sid": "Audit",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Audit": {
+ 					"FindingsDestination": {}
+ 				}
+ 			}
+ 		},
+ 		{
+ 			"Sid": "Redact",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Deidentify": {
+ 					"MaskConfig": {}
+ 				}
+ 			}
+ 		}
+ 	]
+ }
+ `), //lintignore:AWSAT005
 				),
 			},
 			{
@@ -111,20 +109,20 @@ func TestAccLogsAccountPolicy_basicDataProtection(t *testing.T) {
 
 func TestAccLogsAccountPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_account_policy.test"
 	var accountPolicy types.AccountPolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPolicyConfig_basicDataProtection(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPolicyExists(ctx, resourceName, &accountPolicy),
+					testAccCheckAccountPolicyExists(ctx, t, resourceName, &accountPolicy),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceAccountPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -135,21 +133,21 @@ func TestAccLogsAccountPolicy_disappears(t *testing.T) {
 
 func TestAccLogsAccountPolicy_selectionCriteria(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	rSelectionCriteria := fmt.Sprintf("LogGroupName NOT IN [\"%s\"]", rName)
 	resourceName := "aws_cloudwatch_log_account_policy.test"
 	var accountPolicy types.AccountPolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckAccountPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAccountPolicyConfig_selectionCriteria(rName, rSelectionCriteria),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAccountPolicyExists(ctx, resourceName, &accountPolicy),
+					testAccCheckAccountPolicyExists(ctx, t, resourceName, &accountPolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "selection_criteria", rSelectionCriteria),
 				),
@@ -164,14 +162,14 @@ func TestAccLogsAccountPolicy_selectionCriteria(t *testing.T) {
 	})
 }
 
-func testAccCheckAccountPolicyExists(ctx context.Context, n string, v *types.AccountPolicy) resource.TestCheckFunc {
+func testAccCheckAccountPolicyExists(ctx context.Context, t *testing.T, n string, v *types.AccountPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindAccountPolicyByTwoPartKey(ctx, conn, types.PolicyType(rs.Primary.Attributes["policy_type"]), rs.Primary.ID)
 
@@ -185,9 +183,9 @@ func testAccCheckAccountPolicyExists(ctx context.Context, n string, v *types.Acc
 	}
 }
 
-func testAccCheckAccountPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckAccountPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_account_policy" {
@@ -196,7 +194,7 @@ func testAccCheckAccountPolicyDestroy(ctx context.Context) resource.TestCheckFun
 
 			_, err := tflogs.FindAccountPolicyByTwoPartKey(ctx, conn, types.PolicyType(rs.Primary.Attributes["policy_type"]), rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -230,7 +228,7 @@ func testAccCheckAccountHasSubscriptionFilterPolicy(ctx context.Context, resourc
 	return func(s *terraform.State) error {
 		expectedJSONTemplate := `{
 			"DestinationArn": "arn:%s:lambda:%s:%s:function:%s",
-			"FilterPattern" : " ",
+			"FilterPattern" : "",
 			"Distribution" : "Random"
 		  }`
 		expectedJSON := fmt.Sprintf(expectedJSONTemplate, acctest.Partition(), acctest.Region(), acctest.AccountID(ctx), rName)
@@ -295,7 +293,7 @@ resource "aws_cloudwatch_log_account_policy" "test" {
 
   policy_document = jsonencode({
     DestinationArn = aws_lambda_function.test.arn
-    FilterPattern  = " "
+    FilterPattern  = ""
     Distribution   = "Random"
   })
 }
@@ -310,7 +308,7 @@ resource "aws_cloudwatch_log_account_policy" "test" {
 
   policy_document = jsonencode({
     DestinationArn = aws_lambda_function.test.arn
-    FilterPattern  = " "
+    FilterPattern  = ""
     Distribution   = "Random"
   })
 

--- a/internal/service/logs/anomaly_detector_tags_gen_test.go
+++ b/internal/service/logs/anomaly_detector_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -37,7 +37,7 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -86,7 +86,7 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -139,7 +139,7 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -185,7 +185,7 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -227,7 +227,7 @@ func TestAccLogsAnomalyDetector_tags_null(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -239,7 +239,7 @@ func TestAccLogsAnomalyDetector_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -292,7 +292,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyMap(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -302,7 +302,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -345,7 +345,7 @@ func TestAccLogsAnomalyDetector_tags_AddOnUpdate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -355,7 +355,7 @@ func TestAccLogsAnomalyDetector_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -378,7 +378,7 @@ func TestAccLogsAnomalyDetector_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -430,7 +430,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -442,7 +442,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -488,7 +488,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -530,7 +530,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -542,7 +542,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -574,7 +574,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -627,7 +627,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -679,7 +679,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -691,7 +691,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -722,7 +722,7 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -774,7 +774,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -787,7 +787,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -836,7 +836,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -887,7 +887,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -932,7 +932,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -975,7 +975,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -990,7 +990,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1049,7 +1049,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1107,7 +1107,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1150,7 +1150,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1165,7 +1165,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1223,7 +1223,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1285,7 +1285,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1341,7 +1341,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly(t *testing
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1353,7 +1353,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1386,7 +1386,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1436,7 +1436,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly(t *testing
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1449,7 +1449,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1477,7 +1477,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly(t *testing
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1530,7 +1530,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1545,7 +1545,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1601,7 +1601,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1614,7 +1614,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1664,7 +1664,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1679,7 +1679,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag(t *t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1736,7 +1736,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1751,7 +1751,7 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullNonOverlappingResourceTag(t
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1810,7 +1810,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1820,7 +1820,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1870,7 +1870,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1882,7 +1882,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1914,7 +1914,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1972,7 +1972,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1984,7 +1984,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2014,7 +2014,7 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -2064,7 +2064,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2083,7 +2083,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2132,7 +2132,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2181,7 +2181,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2226,7 +2226,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
+		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2243,7 +2243,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2301,7 +2301,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2358,7 +2358,7 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAnomalyDetectorExists(ctx, resourceName, &v),
+					testAccCheckAnomalyDetectorExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/logs/data_protection_policy.go
+++ b/internal/service/logs/data_protection_policy.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -81,7 +81,7 @@ func resourceDataProtectionPolicyRead(ctx context.Context, d *schema.ResourceDat
 
 	output, err := findDataProtectionPolicyByLogGroupName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Data Protection Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -149,8 +149,7 @@ func findDataProtectionPolicy(ctx context.Context, conn *cloudwatchlogs.Client, 
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/data_protection_policy_document_data_source_test.go
+++ b/internal/service/logs/data_protection_policy_document_data_source_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/YakDriver/regexache"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -16,14 +15,14 @@ import (
 
 func TestAccLogsDataProtectionPolicyDocumentDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	logGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	targetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	logGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Logs),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicyDocumentDataSourceConfig_basic(logGroupName, targetName),
@@ -39,13 +38,13 @@ func TestAccLogsDataProtectionPolicyDocumentDataSource_basic(t *testing.T) {
 
 func TestAccLogsDataProtectionPolicyDocumentDataSource_empty(t *testing.T) {
 	ctx := acctest.Context(t)
-	logGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	logGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Logs),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicyDocumentDataSourceConfig_empty(logGroupName),
@@ -61,11 +60,11 @@ func TestAccLogsDataProtectionPolicyDocumentDataSource_empty(t *testing.T) {
 
 func TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnBadOrderOfStatements(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Logs),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataProtectionPolicyDocumentDataSourceConfig_errorOnBadOrderOfStatements,
@@ -77,11 +76,11 @@ func TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnBadOrderOfStatemen
 
 func TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnNoOperation(t *testing.T) {
 	ctx := acctest.Context(t)
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Logs),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataProtectionPolicyDocumentDataSourceConfig_errorOnNoOperation,
@@ -93,14 +92,14 @@ func TestAccLogsDataProtectionPolicyDocumentDataSource_errorOnNoOperation(t *tes
 
 func TestAccLogsDataProtectionPolicyDocumentDataSource_customDataIdentifiers(t *testing.T) {
 	ctx := acctest.Context(t)
-	logGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	targetName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	logGroupName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	targetName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Logs),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicyDocumentDataSourceConfig_customDataIdentifiers(logGroupName, targetName),

--- a/internal/service/logs/data_protection_policy_test.go
+++ b/internal/service/logs/data_protection_policy_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -23,54 +21,54 @@ func TestAccLogsDataProtectionPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
 	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicy_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProtectionPolicyExists(ctx, resourceName, &policy),
+					testAccCheckDataProtectionPolicyExists(ctx, t, resourceName, &policy),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrLogGroupName, "aws_cloudwatch_log_group.test", names.AttrName),
 					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
-{
-	"Name": "Test",
-	"Version": "2021-06-01",
-	"Statement": [
-		{
-			"Sid": "Audit",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Audit": {
-					"FindingsDestination": {
-                      "S3": {
-                        "Bucket": %[1]q
-                      }
-                    }
-				}
-			}
-		},
-		{
-			"Sid": "Redact",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Deidentify": {
-					"MaskConfig": {}
-				}
-			}
-		}
-	]
-}
-`, name)),
+ {
+ 	"Name": "Test",
+ 	"Version": "2021-06-01",
+ 	"Statement": [
+ 		{
+ 			"Sid": "Audit",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Audit": {
+ 					"FindingsDestination": {
+                       "S3": {
+                         "Bucket": %[1]q
+                       }
+                     }
+ 				}
+ 			}
+ 		},
+ 		{
+ 			"Sid": "Redact",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Deidentify": {
+ 					"MaskConfig": {}
+ 				}
+ 			}
+ 		}
+ 	]
+ }
+ `, name)),
 				),
 			},
 			{
@@ -86,18 +84,18 @@ func TestAccLogsDataProtectionPolicy_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
 	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicy_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProtectionPolicyExists(ctx, resourceName, &policy),
+					testAccCheckDataProtectionPolicyExists(ctx, t, resourceName, &policy),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceDataProtectionPolicy(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -110,49 +108,49 @@ func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
 	ctx := acctest.Context(t)
 	var policy cloudwatchlogs.GetDataProtectionPolicyOutput
 	resourceName := "aws_cloudwatch_log_data_protection_policy.test"
-	name := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	name := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckDataProtectionPolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataProtectionPolicy_policyDocument1(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProtectionPolicyExists(ctx, resourceName, &policy),
+					testAccCheckDataProtectionPolicyExists(ctx, t, resourceName, &policy),
 					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", `
-{
-	"Name": "Test",
-	"Version": "2021-06-01",
-	"Statement": [
-		{
-			"Sid": "Audit",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Audit": {
-					"FindingsDestination": {}
-				}
-			}
-		},
-		{
-			"Sid": "Redact",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
-			],
-			"Operation": {
-				"Deidentify": {
-					"MaskConfig": {}
-				}
-			}
-		}
-	]
-}
-`),
+ {
+ 	"Name": "Test",
+ 	"Version": "2021-06-01",
+ 	"Statement": [
+ 		{
+ 			"Sid": "Audit",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Audit": {
+ 					"FindingsDestination": {}
+ 				}
+ 			}
+ 		},
+ 		{
+ 			"Sid": "Redact",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress"
+ 			],
+ 			"Operation": {
+ 				"Deidentify": {
+ 					"MaskConfig": {}
+ 				}
+ 			}
+ 		}
+ 	]
+ }
+ `),
 				),
 			},
 			{
@@ -163,44 +161,44 @@ func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
 			{
 				Config: testAccDataProtectionPolicy_policyDocument2(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataProtectionPolicyExists(ctx, resourceName, &policy),
+					testAccCheckDataProtectionPolicyExists(ctx, t, resourceName, &policy),
 					//lintignore:AWSAT005
 					acctest.CheckResourceAttrEquivalentJSON(resourceName, "policy_document", fmt.Sprintf(`
-{
-	"Name": "Test",
-	"Version": "2021-06-01",
-	"Statement": [
-		{
-			"Sid": "Audit",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
-			],
-			"Operation": {
-				"Audit": {
-					"FindingsDestination": {
-                      "S3": {
-                        "Bucket": %[1]q
-                      }
-                    }
-				}
-			}
-		},
-		{
-			"Sid": "Redact",
-			"DataIdentifier": [
-				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
-				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
-			],
-			"Operation": {
-				"Deidentify": {
-					"MaskConfig": {}
-				}
-			}
-		}
-	]
-}
-`, name)),
+ {
+ 	"Name": "Test",
+ 	"Version": "2021-06-01",
+ 	"Statement": [
+ 		{
+ 			"Sid": "Audit",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+ 				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
+ 			],
+ 			"Operation": {
+ 				"Audit": {
+ 					"FindingsDestination": {
+                       "S3": {
+                         "Bucket": %[1]q
+                       }
+                     }
+ 				}
+ 			}
+ 		},
+ 		{
+ 			"Sid": "Redact",
+ 			"DataIdentifier": [
+ 				"arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+ 				"arn:aws:dataprotection::aws:data-identifier/DriversLicense-US"
+ 			],
+ 			"Operation": {
+ 				"Deidentify": {
+ 					"MaskConfig": {}
+ 				}
+ 			}
+ 		}
+ 	]
+ }
+ `, name)),
 				),
 			},
 			{
@@ -212,9 +210,9 @@ func TestAccLogsDataProtectionPolicy_policyDocument(t *testing.T) {
 	})
 }
 
-func testAccCheckDataProtectionPolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDataProtectionPolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_data_protection_policy" {
@@ -223,7 +221,7 @@ func testAccCheckDataProtectionPolicyDestroy(ctx context.Context) resource.TestC
 
 			_, err := tflogs.FindDataProtectionPolicyByLogGroupName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -238,14 +236,14 @@ func testAccCheckDataProtectionPolicyDestroy(ctx context.Context) resource.TestC
 	}
 }
 
-func testAccCheckDataProtectionPolicyExists(ctx context.Context, n string, v *cloudwatchlogs.GetDataProtectionPolicyOutput) resource.TestCheckFunc {
+func testAccCheckDataProtectionPolicyExists(ctx context.Context, t *testing.T, n string, v *cloudwatchlogs.GetDataProtectionPolicyOutput) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDataProtectionPolicyByLogGroupName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/logs/delivery.go
+++ b/internal/service/logs/delivery.go
@@ -22,12 +22,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -219,7 +219,7 @@ func (r *deliveryResource) Read(ctx context.Context, request resource.ReadReques
 
 	output, err := findDeliveryByID(ctx, conn, data.ID.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
@@ -357,8 +357,7 @@ func findDelivery(ctx context.Context, conn *cloudwatchlogs.Client, input *cloud
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/delivery_destination.go
+++ b/internal/service/logs/delivery_destination.go
@@ -20,12 +20,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -139,7 +139,7 @@ func (r *deliveryDestinationResource) Read(ctx context.Context, request resource
 
 	output, err := findDeliveryDestinationByName(ctx, conn, data.Name.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
@@ -246,8 +246,7 @@ func findDeliveryDestination(ctx context.Context, conn *cloudwatchlogs.Client, i
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/delivery_destination_policy.go
+++ b/internal/service/logs/delivery_destination_policy.go
@@ -16,12 +16,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 )
 
@@ -89,7 +89,7 @@ func (r *deliveryDestinationPolicyResource) Read(ctx context.Context, request re
 
 	output, err := findDeliveryDestinationPolicyByDeliveryDestinationName(ctx, conn, data.DeliveryDestinationName.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
@@ -183,8 +183,7 @@ func findDeliveryDestinationPolicy(ctx context.Context, conn *cloudwatchlogs.Cli
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/delivery_destination_test.go
+++ b/internal/service/logs/delivery_destination_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -17,30 +16,29 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccLogsDeliveryDestination_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -69,21 +67,21 @@ func TestAccLogsDeliveryDestination_basic(t *testing.T) {
 func TestAccLogsDeliveryDestination_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflogs.ResourceDeliveryDestination, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -95,21 +93,21 @@ func TestAccLogsDeliveryDestination_disappears(t *testing.T) {
 func TestAccLogsDeliveryDestination_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -132,7 +130,7 @@ func TestAccLogsDeliveryDestination_tags(t *testing.T) {
 			{
 				Config: testAccDeliveryDestinationConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -149,7 +147,7 @@ func TestAccLogsDeliveryDestination_tags(t *testing.T) {
 			{
 				Config: testAccDeliveryDestinationConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -169,21 +167,21 @@ func TestAccLogsDeliveryDestination_tags(t *testing.T) {
 func TestAccLogsDeliveryDestination_outputFormat(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_outputFormat(rName, "w3c"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -204,7 +202,7 @@ func TestAccLogsDeliveryDestination_outputFormat(t *testing.T) {
 			{
 				Config: testAccDeliveryDestinationConfig_outputFormat(rName, "plain"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -222,21 +220,21 @@ func TestAccLogsDeliveryDestination_outputFormat(t *testing.T) {
 func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_deliveryDestinationConfigurationCWL1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -257,7 +255,7 @@ func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameTy
 			{
 				Config: testAccDeliveryDestinationConfig_deliveryDestinationConfigurationCWL2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -275,21 +273,21 @@ func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationSameTy
 func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDifferentType(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DeliveryDestination
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_destination.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryDestinationConfig_deliveryDestinationConfigurationCWL1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -310,7 +308,7 @@ func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDiffer
 			{
 				Config: testAccDeliveryDestinationConfig_deliveryDestinationConfigurationS3(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryDestinationExists(ctx, resourceName, &v),
+					testAccCheckDeliveryDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -325,9 +323,9 @@ func TestAccLogsDeliveryDestination_updateDeliveryDestinationConfigurationDiffer
 	})
 }
 
-func testAccCheckDeliveryDestinationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDeliveryDestinationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_delivery_destination" {
@@ -336,7 +334,7 @@ func testAccCheckDeliveryDestinationDestroy(ctx context.Context) resource.TestCh
 
 			_, err := tflogs.FindDeliveryDestinationByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -351,14 +349,14 @@ func testAccCheckDeliveryDestinationDestroy(ctx context.Context) resource.TestCh
 	}
 }
 
-func testAccCheckDeliveryDestinationExists(ctx context.Context, n string, v *awstypes.DeliveryDestination) resource.TestCheckFunc {
+func testAccCheckDeliveryDestinationExists(ctx context.Context, t *testing.T, n string, v *awstypes.DeliveryDestination) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDeliveryDestinationByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 

--- a/internal/service/logs/delivery_source.go
+++ b/internal/service/logs/delivery_source.go
@@ -18,12 +18,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -127,7 +127,7 @@ func (r *deliverySourceResource) Read(ctx context.Context, request resource.Read
 
 	output, err := findDeliverySourceByName(ctx, conn, data.Name.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
@@ -197,8 +197,7 @@ func findDeliverySource(ctx context.Context, conn *cloudwatchlogs.Client, input 
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/delivery_source_test.go
+++ b/internal/service/logs/delivery_source_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -17,9 +16,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -30,10 +28,10 @@ func testAccDeliverySource_basic(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.DeliverySource
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_source.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -45,12 +43,12 @@ func testAccDeliverySource_basic(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx),
+		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliverySourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliverySourceExists(ctx, resourceName, &v),
+					testAccCheckDeliverySourceExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -83,10 +81,10 @@ func testAccDeliverySource_disappears(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.DeliverySource
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_source.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -98,12 +96,12 @@ func testAccDeliverySource_disappears(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx),
+		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliverySourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliverySourceExists(ctx, resourceName, &v),
+					testAccCheckDeliverySourceExists(ctx, t, resourceName, &v),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflogs.ResourceDeliverySource, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -119,10 +117,10 @@ func testAccDeliverySource_tags(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.DeliverySource
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery_source.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -134,12 +132,12 @@ func testAccDeliverySource_tags(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx),
+		CheckDestroy: testAccCheckDeliverySourceDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliverySourceConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliverySourceExists(ctx, resourceName, &v),
+					testAccCheckDeliverySourceExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -162,7 +160,7 @@ func testAccDeliverySource_tags(t *testing.T) {
 			{
 				Config: testAccDeliverySourceConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliverySourceExists(ctx, resourceName, &v),
+					testAccCheckDeliverySourceExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -179,7 +177,7 @@ func testAccDeliverySource_tags(t *testing.T) {
 			{
 				Config: testAccDeliverySourceConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliverySourceExists(ctx, resourceName, &v),
+					testAccCheckDeliverySourceExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -196,9 +194,9 @@ func testAccDeliverySource_tags(t *testing.T) {
 	})
 }
 
-func testAccCheckDeliverySourceDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDeliverySourceDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_delivery_source" {
@@ -207,7 +205,7 @@ func testAccCheckDeliverySourceDestroy(ctx context.Context) resource.TestCheckFu
 
 			_, err := tflogs.FindDeliverySourceByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -222,14 +220,14 @@ func testAccCheckDeliverySourceDestroy(ctx context.Context) resource.TestCheckFu
 	}
 }
 
-func testAccCheckDeliverySourceExists(ctx context.Context, n string, v *awstypes.DeliverySource) resource.TestCheckFunc {
+func testAccCheckDeliverySourceExists(ctx context.Context, t *testing.T, n string, v *awstypes.DeliverySource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDeliverySourceByName(ctx, conn, rs.Primary.Attributes[names.AttrName])
 

--- a/internal/service/logs/delivery_test.go
+++ b/internal/service/logs/delivery_test.go
@@ -10,7 +10,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -18,9 +17,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -31,10 +29,10 @@ func testAccDelivery_basic(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.Delivery
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -46,12 +44,12 @@ func testAccDelivery_basic(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliveryDestroy(ctx),
+		CheckDestroy: testAccCheckDeliveryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -84,10 +82,10 @@ func testAccDelivery_disappears(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.Delivery
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -99,12 +97,12 @@ func testAccDelivery_disappears(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliveryDestroy(ctx),
+		CheckDestroy: testAccCheckDeliveryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 					acctest.CheckFrameworkResourceDisappears(ctx, acctest.Provider, tflogs.ResourceDelivery, resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -120,10 +118,10 @@ func testAccDelivery_tags(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.Delivery
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -135,12 +133,12 @@ func testAccDelivery_tags(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliveryDestroy(ctx),
+		CheckDestroy: testAccCheckDeliveryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryConfig_tags1(rName, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -165,7 +163,7 @@ func testAccDelivery_tags(t *testing.T) {
 			{
 				Config: testAccDeliveryConfig_tags2(rName, acctest.CtKey1, acctest.CtValue1Updated, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -182,7 +180,7 @@ func testAccDelivery_tags(t *testing.T) {
 			{
 				Config: testAccDeliveryConfig_tags1(rName, acctest.CtKey2, acctest.CtValue2),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -206,10 +204,10 @@ func testAccDelivery_update(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	var v awstypes.Delivery
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 		},
@@ -221,12 +219,12 @@ func testAccDelivery_update(t *testing.T) {
 				VersionConstraint: "3.2.2",
 			},
 		},
-		CheckDestroy: testAccCheckDeliveryDestroy(ctx),
+		CheckDestroy: testAccCheckDeliveryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryConfig_allAttributes(rName, " ", "{region}/{yyyy}/{MM}/"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -253,7 +251,7 @@ func testAccDelivery_update(t *testing.T) {
 			{
 				Config: testAccDeliveryConfig_allAttributes(rName, "", "{region}/{yyyy}/{MM}/{dd}/"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -284,10 +282,10 @@ func testAccDelivery_update(t *testing.T) {
 func testAccDelivery_cloudFrontDistribution(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Delivery
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_delivery.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			// CloudFront distribution delivery source must be in us-east-1.
@@ -295,12 +293,12 @@ func testAccDelivery_cloudFrontDistribution(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDeliveryDestroy(ctx),
+		CheckDestroy:             testAccCheckDeliveryDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDeliveryConfig_cloudFrontDistribution(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDeliveryExists(ctx, resourceName, &v),
+					testAccCheckDeliveryExists(ctx, t, resourceName, &v),
 				),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
@@ -317,9 +315,9 @@ func testAccDelivery_cloudFrontDistribution(t *testing.T) {
 	})
 }
 
-func testAccCheckDeliveryDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDeliveryDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_delivery" {
@@ -328,7 +326,7 @@ func testAccCheckDeliveryDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tflogs.FindDeliveryByID(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -343,14 +341,14 @@ func testAccCheckDeliveryDestroy(ctx context.Context) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckDeliveryExists(ctx context.Context, n string, v *awstypes.Delivery) resource.TestCheckFunc {
+func testAccCheckDeliveryExists(ctx context.Context, t *testing.T, n string, v *awstypes.Delivery) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDeliveryByID(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/logs/destination.go
+++ b/internal/service/logs/destination.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -28,6 +29,8 @@ import (
 // @SDKResource("aws_cloudwatch_log_destination", name="Destination")
 // @Tags(identifierAttribute="arn")
 // @Testing(existsType="github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types;awstypes;awstypes.Destination")
+// @Testing(existsTakesT=true)
+// @Testing(destroyTakesT=true)
 func resourceDestination() *schema.Resource {
 	return &schema.Resource{
 		CreateWithoutTimeout: resourceDestinationCreate,
@@ -110,7 +113,7 @@ func resourceDestinationRead(ctx context.Context, d *schema.ResourceData, meta a
 
 	destination, err := findDestinationByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Destination (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/logs/destination_policy.go
+++ b/internal/service/logs/destination_policy.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -85,7 +86,7 @@ func resourceDestinationPolicyRead(ctx context.Context, d *schema.ResourceData, 
 
 	destination, err := findDestinationPolicyByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Destination Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/logs/destination_policy_test.go
+++ b/internal/service/logs/destination_policy_test.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -21,9 +19,9 @@ func TestAccLogsDestinationPolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v string
 	resourceName := "aws_cloudwatch_log_destination_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -32,7 +30,7 @@ func TestAccLogsDestinationPolicy_basic(t *testing.T) {
 			{
 				Config: testAccDestinationPolicyConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationPolicyExists(ctx, resourceName, &v),
+					testAccCheckDestinationPolicyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "access_policy"),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_name", "aws_cloudwatch_log_destination.test", names.AttrName),
 				),
@@ -45,7 +43,7 @@ func TestAccLogsDestinationPolicy_basic(t *testing.T) {
 			{
 				Config: testAccDestinationPolicyConfig_forceUpdate(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationPolicyExists(ctx, resourceName, &v),
+					testAccCheckDestinationPolicyExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrSet(resourceName, "access_policy"),
 					resource.TestCheckResourceAttrPair(resourceName, "destination_name", "aws_cloudwatch_log_destination.test", names.AttrName),
 				),
@@ -54,14 +52,14 @@ func TestAccLogsDestinationPolicy_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDestinationPolicyExists(ctx context.Context, n string, v *string) resource.TestCheckFunc {
+func testAccCheckDestinationPolicyExists(ctx context.Context, t *testing.T, n string, v *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDestinationPolicyByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/logs/destination_tags_gen_test.go
+++ b/internal/service/logs/destination_tags_gen_test.go
@@ -25,7 +25,7 @@ func TestAccLogsDestination_tags(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -37,7 +37,7 @@ func TestAccLogsDestination_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -81,7 +81,7 @@ func TestAccLogsDestination_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -129,7 +129,7 @@ func TestAccLogsDestination_tags(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -170,7 +170,7 @@ func TestAccLogsDestination_tags(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -207,7 +207,7 @@ func TestAccLogsDestination_tags_null(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -219,7 +219,7 @@ func TestAccLogsDestination_tags_null(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -274,7 +274,7 @@ func TestAccLogsDestination_tags_EmptyMap(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -284,7 +284,7 @@ func TestAccLogsDestination_tags_EmptyMap(t *testing.T) {
 					acctest.CtResourceTags: config.MapVariable(map[string]config.Variable{}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -337,7 +337,7 @@ func TestAccLogsDestination_tags_AddOnUpdate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -347,7 +347,7 @@ func TestAccLogsDestination_tags_AddOnUpdate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -371,7 +371,7 @@ func TestAccLogsDestination_tags_AddOnUpdate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -418,7 +418,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnCreate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -430,7 +430,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnCreate(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -470,7 +470,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnCreate(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -507,7 +507,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -519,7 +519,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -551,7 +551,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -597,7 +597,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -644,7 +644,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -656,7 +656,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -687,7 +687,7 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -733,7 +733,7 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -746,7 +746,7 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -790,7 +790,7 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -836,7 +836,7 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -876,7 +876,7 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -914,7 +914,7 @@ func TestAccLogsDestination_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -929,7 +929,7 @@ func TestAccLogsDestination_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -983,7 +983,7 @@ func TestAccLogsDestination_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1036,7 +1036,7 @@ func TestAccLogsDestination_tags_DefaultTags_nonOverlapping(t *testing.T) {
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1074,7 +1074,7 @@ func TestAccLogsDestination_tags_DefaultTags_overlapping(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1089,7 +1089,7 @@ func TestAccLogsDestination_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1142,7 +1142,7 @@ func TestAccLogsDestination_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1199,7 +1199,7 @@ func TestAccLogsDestination_tags_DefaultTags_overlapping(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1250,7 +1250,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1262,7 +1262,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1295,7 +1295,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{})),
@@ -1340,7 +1340,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1353,7 +1353,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1381,7 +1381,7 @@ func TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1429,7 +1429,7 @@ func TestAccLogsDestination_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1444,7 +1444,7 @@ func TestAccLogsDestination_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1494,7 +1494,7 @@ func TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1507,7 +1507,7 @@ func TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 					acctest.CtResourceTags: nil,
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1551,7 +1551,7 @@ func TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1566,7 +1566,7 @@ func TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1613,7 +1613,7 @@ func TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1628,7 +1628,7 @@ func TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.Null()),
@@ -1675,7 +1675,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnCreate(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1685,7 +1685,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnCreate(t *testing.T) {
 					"unknownTagKey": config.StringVariable("computedkey1"),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1730,7 +1730,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1742,7 +1742,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1774,7 +1774,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 					"knownTagValue": config.StringVariable(acctest.CtValue1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, "tags.computedkey1", "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1827,7 +1827,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -1839,7 +1839,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					}),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1869,7 +1869,7 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 					"unknownTagKey": config.StringVariable(acctest.CtKey1),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttrPair(resourceName, acctest.CtTagsKey1, "null_resource.test", names.AttrID),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -1914,7 +1914,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -1933,7 +1933,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -1982,7 +1982,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2031,7 +2031,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2076,7 +2076,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
-		CheckDestroy: testAccCheckDestinationDestroy(ctx),
+		CheckDestroy: testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			// 1: Create
 			{
@@ -2093,7 +2093,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2156,7 +2156,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{
@@ -2219,7 +2219,7 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 					),
 				},
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &v),
+					testAccCheckDestinationExists(ctx, t, resourceName, &v),
 				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(resourceName, tfjsonpath.New(names.AttrTags), knownvalue.MapExact(map[string]knownvalue.Check{

--- a/internal/service/logs/destination_test.go
+++ b/internal/service/logs/destination_test.go
@@ -10,13 +10,11 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -26,18 +24,18 @@ func TestAccLogsDestination_basic(t *testing.T) {
 	resourceName := "aws_cloudwatch_log_destination.test"
 	streamResourceName := "aws_kinesis_stream.test.0"
 	roleResourceName := "aws_iam_role.test.0"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDestinationConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "logs", regexache.MustCompile(`destination:.+`)),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
@@ -57,18 +55,18 @@ func TestAccLogsDestination_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var destination types.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDestinationConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceDestination(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -85,18 +83,18 @@ func TestAccLogsDestination_update(t *testing.T) {
 	roleResource1Name := "aws_iam_role.test.0"
 	streamResource2Name := "aws_kinesis_stream.test.1"
 	roleResource2Name := "aws_iam_role.test.1"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
+		CheckDestroy:             testAccCheckDestinationDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDestinationConfig_update(rName, 0),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResource1Name, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrTargetARN, streamResource1Name, names.AttrARN),
@@ -110,7 +108,7 @@ func TestAccLogsDestination_update(t *testing.T) {
 			{
 				Config: testAccDestinationConfig_update(rName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResource2Name, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "0"),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrTargetARN, streamResource2Name, names.AttrARN),
@@ -119,7 +117,7 @@ func TestAccLogsDestination_update(t *testing.T) {
 			{
 				Config: testAccDestinationConfig_updateWithTag(rName, 0, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResource1Name, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -129,7 +127,7 @@ func TestAccLogsDestination_update(t *testing.T) {
 			{
 				Config: testAccDestinationConfig_updateWithTag(rName, 1, acctest.CtKey1, acctest.CtValue1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResource2Name, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1),
@@ -139,7 +137,7 @@ func TestAccLogsDestination_update(t *testing.T) {
 			{
 				Config: testAccDestinationConfig_updateWithTag(rName, 1, acctest.CtKey1, acctest.CtValue1Updated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDestinationExists(ctx, resourceName, &destination),
+					testAccCheckDestinationExists(ctx, t, resourceName, &destination),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResource2Name, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsPercent, "1"),
 					resource.TestCheckResourceAttr(resourceName, acctest.CtTagsKey1, acctest.CtValue1Updated),
@@ -150,9 +148,9 @@ func TestAccLogsDestination_update(t *testing.T) {
 	})
 }
 
-func testAccCheckDestinationDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckDestinationDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_destination" {
@@ -160,7 +158,7 @@ func testAccCheckDestinationDestroy(ctx context.Context) resource.TestCheckFunc 
 			}
 			_, err := tflogs.FindDestinationByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -175,14 +173,14 @@ func testAccCheckDestinationDestroy(ctx context.Context) resource.TestCheckFunc 
 	}
 }
 
-func testAccCheckDestinationExists(ctx context.Context, n string, v *types.Destination) resource.TestCheckFunc {
+func testAccCheckDestinationExists(ctx context.Context, t *testing.T, n string, v *types.Destination) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindDestinationByName(ctx, conn, rs.Primary.ID)
 

--- a/internal/service/logs/group.go
+++ b/internal/service/logs/group.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -148,7 +149,7 @@ func resourceGroupRead(ctx context.Context, d *schema.ResourceData, meta any) di
 
 	lg, err := findLogGroupByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Log Group (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/logs/group_data_source_test.go
+++ b/internal/service/logs/group_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,11 +14,11 @@ import (
 
 func TestAccLogsGroupDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
 	resourceName := "aws_cloudwatch_log_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/logs/group_test.go
+++ b/internal/service/logs/group_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -431,7 +431,7 @@ func testAccCheckLogGroupDestroy(ctx context.Context, t *testing.T) resource.Tes
 
 			_, err := tflogs.FindLogGroupByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 

--- a/internal/service/logs/groups_data_source_test.go
+++ b/internal/service/logs/groups_data_source_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"testing"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -15,12 +14,12 @@ import (
 
 func TestAccLogsGroupsDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_cloudwatch_log_groups.test"
 	resource1Name := "aws_cloudwatch_log_group.test.0"
 	resource2Name := "aws_cloudwatch_log_group.test.1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -42,12 +41,12 @@ func TestAccLogsGroupsDataSource_basic(t *testing.T) {
 
 func TestAccLogsGroupsDataSource_noPrefix(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	dataSourceName := "data.aws_cloudwatch_log_groups.test"
 	resource1Name := "aws_cloudwatch_log_group.test.0"
 	resource2Name := "aws_cloudwatch_log_group.test.1"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,

--- a/internal/service/logs/index_policy.go
+++ b/internal/service/logs/index_policy.go
@@ -19,11 +19,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
 	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -93,7 +93,7 @@ func (r *indexPolicyResource) Read(ctx context.Context, request resource.ReadReq
 
 	output, err := findIndexPolicyByLogGroupName(ctx, conn, data.LogGroupName.ValueString())
 
-	if tfresource.NotFound(err) {
+	if retry.NotFound(err) {
 		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
 		response.State.RemoveResource(ctx)
 
@@ -208,8 +208,7 @@ func findIndexPolicies(ctx context.Context, conn *cloudwatchlogs.Client, input *
 
 	if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 		return nil, &retry.NotFoundError{
-			LastError:   err,
-			LastRequest: input,
+			LastError: err,
 		}
 	}
 

--- a/internal/service/logs/metric_filter_test.go
+++ b/internal/service/logs/metric_filter_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -24,18 +22,18 @@ func TestAccLogsMetricFilter_basic(t *testing.T) {
 	var mf types.MetricFilter
 	resourceName := "aws_cloudwatch_log_metric_filter.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricFilterConfig_basic(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMetricFilterExists(ctx, resourceName, &mf),
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrLogGroupName, logGroupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.default_value", ""),
@@ -62,18 +60,18 @@ func TestAccLogsMetricFilter_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var mf types.MetricFilter
 	resourceName := "aws_cloudwatch_log_metric_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricFilterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetricFilterExists(ctx, resourceName, &mf),
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceMetricFilter(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -87,18 +85,18 @@ func TestAccLogsMetricFilter_Disappears_logGroup(t *testing.T) {
 	var mf types.MetricFilter
 	resourceName := "aws_cloudwatch_log_metric_filter.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricFilterConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMetricFilterExists(ctx, resourceName, &mf),
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceGroup(), logGroupResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -110,17 +108,17 @@ func TestAccLogsMetricFilter_Disappears_logGroup(t *testing.T) {
 func TestAccLogsMetricFilter_many(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_log_metric_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricFilterConfig_many(rName, 15),
-				Check:  testAccCheckMetricFilterManyExists(ctx, resourceName, 15),
+				Check:  testAccCheckMetricFilterManyExists(ctx, t, resourceName, 15),
 			},
 		},
 	})
@@ -131,18 +129,18 @@ func TestAccLogsMetricFilter_update(t *testing.T) {
 	var mf types.MetricFilter
 	resourceName := "aws_cloudwatch_log_metric_filter.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckMetricFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMetricFilterConfig_allAttributes1(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMetricFilterExists(ctx, resourceName, &mf),
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrLogGroupName, logGroupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.default_value", "2.5"),
@@ -165,7 +163,7 @@ func TestAccLogsMetricFilter_update(t *testing.T) {
 			{
 				Config: testAccMetricFilterConfig_allAttributes2(rName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckMetricFilterExists(ctx, resourceName, &mf),
+					testAccCheckMetricFilterExists(ctx, t, resourceName, &mf),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrLogGroupName, logGroupResourceName, names.AttrName),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.default_value", ""),
@@ -197,14 +195,14 @@ func testAccMetricFilterImportStateIdFunc(resourceName string) resource.ImportSt
 	}
 }
 
-func testAccCheckMetricFilterExists(ctx context.Context, n string, v *types.MetricFilter) resource.TestCheckFunc {
+func testAccCheckMetricFilterExists(ctx context.Context, t *testing.T, n string, v *types.MetricFilter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindMetricFilterByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.ID)
 
@@ -218,9 +216,9 @@ func testAccCheckMetricFilterExists(ctx context.Context, n string, v *types.Metr
 	}
 }
 
-func testAccCheckMetricFilterDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckMetricFilterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_metric_filter" {
@@ -229,7 +227,7 @@ func testAccCheckMetricFilterDestroy(ctx context.Context) resource.TestCheckFunc
 
 			_, err := tflogs.FindMetricFilterByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -244,13 +242,13 @@ func testAccCheckMetricFilterDestroy(ctx context.Context) resource.TestCheckFunc
 	}
 }
 
-func testAccCheckMetricFilterManyExists(ctx context.Context, basename string, n int) resource.TestCheckFunc {
+func testAccCheckMetricFilterManyExists(ctx context.Context, t *testing.T, basename string, n int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for i := range n {
 			n := fmt.Sprintf("%s.%d", basename, i)
 			var v types.MetricFilter
 
-			err := testAccCheckMetricFilterExists(ctx, n, &v)(s)
+			err := testAccCheckMetricFilterExists(ctx, t, n, &v)(s)
 
 			if err != nil {
 				return err

--- a/internal/service/logs/query_definition.go
+++ b/internal/service/logs/query_definition.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -107,7 +108,7 @@ func resourceQueryDefinitionRead(ctx context.Context, d *schema.ResourceData, me
 
 	result, err := findQueryDefinitionByTwoPartKey(ctx, conn, d.Get(names.AttrName).(string), d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Query Definition (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/logs/query_definition_test.go
+++ b/internal/service/logs/query_definition_test.go
@@ -12,13 +12,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
@@ -27,23 +25,23 @@ func TestAccLogsQueryDefinition_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.QueryDefinition
 	resourceName := "aws_cloudwatch_query_definition.test"
-	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
 	expectedQueryString := `fields @timestamp, @message
 | sort @timestamp desc
 | limit 20
 `
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx),
+		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryDefinitionConfig_basic(queryName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, queryName),
 					resource.TestCheckResourceAttr(resourceName, "query_string", expectedQueryString),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "0"),
@@ -64,18 +62,18 @@ func TestAccLogsQueryDefinition_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.QueryDefinition
 	resourceName := "aws_cloudwatch_query_definition.test"
-	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx),
+		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryDefinitionConfig_basic(queryName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceQueryDefinition(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -88,26 +86,26 @@ func TestAccLogsQueryDefinition_rename(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 types.QueryDefinition
 	resourceName := "aws_cloudwatch_query_definition.test"
-	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
-	updatedQueryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+	updatedQueryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx),
+		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryDefinitionConfig_basic(queryName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v1),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, queryName),
 				),
 			},
 			{
 				Config: testAccQueryDefinitionConfig_basic(updatedQueryName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v2),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, updatedQueryName),
 				),
 			},
@@ -125,18 +123,18 @@ func TestAccLogsQueryDefinition_logGroups(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v1, v2 types.QueryDefinition
 	resourceName := "aws_cloudwatch_query_definition.test"
-	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx),
+		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryDefinitionConfig_logGroups(queryName, 1),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v1),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v1),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, queryName),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "1"),
 					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatch_log_group.test.0", names.AttrName),
@@ -145,7 +143,7 @@ func TestAccLogsQueryDefinition_logGroups(t *testing.T) {
 			{
 				Config: testAccQueryDefinitionConfig_logGroups(queryName, 5),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v2),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v2),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, queryName),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "5"),
 					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatch_log_group.test.0", names.AttrName),
@@ -166,18 +164,18 @@ func TestAccLogsQueryDefinition_logGroupARNs(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.QueryDefinition
 	resourceName := "aws_cloudwatch_query_definition.test"
-	queryName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	queryName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx),
+		CheckDestroy:             testAccCheckQueryDefinitionDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccQueryDefinitionConfig_logGroupARNs(queryName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckQueryDefinitionExists(ctx, resourceName, &v),
+					testAccCheckQueryDefinitionExists(ctx, t, resourceName, &v),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, queryName),
 					resource.TestCheckResourceAttr(resourceName, "log_group_names.#", "2"),
 					resource.TestCheckResourceAttrPair(resourceName, "log_group_names.0", "aws_cloudwatch_log_group.test.0", names.AttrARN),
@@ -208,14 +206,14 @@ func testAccQueryDefinitionImportStateID(ctx context.Context, v *types.QueryDefi
 	}
 }
 
-func testAccCheckQueryDefinitionExists(ctx context.Context, n string, v *types.QueryDefinition) resource.TestCheckFunc {
+func testAccCheckQueryDefinitionExists(ctx context.Context, t *testing.T, n string, v *types.QueryDefinition) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindQueryDefinitionByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrName], rs.Primary.ID)
 
@@ -229,9 +227,9 @@ func testAccCheckQueryDefinitionExists(ctx context.Context, n string, v *types.Q
 	}
 }
 
-func testAccCheckQueryDefinitionDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckQueryDefinitionDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_query_definition" {
@@ -240,7 +238,7 @@ func testAccCheckQueryDefinitionDestroy(ctx context.Context) resource.TestCheckF
 
 			_, err := tflogs.FindQueryDefinitionByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrName], rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 

--- a/internal/service/logs/resource_policy.go
+++ b/internal/service/logs/resource_policy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	"github.com/hashicorp/terraform-provider-aws/internal/sdkv2"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
@@ -82,7 +83,7 @@ func resourceResourcePolicyRead(ctx context.Context, d *schema.ResourceData, met
 
 	resourcePolicy, err := findResourcePolicyByName(ctx, conn, d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Resource Policy (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags

--- a/internal/service/logs/resource_policy_test.go
+++ b/internal/service/logs/resource_policy_test.go
@@ -9,32 +9,30 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccLogsResourcePolicy_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
 	var resourcePolicy types.ResourcePolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_basic1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
+					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/*\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
@@ -47,7 +45,7 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 			{
 				Config: testAccResourcePolicyConfig_basic2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
+					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"rds.%s\"},\"Resource\":\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
@@ -58,20 +56,20 @@ func TestAccLogsResourcePolicy_basic(t *testing.T) {
 
 func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 	ctx := acctest.Context(t)
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	resourceName := "aws_cloudwatch_log_resource_policy.test"
 	var resourcePolicy types.ResourcePolicy
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx),
+		CheckDestroy:             testAccCheckResourcePolicyDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccResourcePolicyConfig_order(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
+					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
@@ -79,7 +77,7 @@ func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 			{
 				Config: testAccResourcePolicyConfig_newOrder(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourcePolicyExists(ctx, resourceName, &resourcePolicy),
+					testAccCheckResourcePolicyExists(ctx, t, resourceName, &resourcePolicy),
 					resource.TestCheckResourceAttr(resourceName, "policy_name", rName),
 					resource.TestCheckResourceAttr(resourceName, "policy_document", fmt.Sprintf("{\"Statement\":[{\"Action\":[\"logs:CreateLogStream\",\"logs:PutLogEvents\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"rds.%s\"]},\"Resource\":[\"arn:%s:logs:*:*:log-group:/aws/rds/example.com\"]}],\"Version\":\"2012-10-17\"}", acctest.PartitionDNSSuffix(), acctest.Partition())),
 				),
@@ -88,14 +86,14 @@ func TestAccLogsResourcePolicy_ignoreEquivalent(t *testing.T) {
 	})
 }
 
-func testAccCheckResourcePolicyExists(ctx context.Context, n string, v *types.ResourcePolicy) resource.TestCheckFunc {
+func testAccCheckResourcePolicyExists(ctx context.Context, t *testing.T, n string, v *types.ResourcePolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindResourcePolicyByName(ctx, conn, rs.Primary.ID)
 
@@ -109,9 +107,9 @@ func testAccCheckResourcePolicyExists(ctx context.Context, n string, v *types.Re
 	}
 }
 
-func testAccCheckResourcePolicyDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckResourcePolicyDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_resource_policy" {
@@ -120,7 +118,7 @@ func testAccCheckResourcePolicyDestroy(ctx context.Context) resource.TestCheckFu
 
 			_, err := tflogs.FindResourcePolicyByName(ctx, conn, rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 

--- a/internal/service/logs/stream.go
+++ b/internal/service/logs/stream.go
@@ -13,11 +13,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
@@ -89,7 +89,7 @@ func resourceStreamRead(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	ls, err := findLogStreamByTwoPartKey(ctx, conn, d.Get(names.AttrLogGroupName).(string), d.Id())
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Log Stream (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -172,8 +172,7 @@ func findLogStreams(ctx context.Context, conn *cloudwatchlogs.Client, input *clo
 
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 

--- a/internal/service/logs/stream_test.go
+++ b/internal/service/logs/stream_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -23,18 +21,18 @@ func TestAccLogsStream_basic(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ls types.LogStream
 	resourceName := "aws_cloudwatch_log_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStreamDestroy(ctx),
+		CheckDestroy:             testAccCheckStreamDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStreamExists(ctx, resourceName, &ls),
+					testAccCheckStreamExists(ctx, t, resourceName, &ls),
 				),
 			},
 			{
@@ -51,18 +49,18 @@ func TestAccLogsStream_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var ls types.LogStream
 	resourceName := "aws_cloudwatch_log_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStreamDestroy(ctx),
+		CheckDestroy:             testAccCheckStreamDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStreamExists(ctx, resourceName, &ls),
+					testAccCheckStreamExists(ctx, t, resourceName, &ls),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceStream(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -76,18 +74,18 @@ func TestAccLogsStream_Disappears_logGroup(t *testing.T) {
 	var ls types.LogStream
 	resourceName := "aws_cloudwatch_log_stream.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckStreamDestroy(ctx),
+		CheckDestroy:             testAccCheckStreamDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccStreamConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStreamExists(ctx, resourceName, &ls),
+					testAccCheckStreamExists(ctx, t, resourceName, &ls),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceGroup(), logGroupResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -96,14 +94,14 @@ func TestAccLogsStream_Disappears_logGroup(t *testing.T) {
 	})
 }
 
-func testAccCheckStreamExists(ctx context.Context, n string, v *types.LogStream) resource.TestCheckFunc {
+func testAccCheckStreamExists(ctx context.Context, t *testing.T, n string, v *types.LogStream) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindLogStreamByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.ID)
 
@@ -117,9 +115,9 @@ func testAccCheckStreamExists(ctx context.Context, n string, v *types.LogStream)
 	}
 }
 
-func testAccCheckStreamDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckStreamDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_stream" {
@@ -128,7 +126,7 @@ func testAccCheckStreamDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			_, err := tflogs.FindLogStreamByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.ID)
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 

--- a/internal/service/logs/subscription_filter.go
+++ b/internal/service/logs/subscription_filter.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -23,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs"
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tfslices "github.com/hashicorp/terraform-provider-aws/internal/slices"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/internal/verify"
@@ -141,7 +141,7 @@ func resourceSubscriptionFilterRead(ctx context.Context, d *schema.ResourceData,
 
 	subscriptionFilter, err := findSubscriptionFilterByTwoPartKey(ctx, conn, d.Get(names.AttrLogGroupName).(string), d.Get(names.AttrName).(string))
 
-	if !d.IsNewResource() && tfresource.NotFound(err) {
+	if !d.IsNewResource() && retry.NotFound(err) {
 		log.Printf("[WARN] CloudWatch Logs Subscription Filter (%s) not found, removing from state", d.Id())
 		d.SetId("")
 		return diags
@@ -237,8 +237,7 @@ func findSubscriptionFilters(ctx context.Context, conn *cloudwatchlogs.Client, i
 
 		if errs.IsA[*awstypes.ResourceNotFoundException](err) {
 			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: input,
+				LastError: err,
 			}
 		}
 

--- a/internal/service/logs/subscription_filter_test.go
+++ b/internal/service/logs/subscription_filter_test.go
@@ -9,13 +9,11 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/retry"
 	tflogs "github.com/hashicorp/terraform-provider-aws/internal/service/logs"
-	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -25,18 +23,18 @@ func TestAccLogsSubscriptionFilter_basic(t *testing.T) {
 	lambdaFunctionResourceName := "aws_lambda_function.test"
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNLambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDestinationARN, lambdaFunctionResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "distribution", "ByLogStream"),
 					resource.TestCheckResourceAttr(resourceName, "filter_pattern", "logtype test"),
@@ -58,17 +56,17 @@ func TestAccLogsSubscriptionFilter_basic(t *testing.T) {
 func TestAccLogsSubscriptionFilter_many(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNLambdaMany(rName, 2), // This is the default limit of subscription filters on an account
-				Check:  testAccCheckSubscriptionFilterManyExists(ctx, resourceName, 2),
+				Check:  testAccCheckSubscriptionFilterManyExists(ctx, t, resourceName, 2),
 			},
 		},
 	})
@@ -78,18 +76,18 @@ func TestAccLogsSubscriptionFilter_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
 	var filter types.SubscriptionFilter
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNLambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceSubscriptionFilter(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -103,18 +101,18 @@ func TestAccLogsSubscriptionFilter_Disappears_logGroup(t *testing.T) {
 	var filter types.SubscriptionFilter
 	logGroupResourceName := "aws_cloudwatch_log_group.test"
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNLambda(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tflogs.ResourceGroup(), logGroupResourceName),
 				),
 				ExpectNonEmptyPlan: true,
@@ -128,18 +126,18 @@ func TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose(t *testing
 	var filter types.SubscriptionFilter
 	firehoseResourceName := "aws_kinesis_firehose_delivery_stream.test"
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNKinesisDataFirehose(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDestinationARN, firehoseResourceName, names.AttrARN),
 				),
 			},
@@ -158,18 +156,18 @@ func TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream(t *testing.T) {
 	var filter types.SubscriptionFilter
 	kinesisStream := "aws_kinesis_stream.test"
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_destinationARNKinesisStream(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrDestinationARN, kinesisStream, names.AttrARN),
 				),
 			},
@@ -187,18 +185,18 @@ func TestAccLogsSubscriptionFilter_distribution(t *testing.T) {
 	ctx := acctest.Context(t)
 	var filter types.SubscriptionFilter
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_distribution(rName, "Random"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttr(resourceName, "distribution", "Random"),
 				),
 			},
@@ -212,7 +210,7 @@ func TestAccLogsSubscriptionFilter_distribution(t *testing.T) {
 			{
 				Config: testAccSubscriptionFilterConfig_distribution(rName, "ByLogStream"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttr(resourceName, "distribution", "ByLogStream"),
 				),
 			},
@@ -226,18 +224,18 @@ func TestAccLogsSubscriptionFilter_roleARN(t *testing.T) {
 	iamRoleResourceName1 := "aws_iam_role.test"
 	iamRoleResourceName2 := "aws_iam_role.test2"
 	resourceName := "aws_cloudwatch_log_subscription_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx),
+		CheckDestroy:             testAccCheckSubscriptionFilterDestroy(ctx, t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSubscriptionFilterConfig_roleARN1(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, iamRoleResourceName1, names.AttrARN),
 				),
 			},
@@ -250,7 +248,7 @@ func TestAccLogsSubscriptionFilter_roleARN(t *testing.T) {
 			{
 				Config: testAccSubscriptionFilterConfig_roleARN2(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSubscriptionFilterExists(ctx, resourceName, &filter),
+					testAccCheckSubscriptionFilterExists(ctx, t, resourceName, &filter),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, iamRoleResourceName2, names.AttrARN),
 				),
 			},
@@ -258,9 +256,9 @@ func TestAccLogsSubscriptionFilter_roleARN(t *testing.T) {
 	})
 }
 
-func testAccCheckSubscriptionFilterDestroy(ctx context.Context) resource.TestCheckFunc {
+func testAccCheckSubscriptionFilterDestroy(ctx context.Context, t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "aws_cloudwatch_log_subscription_filter" {
@@ -269,7 +267,7 @@ func testAccCheckSubscriptionFilterDestroy(ctx context.Context) resource.TestChe
 
 			_, err := tflogs.FindSubscriptionFilterByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.Attributes[names.AttrName])
 
-			if tfresource.NotFound(err) {
+			if retry.NotFound(err) {
 				continue
 			}
 
@@ -284,14 +282,14 @@ func testAccCheckSubscriptionFilterDestroy(ctx context.Context) resource.TestChe
 	}
 }
 
-func testAccCheckSubscriptionFilterExists(ctx context.Context, n string, v *types.SubscriptionFilter) resource.TestCheckFunc {
+func testAccCheckSubscriptionFilterExists(ctx context.Context, t *testing.T, n string, v *types.SubscriptionFilter) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		conn := acctest.Provider.Meta().(*conns.AWSClient).LogsClient(ctx)
+		conn := acctest.ProviderMeta(ctx, t).LogsClient(ctx)
 
 		output, err := tflogs.FindSubscriptionFilterByTwoPartKey(ctx, conn, rs.Primary.Attributes[names.AttrLogGroupName], rs.Primary.Attributes[names.AttrName])
 
@@ -320,13 +318,13 @@ func testAccSubscriptionFilterImportStateIDFunc(resourceName string) resource.Im
 	}
 }
 
-func testAccCheckSubscriptionFilterManyExists(ctx context.Context, basename string, n int) resource.TestCheckFunc {
+func testAccCheckSubscriptionFilterManyExists(ctx context.Context, t *testing.T, basename string, n int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for i := range n {
 			n := fmt.Sprintf("%s.%d", basename, i)
 			var v types.SubscriptionFilter
 
-			err := testAccCheckSubscriptionFilterExists(ctx, n, &v)(s)
+			err := testAccCheckSubscriptionFilterExists(ctx, t, n, &v)(s)
 
 			if err != nil {
 				return err


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Enables Go-VCR in the `logs` service.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/25602

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% VCR_MODE=RECORD_ONLY VCR_PATH=/Users/jaredbaker/development/_vcr-testdata/ make testacc PKG=logs TESTS="TestAccLogsAccountPolicy_|TestAccLogsAnomalyDetector_|TestAccLogsDataProtectionPolicy_|TestAccLogsDestination_|TestAccLogsGroup|TestAccLogsIndexPolicy|TestAccLogsMetricFilter|TestAccLogsQueryDefinition|TestAccLogsResourcePolicy|TestAccLogsStream|TestAccLogsSubscriptionFilter"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsAccountPolicy_|TestAccLogsAnomalyDetector_|TestAccLogsDataProtectionPolicy_|TestAccLogsDestination_|TestAccLogsGroup|TestAccLogsIndexPolicy|TestAccLogsMetricFilter|TestAccLogsQueryDefinition|TestAccLogsResourcePolicy|TestAccLogsStream|TestAccLogsSubscriptionFilter'  -timeout 360m -vet=off
2025/07/10 09:20:03 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/10 09:20:03 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLogsMetricFilter_Disappears_logGroup (21.99s)
=== CONT  TestAccLogsDestination_tags_DefaultTags_providerOnly
=== NAME  TestAccLogsQueryDefinition_basic
    query_definition_test.go:35: stopping VCR recorder
    query_definition_test.go:35: persisting randomness seed
--- PASS: TestAccLogsQueryDefinition_basic (22.43s)
=== CONT  TestAccLogsMetricFilter_disappears
=== NAME  TestAccLogsAnomalyDetector_basic
    anomaly_detector_test.go:26: stopping VCR recorder
    anomaly_detector_test.go:26: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_basic (24.24s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping
=== NAME  TestAccLogsResourcePolicy_ignoreEquivalent
    resource_policy_test.go:63: stopping VCR recorder
    resource_policy_test.go:63: persisting randomness seed
--- PASS: TestAccLogsResourcePolicy_ignoreEquivalent (28.67s)
=== CONT  TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag
=== NAME  TestAccLogsIndexPolicy_update
    index_policy_test.go:85: stopping VCR recorder
    index_policy_test.go:85: persisting randomness seed
--- PASS: TestAccLogsIndexPolicy_update (29.84s)
=== CONT  TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag
=== NAME  TestAccLogsMetricFilter_many
    metric_filter_test.go:113: stopping VCR recorder
    metric_filter_test.go:113: persisting randomness seed
--- PASS: TestAccLogsMetricFilter_many (30.03s)
=== CONT  TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace
=== NAME  TestAccLogsMetricFilter_update
    metric_filter_test.go:134: stopping VCR recorder
    metric_filter_test.go:134: persisting randomness seed
--- PASS: TestAccLogsMetricFilter_update (31.23s)
=== CONT  TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add
=== NAME  TestAccLogsAccountPolicy_basicSubscriptionFilter
    account_policy_test.go:26: stopping VCR recorder
    account_policy_test.go:26: persisting randomness seed
--- PASS: TestAccLogsAccountPolicy_basicSubscriptionFilter (35.31s)
=== CONT  TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate
=== NAME  TestAccLogsMetricFilter_disappears
    metric_filter_test.go:65: stopping VCR recorder
    metric_filter_test.go:65: persisting randomness seed
--- PASS: TestAccLogsMetricFilter_disappears (14.12s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_nullNonOverlappingResourceTag
    anomaly_detector_tags_gen_test.go:1736: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_nullNonOverlappingResourceTag (34.37s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag
=== NAME  TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate
    anomaly_detector_tags_gen_test.go:1810: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate (38.93s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag
=== NAME  TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag
    destination_tags_gen_test.go:1551: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag (83.85s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag
=== NAME  TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag
    destination_tags_gen_test.go:1613: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag (89.25s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly
=== NAME  TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace
    anomaly_detector_tags_gen_test.go:1972: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace (59.44s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly
=== NAME  TestAccLogsDestination_tags_DefaultTags_emptyResourceTag
    destination_tags_gen_test.go:1429: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_emptyResourceTag (89.92s)
=== CONT  TestAccLogsGroup_kmsKey
=== NAME  TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add
    anomaly_detector_tags_gen_test.go:1870: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add (59.78s)
=== CONT  TestAccLogsIndexPolicy_disappears
=== NAME  TestAccLogsDestination_tags_ComputedTag_OnCreate
    destination_tags_gen_test.go:1675: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnCreate (94.06s)
=== CONT  TestAccLogsIndexPolicy_basic
=== NAME  TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag
    destination_tags_gen_test.go:1494: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag (94.29s)
=== CONT  TestAccLogsGroupsDataSource_noPrefix
=== NAME  TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag
    anomaly_detector_tags_gen_test.go:2064: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag (73.33s)
=== CONT  TestAccLogsQueryDefinition_logGroups
=== NAME  TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag
    anomaly_detector_tags_gen_test.go:2226: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag (80.79s)
=== CONT  TestAccLogsResourcePolicy_basic
=== NAME  TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace
    destination_tags_gen_test.go:644: stopping VCR recorder
    destination_tags_gen_test.go:644: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace (111.39s)
=== CONT  TestAccLogsGroupsDataSource_basic
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag
    anomaly_detector_tags_gen_test.go:1664: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag (43.70s)
=== CONT  TestAccLogsQueryDefinition_logGroupARNs
=== NAME  TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly
    destination_tags_gen_test.go:1250: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly (116.22s)
=== CONT  TestAccLogsGroup_logGroupClassDELIVERY2
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag
    anomaly_detector_tags_gen_test.go:1601: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag (42.60s)
=== CONT  TestAccLogsAnomalyDetector_tags_AddOnUpdate
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping
    anomaly_detector_tags_gen_test.go:1150: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping (94.84s)
=== CONT  TestAccLogsGroup_logGroupClassDELIVERY1
=== NAME  TestAccLogsIndexPolicy_disappears
    index_policy_test.go:57: stopping VCR recorder
    index_policy_test.go:57: persisting randomness seed
--- PASS: TestAccLogsIndexPolicy_disappears (28.93s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping
=== NAME  TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add
    destination_tags_gen_test.go:1730: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add (122.54s)
=== CONT  TestAccLogsGroup_skipDestroyInconsistentPlan
=== NAME  TestAccLogsGroupsDataSource_noPrefix
    groups_data_source_test.go:49: stopping VCR recorder
    groups_data_source_test.go:49: persisting randomness seed
--- PASS: TestAccLogsGroupsDataSource_noPrefix (28.52s)
=== CONT  TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag
    anomaly_detector_tags_gen_test.go:1530: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag (43.04s)
=== CONT  TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace
=== NAME  TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace
    destination_tags_gen_test.go:1827: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace (127.54s)
=== CONT  TestAccLogsGroup_skipDestroy
=== NAME  TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly
    destination_tags_gen_test.go:1340: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly (128.79s)
=== CONT  TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add
=== NAME  TestAccLogsIndexPolicy_basic
    index_policy_test.go:25: stopping VCR recorder
    index_policy_test.go:25: persisting randomness seed
--- PASS: TestAccLogsIndexPolicy_basic (36.13s)
=== CONT  TestAccLogsGroup_multiple
=== NAME  TestAccLogsGroupsDataSource_basic
    groups_data_source_test.go:22: stopping VCR recorder
    groups_data_source_test.go:22: persisting randomness seed
--- PASS: TestAccLogsGroupsDataSource_basic (26.68s)
=== CONT  TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate
=== NAME  TestAccLogsGroup_logGroupClassDELIVERY2
    group_test.go:384: stopping VCR recorder
    group_test.go:384: persisting randomness seed
--- PASS: TestAccLogsGroup_logGroupClassDELIVERY2 (28.03s)
=== CONT  TestAccLogsGroup_retentionPolicy
=== NAME  TestAccLogsQueryDefinition_logGroupARNs
    query_definition_test.go:169: stopping VCR recorder
    query_definition_test.go:169: persisting randomness seed
--- PASS: TestAccLogsQueryDefinition_logGroupARNs (37.59s)
=== CONT  TestAccLogsQueryDefinition_rename
=== NAME  TestAccLogsGroup_skipDestroy
    group_test.go:288: stopping VCR recorder
    group_test.go:288: persisting randomness seed
--- PASS: TestAccLogsGroup_skipDestroy (29.55s)
=== CONT  TestAccLogsGroup_logGroupClass
=== NAME  TestAccLogsGroup_multiple
    group_test.go:264: stopping VCR recorder
    group_test.go:264: persisting randomness seed
--- PASS: TestAccLogsGroup_multiple (33.63s)
=== CONT  TestAccLogsMetricFilter_basic
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly
    anomaly_detector_tags_gen_test.go:1341: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly (75.87s)
=== CONT  TestAccLogsSubscriptionFilter_disappears
=== NAME  TestAccLogsDestination_tags_DefaultTags_overlapping
    destination_tags_gen_test.go:1074: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_overlapping (166.86s)
=== CONT  TestAccLogsStream_Disappears_logGroup
=== NAME  TestAccLogsQueryDefinition_logGroups
    query_definition_test.go:128: stopping VCR recorder
    query_definition_test.go:128: persisting randomness seed
--- PASS: TestAccLogsQueryDefinition_logGroups (63.85s)
=== CONT  TestAccLogsSubscriptionFilter_roleARN
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly
    anomaly_detector_tags_gen_test.go:1436: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly (78.75s)
=== CONT  TestAccLogsSubscriptionFilter_many
=== NAME  TestAccLogsResourcePolicy_basic
    resource_policy_test.go:26: stopping VCR recorder
    resource_policy_test.go:26: persisting randomness seed
--- PASS: TestAccLogsResourcePolicy_basic (58.79s)
=== CONT  TestAccLogsSubscriptionFilter_basic
=== NAME  TestAccLogsGroup_skipDestroyInconsistentPlan
    group_test.go:311: stopping VCR recorder
    group_test.go:311: persisting randomness seed
--- PASS: TestAccLogsGroup_skipDestroyInconsistentPlan (53.95s)
=== CONT  TestAccLogsSubscriptionFilter_distribution
=== NAME  TestAccLogsGroup_logGroupClass
    group_test.go:193: stopping VCR recorder
    group_test.go:193: persisting randomness seed
--- PASS: TestAccLogsGroup_logGroupClass (27.91s)
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream
=== NAME  TestAccLogsDestination_tags_DefaultTags_nonOverlapping
    destination_tags_gen_test.go:914: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_nonOverlapping (187.62s)
=== CONT  TestAccLogsAnomalyDetector_tags
=== NAME  TestAccLogsGroup_logGroupClassDELIVERY1
    group_test.go:343: stopping VCR recorder
    group_test.go:343: persisting randomness seed
--- PASS: TestAccLogsGroup_logGroupClassDELIVERY1 (69.37s)
=== CONT  TestAccLogsAnomalyDetector_tags_EmptyMap
=== NAME  TestAccLogsAnomalyDetector_tags_AddOnUpdate
    anomaly_detector_tags_gen_test.go:345: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:345: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_AddOnUpdate (73.72s)
=== CONT  TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
=== NAME  TestAccLogsStream_Disappears_logGroup
    stream_test.go:79: stopping VCR recorder
    stream_test.go:79: persisting randomness seed
--- PASS: TestAccLogsStream_Disappears_logGroup (29.57s)
=== CONT  TestAccLogsAnomalyDetector_tags_null
=== NAME  TestAccLogsMetricFilter_basic
    metric_filter_test.go:27: stopping VCR recorder
    metric_filter_test.go:27: persisting randomness seed
--- PASS: TestAccLogsMetricFilter_basic (35.42s)
=== CONT  TestAccLogsSubscriptionFilter_Disappears_logGroup
=== NAME  TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace
    anomaly_detector_tags_gen_test.go:679: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:679: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace (72.49s)
=== CONT  TestAccLogsGroupDataSource_basic
=== NAME  TestAccLogsQueryDefinition_rename
    query_definition_test.go:92: stopping VCR recorder
    query_definition_test.go:92: persisting randomness seed
--- PASS: TestAccLogsQueryDefinition_rename (51.36s)
=== CONT  TestAccLogsGroup_nameGenerate
=== NAME  TestAccLogsGroup_kmsKey
    group_test.go:151: stopping VCR recorder
    group_test.go:151: persisting randomness seed
--- PASS: TestAccLogsGroup_kmsKey (115.36s)
=== CONT  TestAccLogsGroup_basic
=== NAME  TestAccLogsSubscriptionFilter_disappears
    subscription_filter_test.go:81: stopping VCR recorder
    subscription_filter_test.go:81: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_disappears (43.86s)
=== CONT  TestAccLogsGroup_disappears
=== NAME  TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate
    anomaly_detector_tags_gen_test.go:430: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:430: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate (73.27s)
=== CONT  TestAccLogsGroupDataSource_retentionPolicy
=== NAME  TestAccLogsDestination_tags_DefaultTags_providerOnly
    destination_tags_gen_test.go:733: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_DefaultTags_providerOnly (195.93s)
=== CONT  TestAccLogsGroup_namePrefix
=== NAME  TestAccLogsGroup_retentionPolicy
    group_test.go:220: stopping VCR recorder
    group_test.go:220: persisting randomness seed
--- PASS: TestAccLogsGroup_retentionPolicy (75.46s)
=== CONT  TestAccLogsAccountPolicy_disappears
=== NAME  TestAccLogsSubscriptionFilter_many
    subscription_filter_test.go:61: stopping VCR recorder
    subscription_filter_test.go:61: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_many (54.66s)
=== CONT  TestAccLogsAccountPolicy_basicDataProtection
=== NAME  TestAccLogsGroupDataSource_basic
    group_data_source_test.go:21: stopping VCR recorder
    group_data_source_test.go:21: persisting randomness seed
--- PASS: TestAccLogsGroupDataSource_basic (24.30s)
=== CONT  TestAccLogsAccountPolicy_selectionCriteria
=== NAME  TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add
    anomaly_detector_tags_gen_test.go:530: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:530: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add (95.48s)
=== CONT  TestAccLogsQueryDefinition_disappears
=== NAME  TestAccLogsAnomalyDetector_tags_EmptyMap
    anomaly_detector_tags_gen_test.go:292: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:292: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_EmptyMap (36.68s)
=== CONT  TestAccLogsStream_disappears
=== NAME  TestAccLogsAnomalyDetector_tags_null
    anomaly_detector_tags_gen_test.go:227: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:227: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_null (36.87s)
=== CONT  TestAccLogsDestination_basic
=== NAME  TestAccLogsSubscriptionFilter_basic
    subscription_filter_test.go:28: stopping VCR recorder
    subscription_filter_test.go:28: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_basic (69.95s)
=== CONT  TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag
=== NAME  TestAccLogsGroup_nameGenerate
    group_test.go:68: stopping VCR recorder
--- PASS: TestAccLogsGroup_nameGenerate (34.75s)
=== CONT  TestAccLogsDestination_update
=== NAME  TestAccLogsGroup_basic
    group_test.go:34: stopping VCR recorder
    group_test.go:34: persisting randomness seed
--- PASS: TestAccLogsGroup_basic (33.33s)
=== CONT  TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag
=== NAME  TestAccLogsGroupDataSource_retentionPolicy
    group_data_source_test.go:48: stopping VCR recorder
    group_data_source_test.go:48: persisting randomness seed
--- PASS: TestAccLogsGroupDataSource_retentionPolicy (27.38s)
=== CONT  TestAccLogsDestination_disappears
=== NAME  TestAccLogsGroup_disappears
    group_test.go:125: stopping VCR recorder
    group_test.go:125: persisting randomness seed
--- PASS: TestAccLogsGroup_disappears (29.83s)
=== CONT  TestAccLogsStream_basic
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping
    anomaly_detector_tags_gen_test.go:975: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping (120.05s)
=== CONT  TestAccLogsDestination_tags
=== NAME  TestAccLogsSubscriptionFilter_Disappears_logGroup
    subscription_filter_test.go:106: stopping VCR recorder
    subscription_filter_test.go:106: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_Disappears_logGroup (45.93s)
=== CONT  TestAccLogsDestination_tags_AddOnUpdate
=== NAME  TestAccLogsAccountPolicy_disappears
    account_policy_test.go:116: stopping VCR recorder
    account_policy_test.go:116: persisting randomness seed
--- PASS: TestAccLogsAccountPolicy_disappears (29.76s)
=== CONT  TestAccLogsDestination_tags_EmptyMap
=== NAME  TestAccLogsGroup_namePrefix
    group_test.go:96: stopping VCR recorder
--- PASS: TestAccLogsGroup_namePrefix (35.96s)
=== CONT  TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add
=== NAME  TestAccLogsQueryDefinition_disappears
    query_definition_test.go:67: stopping VCR recorder
    query_definition_test.go:67: persisting randomness seed
--- PASS: TestAccLogsQueryDefinition_disappears (30.50s)
=== CONT  TestAccLogsDestination_tags_null
=== NAME  TestAccLogsStream_disappears
    stream_test.go:54: stopping VCR recorder
    stream_test.go:54: persisting randomness seed
--- PASS: TestAccLogsStream_disappears (31.80s)
=== CONT  TestAccLogsDestination_tags_EmptyTag_OnCreate
=== NAME  TestAccLogsAccountPolicy_basicDataProtection
    account_policy_test.go:56: stopping VCR recorder
    account_policy_test.go:56: persisting randomness seed
--- PASS: TestAccLogsAccountPolicy_basicDataProtection (34.86s)
=== CONT  TestAccLogsDataProtectionPolicy_basic
=== NAME  TestAccLogsSubscriptionFilter_distribution
    subscription_filter_test.go:190: stopping VCR recorder
    subscription_filter_test.go:190: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_distribution (83.39s)
=== CONT  TestAccLogsDataProtectionPolicy_policyDocument
=== NAME  TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream
    subscription_filter_test.go:161: stopping VCR recorder
    subscription_filter_test.go:161: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_DestinationARN_kinesisStream (77.13s)
=== CONT  TestAccLogsAnomalyDetector_disappears
=== NAME  TestAccLogsStream_basic
    stream_test.go:26: stopping VCR recorder
    stream_test.go:26: persisting randomness seed
--- PASS: TestAccLogsStream_basic (26.62s)
=== CONT  TestAccLogsAnomalyDetector_update
=== NAME  TestAccLogsAccountPolicy_selectionCriteria
    account_policy_test.go:141: stopping VCR recorder
    account_policy_test.go:141: persisting randomness seed
--- PASS: TestAccLogsAccountPolicy_selectionCriteria (41.99s)
=== CONT  TestAccLogsDataProtectionPolicy_disappears
=== NAME  TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly
    anomaly_detector_tags_gen_test.go:774: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly (145.41s)
=== NAME  TestAccLogsSubscriptionFilter_roleARN
    subscription_filter_test.go:229: stopping VCR recorder
    subscription_filter_test.go:229: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_roleARN (104.05s)
=== NAME  TestAccLogsAnomalyDetector_disappears
    anomaly_detector_test.go:119: stopping VCR recorder
    anomaly_detector_test.go:119: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_disappears (14.76s)
=== NAME  TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose
    subscription_filter_test.go:131: stopping VCR recorder
    subscription_filter_test.go:131: persisting randomness seed
--- PASS: TestAccLogsSubscriptionFilter_DestinationARN_kinesisDataFirehose (87.55s)
=== NAME  TestAccLogsDataProtectionPolicy_basic
    data_protection_policy_test.go:26: stopping VCR recorder
    data_protection_policy_test.go:26: persisting randomness seed
--- PASS: TestAccLogsDataProtectionPolicy_basic (21.74s)
=== NAME  TestAccLogsDataProtectionPolicy_disappears
    data_protection_policy_test.go:89: stopping VCR recorder
    data_protection_policy_test.go:89: persisting randomness seed
--- PASS: TestAccLogsDataProtectionPolicy_disappears (18.54s)
=== NAME  TestAccLogsAnomalyDetector_tags
    anomaly_detector_tags_gen_test.go:25: stopping VCR recorder
    anomaly_detector_tags_gen_test.go:25: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_tags (101.24s)
=== NAME  TestAccLogsAnomalyDetector_update
    anomaly_detector_test.go:62: stopping VCR recorder
    anomaly_detector_test.go:62: persisting randomness seed
--- PASS: TestAccLogsAnomalyDetector_update (30.83s)
=== NAME  TestAccLogsDestination_basic
    destination_test.go:29: stopping VCR recorder
    destination_test.go:29: persisting randomness seed
--- PASS: TestAccLogsDestination_basic (63.35s)
=== NAME  TestAccLogsDataProtectionPolicy_policyDocument
    data_protection_policy_test.go:113: stopping VCR recorder
    data_protection_policy_test.go:113: persisting randomness seed
--- PASS: TestAccLogsDataProtectionPolicy_policyDocument (37.16s)
=== NAME  TestAccLogsDestination_disappears
    destination_test.go:60: stopping VCR recorder
    destination_test.go:60: persisting randomness seed
--- PASS: TestAccLogsDestination_disappears (62.95s)
=== NAME  TestAccLogsDestination_tags_EmptyMap
    destination_tags_gen_test.go:274: stopping VCR recorder
    destination_tags_gen_test.go:274: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_EmptyMap (75.28s)
=== NAME  TestAccLogsDestination_tags_AddOnUpdate
    destination_tags_gen_test.go:337: stopping VCR recorder
    destination_tags_gen_test.go:337: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_AddOnUpdate (79.81s)
=== NAME  TestAccLogsDestination_tags_null
    destination_tags_gen_test.go:207: stopping VCR recorder
    destination_tags_gen_test.go:207: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_null (75.57s)
=== NAME  TestAccLogsDestination_tags_EmptyTag_OnCreate
    destination_tags_gen_test.go:418: stopping VCR recorder
    destination_tags_gen_test.go:418: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnCreate (79.47s)
=== NAME  TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag
    destination_tags_gen_test.go:1914: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag (99.31s)
=== NAME  TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag
    destination_tags_gen_test.go:2076: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag (105.56s)
=== NAME  TestAccLogsDestination_update
    destination_test.go:88: stopping VCR recorder
    destination_test.go:88: persisting randomness seed
--- PASS: TestAccLogsDestination_update (107.34s)
=== NAME  TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add
    destination_tags_gen_test.go:507: stopping VCR recorder
    destination_tags_gen_test.go:507: persisting randomness seed
--- PASS: TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add (92.31s)
=== NAME  TestAccLogsDestination_tags
    destination_tags_gen_test.go:25: stopping VCR recorder
    destination_tags_gen_test.go:25: persisting randomness seed
--- PASS: TestAccLogsDestination_tags (111.17s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       356.996s
```

