### PR TITLE
[Documentation] Amplify: Proper link to build instance type compute

### DIFF
--- a/website/docs/r/amplify_app.html.markdown
+++ b/website/docs/r/amplify_app.html.markdown
@@ -194,7 +194,7 @@ This resource supports the following arguments:
 * `enable_branch_auto_deletion` - (Optional) Automatically disconnects a branch in the Amplify Console when you delete a branch from your Git repository.
 * `environment_variables` - (Optional) Environment variables map for an Amplify app.
 * `iam_service_role_arn` - (Optional) AWS Identity and Access Management (IAM) service role for an Amplify app.
-* `job_config` - (Optional) Used to configure the [Amplify Application build settings](https://docs.aws.amazon.com/amplify/latest/userguide/build-settings.html). See [`job_config` Block](#job_config-block) for details.
+* `job_config` - (Optional) Used to configure the [Amplify Application build instance compute type](https://docs.aws.amazon.com/amplify/latest/APIReference/API_JobConfig.html#amplify-Type-JobConfig-buildComputeType). See [`job_config` Block](#job_config-block) for details.
 * `oauth_token` - (Optional) OAuth token for a third-party source control system for an Amplify app. The OAuth token is used to create a webhook and a read-only deploy key. The OAuth token is not stored.
 * `platform` - (Optional) Platform or framework for an Amplify app. Valid values: `WEB`, `WEB_COMPUTE`. Default value: `WEB`.
 * `repository` - (Optional) Repository for an Amplify app.


### PR DESCRIPTION
The current link that is associated with job_config is wrong. It doesn't contain any information about the job config for setting the build compute. The updated link is the actual link that contains the info. 
<img width="2719" height="1195" alt="image" src="https://github.com/user-attachments/assets/09481970-bc66-4a0d-a887-36dcdf5b232b" />
