### PR TITLE
Add support for apply_on_transformed_logs argument in CloudWatch Logs metric filters

### DIFF
--- a/internal/service/logs/metric_filter.go
+++ b/internal/service/logs/metric_filter.go
@@ -105,6 +105,11 @@ func resourceMetricFilter() *schema.Resource {
 					return strings.TrimSpace(s)
 				},
 			},
+			"apply_on_transformed_logs": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 	}
 }
@@ -116,10 +121,11 @@ func resourceMetricFilterPut(ctx context.Context, d *schema.ResourceData, meta a
 	name := d.Get(names.AttrName).(string)
 	logGroupName := d.Get(names.AttrLogGroupName).(string)
 	input := &cloudwatchlogs.PutMetricFilterInput{
-		FilterName:            aws.String(name),
-		FilterPattern:         aws.String(strings.TrimSpace(d.Get("pattern").(string))),
-		LogGroupName:          aws.String(logGroupName),
-		MetricTransformations: expandMetricTransformations(d.Get("metric_transformation").([]any)),
+		FilterName:             aws.String(name),
+		FilterPattern:          aws.String(strings.TrimSpace(d.Get("pattern").(string))),
+		LogGroupName:           aws.String(logGroupName),
+		MetricTransformations:  expandMetricTransformations(d.Get("metric_transformation").([]any)),
+		ApplyOnTransformedLogs: d.Get("apply_on_transformed_logs").(bool),
 	}
 
 	// Creating multiple filters on the same log group can sometimes cause
@@ -164,6 +170,7 @@ func resourceMetricFilterRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	d.Set(names.AttrName, mf.FilterName)
 	d.Set("pattern", mf.FilterPattern)
+	d.Set("apply_on_transformed_logs", mf.ApplyOnTransformedLogs)
 
 	return diags
 }

--- a/internal/service/logs/metric_filter_test.go
+++ b/internal/service/logs/metric_filter_test.go
@@ -153,6 +153,7 @@ func TestAccLogsMetricFilter_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.value", "3"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "pattern", "[TEST]"),
+					resource.TestCheckResourceAttr(resourceName, "apply_on_transformed_logs", "false"),
 				),
 			},
 			{
@@ -178,6 +179,7 @@ func TestAccLogsMetricFilter_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "metric_transformation.0.value", "10"),
 					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
 					resource.TestCheckResourceAttr(resourceName, "pattern", `{ $.d1 = "OK" }`),
+					resource.TestCheckResourceAttr(resourceName, "apply_on_transformed_logs", "true"),
 				),
 			},
 		},
@@ -335,7 +337,8 @@ resource "aws_cloudwatch_log_metric_filter" "test" {
     { $.d1 = "OK" }
 EOS
 
-  log_group_name = aws_cloudwatch_log_group.test.name
+  log_group_name            = aws_cloudwatch_log_group.test.name
+  apply_on_transformed_logs = true
 
   metric_transformation {
     name      = "metric2"

--- a/website/docs/r/cloudwatch_log_metric_filter.html.markdown
+++ b/website/docs/r/cloudwatch_log_metric_filter.html.markdown
@@ -40,6 +40,7 @@ This resource supports the following arguments:
   for extracting metric data out of ingested log events.
 * `log_group_name` - (Required) The name of the log group to associate the metric filter with.
 * `metric_transformation` - (Required) A block defining collection of information needed to define how metric data gets emitted. See below.
+* `apply_on_transformed_logs` - (Optional) Whether the metric filter will be applied on the transformed version of the log events instead of the original ingested log events. Defaults to `false`. Valid only for log groups that have an active log transformer.
 
 The `metric_transformation` block supports the following arguments:
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

There are no security controls changes.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds support for `apply_on_transformed_logs` argument in CloudWatch Logs metric filters.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #40780

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutMetricFilter.html

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccLogsMetricFilter PKG=logs
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.23.10 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsMetricFilter'  -timeout 360m -vet=off
2025/06/30 11:32:46 Initializing Terraform AWS Provider...
=== RUN   TestAccLogsMetricFilter_basic
=== PAUSE TestAccLogsMetricFilter_basic
=== RUN   TestAccLogsMetricFilter_disappears
=== PAUSE TestAccLogsMetricFilter_disappears
=== RUN   TestAccLogsMetricFilter_Disappears_logGroup
=== PAUSE TestAccLogsMetricFilter_Disappears_logGroup
=== RUN   TestAccLogsMetricFilter_many
=== PAUSE TestAccLogsMetricFilter_many
=== RUN   TestAccLogsMetricFilter_update
=== PAUSE TestAccLogsMetricFilter_update
=== CONT  TestAccLogsMetricFilter_basic
=== CONT  TestAccLogsMetricFilter_update
=== CONT  TestAccLogsMetricFilter_many
=== CONT  TestAccLogsMetricFilter_Disappears_logGroup
=== CONT  TestAccLogsMetricFilter_disappears
--- PASS: TestAccLogsMetricFilter_Disappears_logGroup (14.81s)
--- PASS: TestAccLogsMetricFilter_disappears (15.00s)
--- PASS: TestAccLogsMetricFilter_basic (17.13s)
--- PASS: TestAccLogsMetricFilter_many (23.70s)
--- PASS: TestAccLogsMetricFilter_update (25.98s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       30.600s
```