### PR TITLE
Remove duplicated words from the aws_bedrock_inference_profiles documentation

### DIFF
--- a/website/docs/d/bedrock_inference_profiles.html.markdown
+++ b/website/docs/d/bedrock_inference_profiles.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Data Source: aws_bedrock_inference_profiles
 
-Terraform data source for managing AWS Bedrock AWS Bedrock Inference Profiles.
+Terraform data source for managing AWS Bedrock Inference Profiles.
 
 ## Example Usage
 


### PR DESCRIPTION
Removed two words from the documentation which says the string  "AWS Bedrock" twice back-to-back.