### PR TITLE
[Enhancement] aws_lakeformation_resource: support `with_privileged_access` argument

### DIFF
--- a/.changelog/43377.txt
+++ b/.changelog/43377.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_lakeformation_resource: Support `with_privileged_access` argument
+```
+
+```release-note:enhancement
+data-source/aws_lakeformation_resource: Support `hybrid_access_enabled`, `with_federation` and `with_privileged_access` attributes
+```

--- a/internal/service/lakeformation/resource.go
+++ b/internal/service/lakeformation/resource.go
@@ -64,6 +64,12 @@ func ResourceResource() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"with_privileged_access": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -93,6 +99,10 @@ func resourceResourceCreate(ctx context.Context, d *schema.ResourceData, meta an
 
 	if v, ok := d.GetOk("with_federation"); ok {
 		input.WithFederation = aws.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("with_privileged_access"); ok {
+		input.WithPrivilegedAccess = v.(bool)
 	}
 
 	_, err := conn.RegisterResource(ctx, input)
@@ -131,6 +141,7 @@ func resourceResourceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 	d.Set(names.AttrRoleARN, resource.RoleArn)
 	d.Set("with_federation", resource.WithFederation)
+	d.Set("with_privileged_access", resource.WithPrivilegedAccess)
 
 	return diags
 }

--- a/internal/service/lakeformation/resource_data_source.go
+++ b/internal/service/lakeformation/resource_data_source.go
@@ -31,12 +31,24 @@ func DataSourceResource() *schema.Resource {
 				Required:     true,
 				ValidateFunc: verify.ValidARN,
 			},
+			"hybrid_access_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			names.AttrRoleARN: {
 				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"with_federation": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"with_privileged_access": {
+				Type:     schema.TypeBool,
 				Computed: true,
 			},
 		},
@@ -71,10 +83,13 @@ func dataSourceResourceRead(ctx context.Context, d *schema.ResourceData, meta an
 
 	d.SetId(aws.ToString(input.ResourceArn))
 	// d.Set("arn", output.ResourceInfo.ResourceArn) // output not including resource arn currently
-	d.Set(names.AttrRoleARN, output.ResourceInfo.RoleArn)
+	d.Set("hybrid_access_enabled", output.ResourceInfo.HybridAccessEnabled)
 	if output.ResourceInfo.LastModified != nil { // output not including last modified currently
 		d.Set("last_modified", output.ResourceInfo.LastModified.Format(time.RFC3339))
 	}
+	d.Set(names.AttrRoleARN, output.ResourceInfo.RoleArn)
+	d.Set("with_federation", output.ResourceInfo.WithFederation)
+	d.Set("with_privileged_access", output.ResourceInfo.WithPrivilegedAccess)
 
 	return diags
 }

--- a/internal/service/lakeformation/resource_data_source_test.go
+++ b/internal/service/lakeformation/resource_data_source_test.go
@@ -30,6 +30,9 @@ func TestAccLakeFormationResourceDataSource_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrARN, resourceName, names.AttrARN),
 					resource.TestCheckResourceAttrPair(dataSourceName, names.AttrRoleARN, resourceName, names.AttrRoleARN),
+					resource.TestCheckResourceAttr(dataSourceName, "hybrid_access_enabled", acctest.CtFalse),
+					resource.TestCheckResourceAttr(dataSourceName, "with_federation", acctest.CtFalse),
+					resource.TestCheckResourceAttr(dataSourceName, "with_privileged_access", acctest.CtFalse),
 				),
 			},
 		},

--- a/internal/service/lakeformation/resource_test.go
+++ b/internal/service/lakeformation/resource_test.go
@@ -40,6 +40,7 @@ func TestAccLakeFormationResource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "hybrid_access_enabled", acctest.CtFalse),
 					resource.TestCheckResourceAttrPair(resourceName, names.AttrRoleARN, roleResourceName, names.AttrARN),
 					resource.TestCheckResourceAttr(resourceName, "with_federation", acctest.CtFalse),
+					resource.TestCheckResourceAttr(resourceName, "with_privileged_access", acctest.CtFalse),
 				),
 			},
 		},
@@ -197,6 +198,33 @@ func TestAccLakeFormationResource_hybridAccessEnabled(t *testing.T) {
 	})
 }
 
+func TestAccLakeFormationResource_withPrivilegedAccessEnabled(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_lakeformation_resource.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(ctx, t)
+			acctest.PreCheckPartitionHasService(t, names.LakeFormation)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.LakeFormationServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckResourceDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceConfig_withPrivilegedAccessEnabled(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceExists(ctx, resourceName),
+					resource.TestCheckResourceAttrPair(resourceName, names.AttrARN, bucketResourceName, names.AttrARN),
+					resource.TestCheckResourceAttr(resourceName, "with_privileged_access", acctest.CtTrue),
+				),
+			},
+		},
+	})
+}
+
 // AWS does not support changing from an IAM role to an SLR. No error is thrown
 // but the registration is not changed (the IAM role continues in the registration).
 //
@@ -333,4 +361,71 @@ resource "aws_lakeformation_resource" "test" {
   hybrid_access_enabled = true
 }
 `, rName)
