### PR TITLE
r/aws_datazone_environment_blueprint_configuration: Fix `Inappropriate value for attribute "regional_parameters"` errors

### DIFF
--- a/.changelog/#####.txt
+++ b/.changelog/#####.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_datazone_environment_blueprint_configuration: Fix `Inappropriate value for attribute "regional_parameters"` errors during planning. This fixes a regression introduced in [v6.0.0](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#600-june-18-2025)
+```

--- a/internal/framework/types/mapof.go
+++ b/internal/framework/types/mapof.go
@@ -20,7 +20,10 @@ var (
 )
 
 var (
-	// MapOfStringType is a custom type used for defining a Map of strings.
+	// MapOfMapOfStringType is a custom type used for defining a map[string]map[string]string.
+	MapOfMapOfStringType = mapTypeOf[MapOfString]{basetypes.MapType{ElemType: MapOfStringType}}
+
+	// MapOfStringType is a custom type used for defining a map[string]string.
 	MapOfStringType = mapTypeOf[basetypes.StringValue]{basetypes.MapType{ElemType: basetypes.StringType{}}}
 )
 
@@ -101,7 +104,8 @@ type MapValueOf[T attr.Value] struct {
 }
 
 type (
-	MapOfString = MapValueOf[basetypes.StringValue]
+	MapOfMapOfString = MapValueOf[MapOfString]
+	MapOfString      = MapValueOf[basetypes.StringValue]
 )
 
 func (v MapValueOf[T]) Equal(o attr.Value) bool {

--- a/internal/service/bcmdataexports/export.go
+++ b/internal/service/bcmdataexports/export.go
@@ -117,8 +117,7 @@ func exportDataQuerySchema(ctx context.Context) schema.ListNestedBlock {
 					Required: true,
 				},
 				"table_configurations": schema.MapAttribute{
-					// map[string]map[string]string
-					CustomType: fwtypes.NewMapTypeOf[fwtypes.MapValueOf[types.String]](ctx),
+					CustomType: fwtypes.MapOfMapOfStringType,
 					Optional:   true,
 					PlanModifiers: []planmodifier.Map{
 						mapplanmodifier.UseStateForUnknown(),
@@ -496,8 +495,8 @@ type exportData struct {
 }
 
 type dataQueryData struct {
-	QueryStatement      types.String                                         `tfsdk:"query_statement"`
-	TableConfigurations fwtypes.MapValueOf[fwtypes.MapValueOf[types.String]] `tfsdk:"table_configurations"`
+	QueryStatement      types.String             `tfsdk:"query_statement"`
+	TableConfigurations fwtypes.MapOfMapOfString `tfsdk:"table_configurations"`
 }
 
 type s3OutputConfigurations struct {

--- a/internal/service/datazone/domain.go
+++ b/internal/service/datazone/domain.go
@@ -153,7 +153,7 @@ func (r *domainResource) Create(ctx context.Context, request resource.CreateRequ
 	)
 	outputRaw, err := tfresource.RetryWhenAWSErrCodeContains(ctx, timeout, func() (any, error) {
 		return conn.CreateDomain(ctx, &input)
-	}, ErrorCodeAccessDenied)
+	}, errCodeAccessDenied)
 
 	if err != nil {
 		response.Diagnostics.AddError(fmt.Sprintf("creating DataZone Domain (%s)", name), err.Error())

--- a/internal/service/datazone/environment_blueprint_configuration.go
+++ b/internal/service/datazone/environment_blueprint_configuration.go
@@ -5,13 +5,11 @@ package datazone
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/datazone"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -19,30 +17,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
+	"github.com/hashicorp/terraform-provider-aws/internal/errs/fwdiag"
 	"github.com/hashicorp/terraform-provider-aws/internal/framework"
-	"github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
+	fwflex "github.com/hashicorp/terraform-provider-aws/internal/framework/flex"
 	fwtypes "github.com/hashicorp/terraform-provider-aws/internal/framework/types"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
-	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 // @FrameworkResource("aws_datazone_environment_blueprint_configuration", name="Environment Blueprint Configuration")
 func newEnvironmentBlueprintConfigurationResource(_ context.Context) (resource.ResourceWithConfigure, error) {
 	r := &environmentBlueprintConfigurationResource{}
+
 	return r, nil
 }
-
-const (
-	ResNameEnvironmentBlueprintConfiguration = "Environment Blueprint Configuration"
-)
 
 type environmentBlueprintConfigurationResource struct {
 	framework.ResourceWithModel[environmentBlueprintConfigurationResourceModel]
 }
 
-func (r *environmentBlueprintConfigurationResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	resp.Schema = schema.Schema{
+func (r *environmentBlueprintConfigurationResource) Schema(ctx context.Context, request resource.SchemaRequest, response *resource.SchemaResponse) {
+	response.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"domain_id": schema.StringAttribute{
 				Required: true,
@@ -70,261 +64,180 @@ func (r *environmentBlueprintConfigurationResource) Schema(ctx context.Context, 
 				Optional:   true,
 			},
 			"regional_parameters": schema.MapAttribute{
-				CustomType: fwtypes.MapOfStringType,
+				CustomType: fwtypes.MapOfMapOfStringType,
 				Optional:   true,
-				ElementType: types.MapType{
-					ElemType: types.StringType,
-				},
 			},
 		},
 	}
 }
 
-func (r *environmentBlueprintConfigurationResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+func (r *environmentBlueprintConfigurationResource) Create(ctx context.Context, request resource.CreateRequest, response *resource.CreateResponse) {
+	var data environmentBlueprintConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().DataZoneClient(ctx)
 
-	var plan environmentBlueprintConfigurationResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	if resp.Diagnostics.HasError() {
+	domainID, environmentBlueprintID := fwflex.StringValueFromFramework(ctx, data.DomainIdentifier), fwflex.StringValueFromFramework(ctx, data.EnvironmentBlueprintIdentifier)
+	var input datazone.PutEnvironmentBlueprintConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	in := &datazone.PutEnvironmentBlueprintConfigurationInput{
-		DomainIdentifier:               plan.DomainId.ValueStringPointer(),
-		EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
-		EnvironmentBlueprintIdentifier: plan.EnvironmentBlueprintId.ValueStringPointer(),
-	}
+	_, err := conn.PutEnvironmentBlueprintConfiguration(ctx, &input)
 
-	if !plan.ManageAccessRoleArn.IsNull() {
-		in.ManageAccessRoleArn = plan.ManageAccessRoleArn.ValueStringPointer()
-	}
-
-	if !plan.ProvisioningRoleArn.IsNull() {
-		in.ProvisioningRoleArn = plan.ProvisioningRoleArn.ValueStringPointer()
-	}
-
-	if !plan.RegionalParameters.IsNull() {
-		var tfMap map[string]map[string]string
-		resp.Diagnostics.Append(plan.RegionalParameters.ElementsAs(ctx, &tfMap, false)...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-
-		in.RegionalParameters = tfMap
-	}
-
-	out, err := conn.PutEnvironmentBlueprintConfiguration(ctx, in)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("creating DataZone Environment Blueprint Configuration (%s/%s)", domainID, environmentBlueprintID), err.Error())
+
 		return
 	}
 
-	if out == nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.DataZone, create.ErrActionCreating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), nil),
-			errors.New("empty output").Error(),
-		)
-		return
-	}
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
+	response.Diagnostics.Append(response.State.Set(ctx, data)...)
 }
 
-func (r *environmentBlueprintConfigurationResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	conn := r.Meta().DataZoneClient(ctx)
-
-	var state environmentBlueprintConfigurationResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+func (r *environmentBlueprintConfigurationResource) Read(ctx context.Context, request resource.ReadRequest, response *resource.ReadResponse) {
+	var data environmentBlueprintConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	out, err := findEnvironmentBlueprintConfigurationByIDs(ctx, conn, state.DomainId.ValueString(), state.EnvironmentBlueprintId.ValueString())
+	conn := r.Meta().DataZoneClient(ctx)
+
+	domainID, environmentBlueprintID := fwflex.StringValueFromFramework(ctx, data.DomainIdentifier), fwflex.StringValueFromFramework(ctx, data.EnvironmentBlueprintIdentifier)
+	output, err := findEnvironmentBlueprintConfigurationByTwoPartKey(ctx, conn, domainID, environmentBlueprintID)
+
 	if tfresource.NotFound(err) {
-		resp.State.RemoveResource(ctx)
+		response.Diagnostics.Append(fwdiag.NewResourceNotFoundWarningDiagnostic(err))
+		response.State.RemoveResource(ctx)
+
 		return
 	}
+
 	if err != nil {
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.DataZone, create.ErrActionSetting, ResNameEnvironmentBlueprintConfiguration, state.EnvironmentBlueprintId.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("reading DataZone Environment Blueprint Configuration (%s/%s)", domainID, environmentBlueprintID), err.Error())
+
 		return
 	}
 
-	state.DomainId = flex.StringToFramework(ctx, out.DomainId)
-	state.EnabledRegions = flex.FlattenFrameworkStringValueListOfStringLegacy(ctx, out.EnabledRegions)
-	state.EnvironmentBlueprintId = flex.StringToFramework(ctx, out.EnvironmentBlueprintId)
-	state.ManageAccessRoleArn = flex.StringToFrameworkARN(ctx, out.ManageAccessRoleArn)
-	state.ProvisioningRoleArn = flex.StringToFrameworkARN(ctx, out.ProvisioningRoleArn)
+	// Set attributes for import.
+	response.Diagnostics.Append(fwflex.Flatten(ctx, output, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
 
-	regionalParameters, d := flattenRegionalParameters(ctx, &out.RegionalParameters)
-	resp.Diagnostics.Append(d...)
-	state.RegionalParameters = fwtypes.MapValueOf[types.String]{MapValue: regionalParameters}
+	data.DomainIdentifier = fwflex.StringToFramework(ctx, output.DomainId)
+	data.EnvironmentBlueprintIdentifier = fwflex.StringToFramework(ctx, output.EnvironmentBlueprintId)
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-func (r *environmentBlueprintConfigurationResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *environmentBlueprintConfigurationResource) Update(ctx context.Context, request resource.UpdateRequest, response *resource.UpdateResponse) {
+	var data environmentBlueprintConfigurationResourceModel
+	response.Diagnostics.Append(request.Plan.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().DataZoneClient(ctx)
 
-	var plan, state environmentBlueprintConfigurationResourceModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	domainID, environmentBlueprintID := fwflex.StringValueFromFramework(ctx, data.DomainIdentifier), fwflex.StringValueFromFramework(ctx, data.EnvironmentBlueprintIdentifier)
+	var input datazone.PutEnvironmentBlueprintConfigurationInput
+	response.Diagnostics.Append(fwflex.Expand(ctx, data, &input)...)
+	if response.Diagnostics.HasError() {
 		return
 	}
 
-	if !plan.EnabledRegions.Equal(state.EnabledRegions) ||
-		!plan.ManageAccessRoleArn.Equal(state.ManageAccessRoleArn) ||
-		!plan.ProvisioningRoleArn.Equal(state.ProvisioningRoleArn) ||
-		!plan.RegionalParameters.Equal(state.RegionalParameters) {
-		in := &datazone.PutEnvironmentBlueprintConfigurationInput{
-			DomainIdentifier:               plan.DomainId.ValueStringPointer(),
-			EnabledRegions:                 flex.ExpandFrameworkStringValueList(ctx, plan.EnabledRegions),
-			EnvironmentBlueprintIdentifier: plan.EnvironmentBlueprintId.ValueStringPointer(),
-		}
+	_, err := conn.PutEnvironmentBlueprintConfiguration(ctx, &input)
 
-		if !plan.ManageAccessRoleArn.IsNull() {
-			in.ManageAccessRoleArn = plan.ManageAccessRoleArn.ValueStringPointer()
-		}
+	if err != nil {
+		response.Diagnostics.AddError(fmt.Sprintf("updating DataZone Environment Blueprint Configuration (%s/%s)", domainID, environmentBlueprintID), err.Error())
 
-		if !plan.ProvisioningRoleArn.IsNull() {
-			in.ProvisioningRoleArn = plan.ProvisioningRoleArn.ValueStringPointer()
-		}
-
-		if !plan.RegionalParameters.IsNull() {
-			var tfMap map[string]map[string]string
-			resp.Diagnostics.Append(plan.RegionalParameters.ElementsAs(ctx, &tfMap, false)...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-
-			in.RegionalParameters = tfMap
-		}
-
-		out, err := conn.PutEnvironmentBlueprintConfiguration(ctx, in)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), err),
-				err.Error(),
-			)
-			return
-		}
-		if out == nil {
-			resp.Diagnostics.AddError(
-				create.ProblemStandardMessage(names.DataZone, create.ErrActionUpdating, ResNameEnvironmentBlueprintConfiguration, plan.EnvironmentBlueprintId.String(), nil),
-				errors.New("empty output").Error(),
-			)
-			return
-		}
+		return
 	}
 
-	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+	response.Diagnostics.Append(response.State.Set(ctx, &data)...)
 }
 
-func (r *environmentBlueprintConfigurationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+func (r *environmentBlueprintConfigurationResource) Delete(ctx context.Context, request resource.DeleteRequest, response *resource.DeleteResponse) {
+	var data environmentBlueprintConfigurationResourceModel
+	response.Diagnostics.Append(request.State.Get(ctx, &data)...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
 	conn := r.Meta().DataZoneClient(ctx)
 
-	var state environmentBlueprintConfigurationResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	domainID, environmentBlueprintID := fwflex.StringValueFromFramework(ctx, data.DomainIdentifier), fwflex.StringValueFromFramework(ctx, data.EnvironmentBlueprintIdentifier)
+	input := datazone.DeleteEnvironmentBlueprintConfigurationInput{
+		DomainIdentifier:               aws.String(domainID),
+		EnvironmentBlueprintIdentifier: aws.String(environmentBlueprintID),
+	}
+
+	_, err := conn.DeleteEnvironmentBlueprintConfiguration(ctx, &input)
+
+	if isResourceMissing(err) {
 		return
 	}
 
-	in := &datazone.DeleteEnvironmentBlueprintConfigurationInput{
-		DomainIdentifier:               state.DomainId.ValueStringPointer(),
-		EnvironmentBlueprintIdentifier: state.EnvironmentBlueprintId.ValueStringPointer(),
-	}
-
-	_, err := conn.DeleteEnvironmentBlueprintConfiguration(ctx, in)
 	if err != nil {
-		if isResourceMissing(err) {
-			return
-		}
-		resp.Diagnostics.AddError(
-			create.ProblemStandardMessage(names.DataZone, create.ErrActionDeleting, ResNameEnvironmentBlueprintConfiguration, state.EnvironmentBlueprintId.String(), err),
-			err.Error(),
-		)
+		response.Diagnostics.AddError(fmt.Sprintf("deleting DataZone Environment Blueprint Configuration (%s/%s)", domainID, environmentBlueprintID), err.Error())
+
 		return
 	}
 }
 
-func (r *environmentBlueprintConfigurationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	parts := strings.Split(req.ID, "/")
-	if len(parts) != 2 {
-		resp.Diagnostics.AddError("Resource Import Invalid ID", fmt.Sprintf("Wrong format for import ID (%s), use: 'domain-id/environment-blueprint-id'", req.ID))
+func (r *environmentBlueprintConfigurationResource) ImportState(ctx context.Context, request resource.ImportStateRequest, response *resource.ImportStateResponse) {
+	const (
+		environmentBlueprintConfigurationIDParts     = 2
+		environmentBlueprintConfigurationIDSeparator = "/"
+	)
+	parts := strings.Split(request.ID, environmentBlueprintConfigurationIDSeparator)
+	if len(parts) != environmentBlueprintConfigurationIDParts {
+		err := fmt.Errorf("unexpected format for ID (%[1]s), expected DOMAIN-ID%[2]sENVIRONMENT-BLUEPRINT-ID", request.ID, environmentBlueprintConfigurationIDSeparator)
+		response.Diagnostics.Append(fwdiag.NewParsingResourceIDErrorDiagnostic(err))
+
 		return
 	}
-	domainId := parts[0]
-	environmentBlueprintId := parts[1]
 
-	environmentBlueprintConfiguration, err := findEnvironmentBlueprintConfigurationByIDs(ctx, r.Meta().DataZoneClient(ctx), domainId, environmentBlueprintId)
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Importing Resource",
-			err.Error(),
-		)
-	}
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("domain_id"), aws.ToString(environmentBlueprintConfiguration.DomainId))...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("environment_blueprint_id"), aws.ToString(environmentBlueprintConfiguration.EnvironmentBlueprintId))...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("domain_id"), parts[0])...)
+	response.Diagnostics.Append(response.State.SetAttribute(ctx, path.Root("environment_blueprint_id"), parts[1])...)
 }
 
-func findEnvironmentBlueprintConfigurationByIDs(ctx context.Context, conn *datazone.Client, domainId, environmentBlueprintId string) (*datazone.GetEnvironmentBlueprintConfigurationOutput, error) {
-	in := &datazone.GetEnvironmentBlueprintConfigurationInput{
-		DomainIdentifier:               aws.String(domainId),
-		EnvironmentBlueprintIdentifier: aws.String(environmentBlueprintId),
+func findEnvironmentBlueprintConfigurationByTwoPartKey(ctx context.Context, conn *datazone.Client, domainID, environmentBlueprintID string) (*datazone.GetEnvironmentBlueprintConfigurationOutput, error) {
+	input := datazone.GetEnvironmentBlueprintConfigurationInput{
+		DomainIdentifier:               aws.String(domainID),
+		EnvironmentBlueprintIdentifier: aws.String(environmentBlueprintID),
+	}
+	output, err := conn.GetEnvironmentBlueprintConfiguration(ctx, &input)
+
+	if isResourceMissing(err) {
+		return nil, &retry.NotFoundError{
+			LastError:   err,
+			LastRequest: input,
+		}
 	}
 
-	out, err := conn.GetEnvironmentBlueprintConfiguration(ctx, in)
 	if err != nil {
-		if isResourceMissing(err) {
-			return nil, &retry.NotFoundError{
-				LastError:   err,
-				LastRequest: in,
-			}
-		}
-
 		return nil, err
 	}
 
-	if out == nil {
-		return nil, tfresource.NewEmptyResultError(in)
+	if output == nil {
+		return nil, tfresource.NewEmptyResultError(input)
 	}
 
-	return out, nil
-}
-
-func flattenRegionalParameters(ctx context.Context, apiObject *map[string]map[string]string) (types.Map, diag.Diagnostics) {
-	var diags diag.Diagnostics
-	elemType := types.MapType{ElemType: types.StringType}
-
-	if apiObject == nil || len(*apiObject) == 0 {
-		return types.MapNull(elemType), diags
-	}
-
-	elements := map[string]types.Map{}
-
-	for k, v := range *apiObject {
-		elements[k] = flex.FlattenFrameworkStringValueMap(ctx, v)
-	}
-
-	mapVal, d := types.MapValueFrom(ctx, types.MapType{ElemType: types.StringType}, elements)
-	diags.Append(d...)
-
-	return mapVal, diags
+	return output, nil
 }
 
 type environmentBlueprintConfigurationResourceModel struct {
 	framework.WithRegionModel
-	DomainId               types.String         `tfsdk:"domain_id"`
-	EnabledRegions         fwtypes.ListOfString `tfsdk:"enabled_regions"`
-	EnvironmentBlueprintId types.String         `tfsdk:"environment_blueprint_id"`
-	ManageAccessRoleArn    fwtypes.ARN          `tfsdk:"manage_access_role_arn"`
-	ProvisioningRoleArn    fwtypes.ARN          `tfsdk:"provisioning_role_arn"`
-	RegionalParameters     fwtypes.MapOfString  `tfsdk:"regional_parameters"`
+	DomainIdentifier               types.String             `tfsdk:"domain_id"`
+	EnabledRegions                 fwtypes.ListOfString     `tfsdk:"enabled_regions"`
+	EnvironmentBlueprintIdentifier types.String             `tfsdk:"environment_blueprint_id"`
+	ManageAccessRoleARN            fwtypes.ARN              `tfsdk:"manage_access_role_arn"`
+	ProvisioningRoleARN            fwtypes.ARN              `tfsdk:"provisioning_role_arn"`
+	RegionalParameters             fwtypes.MapOfMapOfString `tfsdk:"regional_parameters"`
 }

--- a/internal/service/datazone/environment_blueprint_configuration_test.go
+++ b/internal/service/datazone/environment_blueprint_configuration_test.go
@@ -5,11 +5,9 @@ package datazone_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/datazone"
 	"github.com/hashicorp/aws-sdk-go-base/v2/endpoints"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -17,14 +15,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
 	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
+	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccDataZoneEnvironmentBlueprintConfiguration_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -59,7 +56,6 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_basic(t *testing.T) {
 
 func TestAccDataZoneEnvironmentBlueprintConfiguration_disappears(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -87,7 +83,6 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_disappears(t *testing.T) {
 
 func TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -130,37 +125,8 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions(t *testing
 	})
 }
 
-func testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_datazone_environment_blueprint_configuration" {
-				continue
-			}
-
-			input := datazone.GetEnvironmentBlueprintConfigurationInput{
-				DomainIdentifier:               aws.String(rs.Primary.Attributes["domain_id"]),
-				EnvironmentBlueprintIdentifier: aws.String(rs.Primary.Attributes["environment_blueprint_id"]),
-			}
-			_, err := conn.GetEnvironmentBlueprintConfiguration(ctx, &input)
-			if tfdatazone.IsResourceMissing(err) {
-				return nil
-			}
-			if err != nil {
-				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
-			}
-
-			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, errors.New("not destroyed"))
-		}
-
-		return nil
-	}
-}
-
 func TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -195,7 +161,6 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn(t *
 
 func TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -230,7 +195,6 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn(t *t
 
 func TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters(t *testing.T) {
 	ctx := acctest.Context(t)
-
 	var environmentblueprintconfiguration datazone.GetEnvironmentBlueprintConfigurationOutput
 	domainName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	resourceName := "aws_datazone_environment_blueprint_configuration.test"
@@ -275,39 +239,58 @@ func TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters(t *tes
 	})
 }
 
-func testAccCheckEnvironmentBlueprintConfigurationExists(ctx context.Context, name string, environmentblueprintconfiguration *datazone.GetEnvironmentBlueprintConfigurationOutput) resource.TestCheckFunc {
+func testAccCheckEnvironmentBlueprintConfigurationDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, name, errors.New("not set"))
-		}
-
 		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
-		input := datazone.GetEnvironmentBlueprintConfigurationInput{
-			DomainIdentifier:               aws.String(rs.Primary.Attributes["domain_id"]),
-			EnvironmentBlueprintIdentifier: aws.String(rs.Primary.Attributes["environment_blueprint_id"]),
-		}
-		resp, err := conn.GetEnvironmentBlueprintConfiguration(ctx, &input)
 
-		if err != nil {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
-		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_datazone_environment_blueprint_configuration" {
+				continue
+			}
 
-		*environmentblueprintconfiguration = *resp
+			_, err := tfdatazone.FindEnvironmentBlueprintConfigurationByTwoPartKey(ctx, conn, rs.Primary.Attributes["domain_id"], rs.Primary.Attributes["environment_blueprint_id"])
+
+			if tfresource.NotFound(err) {
+				continue
+			}
+
+			if err != nil {
+				return err
+			}
+
+			return fmt.Errorf("DataZone Environment Blueprint Configuration %s/%s still exists", rs.Primary.Attributes["domain_id"], rs.Primary.Attributes["environment_blueprint_id"])
+		}
 
 		return nil
 	}
 }
 
-func testAccEnvironmentBlueprintConfigurationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[resourceName]
+func testAccCheckEnvironmentBlueprintConfigurationExists(ctx context.Context, n string, v *datazone.GetEnvironmentBlueprintConfigurationOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return "", fmt.Errorf("Not found: %s", resourceName)
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
+
+		output, err := tfdatazone.FindEnvironmentBlueprintConfigurationByTwoPartKey(ctx, conn, rs.Primary.Attributes["domain_id"], rs.Primary.Attributes["environment_blueprint_id"])
+
+		if err != nil {
+			return err
+		}
+
+		*v = *output
+
+		return nil
+	}
+}
+
+func testAccEnvironmentBlueprintConfigurationImportStateIdFunc(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", n)
 		}
 
 		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["domain_id"], rs.Primary.Attributes["environment_blueprint_id"]), nil

--- a/internal/service/datazone/environment_blueprint_data_source_test.go
+++ b/internal/service/datazone/environment_blueprint_data_source_test.go
@@ -4,26 +4,16 @@
 package datazone_test
 
 import (
-	"context"
-	"errors"
 	"testing"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/datazone"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
-	"github.com/hashicorp/terraform-provider-aws/internal/conns"
-	"github.com/hashicorp/terraform-provider-aws/internal/create"
-	tfdatazone "github.com/hashicorp/terraform-provider-aws/internal/service/datazone"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
 func TestAccDataZoneEnvironmentBlueprintDataSource_basic(t *testing.T) {
 	ctx := acctest.Context(t)
-
-	var environmentblueprint datazone.GetEnvironmentBlueprintOutput
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
 	dataSourceName := "data.aws_datazone_environment_blueprint.test"
 
@@ -34,74 +24,16 @@ func TestAccDataZoneEnvironmentBlueprintDataSource_basic(t *testing.T) {
 		},
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataZoneServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckEnvironmentBlueprintDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccEnvironmentBlueprintDataSourceConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckEnvironmentBlueprintExists(ctx, dataSourceName, &environmentblueprint),
 					resource.TestCheckResourceAttrSet(dataSourceName, names.AttrID),
 					resource.TestCheckResourceAttrSet(dataSourceName, "blueprint_provider"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckEnvironmentBlueprintExists(ctx context.Context, name string, environmentblueprint *datazone.GetEnvironmentBlueprintOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, name, errors.New("not found"))
-		}
-
-		if rs.Primary.ID == "" {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, name, errors.New("not set"))
-		}
-
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
-		input := datazone.GetEnvironmentBlueprintInput{
-			DomainIdentifier: aws.String(rs.Primary.Attributes["domain_id"]),
-			Identifier:       aws.String(rs.Primary.Attributes[names.AttrID]),
-		}
-		resp, err := conn.GetEnvironmentBlueprint(ctx, &input)
-
-		if err != nil {
-			return create.Error(names.DataZone, create.ErrActionCheckingExistence, tfdatazone.DSNameEnvironmentBlueprint, rs.Primary.ID, err)
-		}
-
-		*environmentblueprint = *resp
-
-		return nil
-	}
-}
-
-func testAccCheckEnvironmentBlueprintDestroy(ctx context.Context) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		conn := acctest.Provider.Meta().(*conns.AWSClient).DataZoneClient(ctx)
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "aws_datazone_environment_blueprint" {
-				continue
-			}
-
-			input := datazone.GetEnvironmentBlueprintInput{
-				DomainIdentifier: aws.String(rs.Primary.Attributes["domain_id"]),
-				Identifier:       aws.String(rs.Primary.Attributes[names.AttrID]),
-			}
-			_, err := conn.GetEnvironmentBlueprint(ctx, &input)
-			if tfdatazone.IsResourceMissing(err) {
-				return nil
-			}
-			if err != nil {
-				return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, err)
-			}
-
-			return create.Error(names.DataZone, create.ErrActionCheckingDestroyed, tfdatazone.ResNameEnvironmentBlueprintConfiguration, rs.Primary.ID, errors.New("not destroyed"))
-		}
-
-		return nil
-	}
 }
 
 func testAccEnvironmentBlueprintDataSourceConfig_basic(rName string) string {

--- a/internal/service/datazone/errors.go
+++ b/internal/service/datazone/errors.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ErrorCodeAccessDenied = "AccessDeniedException"
+	errCodeAccessDenied = "AccessDeniedException"
 )
 
 func isResourceMissing(err error) bool {

--- a/internal/service/datazone/exports_test.go
+++ b/internal/service/datazone/exports_test.go
@@ -16,14 +16,15 @@ var (
 	ResourceProject                           = newProjectResource
 	ResourceUserProfile                       = newUserProfileResource
 
-	FindAssetTypeByID          = findAssetTypeByID
-	FindDomainByID             = findDomainByID
-	FindEnvironmentByID        = findEnvironmentByID
-	FindEnvironmentProfileByID = findEnvironmentProfileByID
-	FindFormTypeByID           = findFormTypeByID
-	FindGlossaryByID           = findGlossaryByID
-	FindGlossaryTermByID       = findGlossaryTermByID
-	FindUserProfileByID        = findUserProfileByID
+	FindAssetTypeByID                                 = findAssetTypeByID
+	FindDomainByID                                    = findDomainByID
+	FindEnvironmentBlueprintConfigurationByTwoPartKey = findEnvironmentBlueprintConfigurationByTwoPartKey
+	FindEnvironmentByID                               = findEnvironmentByID
+	FindEnvironmentProfileByID                        = findEnvironmentProfileByID
+	FindFormTypeByID                                  = findFormTypeByID
+	FindGlossaryByID                                  = findGlossaryByID
+	FindGlossaryTermByID                              = findGlossaryTermByID
+	FindUserProfileByID                               = findUserProfileByID
 
 	IsResourceMissing = isResourceMissing
 )


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Fixes a **v6.0.0** regression in the `aws_datazone_environment_blueprint_configuration` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes https://github.com/hashicorp/terraform-provider-aws/issues/43316.

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTARGS='-run=TestAccBCMDataExportsExport_basic' PKG=bcmdataexports
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/bcmdataexports/... -v -count 1 -parallel 20  -run=TestAccBCMDataExportsExport_basic -timeout 360m -vet=off
2025/07/15 09:29:36 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 09:29:36 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccBCMDataExportsExport_basic
=== PAUSE TestAccBCMDataExportsExport_basic
=== CONT  TestAccBCMDataExportsExport_basic
--- PASS: TestAccBCMDataExportsExport_basic (19.48s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/bcmdataexports	24.429s
```
```console
% make testacc TESTARGS='-run=TestAccDataZoneEnvironmentBlueprintConfiguration_' PKG=datazone ACCTEST_PARALLELISM=3
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/datazone/... -v -count 1 -parallel 3  -run=TestAccDataZoneEnvironmentBlueprintConfiguration_ -timeout 360m -vet=off
2025/07/15 09:40:29 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 09:40:29 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
=== RUN   TestAccDataZoneEnvironmentBlueprintConfiguration_upgradeFromV5_100_0
=== PAUSE TestAccDataZoneEnvironmentBlueprintConfiguration_upgradeFromV5_100_0
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_basic
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_upgradeFromV5_100_0
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_manage_access_role_arn (29.00s)
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_basic (29.09s)
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_enabled_regions (39.45s)
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_regional_parameters (39.70s)
=== CONT  TestAccDataZoneEnvironmentBlueprintConfiguration_disappears
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_upgradeFromV5_100_0 (93.67s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_disappears (26.11s)
--- PASS: TestAccDataZoneEnvironmentBlueprintConfiguration_provisioning_role_arn (27.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/datazone	101.160s
```
