### PR TITLE
Add support for `aws_glue_crawler` to retry updates when the crawler is running

### DIFF
--- a/internal/service/glue/crawler.go
+++ b/internal/service/glue/crawler.go
@@ -612,6 +612,11 @@ func resourceCrawlerUpdate(ctx context.Context, d *schema.ResourceData, meta any
 					return retry.RetryableError(err)
 				}
 
+				// Glue will allow updating crawlers when a crawler is running. Retry occassionally to persist the updates once a crawler has finished the run.
+				if errs.IsAErrorMessageContains[*awstypes.CrawlerRunningException](err, "Cannot update Crawler while running") {
+					return retry.RetryableError(err)
+				}
+
 				return retry.NonRetryableError(err)
 			}
 			return nil


### PR DESCRIPTION
### Description

AWS Doesn't allow updates made to running crawlers, which results in terraform immediately throwing an error when attempting to make an update to a running crawler. Users of the resource simply need to wait a bit for their run to finish, then retry their update with the exact same configuration, which is a poor user experience and can cause frustration with the resource.

This PR adds the `Cannot update Crawler while running` error to the list of retryable errors that are currently checked when performing an update to the crawler, which will allow the resource to retry the operation after receiving that error.

A new test is included that creates a crawler with an s3 target, then _runs_ that crawler before updating the name to validate the error handling retries properly.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library without the included error handling

## Changes to Security Controls

N/A

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

TODO

```console
% make testacc TESTS=TestAccXXX PKG=ec2

...
```