+}
+
+func testAccResourceConfig_withPrivilegedAccessEnabled(bucket, role string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_iam_role" "test" {
+  name = %[2]q
+  path = "/test/"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+data "aws_partition" "current" {}
+
+resource "aws_iam_role_policy" "test" {
+  name = %[2]q
+  role = aws_iam_role.test.id
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListAllMyBuckets",
+        "s3:GetObjectVersion",
+        "s3:GetBucketAcl",
+        "s3:GetObject",
+        "s3:GetObjectACL",
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}/*",
+        "arn:${data.aws_partition.current.partition}:s3:::${aws_s3_bucket.test.id}"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lakeformation_resource" "test" {
+  arn                    = aws_s3_bucket.test.arn
+  role_arn               = aws_iam_role.test.arn
+  with_privileged_access = true
+}
+`, bucket, role)
 }

--- a/website/docs/d/lakeformation_resource.html.markdown
+++ b/website/docs/d/lakeformation_resource.html.markdown
@@ -29,5 +29,8 @@ This data source supports the following arguments:
 
 This data source exports the following attributes in addition to the arguments above:
 
+* `hybrid_access_enabled` - Flag to enable AWS LakeFormation hybrid access permission mode.
 * `last_modified` - Date and time the resource was last modified in [RFC 3339 format](https://tools.ietf.org/html/rfc3339#section-5.8).
 * `role_arn` - Role that the resource was registered with.
+* `with_federation` - Whether the resource is a federated resource.
+* `with_privileged_access` - Boolean to grant the calling principal the permissions to perform all supported Lake Formation operations on the registered data location.

--- a/website/docs/r/lakeformation_resource.html.markdown
+++ b/website/docs/r/lakeformation_resource.html.markdown
@@ -40,7 +40,7 @@ The following arguments are optional:
 * `use_service_linked_role` - (Optional) Designates an AWS Identity and Access Management (IAM) service-linked role by registering this role with the Data Catalog.
 * `hybrid_access_enabled` - (Optional) Flag to enable AWS LakeFormation hybrid access permission mode.
 * `with_federation`- (Optional) Whether or not the resource is a federated resource. Set to true when registering AWS Glue connections for federated catalog functionality.
-* `with_privileged_access` - (Optional) Boolean to grant the calling principal the permissions to perform all supported Lake Formation operations on the registered data location. 
+* `with_privileged_access` - (Optional) Boolean to grant the calling principal the permissions to perform all supported Lake Formation operations on the registered data location.
 
 ~> **NOTE:** AWS does not support registering an S3 location with an IAM role and subsequently updating the S3 location registration to a service-linked role.
 

--- a/website/docs/r/lakeformation_resource.html.markdown
+++ b/website/docs/r/lakeformation_resource.html.markdown
@@ -40,6 +40,7 @@ The following arguments are optional:
 * `use_service_linked_role` - (Optional) Designates an AWS Identity and Access Management (IAM) service-linked role by registering this role with the Data Catalog.
 * `hybrid_access_enabled` - (Optional) Flag to enable AWS LakeFormation hybrid access permission mode.
 * `with_federation`- (Optional) Whether or not the resource is a federated resource. Set to true when registering AWS Glue connections for federated catalog functionality.
+* `with_privileged_access` - (Optional) Boolean to grant the calling principal the permissions to perform all supported Lake Formation operations on the registered data location. 
 
 ~> **NOTE:** AWS does not support registering an S3 location with an IAM role and subsequently updating the S3 location registration to a service-linked role.
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Added the `with_privileged_access` argument to the `aws_lakeformation_resource` resource.
* Added the following attributes to the `aws_lakeformation_resource` data source:

  * `hybrid_access_enabled`
  * `with_federation`
  * `with_privileged_access`

### Relations

Closes #43334 

### References
https://docs.aws.amazon.com/lake-formation/latest/APIReference/API_RegisterResource.html#lakeformation-RegisterResource-request-WithPrivilegedAccess

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccLakeFormationResource_withPrivilegedAccessEnabled PKG=lakeformation
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormationResource_withPrivilegedAccessEnabled'  -timeout 360m -vet=off
2025/07/15 10:14:21 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 10:14:21 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLakeFormationResource_withPrivilegedAccessEnabled
=== PAUSE TestAccLakeFormationResource_withPrivilegedAccessEnabled
=== CONT  TestAccLakeFormationResource_withPrivilegedAccessEnabled
--- PASS: TestAccLakeFormationResource_withPrivilegedAccessEnabled (24.40s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      28.577s
```

```console
$ make testacc TESTS=TestAccLakeFormationResourceDataSource_ PKG=lakeformation            
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormationResourceDataSource_'  -timeout 360m -vet=off
2025/07/15 10:15:25 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 10:15:25 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccLakeFormationResourceDataSource_basic
=== PAUSE TestAccLakeFormationResourceDataSource_basic
=== CONT  TestAccLakeFormationResourceDataSource_basic
--- PASS: TestAccLakeFormationResourceDataSource_basic (24.83s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation      28.468s

```
