### PR TITLE
[Bug] Fix read back of `parent_action_group_signature`

### DIFF
--- a/.changelog/43355.txt
+++ b/.changelog/43355.txt
@@ -1,3 +1,3 @@
-```release-note:new-resource
-aws_bedrockagent_agent_prepare
+```release-note:bug
+aws_bedrockagent_agent_action_group: Fix issue reading back value of `parent_action_group_signature`
 ```

--- a/.changelog/43355.txt
+++ b/.changelog/43355.txt
@@ -1,0 +1,3 @@
+```release-note:new-resource
+aws_bedrockagent_agent_prepare
+```

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -89,6 +89,9 @@ func (r *agentActionGroupResource) Schema(ctx context.Context, request resource.
 			"parent_action_group_signature": schema.StringAttribute{
 				CustomType: fwtypes.StringEnumType[awstypes.ActionGroupSignature](),
 				Optional:   true,
+				Validators: []validator.String{
+					stringvalidator.ConflictsWith(path.MatchRoot(names.AttrDescription)),
+				},
 			},
 			"prepare_agent": schema.BoolAttribute{
 				Optional: true,
@@ -280,6 +283,7 @@ func (r *agentActionGroupResource) Create(ctx context.Context, request resource.
 		}
 	}
 
+	data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.AgentActionGroup.ParentActionSignature)
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -318,6 +322,7 @@ func (r *agentActionGroupResource) Read(ctx context.Context, request resource.Re
 		return
 	}
 
+	data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -374,6 +379,7 @@ func (r *agentActionGroupResource) Update(ctx context.Context, request resource.
 	}
 
 	new.ActionGroupState = fwtypes.StringEnumValue(output.ActionGroupState)
+	new.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
 
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }

--- a/internal/service/bedrockagent/agent_action_group.go
+++ b/internal/service/bedrockagent/agent_action_group.go
@@ -283,7 +283,9 @@ func (r *agentActionGroupResource) Create(ctx context.Context, request resource.
 		}
 	}
 
-	data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.AgentActionGroup.ParentActionSignature)
+	if output.AgentActionGroup.ParentActionSignature != "" {
+		data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.AgentActionGroup.ParentActionSignature)
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -322,7 +324,9 @@ func (r *agentActionGroupResource) Read(ctx context.Context, request resource.Re
 		return
 	}
 
-	data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
+	if output.ParentActionSignature != "" {
+		data.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
@@ -379,8 +383,9 @@ func (r *agentActionGroupResource) Update(ctx context.Context, request resource.
 	}
 
 	new.ActionGroupState = fwtypes.StringEnumValue(output.ActionGroupState)
-	new.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
-
+	if output.ParentActionSignature != "" {
+		new.ParentActionGroupSignature = fwtypes.StringEnumValue[awstypes.ActionGroupSignature](output.ParentActionSignature)
+	}
 	response.Diagnostics.Append(response.State.Set(ctx, &new)...)
 }
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Fix read of `parent_action_group_signature` as the field is named differently in input and outputs.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43045

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccBedrockAgentAgentActionGroup_' PKG=bedrockagent ACCTEST_PARALLELISM=4
make: Verifying source code with gofmt...               <aws:terraform-testing>
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.4 test ./internal/service/bedrockagent/... -v -count 1 -parallel 4  -run=TestAccBedrockAgentAgentActionGroup_ -timeout 360m -vet=off
2025/07/11 13:26:56 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/11 13:26:56 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBedrockAgentAgentActionGroup_basic
=== PAUSE TestAccBedrockAgentAgentActionGroup_basic
=== RUN   TestAccBedrockAgentAgentActionGroup_upgradeToPrepareAgent
=== PAUSE TestAccBedrockAgentAgentActionGroup_upgradeToPrepareAgent
=== RUN   TestAccBedrockAgentAgentActionGroup_parentActionGroupSignature
=== PAUSE TestAccBedrockAgentAgentActionGroup_parentActionGroupSignature
=== RUN   TestAccBedrockAgentAgentActionGroup_APISchema_s3
=== PAUSE TestAccBedrockAgentAgentActionGroup_APISchema_s3
=== RUN   TestAccBedrockAgentAgentActionGroup_update
=== PAUSE TestAccBedrockAgentAgentActionGroup_update
=== RUN   TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions
=== PAUSE TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions
=== RUN   TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl
=== PAUSE TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl
=== CONT  TestAccBedrockAgentAgentActionGroup_basic
=== CONT  TestAccBedrockAgentAgentActionGroup_update
=== CONT  TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl
=== CONT  TestAccBedrockAgentAgentActionGroup_parentActionGroupSignature
--- PASS: TestAccBedrockAgentAgentActionGroup_basic (51.80s)
=== CONT  TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions
--- PASS: TestAccBedrockAgentAgentActionGroup_parentActionGroupSignature (53.01s)
=== CONT  TestAccBedrockAgentAgentActionGroup_APISchema_s3
--- PASS: TestAccBedrockAgentAgentActionGroup_ActionGroupExecutor_customControl (60.49s)
=== CONT  TestAccBedrockAgentAgentActionGroup_upgradeToPrepareAgent
--- PASS: TestAccBedrockAgentAgentActionGroup_update (96.77s)
--- PASS: TestAccBedrockAgentAgentActionGroup_FunctionSchema_memberFunctions (45.84s)
--- PASS: TestAccBedrockAgentAgentActionGroup_APISchema_s3 (55.47s)
--- PASS: TestAccBedrockAgentAgentActionGroup_upgradeToPrepareAgent (73.22s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/bedrockagent       138.648s

```
