### PR TITLE
Technical debt: Use `internal/retry` for `tfresource.RetryUntilNotFound`

### DIFF
--- a/internal/service/appautoscaling/target.go
+++ b/internal/service/appautoscaling/target.go
@@ -226,7 +226,7 @@ func resourceTargetDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "deleting Application AutoScaling Target (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return FindTargetByThreePartKey(ctx, conn, d.Id(), d.Get("service_namespace").(string), d.Get("scalable_dimension").(string))
 	})
 

--- a/internal/service/appstream/stack.go
+++ b/internal/service/appstream/stack.go
@@ -426,7 +426,7 @@ func resourceStackDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "deleting AppStream Stack (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, stackOperationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, stackOperationTimeout, func(ctx context.Context) (any, error) {
 		return findStackByID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/autoscaling/group.go
+++ b/internal/service/autoscaling/group.go
@@ -1909,7 +1909,7 @@ func resourceGroupDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 	}
 
 	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete),
-		func() (any, error) {
+		func(ctx context.Context) (any, error) {
 			return findGroupByName(ctx, conn, d.Id())
 		})
 

--- a/internal/service/detective/organization_admin_account.go
+++ b/internal/service/detective/organization_admin_account.go
@@ -115,7 +115,7 @@ func resourceOrganizationAdminAccountDelete(ctx context.Context, d *schema.Resou
 		return sdkdiag.AppendErrorf(diags, "disabling Detective Organization Admin Account (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return findOrganizationAdminAccountByAccountID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/docdb/cluster.go
+++ b/internal/service/docdb/cluster.go
@@ -946,7 +946,7 @@ func removeClusterFromGlobalCluster(ctx context.Context, conn *docdb.Client, clu
 		return fmt.Errorf("removing DocumentDB Cluster (%s) from DocumentDB Global Cluster (%s): %w", clusterARN, globalClusterID, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findGlobalClusterByClusterARN(ctx, conn, clusterARN)
 	})
 

--- a/internal/service/docdb/cluster_parameter_group.go
+++ b/internal/service/docdb/cluster_parameter_group.go
@@ -208,7 +208,7 @@ func resourceClusterParameterGroupDelete(ctx context.Context, d *schema.Resource
 		return sdkdiag.AppendErrorf(diags, "deleting DocumentDB Cluster Parameter Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 10*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 10*time.Minute, func(ctx context.Context) (any, error) {
 		return findDBClusterParameterGroupByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/docdb/subnet_group.go
+++ b/internal/service/docdb/subnet_group.go
@@ -166,7 +166,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting DocumentDB Subnet Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 10*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 10*time.Minute, func(ctx context.Context) (any, error) {
 		return findDBSubnetGroupByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ec2/ebs_snapshot_create_volume_permission.go
+++ b/internal/service/ec2/ebs_snapshot_create_volume_permission.go
@@ -140,7 +140,7 @@ func resourceSnapshotCreateVolumePermissionDelete(ctx context.Context, d *schema
 		return sdkdiag.AppendErrorf(diags, "deleting EBS Snapshot CreateVolumePermission (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findCreateSnapshotCreateVolumePermissionByTwoPartKey(ctx, conn, snapshotID, accountID)
 	})
 

--- a/internal/service/ec2/ec2_eip.go
+++ b/internal/service/ec2/ec2_eip.go
@@ -339,7 +339,7 @@ func resourceEIPDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 		const (
 			timeout = 10 * time.Minute // IPAM eventual consistency
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 			return findIPAMPoolAllocationsForEIP(ctx, conn, ipamPoolID, d.Get("allocation_id").(string))
 		})
 

--- a/internal/service/ec2/ec2_spot_fleet_request.go
+++ b/internal/service/ec2/ec2_spot_fleet_request.go
@@ -1186,7 +1186,7 @@ func resourceSpotFleetRequestDelete(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		input := ec2.DescribeSpotFleetInstancesInput{
 			SpotFleetRequestId: aws.String(d.Id()),
 		}

--- a/internal/service/ec2/transitgateway_multicast_group_member.go
+++ b/internal/service/ec2/transitgateway_multicast_group_member.go
@@ -149,7 +149,7 @@ func deregisterTransitGatewayMulticastGroupMember(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Member (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return findTransitGatewayMulticastGroupMemberByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/transitgateway_multicast_group_source.go
+++ b/internal/service/ec2/transitgateway_multicast_group_source.go
@@ -152,7 +152,7 @@ func deregisterTransitGatewayMulticastGroupSource(ctx context.Context, conn *ec2
 		return fmt.Errorf("deleting EC2 Transit Gateway Multicast Group Source (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return findTransitGatewayMulticastGroupSourceByThreePartKey(ctx, conn, multicastDomainID, groupIPAddress, eniID)
 	})
 

--- a/internal/service/ec2/vpc_.go
+++ b/internal/service/ec2/vpc_.go
@@ -470,7 +470,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 		return sdkdiag.AppendErrorf(diags, "deleting EC2 VPC (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findVPCByID(ctx, conn, d.Id())
 	})
 
@@ -492,7 +492,7 @@ func resourceVPCDelete(ctx context.Context, d *schema.ResourceData, meta any) di
 		const (
 			timeout = 35 * time.Minute // IPAM eventual consistency. It can take ~30 min to release allocations.
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 			return findIPAMPoolAllocationsForVPC(ctx, conn, ipamPoolID, d.Id())
 		})
 

--- a/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
+++ b/internal/service/ec2/vpc_ipv4_cidr_block_association_test.go
@@ -276,7 +276,7 @@ func testAccCheckVPCIPv4CIDRBlockAssociationWaitVPCIPAMPoolAllocationDeleted(ctx
 		const (
 			timeout = 35 * time.Minute // IPAM eventual consistency. It can take ~30 min to release allocations.
 		)
-		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+		_, err := tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 			return tfec2.FindIPAMPoolAllocationsForVPC(ctx, conn, rsIPAMPool.Primary.ID, rsVPC.Primary.ID)
 		})
 

--- a/internal/service/ec2/vpc_security_group.go
+++ b/internal/service/ec2/vpc_security_group.go
@@ -415,7 +415,7 @@ func resourceSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, me
 		return sdkdiag.AppendErrorf(diags, "deleting Security Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, ec2PropagationTimeout, func(ctx context.Context) (any, error) {
 		return findSecurityGroupByID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/ecr/repository.go
+++ b/internal/service/ecr/repository.go
@@ -259,7 +259,7 @@ func resourceRepositoryDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "deleting ECR Repository (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findRepositoryByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/elasticbeanstalk/application.go
+++ b/internal/service/elasticbeanstalk/application.go
@@ -211,7 +211,7 @@ func resourceApplicationDelete(ctx context.Context, d *schema.ResourceData, meta
 	const (
 		timeout = 10 * time.Second
 	)
-	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findApplicationByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/elbv2/load_balancer.go
+++ b/internal/service/elbv2/load_balancer.go
@@ -1154,7 +1154,7 @@ func waitForALBNetworkInterfacesToDetach(ctx context.Context, conn *ec2.Client, 
 			}
 
 			if ipv4IPAMPoolID != "" {
-				if _, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+				if _, err := tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 					output, err := tfec2.FindIPAMPoolAllocationsByIPAMPoolIDAndResourceID(ctx, conn, aws.ToString(v.Association.AllocationId), ipv4IPAMPoolID)
 					if err != nil {
 						return nil, err

--- a/internal/service/emr/cluster.go
+++ b/internal/service/emr/cluster.go
@@ -1328,7 +1328,7 @@ func resourceClusterUpdate(ctx context.Context, d *schema.ResourceData, meta any
 			const (
 				timeout = 1 * time.Minute
 			)
-			_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+			_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 				return findCoreInstanceGroupAutoScalingPolicy(ctx, conn, d.Id())
 			})
 

--- a/internal/service/gamelift/game_session_queue.go
+++ b/internal/service/gamelift/game_session_queue.go
@@ -207,7 +207,7 @@ func resourceGameSessionQueueDelete(ctx context.Context, d *schema.ResourceData,
 	const (
 		timeout = 30 * time.Second
 	)
-	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findGameSessionQueueByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/keyspaces/keyspace.go
+++ b/internal/service/keyspaces/keyspace.go
@@ -185,7 +185,7 @@ func resourceKeyspaceDelete(ctx context.Context, d *schema.ResourceData, meta an
 		return sdkdiag.AppendErrorf(diags, "deleting Keyspaces Keyspace (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findKeyspaceByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/kms/grant.go
+++ b/internal/service/kms/grant.go
@@ -266,7 +266,7 @@ func resourceGrantDelete(ctx context.Context, d *schema.ResourceData, meta any) 
 		return sdkdiag.AppendErrorf(diags, "deleting KMS Grant (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findGrantByTwoPartKey(ctx, conn, keyID, grantID)
 	})
 

--- a/internal/service/lambda/permission.go
+++ b/internal/service/lambda/permission.go
@@ -271,7 +271,7 @@ func resourcePermissionDelete(ctx context.Context, d *schema.ResourceData, meta 
 		return sdkdiag.AppendErrorf(diags, "removing Lambda Permission (%s/%s): %s", functionName, d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, lambdaPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, lambdaPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findPolicyStatementByTwoPartKey(ctx, conn, functionName, d.Id(), d.Get("qualifier").(string))
 	})
 

--- a/internal/service/mediapackagev2/channel_group.go
+++ b/internal/service/mediapackagev2/channel_group.go
@@ -219,7 +219,7 @@ func (r *channelGroupResource) Delete(ctx context.Context, request resource.Dele
 		return
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 5*time.Minute, func(ctx context.Context) (any, error) {
 		return findChannelGroupByID(ctx, conn, data.Name.ValueString())
 	})
 

--- a/internal/service/neptune/cluster.go
+++ b/internal/service/neptune/cluster.go
@@ -876,7 +876,7 @@ func removeClusterFromGlobalCluster(ctx context.Context, conn *neptune.Client, c
 		return fmt.Errorf("removing Neptune Cluster (%s) from Neptune Global Cluster (%s): %w", clusterARN, globalClusterID, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findGlobalClusterByClusterARN(ctx, conn, clusterARN)
 	})
 

--- a/internal/service/quicksight/iam_policy_assignment.go
+++ b/internal/service/quicksight/iam_policy_assignment.go
@@ -289,7 +289,7 @@ func (r *iamPolicyAssignmentResource) Delete(ctx context.Context, request resour
 	}
 
 	// wait for IAM to propagate before returning
-	_, err = tfresource.RetryUntilNotFound(ctx, iamPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, iamPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findIAMPolicyAssignmentByThreePartKey(ctx, conn, awsAccountID, namespace, assignmentName)
 	})
 

--- a/internal/service/rds/global_cluster.go
+++ b/internal/service/rds/global_cluster.go
@@ -529,7 +529,7 @@ func waitGlobalClusterDeleted(ctx context.Context, conn *rds.Client, id string, 
 }
 
 func waitGlobalClusterMemberRemoved(ctx context.Context, conn *rds.Client, dbClusterARN string, timeout time.Duration) (*types.GlobalCluster, error) { //nolint:unparam
-	outputRaw, err := tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findGlobalClusterByDBClusterARN(ctx, conn, dbClusterARN)
 	})
 

--- a/internal/service/rds/subnet_group.go
+++ b/internal/service/rds/subnet_group.go
@@ -175,7 +175,7 @@ func resourceSubnetGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 		return sdkdiag.AppendErrorf(diags, "deleting RDS Subnet Group (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func(ctx context.Context) (any, error) {
 		return findDBSubnetGroupByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/redshift/snapshot_copy_grant.go
+++ b/internal/service/redshift/snapshot_copy_grant.go
@@ -149,7 +149,7 @@ func resourceSnapshotCopyGrantDelete(ctx context.Context, d *schema.ResourceData
 		return sdkdiag.AppendErrorf(diags, "deleting Redshift Snapshot Copy Grant (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, 3*time.Minute, func(ctx context.Context) (any, error) {
 		return findSnapshotCopyGrantByName(ctx, conn, d.Id())
 	})
 

--- a/internal/service/s3/bucket.go
+++ b/internal/service/s3/bucket.go
@@ -1590,7 +1590,7 @@ func resourceBucketDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findBucket(ctx, conn, d.Id())
 	})
 

--- a/internal/service/s3/bucket_analytics_configuration.go
+++ b/internal/service/s3/bucket_analytics_configuration.go
@@ -249,7 +249,7 @@ func resourceBucketAnalyticsConfigurationDelete(ctx context.Context, d *schema.R
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Analytics Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findAnalyticsConfiguration(ctx, conn, bucket, name)
 	})
 

--- a/internal/service/s3/bucket_cors_configuration.go
+++ b/internal/service/s3/bucket_cors_configuration.go
@@ -230,7 +230,7 @@ func resourceBucketCorsConfigurationDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket CORS Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findCORSRules(ctx, conn, bucket, expectedBucketOwner)
 	})
 

--- a/internal/service/s3/bucket_intelligent_tiering_configuration.go
+++ b/internal/service/s3/bucket_intelligent_tiering_configuration.go
@@ -219,7 +219,7 @@ func resourceBucketIntelligentTieringConfigurationDelete(ctx context.Context, d 
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Intelligent-Tiering Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findIntelligentTieringConfiguration(ctx, conn, bucket, name)
 	})
 

--- a/internal/service/s3/bucket_inventory.go
+++ b/internal/service/s3/bucket_inventory.go
@@ -323,7 +323,7 @@ func resourceBucketInventoryDelete(ctx context.Context, d *schema.ResourceData, 
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Inventory (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findInventoryConfiguration(ctx, conn, bucket, name)
 	})
 

--- a/internal/service/s3/bucket_lifecycle_configuration.go
+++ b/internal/service/s3/bucket_lifecycle_configuration.go
@@ -596,7 +596,7 @@ func (r *bucketLifecycleConfigurationResource) Delete(ctx context.Context, reque
 		return
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findBucketLifecycleConfiguration(ctx, conn, bucket, expectedBucketOwner)
 	})
 	if err != nil {

--- a/internal/service/s3/bucket_metric.go
+++ b/internal/service/s3/bucket_metric.go
@@ -194,7 +194,7 @@ func resourceBucketMetricDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Metric (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findMetricsConfiguration(ctx, conn, bucket, name)
 	})
 

--- a/internal/service/s3/bucket_ownership_controls.go
+++ b/internal/service/s3/bucket_ownership_controls.go
@@ -177,7 +177,7 @@ func resourceBucketOwnershipControlsDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Ownership Controls (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findOwnershipControls(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_policy.go
+++ b/internal/service/s3/bucket_policy.go
@@ -140,7 +140,7 @@ func resourceBucketPolicyDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Policy (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findBucketPolicy(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -195,7 +195,7 @@ func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.Resour
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Public Access Block (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findPublicAccessBlockConfiguration(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_replication_configuration.go
+++ b/internal/service/s3/bucket_replication_configuration.go
@@ -453,7 +453,7 @@ func resourceBucketReplicationConfigurationDelete(ctx context.Context, d *schema
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Replication Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findReplicationConfiguration(ctx, conn, bucket)
 	})
 

--- a/internal/service/s3/bucket_test.go
+++ b/internal/service/s3/bucket_test.go
@@ -2663,7 +2663,7 @@ func testAccCheckBucketDestroyWithProvider(ctx context.Context) acctest.TestChec
 
 			// S3 seems to be highly eventually consistent. Even if one connection reports that the queue is gone,
 			// another connection may still report it as present.
-			_, err := tfresource.RetryUntilNotFound(ctx, tfs3.BucketPropagationTimeout, func() (any, error) {
+			_, err := tfresource.RetryUntilNotFound(ctx, tfs3.BucketPropagationTimeout, func(ctx context.Context) (any, error) {
 				return tfs3.FindBucket(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/s3/bucket_website_configuration.go
+++ b/internal/service/s3/bucket_website_configuration.go
@@ -407,7 +407,7 @@ func resourceBucketWebsiteConfigurationDelete(ctx context.Context, d *schema.Res
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Bucket Website Configuration (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, bucketPropagationTimeout, func(ctx context.Context) (any, error) {
 		return findBucketWebsite(ctx, conn, bucket, expectedBucketOwner)
 	})
 

--- a/internal/service/s3control/account_public_access_block.go
+++ b/internal/service/s3control/account_public_access_block.go
@@ -177,7 +177,7 @@ func resourceAccountPublicAccessBlockDelete(ctx context.Context, d *schema.Resou
 		return sdkdiag.AppendErrorf(diags, "deleting S3 Account Public Access Block (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, s3PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, s3PropagationTimeout, func(ctx context.Context) (any, error) {
 		return findPublicAccessBlockByAccountID(ctx, conn, d.Id())
 	})
 

--- a/internal/service/secretsmanager/consts.go
+++ b/internal/service/secretsmanager/consts.go
@@ -8,5 +8,5 @@ import (
 )
 
 const (
-	PropagationTimeout = 2 * time.Minute
+	propagationTimeout = 2 * time.Minute
 )

--- a/internal/service/secretsmanager/secret.go
+++ b/internal/service/secretsmanager/secret.go
@@ -175,7 +175,7 @@ func resourceSecretCreate(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	// Retry for secret recreation after deletion.
-	outputRaw, err := tfresource.RetryWhen(ctx, PropagationTimeout,
+	outputRaw, err := tfresource.RetryWhen(ctx, propagationTimeout,
 		func() (any, error) {
 			return conn.CreateSecret(ctx, input)
 		},
@@ -196,7 +196,7 @@ func resourceSecretCreate(ctx context.Context, d *schema.ResourceData, meta any)
 
 	d.SetId(aws.ToString(outputRaw.(*secretsmanager.CreateSecretOutput).ARN))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findSecretByID(ctx, conn, d.Id())
 	})
 
@@ -249,7 +249,7 @@ func resourceSecretRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	}
 
 	var policy *secretsmanager.GetResourcePolicyOutput
-	err = tfresource.Retry(ctx, PropagationTimeout, func() *retry.RetryError {
+	err = tfresource.Retry(ctx, propagationTimeout, func() *retry.RetryError {
 		output, err := findSecretPolicyByID(ctx, conn, d.Id())
 
 		if err != nil {
@@ -383,7 +383,7 @@ func resourceSecretDelete(ctx context.Context, d *schema.ResourceData, meta any)
 		return sdkdiag.AppendErrorf(diags, "deleting Secrets Manager Secret (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findSecretByID(ctx, conn, d.Id())
 	})
 
@@ -442,7 +442,7 @@ func removeSecretReplicas(ctx context.Context, conn *secretsmanager.Client, id s
 }
 
 func putSecretPolicy(ctx context.Context, conn *secretsmanager.Client, input *secretsmanager.PutResourcePolicyInput) (*secretsmanager.PutResourcePolicyOutput, error) {
-	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.MalformedPolicyDocumentException](ctx, PropagationTimeout, func() (any, error) {
+	outputRaw, err := tfresource.RetryWhenIsAErrorMessageContains[*types.MalformedPolicyDocumentException](ctx, propagationTimeout, func() (any, error) {
 		return conn.PutResourcePolicy(ctx, input)
 	}, "This resource policy contains an unsupported principal")
 

--- a/internal/service/secretsmanager/secret_policy.go
+++ b/internal/service/secretsmanager/secret_policy.go
@@ -87,7 +87,7 @@ func resourceSecretPolicyCreate(ctx context.Context, d *schema.ResourceData, met
 
 	d.SetId(aws.ToString(output.ARN))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findSecretPolicyByID(ctx, conn, d.Id())
 	})
 
@@ -169,7 +169,7 @@ func resourceSecretPolicyDelete(ctx context.Context, d *schema.ResourceData, met
 		return sdkdiag.AppendFromErr(diags, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		output, err := findSecretPolicyByID(ctx, conn, d.Id())
 
 		if err != nil {

--- a/internal/service/secretsmanager/secret_version.go
+++ b/internal/service/secretsmanager/secret_version.go
@@ -149,7 +149,7 @@ func resourceSecretVersionCreate(ctx context.Context, d *schema.ResourceData, me
 	versionID := aws.ToString(output.VersionId)
 	d.SetId(secretVersionCreateResourceID(secretID, versionID))
 
-	_, err = tfresource.RetryWhenNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryWhenNotFound(ctx, propagationTimeout, func() (any, error) {
 		return findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
 	})
 
@@ -333,7 +333,7 @@ func resourceSecretVersionDelete(ctx context.Context, d *schema.ResourceData, me
 		}
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, PropagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		output, err := findSecretVersionByTwoPartKey(ctx, conn, secretID, versionID)
 
 		if err != nil {

--- a/internal/service/servicecatalog/principal_portfolio_association.go
+++ b/internal/service/servicecatalog/principal_portfolio_association.go
@@ -171,7 +171,7 @@ func resourcePrincipalPortfolioAssociationDelete(ctx context.Context, d *schema.
 		return sdkdiag.AppendErrorf(diags, "deleting Service Catalog Principal Portfolio Association (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, d.Timeout(schema.TimeoutDelete), func(ctx context.Context) (any, error) {
 		return findPrincipalPortfolioAssociation(ctx, conn, acceptLanguage, principalARN, portfolioID, principalType)
 	})
 

--- a/internal/service/shield/drt_access_log_bucket_association.go
+++ b/internal/service/shield/drt_access_log_bucket_association.go
@@ -173,7 +173,7 @@ func (r *drtAccessLogBucketAssociationResource) Delete(ctx context.Context, requ
 		return
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, r.DeleteTimeout(ctx, data.Timeouts), func(ctx context.Context) (any, error) {
 		return findDRTLogBucketAssociation(ctx, conn, logBucket)
 	})
 

--- a/internal/service/shield/drt_access_role_arn_association.go
+++ b/internal/service/shield/drt_access_role_arn_association.go
@@ -195,7 +195,7 @@ func (r *drtAccessRoleARNAssociationResource) Delete(ctx context.Context, reques
 		return
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, r.DeleteTimeout(ctx, data.Timeouts), func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, r.DeleteTimeout(ctx, data.Timeouts), func(ctx context.Context) (any, error) {
 		return findDRTRoleARNAssociation(ctx, conn, roleARN)
 	})
 

--- a/internal/service/signer/signing_profile_permission.go
+++ b/internal/service/signer/signing_profile_permission.go
@@ -217,7 +217,7 @@ func resourceSigningProfilePermissionDelete(ctx context.Context, d *schema.Resou
 		return sdkdiag.AppendErrorf(diags, "deleting Signer Signing Profile Permission (%s): %s", d.Id(), err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, propagationTimeout, func(ctx context.Context) (any, error) {
 		return findPermissionByTwoPartKey(ctx, conn, profileName, statementID)
 	})
 

--- a/internal/service/sqs/queue_test.go
+++ b/internal/service/sqs/queue_test.go
@@ -967,7 +967,7 @@ func testAccCheckQueueDestroy(ctx context.Context) resource.TestCheckFunc {
 
 			// SQS seems to be highly eventually consistent. Even if one connection reports that the queue is gone,
 			// another connection may still report it as present.
-			_, err := tfresource.RetryUntilNotFound(ctx, tfsqs.QueueDeletedTimeout, func() (any, error) {
+			_, err := tfresource.RetryUntilNotFound(ctx, tfsqs.QueueDeletedTimeout, func(ctx context.Context) (any, error) {
 				return tfsqs.FindQueueAttributesByURL(ctx, conn, rs.Primary.ID)
 			})
 			if errors.Is(err, tfresource.ErrFoundResource) {

--- a/internal/service/swf/domain_test.go
+++ b/internal/service/swf/domain_test.go
@@ -240,7 +240,7 @@ func testAccCheckDomainDestroy(ctx context.Context) resource.TestCheckFunc {
 			}
 
 			// Retrying as Read after Delete is not always consistent.
-			_, err := tfresource.RetryUntilNotFound(ctx, 2*time.Minute, func() (any, error) {
+			_, err := tfresource.RetryUntilNotFound(ctx, 2*time.Minute, func(ctx context.Context) (any, error) {
 				return tfswf.FindDomainByName(ctx, conn, rs.Primary.ID)
 			})
 

--- a/internal/service/transfer/user.go
+++ b/internal/service/transfer/user.go
@@ -356,7 +356,7 @@ func userDelete(ctx context.Context, conn *transfer.Client, serverID, userName s
 		return fmt.Errorf("deleting Transfer User (%s): %w", id, err)
 	}
 
-	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func() (any, error) {
+	_, err = tfresource.RetryUntilNotFound(ctx, timeout, func(ctx context.Context) (any, error) {
 		return findUserByTwoPartKey(ctx, conn, serverID, userName)
 	})
 

--- a/internal/tfresource/retry.go
+++ b/internal/tfresource/retry.go
@@ -216,18 +216,8 @@ func RetryUntilEqual[T comparable](ctx context.Context, timeout time.Duration, t
 }
 
 // RetryUntilNotFound retries the specified function until it returns a retry.NotFoundError.
-func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func() (any, error)) (any, error) {
-	return RetryWhen(ctx, timeout, f, func(err error) (bool, error) {
-		if NotFound(err) {
-			return false, nil
-		}
-
-		if err != nil {
-			return false, err
-		}
-
-		return true, ErrFoundResource
-	})
+func RetryUntilNotFound(ctx context.Context, timeout time.Duration, f func(context.Context) (any, error)) (any, error) {
+	return retry.Op(f).UntilNotFound()(ctx, timeout)
 }
 
 // RetryWhenNotFound retries the specified function when it returns a retry.NotFoundError.

--- a/internal/tfresource/retry_test.go
+++ b/internal/tfresource/retry_test.go
@@ -299,32 +299,32 @@ func TestRetryUntilNotFound(t *testing.T) {
 	var retryCount int32
 	testCases := []struct {
 		Name        string
-		F           func() (any, error)
+		F           func(context.Context) (any, error)
 		ExpectError bool
 	}{
 		{
 			Name: "no error",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				return nil, nil
 			},
 			ExpectError: true,
 		},
 		{
 			Name: "other error",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				return nil, errors.New("TestCode")
 			},
 			ExpectError: true,
 		},
 		{
 			Name: "NotFoundError",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				return nil, &retry.NotFoundError{}
 			},
 		},
 		{
 			Name: "retryable NotFoundError",
-			F: func() (any, error) {
+			F: func(context.Context) (any, error) {
 				if atomic.CompareAndSwapInt32(&retryCount, 0, 1) {
 					return nil, nil
 				}


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Use the new primitives in `internal/retry` (as a replacement for the SDKv2 `helper/retry` package) for `tfresource.RetryUntilNotFound`.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates https://github.com/hashicorp/terraform-provider-aws/issues/42554.
Relates https://github.com/hashicorp/terraform-provider-aws/pull/43267.

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccAutoScalingGroup_basic' PKG=autoscaling
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/autoscaling/... -v -count 1 -parallel 20  -run=TestAccAutoScalingGroup_basic -timeout 360m -vet=off
2025/07/10 13:28:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/10 13:28:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccAutoScalingGroup_basic
=== PAUSE TestAccAutoScalingGroup_basic
=== CONT  TestAccAutoScalingGroup_basic
--- PASS: TestAccAutoScalingGroup_basic (102.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/autoscaling	107.075s
```
```console
% make testacc TESTARGS='-run=TestAccVPC_basic' PKG=ec2     
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/ec2/... -v -count 1 -parallel 20  -run=TestAccVPC_basic -timeout 360m -vet=off
2025/07/10 13:32:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/10 13:32:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccVPC_basic
=== PAUSE TestAccVPC_basic
=== CONT  TestAccVPC_basic
--- PASS: TestAccVPC_basic (17.89s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/ec2	23.004s
```
```console
% make testacc TESTARGS='-run=TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName' PKG=rds
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/rds/... -v -count 1 -parallel 20  -run=TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName -timeout 360m -vet=off
2025/07/10 13:37:07 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/10 13:37:07 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName
=== PAUSE TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName
=== CONT  TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName
--- PASS: TestAccRDSGlobalCluster_SourceDBClusterIdentifier_databaseName (222.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/rds	227.376s
```
```console
% make testacc TESTARGS='-run=TestAccS3Bucket.*_basic$$' PKG=s3                                  
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/s3/... -v -count 1 -parallel 20  -run=TestAccS3Bucket.*_basic$ -timeout 360m -vet=off
2025/07/10 14:06:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/10 14:06:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccS3BucketAccelerateConfiguration_basic
=== PAUSE TestAccS3BucketAccelerateConfiguration_basic
=== RUN   TestAccS3BucketACL_basic
=== PAUSE TestAccS3BucketACL_basic
=== RUN   TestAccS3BucketAnalyticsConfiguration_basic
=== PAUSE TestAccS3BucketAnalyticsConfiguration_basic
=== RUN   TestAccS3BucketCORSConfiguration_basic
=== PAUSE TestAccS3BucketCORSConfiguration_basic
=== RUN   TestAccS3BucketDataSource_basic
=== PAUSE TestAccS3BucketDataSource_basic
=== RUN   TestAccS3BucketIntelligentTieringConfiguration_basic
=== PAUSE TestAccS3BucketIntelligentTieringConfiguration_basic
=== RUN   TestAccS3BucketInventory_basic
=== PAUSE TestAccS3BucketInventory_basic
=== RUN   TestAccS3BucketLifecycleConfiguration_basic
=== PAUSE TestAccS3BucketLifecycleConfiguration_basic
=== RUN   TestAccS3BucketLogging_basic
=== PAUSE TestAccS3BucketLogging_basic
=== RUN   TestAccS3BucketMetric_basic
=== PAUSE TestAccS3BucketMetric_basic
=== RUN   TestAccS3BucketObjectDataSource_basic
=== PAUSE TestAccS3BucketObjectDataSource_basic
=== RUN   TestAccS3BucketObjectLockConfiguration_basic
=== PAUSE TestAccS3BucketObjectLockConfiguration_basic
=== RUN   TestAccS3BucketObject_basic
=== PAUSE TestAccS3BucketObject_basic
=== RUN   TestAccS3BucketObjectsDataSource_basic
=== PAUSE TestAccS3BucketObjectsDataSource_basic
=== RUN   TestAccS3BucketOwnershipControls_basic
=== PAUSE TestAccS3BucketOwnershipControls_basic
=== RUN   TestAccS3BucketPolicyDataSource_basic
=== PAUSE TestAccS3BucketPolicyDataSource_basic
=== RUN   TestAccS3BucketPolicy_basic
=== PAUSE TestAccS3BucketPolicy_basic
=== RUN   TestAccS3BucketPublicAccessBlock_basic
=== PAUSE TestAccS3BucketPublicAccessBlock_basic
=== RUN   TestAccS3BucketReplicationConfiguration_basic
=== PAUSE TestAccS3BucketReplicationConfiguration_basic
=== RUN   TestAccS3BucketServerSideEncryptionConfiguration_basic
=== PAUSE TestAccS3BucketServerSideEncryptionConfiguration_basic
=== RUN   TestAccS3Bucket_Basic_basic
=== PAUSE TestAccS3Bucket_Basic_basic
=== RUN   TestAccS3Bucket_Duplicate_basic
=== PAUSE TestAccS3Bucket_Duplicate_basic
=== RUN   TestAccS3Bucket_Replication_basic
=== PAUSE TestAccS3Bucket_Replication_basic
=== RUN   TestAccS3BucketVersioning_basic
=== PAUSE TestAccS3BucketVersioning_basic
=== RUN   TestAccS3BucketWebsiteConfiguration_basic
=== PAUSE TestAccS3BucketWebsiteConfiguration_basic
=== CONT  TestAccS3BucketAccelerateConfiguration_basic
=== CONT  TestAccS3BucketObjectsDataSource_basic
=== CONT  TestAccS3BucketServerSideEncryptionConfiguration_basic
=== CONT  TestAccS3Bucket_Replication_basic
=== CONT  TestAccS3BucketLifecycleConfiguration_basic
=== CONT  TestAccS3BucketObjectDataSource_basic
=== CONT  TestAccS3BucketDataSource_basic
=== CONT  TestAccS3BucketAnalyticsConfiguration_basic
=== CONT  TestAccS3BucketObject_basic
=== CONT  TestAccS3Bucket_Duplicate_basic
=== CONT  TestAccS3BucketInventory_basic
=== CONT  TestAccS3BucketObjectLockConfiguration_basic
=== CONT  TestAccS3BucketCORSConfiguration_basic
=== CONT  TestAccS3Bucket_Basic_basic
=== CONT  TestAccS3BucketReplicationConfiguration_basic
=== CONT  TestAccS3BucketWebsiteConfiguration_basic
=== CONT  TestAccS3BucketPublicAccessBlock_basic
=== CONT  TestAccS3BucketMetric_basic
=== CONT  TestAccS3BucketPolicy_basic
=== CONT  TestAccS3BucketIntelligentTieringConfiguration_basic
--- PASS: TestAccS3Bucket_Duplicate_basic (15.25s)
=== CONT  TestAccS3BucketACL_basic
--- PASS: TestAccS3BucketObjectsDataSource_basic (24.88s)
=== CONT  TestAccS3BucketPolicyDataSource_basic
--- PASS: TestAccS3BucketDataSource_basic (23.83s)
=== CONT  TestAccS3BucketLogging_basic
--- PASS: TestAccS3BucketObjectDataSource_basic (24.37s)
=== CONT  TestAccS3BucketVersioning_basic
--- PASS: TestAccS3BucketWebsiteConfiguration_basic (28.90s)
=== CONT  TestAccS3BucketOwnershipControls_basic
--- PASS: TestAccS3BucketObjectLockConfiguration_basic (28.92s)
--- PASS: TestAccS3BucketInventory_basic (29.15s)
--- PASS: TestAccS3BucketMetric_basic (29.24s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (29.31s)
--- PASS: TestAccS3BucketIntelligentTieringConfiguration_basic (29.33s)
--- PASS: TestAccS3BucketAnalyticsConfiguration_basic (29.44s)
--- PASS: TestAccS3Bucket_Basic_basic (29.45s)
--- PASS: TestAccS3BucketServerSideEncryptionConfiguration_basic (29.50s)
--- PASS: TestAccS3BucketCORSConfiguration_basic (29.56s)
--- PASS: TestAccS3BucketPolicy_basic (30.21s)
--- PASS: TestAccS3BucketObject_basic (31.15s)
--- PASS: TestAccS3BucketAccelerateConfiguration_basic (33.38s)
--- PASS: TestAccS3BucketACL_basic (22.37s)
--- PASS: TestAccS3BucketPolicyDataSource_basic (17.54s)
--- PASS: TestAccS3BucketOwnershipControls_basic (18.28s)
--- PASS: TestAccS3BucketVersioning_basic (23.54s)
--- PASS: TestAccS3BucketLogging_basic (26.63s)
--- PASS: TestAccS3BucketReplicationConfiguration_basic (80.58s)
--- PASS: TestAccS3BucketLifecycleConfiguration_basic (81.96s)
--- PASS: TestAccS3Bucket_Replication_basic (90.70s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/s3	95.916s
```