### PR TITLE
docs: add required attributes to example

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -216,9 +216,11 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
   # AWS Managed Caching Policy (CachingDisabled)
   default_cache_behavior {
     # Using the CachingDisabled managed policy ID:
-    cache_policy_id  = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    target_origin_id = local.s3_origin_id
+    cache_policy_id        = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = local.s3_origin_id
+    viewer_protocol_policy = "allow-all"
   }
 
   restrictions {


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No security controls are modified.

### Description

The example [With Managed Caching Policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#with-managed-caching-policy) for resource `aws_cloudfront_distribution` is missing required fields in `default_cache_behavior`.

When trying to run the example code below errors are reported

-  The argument ["viewer_protocol_policy"](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#viewer_protocol_policy-1) is required, but no definition was found.
- The argument ["cached_methods"](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cached_methods-1) is required, but no definition was found.

Missing fields are added, so that `terraform plan` and `terraform apply` succeed.

### Relations

Closes #34095

### References

- [Cache Behaviour Arguments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_distribution#cache-behavior-arguments)

### Output from Acceptance Testing

Not applicable. Only documentation is updated.