### PR TITLE
internal/generate/tagstests: enable go-vcr support

### DIFF
--- a/internal/generate/tagstests/data_source_test.go.gtpl
+++ b/internal/generate/tagstests/data_source_test.go.gtpl
@@ -11,7 +11,7 @@
 {{ end }}
 
 {{ define "Test" -}}
-resource.{{ if and .Serialize (not .SerializeParallelTests) }}Test{{ else }}ParallelTest{{ end }}
+acctest.{{ if and .Serialize (not .SerializeParallelTests) }}Test{{ else }}ParallelTest{{ end }}
 {{- end }}
 
 {{ define "TestCaseSetup" -}}
@@ -133,7 +133,7 @@ func {{ template "testname" . }}_tagsSerial(t *testing.T) {
 func {{ template "testname" . }}_tags(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -161,7 +161,7 @@ func {{ template "testname" . }}_tags(t *testing.T) {
 func {{ template "testname" . }}_tags_NullMap(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -185,7 +185,7 @@ func {{ template "testname" . }}_tags_NullMap(t *testing.T) {
 func {{ template "testname" . }}_tags_EmptyMap(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -209,7 +209,7 @@ func {{ template "testname" . }}_tags_EmptyMap(t *testing.T) {
 func {{ template "testname" . }}_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -243,7 +243,7 @@ func {{ template "testname" . }}_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func {{ template "testname" . }}_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -283,7 +283,7 @@ func {{ template "testname" . }}_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func {{ template "testname" . }}_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{

--- a/internal/generate/tagstests/main.go
+++ b/internal/generate/tagstests/main.go
@@ -851,12 +851,8 @@ func (v *visitor) processFuncDecl(funcDecl *ast.FuncDecl) {
 				return
 			}
 			if !generatorSeen {
-				d.Generator = "sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)"
+				d.Generator = "acctest.RandomWithPrefix(t, acctest.ResourcePrefix)"
 				d.GoImports = append(d.GoImports,
-					goImport{
-						Path:  "github.com/hashicorp/terraform-plugin-testing/helper/acctest",
-						Alias: "sdkacctest",
-					},
 					goImport{
 						Path: "github.com/hashicorp/terraform-provider-aws/internal/acctest",
 					},

--- a/internal/generate/tagstests/resource_test.go.gtpl
+++ b/internal/generate/tagstests/resource_test.go.gtpl
@@ -14,7 +14,7 @@
 {{ end }}
 
 {{ define "Test" -}}
-resource.{{ if and .Serialize (not .SerializeParallelTests) }}Test{{ else }}ParallelTest{{ end }}
+acctest.{{ if and .Serialize (not .SerializeParallelTests) }}Test{{ else }}ParallelTest{{ end }}
 {{- end }}
 
 {{ define "TestCaseSetup" -}}
@@ -193,7 +193,7 @@ func {{ template "testname" . }}_tagsSerial(t *testing.T) {
 func {{ template "testname" . }}_tags(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -416,7 +416,7 @@ func {{ template "testname" . }}_tags_null(t *testing.T) {
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -509,7 +509,7 @@ func {{ template "testname" . }}_tags_null(t *testing.T) {
 func {{ template "testname" . }}_tags_EmptyMap(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -590,7 +590,7 @@ func {{ template "testname" . }}_tags_EmptyMap(t *testing.T) {
 func {{ template "testname" . }}_tags_AddOnUpdate(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -684,7 +684,7 @@ func {{ template "testname" . }}_tags_EmptyTag_OnCreate(t *testing.T) {
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -792,7 +792,7 @@ func {{ template "testname" . }}_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -953,7 +953,7 @@ func {{ template "testname" . }}_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetup" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1054,7 +1054,7 @@ func {{ template "testname" . }}_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func {{ template "testname" . }}_tags_DefaultTags_providerOnly(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1282,7 +1282,7 @@ func {{ template "testname" . }}_tags_DefaultTags_providerOnly(t *testing.T) {
 func {{ template "testname" . }}_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1473,7 +1473,7 @@ func {{ template "testname" . }}_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func {{ template "testname" . }}_tags_DefaultTags_overlapping(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1674,7 +1674,7 @@ func {{ template "testname" . }}_tags_DefaultTags_overlapping(t *testing.T) {
 func {{ template "testname" . }}_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1774,7 +1774,7 @@ func {{ template "testname" . }}_tags_DefaultTags_updateToProviderOnly(t *testin
 func {{ template "testname" . }}_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1876,7 +1876,7 @@ func {{ template "testname" . }}_tags_DefaultTags_emptyResourceTag(t *testing.T)
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -1955,7 +1955,7 @@ func {{ template "testname" . }}_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2026,7 +2026,7 @@ func {{ template "testname" . }}_tags_DefaultTags_nullOverlappingResourceTag(t *
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2114,7 +2114,7 @@ func {{ template "testname" . }}_tags_DefaultTags_nullNonOverlappingResourceTag(
 {{ end }}
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2201,7 +2201,7 @@ func {{ template "testname" . }}_tags_DefaultTags_nullNonOverlappingResourceTag(
 func {{ template "testname" . }}_tags_ComputedTag_OnCreate(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2261,7 +2261,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnCreate(t *testing.T) {
 func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2368,7 +2368,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			{
@@ -2465,7 +2465,7 @@ func {{ template "testname" . }}_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func {{ template "testname" . }}_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			// 1: Create
@@ -2637,7 +2637,7 @@ func {{ template "testname" . }}_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func {{ template "testname" . }}_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	{{- template "Init" . }}
 
-	{{ template "Test" . }}(t, resource.TestCase{
+	{{ template "Test" . }}(ctx, t, resource.TestCase{
 		{{ template "TestCaseSetupNoProviders" . }}
 		Steps: []resource.TestStep{
 			// 1: Create

--- a/internal/service/accessanalyzer/analyzer_tags_gen_test.go
+++ b/internal/service/accessanalyzer/analyzer_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAccessAnalyzerAnalyzer_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -235,9 +234,9 @@ func testAccAccessAnalyzerAnalyzer_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -305,9 +304,9 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -371,9 +370,9 @@ func testAccAccessAnalyzerAnalyzer_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -455,9 +454,9 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -547,9 +546,9 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -687,9 +686,9 @@ func testAccAccessAnalyzerAnalyzer_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -779,9 +778,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -963,9 +962,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nonOverlapping(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1126,9 +1125,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1305,9 +1304,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToProviderOnly(t *test
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1398,9 +1397,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_updateToResourceOnly(t *test
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1490,9 +1489,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1558,9 +1557,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_emptyProviderOnlyTag(t *test
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1618,9 +1617,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1683,9 +1682,9 @@ func testAccAccessAnalyzerAnalyzer_tags_DefaultTags_nullNonOverlappingResourceTa
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1748,9 +1747,9 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1806,9 +1805,9 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1906,9 +1905,9 @@ func testAccAccessAnalyzerAnalyzer_tags_ComputedTag_OnUpdate_Replace(t *testing.
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1996,9 +1995,9 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -2161,9 +2160,9 @@ func testAccAccessAnalyzerAnalyzer_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v types.AnalyzerSummary
 	resourceName := "aws_accessanalyzer_analyzer.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)

--- a/internal/service/acm/certificate_data_source_tags_gen_test.go
+++ b/internal/service/acm/certificate_data_source_tags_gen_test.go
@@ -20,7 +20,7 @@ func TestAccACMCertificateDataSource_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -50,7 +50,7 @@ func TestAccACMCertificateDataSource_tags_NullMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -76,7 +76,7 @@ func TestAccACMCertificateDataSource_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -102,7 +102,7 @@ func TestAccACMCertificateDataSource_tags_DefaultTags_nonOverlapping(t *testing.
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMServiceID),
 		Steps: []resource.TestStep{
@@ -136,7 +136,7 @@ func TestAccACMCertificateDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMServiceID),
 		Steps: []resource.TestStep{
@@ -176,7 +176,7 @@ func TestAccACMCertificateDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *test
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/acm/certificate_tags_gen_test.go
+++ b/internal/service/acm/certificate_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccACMCertificate_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -226,7 +226,7 @@ func TestAccACMCertificate_tags_null(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -300,7 +300,7 @@ func TestAccACMCertificate_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -370,7 +370,7 @@ func TestAccACMCertificate_tags_AddOnUpdate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -458,7 +458,7 @@ func TestAccACMCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -558,7 +558,7 @@ func TestAccACMCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -707,7 +707,7 @@ func TestAccACMCertificate_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -803,7 +803,7 @@ func TestAccACMCertificate_tags_DefaultTags_providerOnly(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1005,7 +1005,7 @@ func TestAccACMCertificate_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1181,7 +1181,7 @@ func TestAccACMCertificate_tags_DefaultTags_overlapping(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1373,7 +1373,7 @@ func TestAccACMCertificate_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1470,7 +1470,7 @@ func TestAccACMCertificate_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1566,7 +1566,7 @@ func TestAccACMCertificate_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1637,7 +1637,7 @@ func TestAccACMCertificate_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1700,7 +1700,7 @@ func TestAccACMCertificate_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1768,7 +1768,7 @@ func TestAccACMCertificate_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1836,7 +1836,7 @@ func TestAccACMCertificate_tags_ComputedTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1897,7 +1897,7 @@ func TestAccACMCertificate_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -2001,7 +2001,7 @@ func TestAccACMCertificate_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -2095,7 +2095,7 @@ func TestAccACMCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -2261,7 +2261,7 @@ func TestAccACMCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),

--- a/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccACMPCACertificateAuthorityDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccACMPCACertificateAuthorityDataSource_tags(t *testing.T) {
 func TestAccACMPCACertificateAuthorityDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccACMPCACertificateAuthorityDataSource_tags_NullMap(t *testing.T) {
 func TestAccACMPCACertificateAuthorityDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccACMPCACertificateAuthorityDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccACMPCACertificateAuthorityDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccACMPCACertificateAuthorityDataSource_tags_DefaultTags_nonOverlapping
 func TestAccACMPCACertificateAuthorityDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccACMPCACertificateAuthorityDataSource_tags_IgnoreTags_Overlap_Default
 func TestAccACMPCACertificateAuthorityDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_acmpca_certificate_authority.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/acmpca/certificate_authority_tags_gen_test.go
+++ b/internal/service/acmpca/certificate_authority_tags_gen_test.go
@@ -22,7 +22,7 @@ func TestAccACMPCACertificateAuthority_tags(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -216,7 +216,7 @@ func TestAccACMPCACertificateAuthority_tags_null(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -286,7 +286,7 @@ func TestAccACMPCACertificateAuthority_tags_EmptyMap(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -352,7 +352,7 @@ func TestAccACMPCACertificateAuthority_tags_AddOnUpdate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -436,7 +436,7 @@ func TestAccACMPCACertificateAuthority_tags_EmptyTag_OnCreate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -531,7 +531,7 @@ func TestAccACMPCACertificateAuthority_tags_EmptyTag_OnUpdate_Add(t *testing.T) 
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -674,7 +674,7 @@ func TestAccACMPCACertificateAuthority_tags_EmptyTag_OnUpdate_Replace(t *testing
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy:             testAccCheckCertificateAuthorityDestroy(ctx),
@@ -766,7 +766,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_providerOnly(t *testing.
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -959,7 +959,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_nonOverlapping(t *testin
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1128,7 +1128,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_overlapping(t *testing.T
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1313,7 +1313,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_updateToProviderOnly(t *
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1406,7 +1406,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_updateToResourceOnly(t *
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1498,7 +1498,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_emptyResourceTag(t *test
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1566,7 +1566,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_emptyProviderOnlyTag(t *
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1626,7 +1626,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_nullOverlappingResourceT
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1691,7 +1691,7 @@ func TestAccACMPCACertificateAuthority_tags_DefaultTags_nullNonOverlappingResour
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1756,7 +1756,7 @@ func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnCreate(t *testing.T) {
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1814,7 +1814,7 @@ func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnUpdate_Add(t *testing.
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -1914,7 +1914,7 @@ func TestAccACMPCACertificateAuthority_tags_ComputedTag_OnUpdate_Replace(t *test
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -2004,7 +2004,7 @@ func TestAccACMPCACertificateAuthority_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),
@@ -2166,7 +2166,7 @@ func TestAccACMPCACertificateAuthority_tags_IgnoreTags_Overlap_ResourceTag(t *te
 	resourceName := "aws_acmpca_certificate_authority.test"
 	rName := acctest.RandomDomainName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ACMPCAServiceID),
 		CheckDestroy: testAccCheckCertificateAuthorityDestroy(ctx),

--- a/internal/service/amp/rule_group_namespace_tags_gen_test.go
+++ b/internal/service/amp/rule_group_namespace_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/amp/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAMPRuleGroupNamespace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAMPRuleGroupNamespace_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAMPRuleGroupNamespace_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAMPRuleGroupNamespace_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAMPRuleGroupNamespace_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAMPRuleGroupNamespace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAMPRuleGroupNamespace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAMPRuleGroupNamespace_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAMPRuleGroupNamespace_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAMPRuleGroupNamespace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAMPRuleGroupNamespace_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAMPRuleGroupNamespace_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAMPRuleGroupNamespace_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.RuleGroupsNamespaceDescription
 	resourceName := "aws_prometheus_rule_group_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckRuleGroupNamespaceDestroy(ctx),

--- a/internal/service/amp/scraper_tags_gen_test.go
+++ b/internal/service/amp/scraper_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/amp/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAMPScraper_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAMPScraper_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccAMPScraper_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccAMPScraper_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccAMPScraper_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccAMPScraper_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccAMPScraper_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckScraperDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccAMPScraper_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccAMPScraper_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccAMPScraper_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccAMPScraper_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccAMPScraper_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccAMPScraper_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccAMPScraper_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccAMPScraper_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccAMPScraper_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccAMPScraper_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccAMPScraper_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccAMPScraper_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccAMPScraper_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccAMPScraper_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ScraperDescription
 	resourceName := "aws_prometheus_scraper.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckScraperDestroy(ctx),

--- a/internal/service/amp/workspace_data_source_tags_gen_test.go
+++ b/internal/service/amp/workspace_data_source_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccAMPWorkspaceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -49,7 +49,7 @@ func TestAccAMPWorkspaceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccAMPWorkspaceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -93,7 +93,7 @@ func TestAccAMPWorkspaceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T)
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AMPServiceID),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccAMPWorkspaceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AMPServiceID),
 		Steps: []resource.TestStep{
@@ -159,7 +159,7 @@ func TestAccAMPWorkspaceDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AMPServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/amp/workspace_tags_gen_test.go
+++ b/internal/service/amp/workspace_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccAMPWorkspace_tags(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccAMPWorkspace_tags_null(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccAMPWorkspace_tags_EmptyMap(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccAMPWorkspace_tags_AddOnUpdate(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccAMPWorkspace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy:             testAccCheckWorkspaceDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_overlapping(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccAMPWorkspace_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccAMPWorkspace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccAMPWorkspace_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccAMPWorkspace_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v types.WorkspaceDescription
 	resourceName := "aws_prometheus_workspace.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AMPServiceID),
 		CheckDestroy: testAccCheckWorkspaceDestroy(ctx),

--- a/internal/service/amplify/app_tags_gen_test.go
+++ b/internal/service/amplify/app_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAmplifyApp_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -232,9 +231,9 @@ func testAccAmplifyApp_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -299,9 +298,9 @@ func testAccAmplifyApp_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -362,9 +361,9 @@ func testAccAmplifyApp_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -443,9 +442,9 @@ func testAccAmplifyApp_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -532,9 +531,9 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -669,9 +668,9 @@ func testAccAmplifyApp_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckAppDestroy(ctx),
@@ -758,9 +757,9 @@ func testAccAmplifyApp_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -939,9 +938,9 @@ func testAccAmplifyApp_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1099,9 +1098,9 @@ func testAccAmplifyApp_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1275,9 +1274,9 @@ func testAccAmplifyApp_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1365,9 +1364,9 @@ func testAccAmplifyApp_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1454,9 +1453,9 @@ func testAccAmplifyApp_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1519,9 +1518,9 @@ func testAccAmplifyApp_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1576,9 +1575,9 @@ func testAccAmplifyApp_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1638,9 +1637,9 @@ func testAccAmplifyApp_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1700,9 +1699,9 @@ func testAccAmplifyApp_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1755,9 +1754,9 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1852,9 +1851,9 @@ func testAccAmplifyApp_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -1939,9 +1938,9 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),
@@ -2101,9 +2100,9 @@ func testAccAmplifyApp_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.App
 	resourceName := "aws_amplify_app.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckAppDestroy(ctx),

--- a/internal/service/amplify/branch_tags_gen_test.go
+++ b/internal/service/amplify/branch_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/amplify/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAmplifyBranch_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -232,9 +231,9 @@ func testAccAmplifyBranch_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -299,9 +298,9 @@ func testAccAmplifyBranch_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -362,9 +361,9 @@ func testAccAmplifyBranch_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -443,9 +442,9 @@ func testAccAmplifyBranch_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -532,9 +531,9 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -669,9 +668,9 @@ func testAccAmplifyBranch_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy:             testAccCheckBranchDestroy(ctx),
@@ -758,9 +757,9 @@ func testAccAmplifyBranch_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -939,9 +938,9 @@ func testAccAmplifyBranch_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1099,9 +1098,9 @@ func testAccAmplifyBranch_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1275,9 +1274,9 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1365,9 +1364,9 @@ func testAccAmplifyBranch_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1454,9 +1453,9 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1519,9 +1518,9 @@ func testAccAmplifyBranch_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1576,9 +1575,9 @@ func testAccAmplifyBranch_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1638,9 +1637,9 @@ func testAccAmplifyBranch_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1700,9 +1699,9 @@ func testAccAmplifyBranch_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1755,9 +1754,9 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1852,9 +1851,9 @@ func testAccAmplifyBranch_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -1939,9 +1938,9 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),
@@ -2101,9 +2100,9 @@ func testAccAmplifyBranch_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Branch
 	resourceName := "aws_amplify_branch.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AmplifyServiceID),
 		CheckDestroy: testAccCheckBranchDestroy(ctx),

--- a/internal/service/apigateway/api_key_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/api_key_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAPIGatewayAPIKeyDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAPIGatewayAPIKeyDataSource_tags(t *testing.T) {
 func TestAccAPIGatewayAPIKeyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAPIGatewayAPIKeyDataSource_tags_NullMap(t *testing.T) {
 func TestAccAPIGatewayAPIKeyDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAPIGatewayAPIKeyDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayAPIKeyDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAPIGatewayAPIKeyDataSource_tags_DefaultTags_nonOverlapping(t *testin
 func TestAccAPIGatewayAPIKeyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAPIGatewayAPIKeyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 func TestAccAPIGatewayAPIKeyDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/api_key_tags_gen_test.go
+++ b/internal/service/apigateway/api_key_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayAPIKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAPIGatewayAPIKey_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAPIGatewayAPIKey_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAPIGatewayAPIKey_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAPIGatewayAPIKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckAPIKeyDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAPIGatewayAPIKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAPIGatewayAPIKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAPIGatewayAPIKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetApiKeyOutput
 	resourceName := "aws_api_gateway_api_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckAPIKeyDestroy(ctx),

--- a/internal/service/apigateway/client_certificate_tags_gen_test.go
+++ b/internal/service/apigateway/client_certificate_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccAPIGatewayClientCertificate_tags(t *testing.T) {
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccAPIGatewayClientCertificate_tags_null(t *testing.T) {
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyMap(t *testing.T) {
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccAPIGatewayClientCertificate_tags_AddOnUpdate(t *testing.T) {
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccAPIGatewayClientCertificate_tags_EmptyTag_OnUpdate_Replace(t *testin
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckClientCertificateDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_providerOnly(t *testing
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nonOverlapping(t *testi
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_overlapping(t *testing.
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToProviderOnly(t 
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_updateToResourceOnly(t 
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyResourceTag(t *tes
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_emptyProviderOnlyTag(t 
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullOverlappingResource
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccAPIGatewayClientCertificate_tags_DefaultTags_nullNonOverlappingResou
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnCreate(t *testing.T) 
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Add(t *testing
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccAPIGatewayClientCertificate_tags_ComputedTag_OnUpdate_Replace(t *tes
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *te
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccAPIGatewayClientCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *t
 	var v apigateway.GetClientCertificateOutput
 	resourceName := "aws_api_gateway_client_certificate.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckClientCertificateDestroy(ctx),

--- a/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_access_association_tags_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -224,7 +224,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_null(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -292,7 +292,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -348,7 +348,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_AddOnUpdate(t *testing.T)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -436,7 +436,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnCreate(t *test
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -536,7 +536,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Add(t *
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -687,7 +687,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_EmptyTag_OnUpdate_Replace
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -785,7 +785,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_providerOnly(
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -984,7 +984,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nonOverlappin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1158,7 +1158,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_overlapping(t
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1348,7 +1348,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToProvi
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1446,7 +1446,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_updateToResou
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1543,7 +1543,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyResource
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1615,7 +1615,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_emptyProvider
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1679,7 +1679,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullOverlappi
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1754,7 +1754,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_DefaultTags_nullNonOverla
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1831,7 +1831,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnCreate(t *t
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1892,7 +1892,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Add(
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -1997,7 +1997,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_ComputedTag_OnUpdate_Repl
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -2092,7 +2092,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Defaul
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),
@@ -2262,7 +2262,7 @@ func TestAccAPIGatewayDomainNameAccessAssociation_tags_IgnoreTags_Overlap_Resour
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameAccessAssociationDestroy(ctx),

--- a/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_data_source_tags_gen_test.go
@@ -26,7 +26,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -58,7 +58,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags_NullMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -86,7 +86,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,7 +114,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags_DefaultTags_nonOverlapping(t *te
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -150,7 +150,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -192,7 +192,7 @@ func TestAccAPIGatewayDomainNameDataSource_tags_IgnoreTags_Overlap_ResourceTag(t
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/domain_name_tags_gen_test.go
+++ b/internal/service/apigateway/domain_name_tags_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAPIGatewayDomainName_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -224,7 +224,7 @@ func TestAccAPIGatewayDomainName_tags_null(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -299,7 +299,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -370,7 +370,7 @@ func TestAccAPIGatewayDomainName_tags_AddOnUpdate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -459,7 +459,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -558,7 +558,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -707,7 +707,7 @@ func TestAccAPIGatewayDomainName_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -804,7 +804,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1003,7 +1003,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1177,7 +1177,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_overlapping(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1367,7 +1367,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToProviderOnly(t *testin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1465,7 +1465,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_updateToResourceOnly(t *testin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1562,7 +1562,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1633,7 +1633,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1696,7 +1696,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullOverlappingResourceTag(t *
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1764,7 +1764,7 @@ func TestAccAPIGatewayDomainName_tags_DefaultTags_nullNonOverlappingResourceTag(
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1832,7 +1832,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1893,7 +1893,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1998,7 +1998,7 @@ func TestAccAPIGatewayDomainName_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -2093,7 +2093,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -2263,7 +2263,7 @@ func TestAccAPIGatewayDomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),

--- a/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/rest_api_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAPIGatewayRESTAPIDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAPIGatewayRESTAPIDataSource_tags(t *testing.T) {
 func TestAccAPIGatewayRESTAPIDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAPIGatewayRESTAPIDataSource_tags_NullMap(t *testing.T) {
 func TestAccAPIGatewayRESTAPIDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAPIGatewayRESTAPIDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayRESTAPIDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAPIGatewayRESTAPIDataSource_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccAPIGatewayRESTAPIDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAPIGatewayRESTAPIDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccAPIGatewayRESTAPIDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/rest_api_tags_gen_test.go
+++ b/internal/service/apigateway/rest_api_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayRESTAPI_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccAPIGatewayRESTAPI_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccAPIGatewayRESTAPI_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccAPIGatewayRESTAPI_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckRESTAPIDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccAPIGatewayRESTAPI_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccAPIGatewayRESTAPI_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccAPIGatewayRESTAPI_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetRestApiOutput
 	resourceName := "aws_api_gateway_rest_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckRESTAPIDestroy(ctx),

--- a/internal/service/apigateway/stage_tags_gen_test.go
+++ b/internal/service/apigateway/stage_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -51,9 +50,9 @@ func testAccAPIGatewayStage_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -237,9 +236,9 @@ func testAccAPIGatewayStage_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -305,9 +304,9 @@ func testAccAPIGatewayStage_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -369,9 +368,9 @@ func testAccAPIGatewayStage_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -451,9 +450,9 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -542,9 +541,9 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -681,9 +680,9 @@ func testAccAPIGatewayStage_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -771,9 +770,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -956,9 +955,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1119,9 +1118,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1298,9 +1297,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1389,9 +1388,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1479,9 +1478,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1545,9 +1544,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1603,9 +1602,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1666,9 +1665,9 @@ func testAccAPIGatewayStage_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1729,9 +1728,9 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1785,9 +1784,9 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1883,9 +1882,9 @@ func testAccAPIGatewayStage_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1971,9 +1970,9 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -2133,9 +2132,9 @@ func testAccAPIGatewayStage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetStageOutput
 	resourceName := "aws_api_gateway_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),

--- a/internal/service/apigateway/usage_plan_tags_gen_test.go
+++ b/internal/service/apigateway/usage_plan_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigateway"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayUsagePlan_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAPIGatewayUsagePlan_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAPIGatewayUsagePlan_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAPIGatewayUsagePlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckUsagePlanDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAPIGatewayUsagePlan_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAPIGatewayUsagePlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAPIGatewayUsagePlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigateway.GetUsagePlanOutput
 	resourceName := "aws_api_gateway_usage_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckUsagePlanDestroy(ctx),

--- a/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigateway/vpc_link_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAPIGatewayVPCLinkDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAPIGatewayVPCLinkDataSource_tags(t *testing.T) {
 func TestAccAPIGatewayVPCLinkDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAPIGatewayVPCLinkDataSource_tags_NullMap(t *testing.T) {
 func TestAccAPIGatewayVPCLinkDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAPIGatewayVPCLinkDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayVPCLinkDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAPIGatewayVPCLinkDataSource_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccAPIGatewayVPCLinkDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAPIGatewayVPCLinkDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccAPIGatewayVPCLinkDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigateway/vpc_link_tags_gen_test.go
+++ b/internal/service/apigateway/vpc_link_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAPIGatewayVPCLink_tags(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAPIGatewayVPCLink_tags_null(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAPIGatewayVPCLink_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAPIGatewayVPCLink_tags_AddOnUpdate(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAPIGatewayVPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToProviderOnly(t *testing.T
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_updateToResourceOnly(t *testing.T
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAPIGatewayVPCLink_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAPIGatewayVPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccAPIGatewayVPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_api_gateway_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),

--- a/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/api_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAPIGatewayV2APIDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAPIGatewayV2APIDataSource_tags(t *testing.T) {
 func TestAccAPIGatewayV2APIDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAPIGatewayV2APIDataSource_tags_NullMap(t *testing.T) {
 func TestAccAPIGatewayV2APIDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAPIGatewayV2APIDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayV2APIDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAPIGatewayV2APIDataSource_tags_DefaultTags_nonOverlapping(t *testing
 func TestAccAPIGatewayV2APIDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAPIGatewayV2APIDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *test
 func TestAccAPIGatewayV2APIDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigatewayv2/api_tags_gen_test.go
+++ b/internal/service/apigatewayv2/api_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayV2API_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAPIGatewayV2API_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAPIGatewayV2API_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAPIGatewayV2API_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAPIGatewayV2API_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAPIGatewayV2API_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAPIGatewayV2API_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckAPIDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAPIGatewayV2API_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAPIGatewayV2API_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAPIGatewayV2API_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAPIGatewayV2API_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAPIGatewayV2API_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAPIGatewayV2API_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetApiOutput
 	resourceName := "aws_apigatewayv2_api.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckAPIDestroy(ctx),

--- a/internal/service/apigatewayv2/domain_name_tags_gen_test.go
+++ b/internal/service/apigatewayv2/domain_name_tags_gen_test.go
@@ -24,7 +24,7 @@ func TestAccAPIGatewayV2DomainName_tags(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -224,7 +224,7 @@ func TestAccAPIGatewayV2DomainName_tags_null(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -299,7 +299,7 @@ func TestAccAPIGatewayV2DomainName_tags_EmptyMap(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -370,7 +370,7 @@ func TestAccAPIGatewayV2DomainName_tags_AddOnUpdate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -459,7 +459,7 @@ func TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -558,7 +558,7 @@ func TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -707,7 +707,7 @@ func TestAccAPIGatewayV2DomainName_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckDomainNameDestroy(ctx),
@@ -804,7 +804,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_providerOnly(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1003,7 +1003,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_nonOverlapping(t *testing.T)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1177,7 +1177,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_overlapping(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1367,7 +1367,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_updateToProviderOnly(t *test
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1465,7 +1465,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_updateToResourceOnly(t *test
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1562,7 +1562,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_emptyResourceTag(t *testing.
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1633,7 +1633,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_emptyProviderOnlyTag(t *test
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1696,7 +1696,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_nullOverlappingResourceTag(t
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1764,7 +1764,7 @@ func TestAccAPIGatewayV2DomainName_tags_DefaultTags_nullNonOverlappingResourceTa
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1832,7 +1832,7 @@ func TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnCreate(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1893,7 +1893,7 @@ func TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -1998,7 +1998,7 @@ func TestAccAPIGatewayV2DomainName_tags_ComputedTag_OnUpdate_Replace(t *testing.
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -2093,7 +2093,7 @@ func TestAccAPIGatewayV2DomainName_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),
@@ -2263,7 +2263,7 @@ func TestAccAPIGatewayV2DomainName_tags_IgnoreTags_Overlap_ResourceTag(t *testin
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, rName)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckDomainNameDestroy(ctx),

--- a/internal/service/apigatewayv2/stage_tags_gen_test.go
+++ b/internal/service/apigatewayv2/stage_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayV2Stage_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -207,9 +206,9 @@ func TestAccAPIGatewayV2Stage_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccAPIGatewayV2Stage_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -339,9 +338,9 @@ func TestAccAPIGatewayV2Stage_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -421,9 +420,9 @@ func TestAccAPIGatewayV2Stage_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -512,9 +511,9 @@ func TestAccAPIGatewayV2Stage_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -651,9 +650,9 @@ func TestAccAPIGatewayV2Stage_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckStageDestroy(ctx),
@@ -741,9 +740,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -926,9 +925,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1089,9 +1088,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1268,9 +1267,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1359,9 +1358,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1449,9 +1448,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1515,9 +1514,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1573,9 +1572,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1636,9 +1635,9 @@ func TestAccAPIGatewayV2Stage_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1699,9 +1698,9 @@ func TestAccAPIGatewayV2Stage_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccAPIGatewayV2Stage_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1853,9 +1852,9 @@ func TestAccAPIGatewayV2Stage_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -1941,9 +1940,9 @@ func TestAccAPIGatewayV2Stage_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),
@@ -2103,9 +2102,9 @@ func TestAccAPIGatewayV2Stage_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetStageOutput
 	resourceName := "aws_apigatewayv2_stage.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckStageDestroy(ctx),

--- a/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
+++ b/internal/service/apigatewayv2/vpc_link_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAPIGatewayV2VPCLinkDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags(t *testing.T) {
 func TestAccAPIGatewayV2VPCLinkDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags_NullMap(t *testing.T) {
 func TestAccAPIGatewayV2VPCLinkDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAPIGatewayV2VPCLinkDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags_DefaultTags_nonOverlapping(t *tes
 func TestAccAPIGatewayV2VPCLinkDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAPIGatewayV2VPCLinkDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *
 func TestAccAPIGatewayV2VPCLinkDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/apigatewayv2/vpc_link_tags_gen_test.go
+++ b/internal/service/apigatewayv2/vpc_link_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAPIGatewayV2VPCLink_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAPIGatewayV2VPCLink_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAPIGatewayV2VPCLink_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAPIGatewayV2VPCLink_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAPIGatewayV2VPCLink_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAPIGatewayV2VPCLink_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAPIGatewayV2VPCLink_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy:             testAccCheckVPCLinkDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAPIGatewayV2VPCLink_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAPIGatewayV2VPCLink_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAPIGatewayV2VPCLink_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAPIGatewayV2VPCLink_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAPIGatewayV2VPCLink_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAPIGatewayV2VPCLink_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v apigatewayv2.GetVpcLinkOutput
 	resourceName := "aws_apigatewayv2_vpc_link.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.APIGatewayV2ServiceID),
 		CheckDestroy: testAccCheckVPCLinkDestroy(ctx),

--- a/internal/service/appautoscaling/target_tags_gen_test.go
+++ b/internal/service/appautoscaling/target_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/applicationautoscaling/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAppAutoScalingTarget_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -207,9 +206,9 @@ func TestAccAppAutoScalingTarget_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccAppAutoScalingTarget_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -339,9 +338,9 @@ func TestAccAppAutoScalingTarget_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -423,9 +422,9 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -516,9 +515,9 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -657,9 +656,9 @@ func TestAccAppAutoScalingTarget_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy:             testAccCheckTargetDestroy(ctx),
@@ -747,9 +746,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -932,9 +931,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1095,9 +1094,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1274,9 +1273,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1365,9 +1364,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1457,9 +1456,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1525,9 +1524,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1583,9 +1582,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1646,9 +1645,9 @@ func TestAccAppAutoScalingTarget_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1709,9 +1708,9 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1765,9 +1764,9 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1863,9 +1862,9 @@ func TestAccAppAutoScalingTarget_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -1951,9 +1950,9 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),
@@ -2113,9 +2112,9 @@ func TestAccAppAutoScalingTarget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.ScalableTarget
 	resourceName := "aws_appautoscaling_target.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppAutoScalingServiceID),
 		CheckDestroy: testAccCheckTargetDestroy(ctx),

--- a/internal/service/appconfig/application_tags_gen_test.go
+++ b/internal/service/appconfig/application_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigApplication_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppConfigApplication_tags(t *testing.T) {
 func TestAccAppConfigApplication_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppConfigApplication_tags_null(t *testing.T) {
 func TestAccAppConfigApplication_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppConfigApplication_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigApplication_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppConfigApplication_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigApplication_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppConfigApplication_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigApplication_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppConfigApplication_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigApplication_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppConfigApplication_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppConfigApplication_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppConfigApplication_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppConfigApplication_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppConfigApplication_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_updateToProviderOnly(t *testin
 func TestAccAppConfigApplication_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_updateToResourceOnly(t *testin
 func TestAccAppConfigApplication_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_emptyResourceTag(t *testing.T)
 func TestAccAppConfigApplication_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 func TestAccAppConfigApplication_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_nullOverlappingResourceTag(t *
 func TestAccAppConfigApplication_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppConfigApplication_tags_DefaultTags_nullNonOverlappingResourceTag(
 func TestAccAppConfigApplication_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppConfigApplication_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppConfigApplication_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppConfigApplication_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigApplication_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppConfigApplication_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func TestAccAppConfigApplication_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppConfigApplication_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccAppConfigApplication_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),

--- a/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/configuration_profile_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccAppConfigConfigurationProfileDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccAppConfigConfigurationProfileDataSource_tags(t *testing.T) {
 func TestAccAppConfigConfigurationProfileDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccAppConfigConfigurationProfileDataSource_tags_NullMap(t *testing.T) {
 func TestAccAppConfigConfigurationProfileDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccAppConfigConfigurationProfileDataSource_tags_EmptyMap(t *testing.T) 
 func TestAccAppConfigConfigurationProfileDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccAppConfigConfigurationProfileDataSource_tags_DefaultTags_nonOverlapp
 func TestAccAppConfigConfigurationProfileDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccAppConfigConfigurationProfileDataSource_tags_IgnoreTags_Overlap_Defa
 func TestAccAppConfigConfigurationProfileDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appconfig/configuration_profile_tags_gen_test.go
+++ b/internal/service/appconfig/configuration_profile_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigConfigurationProfile_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppConfigConfigurationProfile_tags(t *testing.T) {
 func TestAccAppConfigConfigurationProfile_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppConfigConfigurationProfile_tags_null(t *testing.T) {
 func TestAccAppConfigConfigurationProfile_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppConfigConfigurationProfile_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigConfigurationProfile_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppConfigConfigurationProfile_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnUpdate_Add(t *testing.
 func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckConfigurationProfileDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppConfigConfigurationProfile_tags_EmptyTag_OnUpdate_Replace(t *test
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_providerOnly(t *testi
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nonOverlapping(t *tes
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_overlapping(t *testin
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_updateToProviderOnly(
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_updateToResourceOnly(
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_emptyResourceTag(t *t
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_emptyProviderOnlyTag(
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nullOverlappingResour
 func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppConfigConfigurationProfile_tags_DefaultTags_nullNonOverlappingRes
 func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnCreate(t *testing.T
 func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnUpdate_Add(t *testi
 func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppConfigConfigurationProfile_tags_ComputedTag_OnUpdate_Replace(t *t
 func TestAccAppConfigConfigurationProfile_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppConfigConfigurationProfile_tags_IgnoreTags_Overlap_DefaultTag(t *
 func TestAccAppConfigConfigurationProfile_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_configuration_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckConfigurationProfileDestroy(ctx),

--- a/internal/service/appconfig/deployment_strategy_tags_gen_test.go
+++ b/internal/service/appconfig/deployment_strategy_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigDeploymentStrategy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppConfigDeploymentStrategy_tags(t *testing.T) {
 func TestAccAppConfigDeploymentStrategy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppConfigDeploymentStrategy_tags_null(t *testing.T) {
 func TestAccAppConfigDeploymentStrategy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppConfigDeploymentStrategy_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigDeploymentStrategy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppConfigDeploymentStrategy_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckDeploymentStrategyDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppConfigDeploymentStrategy_tags_EmptyTag_OnUpdate_Replace(t *testin
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_providerOnly(t *testing
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_overlapping(t *testing.
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_updateToProviderOnly(t 
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_updateToResourceOnly(t 
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_emptyResourceTag(t *tes
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_emptyProviderOnlyTag(t 
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nullOverlappingResource
 func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppConfigDeploymentStrategy_tags_DefaultTags_nullNonOverlappingResou
 func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnCreate(t *testing.T) 
 func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnUpdate_Add(t *testing
 func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppConfigDeploymentStrategy_tags_ComputedTag_OnUpdate_Replace(t *tes
 func TestAccAppConfigDeploymentStrategy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppConfigDeploymentStrategy_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccAppConfigDeploymentStrategy_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment_strategy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckDeploymentStrategyDestroy(ctx),

--- a/internal/service/appconfig/deployment_tags_gen_test.go
+++ b/internal/service/appconfig/deployment_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigDeployment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -212,9 +211,9 @@ func TestAccAppConfigDeployment_tags(t *testing.T) {
 func TestAccAppConfigDeployment_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -281,9 +280,9 @@ func TestAccAppConfigDeployment_tags_null(t *testing.T) {
 func TestAccAppConfigDeployment_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -346,9 +345,9 @@ func TestAccAppConfigDeployment_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigDeployment_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -429,9 +428,9 @@ func TestAccAppConfigDeployment_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigDeployment_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -523,9 +522,9 @@ func TestAccAppConfigDeployment_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigDeployment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -665,9 +664,9 @@ func TestAccAppConfigDeployment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigDeployment_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -756,9 +755,9 @@ func TestAccAppConfigDeployment_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppConfigDeployment_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -948,9 +947,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppConfigDeployment_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1116,9 +1115,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppConfigDeployment_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1300,9 +1299,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppConfigDeployment_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1392,9 +1391,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_updateToProviderOnly(t *testing
 func TestAccAppConfigDeployment_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1483,9 +1482,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_updateToResourceOnly(t *testing
 func TestAccAppConfigDeployment_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1550,9 +1549,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 func TestAccAppConfigDeployment_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1609,9 +1608,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 func TestAccAppConfigDeployment_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1673,9 +1672,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_nullOverlappingResourceTag(t *t
 func TestAccAppConfigDeployment_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1737,9 +1736,9 @@ func TestAccAppConfigDeployment_tags_DefaultTags_nullNonOverlappingResourceTag(t
 func TestAccAppConfigDeployment_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1794,9 +1793,9 @@ func TestAccAppConfigDeployment_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppConfigDeployment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1893,9 +1892,9 @@ func TestAccAppConfigDeployment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigDeployment_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1982,9 +1981,9 @@ func TestAccAppConfigDeployment_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 func TestAccAppConfigDeployment_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -2143,9 +2142,9 @@ func TestAccAppConfigDeployment_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 func TestAccAppConfigDeployment_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_deployment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,

--- a/internal/service/appconfig/environment_data_source_tags_gen_test.go
+++ b/internal/service/appconfig/environment_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccAppConfigEnvironmentDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccAppConfigEnvironmentDataSource_tags(t *testing.T) {
 func TestAccAppConfigEnvironmentDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccAppConfigEnvironmentDataSource_tags_NullMap(t *testing.T) {
 func TestAccAppConfigEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccAppConfigEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigEnvironmentDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccAppConfigEnvironmentDataSource_tags_DefaultTags_nonOverlapping(t *te
 func TestAccAppConfigEnvironmentDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccAppConfigEnvironmentDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 func TestAccAppConfigEnvironmentDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppConfigServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appconfig/environment_tags_gen_test.go
+++ b/internal/service/appconfig/environment_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigEnvironment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppConfigEnvironment_tags(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -261,9 +260,9 @@ func TestAccAppConfigEnvironment_tags_null(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -310,9 +309,9 @@ func TestAccAppConfigEnvironment_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -389,9 +388,9 @@ func TestAccAppConfigEnvironment_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -478,9 +477,9 @@ func TestAccAppConfigEnvironment_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -616,9 +615,9 @@ func TestAccAppConfigEnvironment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -705,9 +704,9 @@ func TestAccAppConfigEnvironment_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -885,9 +884,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1044,9 +1043,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1219,9 +1218,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1308,9 +1307,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_updateToProviderOnly(t *testin
 func TestAccAppConfigEnvironment_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1396,9 +1395,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_updateToResourceOnly(t *testin
 func TestAccAppConfigEnvironment_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1461,9 +1460,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_emptyResourceTag(t *testing.T)
 func TestAccAppConfigEnvironment_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1518,9 +1517,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 func TestAccAppConfigEnvironment_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_nullOverlappingResourceTag(t *
 func TestAccAppConfigEnvironment_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1656,9 +1655,9 @@ func TestAccAppConfigEnvironment_tags_DefaultTags_nullNonOverlappingResourceTag(
 func TestAccAppConfigEnvironment_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1710,9 +1709,9 @@ func TestAccAppConfigEnvironment_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccAppConfigEnvironment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigEnvironment_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1892,9 +1891,9 @@ func TestAccAppConfigEnvironment_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func TestAccAppConfigEnvironment_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -2053,9 +2052,9 @@ func TestAccAppConfigEnvironment_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccAppConfigEnvironment_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),

--- a/internal/service/appconfig/extension_tags_gen_test.go
+++ b/internal/service/appconfig/extension_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppConfigExtension_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppConfigExtension_tags(t *testing.T) {
 func TestAccAppConfigExtension_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppConfigExtension_tags_null(t *testing.T) {
 func TestAccAppConfigExtension_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppConfigExtension_tags_EmptyMap(t *testing.T) {
 func TestAccAppConfigExtension_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppConfigExtension_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppConfigExtension_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppConfigExtension_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppConfigExtension_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppConfigExtension_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigExtension_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy:             testAccCheckExtensionDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppConfigExtension_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppConfigExtension_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppConfigExtension_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppConfigExtension_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppConfigExtension_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_updateToProviderOnly(t *testing.
 func TestAccAppConfigExtension_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_updateToResourceOnly(t *testing.
 func TestAccAppConfigExtension_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccAppConfigExtension_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 func TestAccAppConfigExtension_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_nullOverlappingResourceTag(t *te
 func TestAccAppConfigExtension_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppConfigExtension_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 func TestAccAppConfigExtension_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppConfigExtension_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppConfigExtension_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppConfigExtension_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppConfigExtension_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppConfigExtension_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppConfigExtension_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppConfigExtension_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func TestAccAppConfigExtension_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_appconfig_extension.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppConfigServiceID),
 		CheckDestroy: testAccCheckExtensionDestroy(ctx),

--- a/internal/service/appfabric/app_authorization_tags_gen_test.go
+++ b/internal/service/appfabric/app_authorization_tags_gen_test.go
@@ -50,7 +50,7 @@ func testAccAppFabricAppAuthorization_tags(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -235,7 +235,7 @@ func testAccAppFabricAppAuthorization_tags_null(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -295,7 +295,7 @@ func testAccAppFabricAppAuthorization_tags_EmptyMap(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -343,7 +343,7 @@ func testAccAppFabricAppAuthorization_tags_AddOnUpdate(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -422,7 +422,7 @@ func testAccAppFabricAppAuthorization_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -513,7 +513,7 @@ func testAccAppFabricAppAuthorization_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -652,7 +652,7 @@ func testAccAppFabricAppAuthorization_tags_EmptyTag_OnUpdate_Replace(t *testing.
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy:             testAccCheckAppAuthorizationDestroy(ctx),
@@ -741,7 +741,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_providerOnly(t *testing.T
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -925,7 +925,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_nonOverlapping(t *testing
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1087,7 +1087,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_overlapping(t *testing.T)
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1265,7 +1265,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_updateToProviderOnly(t *t
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1354,7 +1354,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_updateToResourceOnly(t *t
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1442,7 +1442,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_emptyResourceTag(t *testi
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1508,7 +1508,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_emptyProviderOnlyTag(t *t
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1566,7 +1566,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_nullOverlappingResourceTa
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1633,7 +1633,7 @@ func testAccAppFabricAppAuthorization_tags_DefaultTags_nullNonOverlappingResourc
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1702,7 +1702,7 @@ func testAccAppFabricAppAuthorization_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1757,7 +1757,7 @@ func testAccAppFabricAppAuthorization_tags_ComputedTag_OnUpdate_Add(t *testing.T
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1853,7 +1853,7 @@ func testAccAppFabricAppAuthorization_tags_ComputedTag_OnUpdate_Replace(t *testi
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -1939,7 +1939,7 @@ func testAccAppFabricAppAuthorization_tags_IgnoreTags_Overlap_DefaultTag(t *test
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),
@@ -2097,7 +2097,7 @@ func testAccAppFabricAppAuthorization_tags_IgnoreTags_Overlap_ResourceTag(t *tes
 	var v types.AppAuthorization
 	resourceName := "aws_appfabric_app_authorization.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFabricServiceID),
 		CheckDestroy: testAccCheckAppAuthorizationDestroy(ctx),

--- a/internal/service/appfabric/app_bundle_tags_gen_test.go
+++ b/internal/service/appfabric/app_bundle_tags_gen_test.go
@@ -51,7 +51,7 @@ func testAccAppFabricAppBundle_tags(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -227,7 +227,7 @@ func testAccAppFabricAppBundle_tags_null(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -289,7 +289,7 @@ func testAccAppFabricAppBundle_tags_EmptyMap(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -339,7 +339,7 @@ func testAccAppFabricAppBundle_tags_AddOnUpdate(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -418,7 +418,7 @@ func testAccAppFabricAppBundle_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -506,7 +506,7 @@ func testAccAppFabricAppBundle_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -642,7 +642,7 @@ func testAccAppFabricAppBundle_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -731,7 +731,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -906,7 +906,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1062,7 +1062,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_overlapping(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1234,7 +1234,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_updateToProviderOnly(t *testing.
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1323,7 +1323,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_updateToResourceOnly(t *testing.
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1411,7 +1411,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1477,7 +1477,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1535,7 +1535,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1604,7 +1604,7 @@ func testAccAppFabricAppBundle_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1675,7 +1675,7 @@ func testAccAppFabricAppBundle_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1730,7 +1730,7 @@ func testAccAppFabricAppBundle_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1826,7 +1826,7 @@ func testAccAppFabricAppBundle_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -1912,7 +1912,7 @@ func testAccAppFabricAppBundle_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)
@@ -2073,7 +2073,7 @@ func testAccAppFabricAppBundle_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	var v awstypes.AppBundle
 	resourceName := "aws_appfabric_app_bundle.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			acctest.PreCheckRegion(t, endpoints.UsEast1RegionID, endpoints.ApNortheast1RegionID, endpoints.EuWest1RegionID)

--- a/internal/service/appflow/flow_tags_gen_test.go
+++ b/internal/service/appflow/flow_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appflow"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAppFlowFlow_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAppFlowFlow_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAppFlowFlow_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAppFlowFlow_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAppFlowFlow_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAppFlowFlow_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy:             testAccCheckFlowDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAppFlowFlow_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAppFlowFlow_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAppFlowFlow_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAppFlowFlow_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAppFlowFlow_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appflow.DescribeFlowOutput
 	resourceName := "aws_appflow_flow.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppFlowServiceID),
 		CheckDestroy: testAccCheckFlowDestroy(ctx),

--- a/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
+++ b/internal/service/appintegrations/event_integration_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccAppIntegrationsEventIntegrationDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags(t *testing.T) {
 func TestAccAppIntegrationsEventIntegrationDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags_NullMap(t *testing.T)
 func TestAccAppIntegrationsEventIntegrationDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags_EmptyMap(t *testing.T
 func TestAccAppIntegrationsEventIntegrationDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags_DefaultTags_nonOverla
 func TestAccAppIntegrationsEventIntegrationDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccAppIntegrationsEventIntegrationDataSource_tags_IgnoreTags_Overlap_De
 func TestAccAppIntegrationsEventIntegrationDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appintegrations/event_integration_tags_gen_test.go
+++ b/internal/service/appintegrations/event_integration_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appintegrations"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccAppIntegrationsEventIntegration_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccAppIntegrationsEventIntegration_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccAppIntegrationsEventIntegration_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccAppIntegrationsEventIntegration_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccAppIntegrationsEventIntegration_tags_EmptyTag_OnCreate(t *testing.T)
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccAppIntegrationsEventIntegration_tags_EmptyTag_OnUpdate_Add(t *testin
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccAppIntegrationsEventIntegration_tags_EmptyTag_OnUpdate_Replace(t *te
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy:             testAccCheckEventIntegrationDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_providerOnly(t *tes
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_nonOverlapping(t *t
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_overlapping(t *test
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_updateToProviderOnl
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_updateToResourceOnl
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_emptyResourceTag(t 
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_emptyProviderOnlyTa
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_nullOverlappingReso
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccAppIntegrationsEventIntegration_tags_DefaultTags_nullNonOverlappingR
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccAppIntegrationsEventIntegration_tags_ComputedTag_OnCreate(t *testing
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccAppIntegrationsEventIntegration_tags_ComputedTag_OnUpdate_Add(t *tes
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccAppIntegrationsEventIntegration_tags_ComputedTag_OnUpdate_Replace(t 
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccAppIntegrationsEventIntegration_tags_IgnoreTags_Overlap_DefaultTag(t
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccAppIntegrationsEventIntegration_tags_IgnoreTags_Overlap_ResourceTag(
 	ctx := acctest.Context(t)
 	var v appintegrations.GetEventIntegrationOutput
 	resourceName := "aws_appintegrations_event_integration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppIntegrationsServiceID),
 		CheckDestroy: testAccCheckEventIntegrationDestroy(ctx),

--- a/internal/service/applicationinsights/application_tags_gen_test.go
+++ b/internal/service/applicationinsights/application_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/applicationinsights/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccApplicationInsightsApplication_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccApplicationInsightsApplication_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccApplicationInsightsApplication_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccApplicationInsightsApplication_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccApplicationInsightsApplication_tags_EmptyTag_OnCreate(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccApplicationInsightsApplication_tags_EmptyTag_OnUpdate_Add(t *testing
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccApplicationInsightsApplication_tags_EmptyTag_OnUpdate_Replace(t *tes
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_providerOnly(t *test
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_nonOverlapping(t *te
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_overlapping(t *testi
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_updateToProviderOnly
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_updateToResourceOnly
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_emptyResourceTag(t *
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_emptyProviderOnlyTag
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_nullOverlappingResou
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccApplicationInsightsApplication_tags_DefaultTags_nullNonOverlappingRe
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccApplicationInsightsApplication_tags_ComputedTag_OnCreate(t *testing.
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccApplicationInsightsApplication_tags_ComputedTag_OnUpdate_Add(t *test
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccApplicationInsightsApplication_tags_ComputedTag_OnUpdate_Replace(t *
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccApplicationInsightsApplication_tags_IgnoreTags_Overlap_DefaultTag(t 
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccApplicationInsightsApplication_tags_IgnoreTags_Overlap_ResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.ApplicationInfo
 	resourceName := "aws_applicationinsights_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ApplicationInsightsServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),

--- a/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/gateway_route_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshGatewayRouteDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshGatewayRouteDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshGatewayRouteDataSource_tags(t *testing.T) {
 func testAccAppMeshGatewayRouteDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshGatewayRouteDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshGatewayRouteDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshGatewayRouteDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshGatewayRouteDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshGatewayRouteDataSource_tags_DefaultTags_nonOverlapping(t *tes
 func testAccAppMeshGatewayRouteDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshGatewayRouteDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *
 func testAccAppMeshGatewayRouteDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/gateway_route_tags_gen_test.go
+++ b/internal/service/appmesh/gateway_route_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshGatewayRoute_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshGatewayRoute_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshGatewayRoute_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshGatewayRoute_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshGatewayRoute_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshGatewayRoute_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshGatewayRoute_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckGatewayRouteDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshGatewayRoute_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshGatewayRoute_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshGatewayRoute_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshGatewayRoute_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshGatewayRoute_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshGatewayRoute_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.GatewayRouteData
 	resourceName := "aws_appmesh_gateway_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckGatewayRouteDestroy(ctx),

--- a/internal/service/appmesh/mesh_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/mesh_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshServiceMeshDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshServiceMeshDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshServiceMeshDataSource_tags(t *testing.T) {
 func testAccAppMeshServiceMeshDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshServiceMeshDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshServiceMeshDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshServiceMeshDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshServiceMeshDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshServiceMeshDataSource_tags_DefaultTags_nonOverlapping(t *test
 func testAccAppMeshServiceMeshDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshServiceMeshDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func testAccAppMeshServiceMeshDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/mesh_tags_gen_test.go
+++ b/internal/service/appmesh/mesh_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshServiceMesh_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -232,9 +231,9 @@ func testAccAppMeshServiceMesh_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -299,9 +298,9 @@ func testAccAppMeshServiceMesh_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -362,9 +361,9 @@ func testAccAppMeshServiceMesh_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -443,9 +442,9 @@ func testAccAppMeshServiceMesh_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -532,9 +531,9 @@ func testAccAppMeshServiceMesh_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -669,9 +668,9 @@ func testAccAppMeshServiceMesh_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckServiceMeshDestroy(ctx),
@@ -758,9 +757,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -939,9 +938,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1099,9 +1098,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1275,9 +1274,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1365,9 +1364,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1454,9 +1453,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1519,9 +1518,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1576,9 +1575,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1638,9 +1637,9 @@ func testAccAppMeshServiceMesh_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1700,9 +1699,9 @@ func testAccAppMeshServiceMesh_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1755,9 +1754,9 @@ func testAccAppMeshServiceMesh_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1852,9 +1851,9 @@ func testAccAppMeshServiceMesh_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -1939,9 +1938,9 @@ func testAccAppMeshServiceMesh_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),
@@ -2101,9 +2100,9 @@ func testAccAppMeshServiceMesh_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.MeshData
 	resourceName := "aws_appmesh_mesh.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckServiceMeshDestroy(ctx),

--- a/internal/service/appmesh/route_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/route_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshRouteDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshRouteDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshRouteDataSource_tags(t *testing.T) {
 func testAccAppMeshRouteDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshRouteDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshRouteDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshRouteDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshRouteDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshRouteDataSource_tags_DefaultTags_nonOverlapping(t *testing.T)
 func testAccAppMeshRouteDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshRouteDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 func testAccAppMeshRouteDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/route_tags_gen_test.go
+++ b/internal/service/appmesh/route_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshRoute_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshRoute_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshRoute_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshRoute_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshRoute_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshRoute_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshRoute_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckRouteDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshRoute_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshRoute_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshRoute_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshRoute_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshRoute_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshRoute_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshRoute_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshRoute_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshRoute_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshRoute_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshRoute_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshRoute_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshRoute_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshRoute_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.RouteData
 	resourceName := "aws_appmesh_route.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckRouteDestroy(ctx),

--- a/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_gateway_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshVirtualGatewayDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshVirtualGatewayDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshVirtualGatewayDataSource_tags(t *testing.T) {
 func testAccAppMeshVirtualGatewayDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshVirtualGatewayDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshVirtualGatewayDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshVirtualGatewayDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshVirtualGatewayDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshVirtualGatewayDataSource_tags_DefaultTags_nonOverlapping(t *t
 func testAccAppMeshVirtualGatewayDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshVirtualGatewayDataSource_tags_IgnoreTags_Overlap_DefaultTag(t
 func testAccAppMeshVirtualGatewayDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/virtual_gateway_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_gateway_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshVirtualGateway_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshVirtualGateway_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshVirtualGateway_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshVirtualGateway_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshVirtualGateway_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshVirtualGateway_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshVirtualGateway_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualGatewayDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshVirtualGateway_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshVirtualGateway_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshVirtualGateway_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshVirtualGateway_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshVirtualGateway_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshVirtualGateway_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.VirtualGatewayData
 	resourceName := "aws_appmesh_virtual_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualGatewayDestroy(ctx),

--- a/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_node_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshVirtualNodeDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshVirtualNodeDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshVirtualNodeDataSource_tags(t *testing.T) {
 func testAccAppMeshVirtualNodeDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshVirtualNodeDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshVirtualNodeDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshVirtualNodeDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshVirtualNodeDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshVirtualNodeDataSource_tags_DefaultTags_nonOverlapping(t *test
 func testAccAppMeshVirtualNodeDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshVirtualNodeDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func testAccAppMeshVirtualNodeDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/virtual_node_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_node_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshVirtualNode_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshVirtualNode_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshVirtualNode_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshVirtualNode_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshVirtualNode_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshVirtualNode_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshVirtualNode_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualNodeDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshVirtualNode_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshVirtualNode_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshVirtualNode_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshVirtualNode_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshVirtualNode_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshVirtualNode_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.VirtualNodeData
 	resourceName := "aws_appmesh_virtual_node.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualNodeDestroy(ctx),

--- a/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_router_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshVirtualRouterDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshVirtualRouterDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshVirtualRouterDataSource_tags(t *testing.T) {
 func testAccAppMeshVirtualRouterDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshVirtualRouterDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshVirtualRouterDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshVirtualRouterDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshVirtualRouterDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshVirtualRouterDataSource_tags_DefaultTags_nonOverlapping(t *te
 func testAccAppMeshVirtualRouterDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshVirtualRouterDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 func testAccAppMeshVirtualRouterDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/virtual_router_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_router_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshVirtualRouter_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshVirtualRouter_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshVirtualRouter_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshVirtualRouter_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshVirtualRouter_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshVirtualRouter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshVirtualRouter_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualRouterDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshVirtualRouter_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshVirtualRouter_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshVirtualRouter_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshVirtualRouter_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshVirtualRouter_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshVirtualRouter_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualRouterData
 	resourceName := "aws_appmesh_virtual_router.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualRouterDestroy(ctx),

--- a/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_service_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -38,9 +37,9 @@ func testAccAppMeshVirtualServiceDataSource_tagsSerial(t *testing.T) {
 func testAccAppMeshVirtualServiceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -66,9 +65,9 @@ func testAccAppMeshVirtualServiceDataSource_tags(t *testing.T) {
 func testAccAppMeshVirtualServiceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -90,9 +89,9 @@ func testAccAppMeshVirtualServiceDataSource_tags_NullMap(t *testing.T) {
 func testAccAppMeshVirtualServiceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -114,9 +113,9 @@ func testAccAppMeshVirtualServiceDataSource_tags_EmptyMap(t *testing.T) {
 func testAccAppMeshVirtualServiceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -146,9 +145,9 @@ func testAccAppMeshVirtualServiceDataSource_tags_DefaultTags_nonOverlapping(t *t
 func testAccAppMeshVirtualServiceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{
@@ -184,9 +183,9 @@ func testAccAppMeshVirtualServiceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t
 func testAccAppMeshVirtualServiceDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.AppMeshServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/appmesh/virtual_service_tags_gen_test.go
+++ b/internal/service/appmesh/virtual_service_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/appmesh/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccAppMeshVirtualService_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -236,9 +235,9 @@ func testAccAppMeshVirtualService_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccAppMeshVirtualService_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -368,9 +367,9 @@ func testAccAppMeshVirtualService_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -450,9 +449,9 @@ func testAccAppMeshVirtualService_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -541,9 +540,9 @@ func testAccAppMeshVirtualService_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -680,9 +679,9 @@ func testAccAppMeshVirtualService_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy:             testAccCheckVirtualServiceDestroy(ctx),
@@ -770,9 +769,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -955,9 +954,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1118,9 +1117,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1297,9 +1296,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1388,9 +1387,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1478,9 +1477,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1544,9 +1543,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1602,9 +1601,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1665,9 +1664,9 @@ func testAccAppMeshVirtualService_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1728,9 +1727,9 @@ func testAccAppMeshVirtualService_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccAppMeshVirtualService_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1882,9 +1881,9 @@ func testAccAppMeshVirtualService_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -1970,9 +1969,9 @@ func testAccAppMeshVirtualService_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),
@@ -2132,9 +2131,9 @@ func testAccAppMeshVirtualService_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.VirtualServiceData
 	resourceName := "aws_appmesh_virtual_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppMeshServiceID),
 		CheckDestroy: testAccCheckVirtualServiceDestroy(ctx),

--- a/internal/service/apprunner/auto_scaling_configuration_version_tags_gen_test.go
+++ b/internal/service/apprunner/auto_scaling_configuration_version_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags(t *testing.T) {
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_null(t *testing.T) {
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyMap(t *testing.T)
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_AddOnUpdate(t *testing
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnCreate(t *t
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnUpdate_Add(
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_EmptyTag_OnUpdate_Repl
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_providerOn
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nonOverlap
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_overlappin
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_updateToPr
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_updateToRe
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_emptyResou
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_emptyProvi
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nullOverla
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_DefaultTags_nullNonOve
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnCreate(t
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnUpdate_A
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_ComputedTag_OnUpdate_R
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerAutoScalingConfigurationVersion_tags_IgnoreTags_Overlap_Def
 func TestAccAppRunnerAutoScalingConfigurationVersion_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_auto_scaling_configuration_version.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckAutoScalingConfigurationVersionDestroy(ctx),

--- a/internal/service/apprunner/connection_tags_gen_test.go
+++ b/internal/service/apprunner/connection_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerConnection_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerConnection_tags(t *testing.T) {
 func TestAccAppRunnerConnection_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerConnection_tags_null(t *testing.T) {
 func TestAccAppRunnerConnection_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerConnection_tags_EmptyMap(t *testing.T) {
 func TestAccAppRunnerConnection_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerConnection_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppRunnerConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerConnection_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerConnection_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerConnection_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerConnection_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppRunnerConnection_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppRunnerConnection_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppRunnerConnection_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppRunnerConnection_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_updateToProviderOnly(t *testing
 func TestAccAppRunnerConnection_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_updateToResourceOnly(t *testing
 func TestAccAppRunnerConnection_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 func TestAccAppRunnerConnection_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 func TestAccAppRunnerConnection_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_nullOverlappingResourceTag(t *t
 func TestAccAppRunnerConnection_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerConnection_tags_DefaultTags_nullNonOverlappingResourceTag(t
 func TestAccAppRunnerConnection_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerConnection_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerConnection_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerConnection_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerConnection_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerConnection_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 func TestAccAppRunnerConnection_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerConnection_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 func TestAccAppRunnerConnection_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),

--- a/internal/service/apprunner/observability_configuration_tags_gen_test.go
+++ b/internal/service/apprunner/observability_configuration_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerObservabilityConfiguration_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags(t *testing.T) {
 func TestAccAppRunnerObservabilityConfiguration_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_null(t *testing.T) {
 func TestAccAppRunnerObservabilityConfiguration_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_EmptyMap(t *testing.T) {
 func TestAccAppRunnerObservabilityConfiguration_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnCreate(t *testin
 func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnUpdate_Add(t *te
 func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_EmptyTag_OnUpdate_Replace(t
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_providerOnly(t 
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nonOverlapping(
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_overlapping(t *
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_updateToProvide
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_updateToResourc
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_emptyResourceTa
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_emptyProviderOn
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nullOverlapping
 func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_DefaultTags_nullNonOverlapp
 func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnCreate(t *tes
 func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnUpdate_Add(t 
 func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_ComputedTag_OnUpdate_Replac
 func TestAccAppRunnerObservabilityConfiguration_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerObservabilityConfiguration_tags_IgnoreTags_Overlap_DefaultT
 func TestAccAppRunnerObservabilityConfiguration_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_observability_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckObservabilityConfigurationDestroy(ctx),

--- a/internal/service/apprunner/service_tags_gen_test.go
+++ b/internal/service/apprunner/service_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerService_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerService_tags(t *testing.T) {
 func TestAccAppRunnerService_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerService_tags_null(t *testing.T) {
 func TestAccAppRunnerService_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerService_tags_EmptyMap(t *testing.T) {
 func TestAccAppRunnerService_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerService_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppRunnerService_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerService_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerService_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerService_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerService_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckServiceDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerService_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppRunnerService_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerService_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppRunnerService_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerService_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccAppRunnerService_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerService_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppRunnerService_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerService_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 func TestAccAppRunnerService_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerService_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 func TestAccAppRunnerService_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerService_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccAppRunnerService_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerService_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 func TestAccAppRunnerService_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerService_tags_DefaultTags_nullOverlappingResourceTag(t *test
 func TestAccAppRunnerService_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerService_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 func TestAccAppRunnerService_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerService_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerService_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerService_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerService_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerService_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppRunnerService_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerService_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccAppRunnerService_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_service.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckServiceDestroy(ctx),

--- a/internal/service/apprunner/vpc_connector_tags_gen_test.go
+++ b/internal/service/apprunner/vpc_connector_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerVPCConnector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerVPCConnector_tags(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerVPCConnector_tags_null(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerVPCConnector_tags_EmptyMap(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerVPCConnector_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCConnectorDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerVPCConnector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_updateToProviderOnly(t *testi
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_updateToResourceOnly(t *testi
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_emptyResourceTag(t *testing.T
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_nullOverlappingResourceTag(t 
 func TestAccAppRunnerVPCConnector_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerVPCConnector_tags_DefaultTags_nullNonOverlappingResourceTag
 func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerVPCConnector_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 func TestAccAppRunnerVPCConnector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerVPCConnector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccAppRunnerVPCConnector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_connector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCConnectorDestroy(ctx),

--- a/internal/service/apprunner/vpc_ingress_connection_tags_gen_test.go
+++ b/internal/service/apprunner/vpc_ingress_connection_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccAppRunnerVPCIngressConnection_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccAppRunnerVPCIngressConnection_tags(t *testing.T) {
 func TestAccAppRunnerVPCIngressConnection_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_null(t *testing.T) {
 func TestAccAppRunnerVPCIngressConnection_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_EmptyMap(t *testing.T) {
 func TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_AddOnUpdate(t *testing.T) {
 func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Add(t *testing.
 func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy:             testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_EmptyTag_OnUpdate_Replace(t *test
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_providerOnly(t *testi
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nonOverlapping(t *tes
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_overlapping(t *testin
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToProviderOnly(
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_updateToResourceOnly(
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyResourceTag(t *t
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_emptyProviderOnlyTag(
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullOverlappingResour
 func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_DefaultTags_nullNonOverlappingRes
 func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnCreate(t *testing.T
 func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Add(t *testi
 func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_ComputedTag_OnUpdate_Replace(t *t
 func TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_DefaultTag(t *
 func TestAccAppRunnerVPCIngressConnection_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_apprunner_vpc_ingress_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.AppRunnerServiceID),
 		CheckDestroy: testAccCheckVPCIngressConnectionDestroy(ctx),

--- a/internal/service/backup/framework_data_source_tags_gen_test.go
+++ b/internal/service/backup/framework_data_source_tags_gen_test.go
@@ -34,7 +34,7 @@ func testAccBackupFrameworkDataSource_tags(t *testing.T) {
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -62,7 +62,7 @@ func testAccBackupFrameworkDataSource_tags_NullMap(t *testing.T) {
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -86,7 +86,7 @@ func testAccBackupFrameworkDataSource_tags_EmptyMap(t *testing.T) {
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -110,7 +110,7 @@ func testAccBackupFrameworkDataSource_tags_DefaultTags_nonOverlapping(t *testing
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -142,7 +142,7 @@ func testAccBackupFrameworkDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *test
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -180,7 +180,7 @@ func testAccBackupFrameworkDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *tes
 	dataSourceName := "data.aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/backup/framework_tags_gen_test.go
+++ b/internal/service/backup/framework_tags_gen_test.go
@@ -51,7 +51,7 @@ func testAccBackupFramework_tags(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -233,7 +233,7 @@ func testAccBackupFramework_tags_null(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -300,7 +300,7 @@ func testAccBackupFramework_tags_EmptyMap(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -363,7 +363,7 @@ func testAccBackupFramework_tags_AddOnUpdate(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -444,7 +444,7 @@ func testAccBackupFramework_tags_EmptyTag_OnCreate(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -533,7 +533,7 @@ func testAccBackupFramework_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -670,7 +670,7 @@ func testAccBackupFramework_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckFrameworkDestroy(ctx),
@@ -759,7 +759,7 @@ func testAccBackupFramework_tags_DefaultTags_providerOnly(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -940,7 +940,7 @@ func testAccBackupFramework_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1100,7 +1100,7 @@ func testAccBackupFramework_tags_DefaultTags_overlapping(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1276,7 +1276,7 @@ func testAccBackupFramework_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1366,7 +1366,7 @@ func testAccBackupFramework_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1455,7 +1455,7 @@ func testAccBackupFramework_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1520,7 +1520,7 @@ func testAccBackupFramework_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1577,7 +1577,7 @@ func testAccBackupFramework_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1639,7 +1639,7 @@ func testAccBackupFramework_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1701,7 +1701,7 @@ func testAccBackupFramework_tags_ComputedTag_OnCreate(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1756,7 +1756,7 @@ func testAccBackupFramework_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1853,7 +1853,7 @@ func testAccBackupFramework_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -1940,7 +1940,7 @@ func testAccBackupFramework_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),
@@ -2102,7 +2102,7 @@ func testAccBackupFramework_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	resourceName := "aws_backup_framework.test"
 	rName := randomFrameworkName()
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckFrameworkDestroy(ctx),

--- a/internal/service/backup/plan_data_source_tags_gen_test.go
+++ b/internal/service/backup/plan_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccBackupPlanDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccBackupPlanDataSource_tags(t *testing.T) {
 func TestAccBackupPlanDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccBackupPlanDataSource_tags_NullMap(t *testing.T) {
 func TestAccBackupPlanDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccBackupPlanDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBackupPlanDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccBackupPlanDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccBackupPlanDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccBackupPlanDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccBackupPlanDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/backup/plan_tags_gen_test.go
+++ b/internal/service/backup/plan_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBackupPlan_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBackupPlan_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccBackupPlan_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccBackupPlan_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccBackupPlan_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBackupPlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccBackupPlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckPlanDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccBackupPlan_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccBackupPlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccBackupPlan_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccBackupPlan_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccBackupPlan_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccBackupPlan_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccBackupPlan_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBackupPlan_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccBackupPlan_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccBackupPlan_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccBackupPlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccBackupPlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccBackupPlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccBackupPlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.GetBackupPlanOutput
 	resourceName := "aws_backup_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckPlanDestroy(ctx),

--- a/internal/service/backup/report_plan_data_source_tags_gen_test.go
+++ b/internal/service/backup/report_plan_data_source_tags_gen_test.go
@@ -19,7 +19,7 @@ func TestAccBackupReportPlanDataSource_tags(t *testing.T) {
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -47,7 +47,7 @@ func TestAccBackupReportPlanDataSource_tags_NullMap(t *testing.T) {
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccBackupReportPlanDataSource_tags_EmptyMap(t *testing.T) {
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -95,7 +95,7 @@ func TestAccBackupReportPlanDataSource_tags_DefaultTags_nonOverlapping(t *testin
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -127,7 +127,7 @@ func TestAccBackupReportPlanDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -165,7 +165,7 @@ func TestAccBackupReportPlanDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *te
 	dataSourceName := "data.aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/backup/report_plan_tags_gen_test.go
+++ b/internal/service/backup/report_plan_tags_gen_test.go
@@ -22,7 +22,7 @@ func TestAccBackupReportPlan_tags(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -204,7 +204,7 @@ func TestAccBackupReportPlan_tags_null(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -271,7 +271,7 @@ func TestAccBackupReportPlan_tags_EmptyMap(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -334,7 +334,7 @@ func TestAccBackupReportPlan_tags_AddOnUpdate(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -415,7 +415,7 @@ func TestAccBackupReportPlan_tags_EmptyTag_OnCreate(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -504,7 +504,7 @@ func TestAccBackupReportPlan_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -641,7 +641,7 @@ func TestAccBackupReportPlan_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckReportPlanDestroy(ctx),
@@ -730,7 +730,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_providerOnly(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -911,7 +911,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1071,7 +1071,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_overlapping(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1247,7 +1247,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1337,7 +1337,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1426,7 +1426,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1491,7 +1491,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1548,7 +1548,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1610,7 +1610,7 @@ func TestAccBackupReportPlan_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1672,7 +1672,7 @@ func TestAccBackupReportPlan_tags_ComputedTag_OnCreate(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1727,7 +1727,7 @@ func TestAccBackupReportPlan_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1824,7 +1824,7 @@ func TestAccBackupReportPlan_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -1911,7 +1911,7 @@ func TestAccBackupReportPlan_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),
@@ -2073,7 +2073,7 @@ func TestAccBackupReportPlan_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	resourceName := "aws_backup_report_plan.test"
 	rName := randomReportPlanName()
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckReportPlanDestroy(ctx),

--- a/internal/service/backup/vault_data_source_tags_gen_test.go
+++ b/internal/service/backup/vault_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccBackupVaultDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccBackupVaultDataSource_tags(t *testing.T) {
 func TestAccBackupVaultDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccBackupVaultDataSource_tags_NullMap(t *testing.T) {
 func TestAccBackupVaultDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccBackupVaultDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBackupVaultDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccBackupVaultDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccBackupVaultDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccBackupVaultDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccBackupVaultDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BackupServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/backup/vault_tags_gen_test.go
+++ b/internal/service/backup/vault_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBackupVault_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccBackupVault_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccBackupVault_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccBackupVault_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccBackupVault_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccBackupVault_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccBackupVault_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy:             testAccCheckVaultDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccBackupVault_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccBackupVault_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccBackupVault_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccBackupVault_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccBackupVault_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccBackupVault_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccBackupVault_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccBackupVault_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccBackupVault_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccBackupVault_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccBackupVault_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccBackupVault_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccBackupVault_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccBackupVault_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v backup.DescribeBackupVaultOutput
 	resourceName := "aws_backup_vault.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BackupServiceID),
 		CheckDestroy: testAccCheckVaultDestroy(ctx),

--- a/internal/service/batch/compute_environment_data_source_tags_gen_test.go
+++ b/internal/service/batch/compute_environment_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccBatchComputeEnvironmentDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccBatchComputeEnvironmentDataSource_tags(t *testing.T) {
 func TestAccBatchComputeEnvironmentDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccBatchComputeEnvironmentDataSource_tags_NullMap(t *testing.T) {
 func TestAccBatchComputeEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccBatchComputeEnvironmentDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBatchComputeEnvironmentDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccBatchComputeEnvironmentDataSource_tags_DefaultTags_nonOverlapping(t 
 func TestAccBatchComputeEnvironmentDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccBatchComputeEnvironmentDataSource_tags_IgnoreTags_Overlap_DefaultTag
 func TestAccBatchComputeEnvironmentDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/compute_environment_tags_gen_test.go
+++ b/internal/service/batch/compute_environment_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/batch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBatchComputeEnvironment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBatchComputeEnvironment_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccBatchComputeEnvironment_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccBatchComputeEnvironment_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccBatchComputeEnvironment_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBatchComputeEnvironment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccBatchComputeEnvironment_tags_EmptyTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckComputeEnvironmentDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_providerOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_nonOverlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_updateToProviderOnly(t *tes
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_updateToResourceOnly(t *tes
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_emptyResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_emptyProviderOnlyTag(t *tes
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_nullOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccBatchComputeEnvironment_tags_DefaultTags_nullNonOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccBatchComputeEnvironment_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccBatchComputeEnvironment_tags_ComputedTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccBatchComputeEnvironment_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccBatchComputeEnvironment_tags_IgnoreTags_Overlap_ResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.ComputeEnvironmentDetail
 	resourceName := "aws_batch_compute_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckComputeEnvironmentDestroy(ctx),

--- a/internal/service/batch/job_definition_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_definition_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccBatchJobDefinitionDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccBatchJobDefinitionDataSource_tags(t *testing.T) {
 func TestAccBatchJobDefinitionDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccBatchJobDefinitionDataSource_tags_NullMap(t *testing.T) {
 func TestAccBatchJobDefinitionDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccBatchJobDefinitionDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccBatchJobDefinitionDataSource_tags_DefaultTags_nonOverlapping(t *test
 func TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func TestAccBatchJobDefinitionDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/job_definition_tags_gen_test.go
+++ b/internal/service/batch/job_definition_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/batch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBatchJobDefinition_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBatchJobDefinition_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccBatchJobDefinition_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccBatchJobDefinition_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccBatchJobDefinition_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccBatchJobDefinition_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobDefinitionDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccBatchJobDefinition_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccBatchJobDefinition_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccBatchJobDefinition_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccBatchJobDefinition_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.JobDefinition
 	resourceName := "aws_batch_job_definition.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobDefinitionDestroy(ctx),

--- a/internal/service/batch/job_queue_data_source_tags_gen_test.go
+++ b/internal/service/batch/job_queue_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccBatchJobQueueDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccBatchJobQueueDataSource_tags(t *testing.T) {
 func TestAccBatchJobQueueDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccBatchJobQueueDataSource_tags_NullMap(t *testing.T) {
 func TestAccBatchJobQueueDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccBatchJobQueueDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBatchJobQueueDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccBatchJobQueueDataSource_tags_DefaultTags_nonOverlapping(t *testing.T
 func TestAccBatchJobQueueDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccBatchJobQueueDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func TestAccBatchJobQueueDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/job_queue_tags_gen_test.go
+++ b/internal/service/batch/job_queue_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/batch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBatchJobQueue_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBatchJobQueue_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccBatchJobQueue_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccBatchJobQueue_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccBatchJobQueue_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccBatchJobQueue_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckJobQueueDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccBatchJobQueue_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccBatchJobQueue_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccBatchJobQueue_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccBatchJobQueue_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccBatchJobQueue_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.JobQueueDetail
 	resourceName := "aws_batch_job_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckJobQueueDestroy(ctx),

--- a/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
+++ b/internal/service/batch/scheduling_policy_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccBatchSchedulingPolicyDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccBatchSchedulingPolicyDataSource_tags(t *testing.T) {
 func TestAccBatchSchedulingPolicyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccBatchSchedulingPolicyDataSource_tags_NullMap(t *testing.T) {
 func TestAccBatchSchedulingPolicyDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccBatchSchedulingPolicyDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBatchSchedulingPolicyDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccBatchSchedulingPolicyDataSource_tags_DefaultTags_nonOverlapping(t *t
 func TestAccBatchSchedulingPolicyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccBatchSchedulingPolicyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t
 func TestAccBatchSchedulingPolicyDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BatchServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/batch/scheduling_policy_tags_gen_test.go
+++ b/internal/service/batch/scheduling_policy_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/batch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBatchSchedulingPolicy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBatchSchedulingPolicy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccBatchSchedulingPolicy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccBatchSchedulingPolicy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccBatchSchedulingPolicy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBatchSchedulingPolicy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccBatchSchedulingPolicy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy:             testAccCheckSchedulingPolicyDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccBatchSchedulingPolicy_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccBatchSchedulingPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccBatchSchedulingPolicy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccBatchSchedulingPolicy_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.SchedulingPolicyDetail
 	resourceName := "aws_batch_scheduling_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BatchServiceID),
 		CheckDestroy: testAccCheckSchedulingPolicyDestroy(ctx),

--- a/internal/service/bcmdataexports/export_tags_gen_test.go
+++ b/internal/service/bcmdataexports/export_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/bcmdataexports"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBCMDataExportsExport_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccBCMDataExportsExport_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -267,9 +266,9 @@ func TestAccBCMDataExportsExport_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -317,9 +316,9 @@ func TestAccBCMDataExportsExport_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -399,9 +398,9 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -491,9 +490,9 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccBCMDataExportsExport_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy:             testAccCheckExportDestroy(ctx),
@@ -722,9 +721,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -903,9 +902,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1063,9 +1062,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1239,9 +1238,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1329,9 +1328,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1420,9 +1419,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1488,9 +1487,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1548,9 +1547,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1619,9 +1618,9 @@ func TestAccBCMDataExportsExport_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1745,9 +1744,9 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1842,9 +1841,9 @@ func TestAccBCMDataExportsExport_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -1929,9 +1928,9 @@ func TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),
@@ -2091,9 +2090,9 @@ func TestAccBCMDataExportsExport_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v bcmdataexports.GetExportOutput
 	resourceName := "aws_bcmdataexports_export.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BCMDataExportsServiceID),
 		CheckDestroy: testAccCheckExportDestroy(ctx),

--- a/internal/service/bedrock/custom_model_tags_gen_test.go
+++ b/internal/service/bedrock/custom_model_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccBedrockCustomModel_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -244,9 +243,9 @@ func testAccBedrockCustomModel_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -307,9 +306,9 @@ func testAccBedrockCustomModel_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -358,9 +357,9 @@ func testAccBedrockCustomModel_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -441,9 +440,9 @@ func testAccBedrockCustomModel_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -537,9 +536,9 @@ func testAccBedrockCustomModel_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -682,9 +681,9 @@ func testAccBedrockCustomModel_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckCustomModelDestroy(ctx),
@@ -775,9 +774,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -968,9 +967,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1137,9 +1136,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1322,9 +1321,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1415,9 +1414,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1507,9 +1506,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1576,9 +1575,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1637,9 +1636,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1707,9 +1706,9 @@ func testAccBedrockCustomModel_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1779,9 +1778,9 @@ func testAccBedrockCustomModel_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1837,9 +1836,9 @@ func testAccBedrockCustomModel_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -1937,9 +1936,9 @@ func testAccBedrockCustomModel_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -2027,9 +2026,9 @@ func testAccBedrockCustomModel_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),
@@ -2189,9 +2188,9 @@ func testAccBedrockCustomModel_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bedrock.GetModelCustomizationJobOutput
 	resourceName := "aws_bedrock_custom_model.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckCustomModelDestroy(ctx),

--- a/internal/service/bedrock/guardrail_tags_gen_test.go
+++ b/internal/service/bedrock/guardrail_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBedrockGuardrail_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccBedrockGuardrail_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccBedrockGuardrail_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -327,9 +326,9 @@ func TestAccBedrockGuardrail_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -409,9 +408,9 @@ func TestAccBedrockGuardrail_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -646,9 +645,9 @@ func TestAccBedrockGuardrail_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckGuardrailDestroy(ctx),
@@ -738,9 +737,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -927,9 +926,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1093,9 +1092,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1275,9 +1274,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1367,9 +1366,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1458,9 +1457,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1657,9 +1656,9 @@ func TestAccBedrockGuardrail_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1730,9 +1729,9 @@ func TestAccBedrockGuardrail_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1787,9 +1786,9 @@ func TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1886,9 +1885,9 @@ func TestAccBedrockGuardrail_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -1975,9 +1974,9 @@ func TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),
@@ -2137,9 +2136,9 @@ func TestAccBedrockGuardrail_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetGuardrailOutput
 	resourceName := "aws_bedrock_guardrail.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckGuardrailDestroy(ctx),

--- a/internal/service/bedrock/inference_profile_tags_gen_test.go
+++ b/internal/service/bedrock/inference_profile_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBedrockInferenceProfile_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccBedrockInferenceProfile_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -278,9 +277,9 @@ func TestAccBedrockInferenceProfile_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -329,9 +328,9 @@ func TestAccBedrockInferenceProfile_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -412,9 +411,9 @@ func TestAccBedrockInferenceProfile_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -508,9 +507,9 @@ func TestAccBedrockInferenceProfile_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -653,9 +652,9 @@ func TestAccBedrockInferenceProfile_tags_EmptyTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy:             testAccCheckInferenceProfileDestroy(ctx),
@@ -746,9 +745,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_providerOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -939,9 +938,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_nonOverlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1108,9 +1107,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1293,9 +1292,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_updateToProviderOnly(t *tes
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1386,9 +1385,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_updateToResourceOnly(t *tes
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1478,9 +1477,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_emptyResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_emptyProviderOnlyTag(t *tes
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1608,9 +1607,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_nullOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1678,9 +1677,9 @@ func TestAccBedrockInferenceProfile_tags_DefaultTags_nullNonOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1750,9 +1749,9 @@ func TestAccBedrockInferenceProfile_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1808,9 +1807,9 @@ func TestAccBedrockInferenceProfile_tags_ComputedTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1908,9 +1907,9 @@ func TestAccBedrockInferenceProfile_tags_ComputedTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -1998,9 +1997,9 @@ func TestAccBedrockInferenceProfile_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),
@@ -2160,9 +2159,9 @@ func TestAccBedrockInferenceProfile_tags_IgnoreTags_Overlap_ResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v bedrock.GetInferenceProfileOutput
 	resourceName := "aws_bedrock_inference_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BedrockServiceID),
 		CheckDestroy: testAccCheckInferenceProfileDestroy(ctx),

--- a/internal/service/budgets/budget_data_source_tags_gen_test.go
+++ b/internal/service/budgets/budget_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccBudgetsBudgetDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccBudgetsBudgetDataSource_tags(t *testing.T) {
 func TestAccBudgetsBudgetDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccBudgetsBudgetDataSource_tags_NullMap(t *testing.T) {
 func TestAccBudgetsBudgetDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccBudgetsBudgetDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccBudgetsBudgetDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BudgetsServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccBudgetsBudgetDataSource_tags_DefaultTags_nonOverlapping(t *testing.T
 func TestAccBudgetsBudgetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BudgetsServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccBudgetsBudgetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func TestAccBudgetsBudgetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.BudgetsServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/budgets/budget_tags_gen_test.go
+++ b/internal/service/budgets/budget_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/budgets/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccBudgetsBudget_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccBudgetsBudget_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccBudgetsBudget_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccBudgetsBudget_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccBudgetsBudget_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccBudgetsBudget_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccBudgetsBudget_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy:             testAccCheckBudgetDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccBudgetsBudget_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccBudgetsBudget_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccBudgetsBudget_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccBudgetsBudget_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccBudgetsBudget_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccBudgetsBudget_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Budget
 	resourceName := "aws_budgets_budget.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.BudgetsServiceID),
 		CheckDestroy: testAccCheckBudgetDestroy(ctx),

--- a/internal/service/cleanrooms/membership_tags_gen_test.go
+++ b/internal/service/cleanrooms/membership_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cleanrooms"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCleanRoomsMembership_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -203,9 +202,9 @@ func TestAccCleanRoomsMembership_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -265,9 +264,9 @@ func TestAccCleanRoomsMembership_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -315,9 +314,9 @@ func TestAccCleanRoomsMembership_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -395,9 +394,9 @@ func TestAccCleanRoomsMembership_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -485,9 +484,9 @@ func TestAccCleanRoomsMembership_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -624,9 +623,9 @@ func TestAccCleanRoomsMembership_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy:             acctest.CheckDestroyNoop,
@@ -714,9 +713,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -895,9 +894,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1055,9 +1054,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1231,9 +1230,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1321,9 +1320,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1410,9 +1409,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1476,9 +1475,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1534,9 +1533,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1603,9 +1602,9 @@ func TestAccCleanRoomsMembership_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1674,9 +1673,9 @@ func TestAccCleanRoomsMembership_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1729,9 +1728,9 @@ func TestAccCleanRoomsMembership_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1826,9 +1825,9 @@ func TestAccCleanRoomsMembership_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -1913,9 +1912,9 @@ func TestAccCleanRoomsMembership_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,
@@ -2075,9 +2074,9 @@ func TestAccCleanRoomsMembership_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v cleanrooms.GetMembershipOutput
 	resourceName := "aws_cleanrooms_membership.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CleanRoomsServiceID),
 		CheckDestroy: acctest.CheckDestroyNoop,

--- a/internal/service/cloudwatch/composite_alarm_tags_gen_test.go
+++ b/internal/service/cloudwatch/composite_alarm_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccCloudWatchCompositeAlarm_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccCloudWatchCompositeAlarm_tags(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccCloudWatchCompositeAlarm_tags_null(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccCloudWatchCompositeAlarm_tags_EmptyMap(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccCloudWatchCompositeAlarm_tags_AddOnUpdate(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckCompositeAlarmDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccCloudWatchCompositeAlarm_tags_EmptyTag_OnUpdate_Replace(t *testing.T
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_providerOnly(t *testing.T)
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_overlapping(t *testing.T) 
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_updateToProviderOnly(t *te
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_updateToResourceOnly(t *te
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_emptyResourceTag(t *testin
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_emptyProviderOnlyTag(t *te
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nullOverlappingResourceTag
 func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccCloudWatchCompositeAlarm_tags_DefaultTags_nullNonOverlappingResource
 func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnUpdate_Add(t *testing.T)
 func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccCloudWatchCompositeAlarm_tags_ComputedTag_OnUpdate_Replace(t *testin
 func TestAccCloudWatchCompositeAlarm_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccCloudWatchCompositeAlarm_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccCloudWatchCompositeAlarm_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_composite_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckCompositeAlarmDestroy(ctx),

--- a/internal/service/cloudwatch/contributor_insight_rule_tags_gen_test.go
+++ b/internal/service/cloudwatch/contributor_insight_rule_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCloudWatchContributorInsightRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -223,9 +222,9 @@ func TestAccCloudWatchContributorInsightRule_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -288,9 +287,9 @@ func TestAccCloudWatchContributorInsightRule_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -341,9 +340,9 @@ func TestAccCloudWatchContributorInsightRule_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -426,9 +425,9 @@ func TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnCreate(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -526,9 +525,9 @@ func TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Add(t *testi
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -675,9 +674,9 @@ func TestAccCloudWatchContributorInsightRule_tags_EmptyTag_OnUpdate_Replace(t *t
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckContributorInsightRuleDestroy(ctx),
@@ -770,9 +769,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_providerOnly(t *te
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -971,9 +970,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nonOverlapping(t *
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1146,9 +1145,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_overlapping(t *tes
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1337,9 +1336,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToProviderOn
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1432,9 +1431,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_updateToResourceOn
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1597,9 +1596,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_emptyProviderOnlyT
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1660,9 +1659,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullOverlappingRes
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1732,9 +1731,9 @@ func TestAccCloudWatchContributorInsightRule_tags_DefaultTags_nullNonOverlapping
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnCreate(t *testin
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1866,9 +1865,9 @@ func TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Add(t *te
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -1968,9 +1967,9 @@ func TestAccCloudWatchContributorInsightRule_tags_ComputedTag_OnUpdate_Replace(t
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -2060,9 +2059,9 @@ func TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_DefaultTag(
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),
@@ -2222,9 +2221,9 @@ func TestAccCloudWatchContributorInsightRule_tags_IgnoreTags_Overlap_ResourceTag
 	ctx := acctest.Context(t)
 	var v types.InsightRule
 	resourceName := "aws_cloudwatch_contributor_insight_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckContributorInsightRuleDestroy(ctx),

--- a/internal/service/cloudwatch/metric_alarm_tags_gen_test.go
+++ b/internal/service/cloudwatch/metric_alarm_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCloudWatchMetricAlarm_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccCloudWatchMetricAlarm_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccCloudWatchMetricAlarm_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccCloudWatchMetricAlarm_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccCloudWatchMetricAlarm_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccCloudWatchMetricAlarm_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccCloudWatchMetricAlarm_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricAlarmDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccCloudWatchMetricAlarm_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccCloudWatchMetricAlarm_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccCloudWatchMetricAlarm_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccCloudWatchMetricAlarm_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccCloudWatchMetricAlarm_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccCloudWatchMetricAlarm_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.MetricAlarm
 	resourceName := "aws_cloudwatch_metric_alarm.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricAlarmDestroy(ctx),

--- a/internal/service/cloudwatch/metric_stream_tags_gen_test.go
+++ b/internal/service/cloudwatch/metric_stream_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccCloudWatchMetricStream_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccCloudWatchMetricStream_tags(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccCloudWatchMetricStream_tags_null(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccCloudWatchMetricStream_tags_EmptyMap(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccCloudWatchMetricStream_tags_AddOnUpdate(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccCloudWatchMetricStream_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccCloudWatchMetricStream_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy:             testAccCheckMetricStreamDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccCloudWatchMetricStream_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 func TestAccCloudWatchMetricStream_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_nonOverlapping(t *testing.T)
 func TestAccCloudWatchMetricStream_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_updateToProviderOnly(t *test
 func TestAccCloudWatchMetricStream_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_updateToResourceOnly(t *test
 func TestAccCloudWatchMetricStream_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_emptyResourceTag(t *testing.
 func TestAccCloudWatchMetricStream_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_emptyProviderOnlyTag(t *test
 func TestAccCloudWatchMetricStream_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_nullOverlappingResourceTag(t
 func TestAccCloudWatchMetricStream_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccCloudWatchMetricStream_tags_DefaultTags_nullNonOverlappingResourceTa
 func TestAccCloudWatchMetricStream_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccCloudWatchMetricStream_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccCloudWatchMetricStream_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccCloudWatchMetricStream_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccCloudWatchMetricStream_tags_ComputedTag_OnUpdate_Replace(t *testing.
 func TestAccCloudWatchMetricStream_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccCloudWatchMetricStream_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 func TestAccCloudWatchMetricStream_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_cloudwatch_metric_stream.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CloudWatchServiceID),
 		CheckDestroy: testAccCheckMetricStreamDestroy(ctx),

--- a/internal/service/codeconnections/connection_tags_gen_test.go
+++ b/internal/service/codeconnections/connection_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/codeconnections/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCodeConnectionsConnection_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccCodeConnectionsConnection_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccCodeConnectionsConnection_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccCodeConnectionsConnection_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccCodeConnectionsConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccCodeConnectionsConnection_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccCodeConnectionsConnection_tags_EmptyTag_OnUpdate_Replace(t *testing.
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckConnectionDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_providerOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_nonOverlapping(t *testing
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_overlapping(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_updateToProviderOnly(t *t
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_updateToResourceOnly(t *t
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_emptyResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_emptyProviderOnlyTag(t *t
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_nullOverlappingResourceTa
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccCodeConnectionsConnection_tags_DefaultTags_nullNonOverlappingResourc
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccCodeConnectionsConnection_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccCodeConnectionsConnection_tags_ComputedTag_OnUpdate_Add(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccCodeConnectionsConnection_tags_ComputedTag_OnUpdate_Replace(t *testi
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccCodeConnectionsConnection_tags_IgnoreTags_Overlap_DefaultTag(t *test
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccCodeConnectionsConnection_tags_IgnoreTags_Overlap_ResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v types.Connection
 	resourceName := "aws_codeconnections_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckConnectionDestroy(ctx),

--- a/internal/service/codeconnections/host_tags_gen_test.go
+++ b/internal/service/codeconnections/host_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/codeconnections/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCodeConnectionsHost_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccCodeConnectionsHost_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccCodeConnectionsHost_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccCodeConnectionsHost_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccCodeConnectionsHost_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccCodeConnectionsHost_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccCodeConnectionsHost_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy:             testAccCheckHostDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccCodeConnectionsHost_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccCodeConnectionsHost_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccCodeConnectionsHost_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccCodeConnectionsHost_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccCodeConnectionsHost_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccCodeConnectionsHost_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.Host
 	resourceName := "aws_codeconnections_host.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CodeConnectionsServiceID),
 		CheckDestroy: testAccCheckHostDestroy(ctx),

--- a/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
+++ b/internal/service/cognitoidp/user_pool_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccCognitoIDPUserPoolDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccCognitoIDPUserPoolDataSource_tags(t *testing.T) {
 func TestAccCognitoIDPUserPoolDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccCognitoIDPUserPoolDataSource_tags_NullMap(t *testing.T) {
 func TestAccCognitoIDPUserPoolDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccCognitoIDPUserPoolDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccCognitoIDPUserPoolDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccCognitoIDPUserPoolDataSource_tags_DefaultTags_nonOverlapping(t *test
 func TestAccCognitoIDPUserPoolDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccCognitoIDPUserPoolDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func TestAccCognitoIDPUserPoolDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/cognitoidp/user_pool_tags_gen_test.go
+++ b/internal/service/cognitoidp/user_pool_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccCognitoIDPUserPool_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccCognitoIDPUserPool_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccCognitoIDPUserPool_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccCognitoIDPUserPool_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccCognitoIDPUserPool_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccCognitoIDPUserPool_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy:             testAccCheckUserPoolDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccCognitoIDPUserPool_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccCognitoIDPUserPool_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccCognitoIDPUserPool_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccCognitoIDPUserPool_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.UserPoolType
 	resourceName := "aws_cognito_user_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.CognitoIDPServiceID),
 		CheckDestroy: testAccCheckUserPoolDestroy(ctx),

--- a/internal/service/dataexchange/revision_assets_tags_gen_test.go
+++ b/internal/service/dataexchange/revision_assets_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/dataexchange"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDataExchangeRevisionAssets_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -159,9 +158,9 @@ func TestAccDataExchangeRevisionAssets_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -206,9 +205,9 @@ func TestAccDataExchangeRevisionAssets_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -243,9 +242,9 @@ func TestAccDataExchangeRevisionAssets_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -311,9 +310,9 @@ func TestAccDataExchangeRevisionAssets_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -380,9 +379,9 @@ func TestAccDataExchangeRevisionAssets_tags_EmptyTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -495,9 +494,9 @@ func TestAccDataExchangeRevisionAssets_tags_EmptyTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy:             testAccCheckRevisionAssetsDestroy(ctx),
@@ -573,9 +572,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_providerOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -703,9 +702,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_nonOverlapping(t *testin
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -821,9 +820,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_overlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -949,9 +948,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_updateToProviderOnly(t *
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1025,9 +1024,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_updateToResourceOnly(t *
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1101,9 +1100,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_emptyResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1151,9 +1150,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_emptyProviderOnlyTag(t *
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1195,9 +1194,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_nullOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1245,9 +1244,9 @@ func TestAccDataExchangeRevisionAssets_tags_DefaultTags_nullNonOverlappingResour
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1297,9 +1296,9 @@ func TestAccDataExchangeRevisionAssets_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1341,9 +1340,9 @@ func TestAccDataExchangeRevisionAssets_tags_ComputedTag_OnUpdate_Add(t *testing.
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccDataExchangeRevisionAssets_tags_ComputedTag_OnUpdate_Replace(t *test
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1501,9 +1500,9 @@ func TestAccDataExchangeRevisionAssets_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),
@@ -1663,9 +1662,9 @@ func TestAccDataExchangeRevisionAssets_tags_IgnoreTags_Overlap_ResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v dataexchange.GetRevisionOutput
 	resourceName := "aws_dataexchange_revision_assets.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataExchangeServiceID),
 		CheckDestroy: testAccCheckRevisionAssetsDestroy(ctx),

--- a/internal/service/datapipeline/pipeline_data_source_tags_gen_test.go
+++ b/internal/service/datapipeline/pipeline_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccDataPipelinePipelineDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccDataPipelinePipelineDataSource_tags(t *testing.T) {
 func TestAccDataPipelinePipelineDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccDataPipelinePipelineDataSource_tags_NullMap(t *testing.T) {
 func TestAccDataPipelinePipelineDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccDataPipelinePipelineDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDataPipelinePipelineDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccDataPipelinePipelineDataSource_tags_DefaultTags_nonOverlapping(t *te
 func TestAccDataPipelinePipelineDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccDataPipelinePipelineDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 func TestAccDataPipelinePipelineDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/datapipeline/pipeline_tags_gen_test.go
+++ b/internal/service/datapipeline/pipeline_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/datapipeline/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDataPipelinePipeline_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccDataPipelinePipeline_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccDataPipelinePipeline_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccDataPipelinePipeline_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccDataPipelinePipeline_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccDataPipelinePipeline_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccDataPipelinePipeline_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy:             testAccCheckPipelineDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccDataPipelinePipeline_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccDataPipelinePipeline_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccDataPipelinePipeline_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccDataPipelinePipeline_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccDataPipelinePipeline_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccDataPipelinePipeline_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.PipelineDescription
 	resourceName := "aws_datapipeline_pipeline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DataPipelineServiceID),
 		CheckDestroy: testAccCheckPipelineDestroy(ctx),

--- a/internal/service/dms/certificate_data_source_tags_gen_test.go
+++ b/internal/service/dms/certificate_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDMSCertificateDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDMSCertificateDataSource_tags(t *testing.T) {
 func TestAccDMSCertificateDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDMSCertificateDataSource_tags_NullMap(t *testing.T) {
 func TestAccDMSCertificateDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDMSCertificateDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDMSCertificateDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDMSCertificateDataSource_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccDMSCertificateDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDMSCertificateDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccDMSCertificateDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dms/certificate_tags_gen_test.go
+++ b/internal/service/dms/certificate_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDMSCertificate_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccDMSCertificate_tags(t *testing.T) {
 func TestAccDMSCertificate_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccDMSCertificate_tags_null(t *testing.T) {
 func TestAccDMSCertificate_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccDMSCertificate_tags_EmptyMap(t *testing.T) {
 func TestAccDMSCertificate_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccDMSCertificate_tags_AddOnUpdate(t *testing.T) {
 func TestAccDMSCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccDMSCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDMSCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccDMSCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSCertificate_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckCertificateDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccDMSCertificate_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccDMSCertificate_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccDMSCertificate_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccDMSCertificate_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccDMSCertificate_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccDMSCertificate_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccDMSCertificate_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccDMSCertificate_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccDMSCertificate_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccDMSCertificate_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 func TestAccDMSCertificate_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccDMSCertificate_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 func TestAccDMSCertificate_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccDMSCertificate_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDMSCertificate_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccDMSCertificate_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSCertificate_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccDMSCertificate_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccDMSCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccDMSCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckCertificateDestroy(ctx),

--- a/internal/service/dms/endpoint_data_source_tags_gen_test.go
+++ b/internal/service/dms/endpoint_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDMSEndpointDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDMSEndpointDataSource_tags(t *testing.T) {
 func TestAccDMSEndpointDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDMSEndpointDataSource_tags_NullMap(t *testing.T) {
 func TestAccDMSEndpointDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDMSEndpointDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDMSEndpointDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDMSEndpointDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccDMSEndpointDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDMSEndpointDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccDMSEndpointDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dms/endpoint_tags_gen_test.go
+++ b/internal/service/dms/endpoint_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDMSEndpoint_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -212,9 +211,9 @@ func TestAccDMSEndpoint_tags(t *testing.T) {
 func TestAccDMSEndpoint_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -281,9 +280,9 @@ func TestAccDMSEndpoint_tags_null(t *testing.T) {
 func TestAccDMSEndpoint_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -346,9 +345,9 @@ func TestAccDMSEndpoint_tags_EmptyMap(t *testing.T) {
 func TestAccDMSEndpoint_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -429,9 +428,9 @@ func TestAccDMSEndpoint_tags_AddOnUpdate(t *testing.T) {
 func TestAccDMSEndpoint_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -523,9 +522,9 @@ func TestAccDMSEndpoint_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -665,9 +664,9 @@ func TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEndpointDestroy(ctx),
@@ -756,9 +755,9 @@ func TestAccDMSEndpoint_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -948,9 +947,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1116,9 +1115,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1300,9 +1299,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1392,9 +1391,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1483,9 +1482,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1550,9 +1549,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1673,9 +1672,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 func TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1737,9 +1736,9 @@ func TestAccDMSEndpoint_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 func TestAccDMSEndpoint_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1794,9 +1793,9 @@ func TestAccDMSEndpoint_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1893,9 +1892,9 @@ func TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -1982,9 +1981,9 @@ func TestAccDMSEndpoint_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),
@@ -2143,9 +2142,9 @@ func TestAccDMSEndpoint_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccDMSEndpoint_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEndpointDestroy(ctx),

--- a/internal/service/dms/event_subscription_tags_gen_test.go
+++ b/internal/service/dms/event_subscription_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDMSEventSubscription_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccDMSEventSubscription_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccDMSEventSubscription_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccDMSEventSubscription_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccDMSEventSubscription_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccDMSEventSubscription_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccDMSEventSubscription_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckEventSubscriptionDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccDMSEventSubscription_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccDMSEventSubscription_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccDMSEventSubscription_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccDMSEventSubscription_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccDMSEventSubscription_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccDMSEventSubscription_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.EventSubscription
 	resourceName := "aws_dms_event_subscription.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckEventSubscriptionDestroy(ctx),

--- a/internal/service/dms/replication_config_tags_gen_test.go
+++ b/internal/service/dms/replication_config_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDMSReplicationConfig_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccDMSReplicationConfig_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccDMSReplicationConfig_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccDMSReplicationConfig_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccDMSReplicationConfig_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccDMSReplicationConfig_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccDMSReplicationConfig_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccDMSReplicationConfig_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccDMSReplicationConfig_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccDMSReplicationConfig_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccDMSReplicationConfig_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccDMSReplicationConfig_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccDMSReplicationConfig_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfig
 	resourceName := "aws_dms_replication_config.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigDestroy(ctx),

--- a/internal/service/dms/replication_instance_data_source_tags_gen_test.go
+++ b/internal/service/dms/replication_instance_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDMSReplicationInstanceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDMSReplicationInstanceDataSource_tags(t *testing.T) {
 func TestAccDMSReplicationInstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDMSReplicationInstanceDataSource_tags_NullMap(t *testing.T) {
 func TestAccDMSReplicationInstanceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDMSReplicationInstanceDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDMSReplicationInstanceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDMSReplicationInstanceDataSource_tags_DefaultTags_nonOverlapping(t *
 func TestAccDMSReplicationInstanceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDMSReplicationInstanceDataSource_tags_IgnoreTags_Overlap_DefaultTag(
 func TestAccDMSReplicationInstanceDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dms/replication_instance_tags_gen_test.go
+++ b/internal/service/dms/replication_instance_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDMSReplicationInstance_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -212,9 +211,9 @@ func TestAccDMSReplicationInstance_tags(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -281,9 +280,9 @@ func TestAccDMSReplicationInstance_tags_null(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -346,9 +345,9 @@ func TestAccDMSReplicationInstance_tags_EmptyMap(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -429,9 +428,9 @@ func TestAccDMSReplicationInstance_tags_AddOnUpdate(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -523,9 +522,9 @@ func TestAccDMSReplicationInstance_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -665,9 +664,9 @@ func TestAccDMSReplicationInstance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationInstanceDestroy(ctx),
@@ -756,9 +755,9 @@ func TestAccDMSReplicationInstance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) 
 func TestAccDMSReplicationInstance_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -948,9 +947,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1116,9 +1115,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_nonOverlapping(t *testing.T)
 func TestAccDMSReplicationInstance_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1300,9 +1299,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1392,9 +1391,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_updateToProviderOnly(t *test
 func TestAccDMSReplicationInstance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1483,9 +1482,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_updateToResourceOnly(t *test
 func TestAccDMSReplicationInstance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1550,9 +1549,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_emptyResourceTag(t *testing.
 func TestAccDMSReplicationInstance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_emptyProviderOnlyTag(t *test
 func TestAccDMSReplicationInstance_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1673,9 +1672,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_nullOverlappingResourceTag(t
 func TestAccDMSReplicationInstance_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1737,9 +1736,9 @@ func TestAccDMSReplicationInstance_tags_DefaultTags_nullNonOverlappingResourceTa
 func TestAccDMSReplicationInstance_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1794,9 +1793,9 @@ func TestAccDMSReplicationInstance_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1893,9 +1892,9 @@ func TestAccDMSReplicationInstance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSReplicationInstance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -1982,9 +1981,9 @@ func TestAccDMSReplicationInstance_tags_ComputedTag_OnUpdate_Replace(t *testing.
 func TestAccDMSReplicationInstance_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),
@@ -2143,9 +2142,9 @@ func TestAccDMSReplicationInstance_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 func TestAccDMSReplicationInstance_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationInstanceDestroy(ctx),

--- a/internal/service/dms/replication_subnet_group_data_source_tags_gen_test.go
+++ b/internal/service/dms/replication_subnet_group_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDMSReplicationSubnetGroupDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDMSReplicationSubnetGroupDataSource_tags(t *testing.T) {
 func TestAccDMSReplicationSubnetGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDMSReplicationSubnetGroupDataSource_tags_NullMap(t *testing.T) {
 func TestAccDMSReplicationSubnetGroupDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDMSReplicationSubnetGroupDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDMSReplicationSubnetGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDMSReplicationSubnetGroupDataSource_tags_DefaultTags_nonOverlapping(
 func TestAccDMSReplicationSubnetGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDMSReplicationSubnetGroupDataSource_tags_IgnoreTags_Overlap_DefaultT
 func TestAccDMSReplicationSubnetGroupDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dms/replication_subnet_group_tags_gen_test.go
+++ b/internal/service/dms/replication_subnet_group_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDMSReplicationSubnetGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccDMSReplicationSubnetGroup_tags(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccDMSReplicationSubnetGroup_tags_null(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccDMSReplicationSubnetGroup_tags_EmptyMap(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccDMSReplicationSubnetGroup_tags_AddOnUpdate(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccDMSReplicationSubnetGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_providerOnly(t *testing.T
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nonOverlapping(t *testing
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_overlapping(t *testing.T)
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_updateToProviderOnly(t *t
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_updateToResourceOnly(t *t
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_emptyResourceTag(t *testi
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_emptyProviderOnlyTag(t *t
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nullOverlappingResourceTa
 func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccDMSReplicationSubnetGroup_tags_DefaultTags_nullNonOverlappingResourc
 func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T
 func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccDMSReplicationSubnetGroup_tags_ComputedTag_OnUpdate_Replace(t *testi
 func TestAccDMSReplicationSubnetGroup_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccDMSReplicationSubnetGroup_tags_IgnoreTags_Overlap_DefaultTag(t *test
 func TestAccDMSReplicationSubnetGroup_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_replication_subnet_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationSubnetGroupDestroy(ctx),

--- a/internal/service/dms/replication_task_data_source_tags_gen_test.go
+++ b/internal/service/dms/replication_task_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDMSReplicationTaskDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDMSReplicationTaskDataSource_tags(t *testing.T) {
 func TestAccDMSReplicationTaskDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDMSReplicationTaskDataSource_tags_NullMap(t *testing.T) {
 func TestAccDMSReplicationTaskDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDMSReplicationTaskDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDMSReplicationTaskDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDMSReplicationTaskDataSource_tags_DefaultTags_nonOverlapping(t *test
 func TestAccDMSReplicationTaskDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDMSReplicationTaskDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func TestAccDMSReplicationTaskDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DMSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dms/replication_task_tags_gen_test.go
+++ b/internal/service/dms/replication_task_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/databasemigrationservice/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDMSReplicationTask_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccDMSReplicationTask_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccDMSReplicationTask_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccDMSReplicationTask_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccDMSReplicationTask_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccDMSReplicationTask_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccDMSReplicationTask_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckReplicationTaskDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccDMSReplicationTask_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccDMSReplicationTask_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccDMSReplicationTask_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccDMSReplicationTask_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccDMSReplicationTask_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccDMSReplicationTask_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationTask
 	resourceName := "aws_dms_replication_task.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckReplicationTaskDestroy(ctx),

--- a/internal/service/dms/s3_endpoint_tags_gen_test.go
+++ b/internal/service/dms/s3_endpoint_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDMSS3Endpoint_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccDMSS3Endpoint_tags(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccDMSS3Endpoint_tags_null(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccDMSS3Endpoint_tags_EmptyMap(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccDMSS3Endpoint_tags_AddOnUpdate(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccDMSS3Endpoint_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccDMSS3Endpoint_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy:             testAccCheckS3EndpointDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccDMSS3Endpoint_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 func TestAccDMSS3Endpoint_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccDMSS3Endpoint_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 func TestAccDMSS3Endpoint_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccDMSS3Endpoint_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccDMSS3Endpoint_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccDMSS3Endpoint_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccDMSS3Endpoint_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccDMSS3Endpoint_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dms_s3_endpoint.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DMSServiceID),
 		CheckDestroy: testAccCheckS3EndpointDestroy(ctx),

--- a/internal/service/drs/replication_configuration_template_tags_gen_test.go
+++ b/internal/service/drs/replication_configuration_template_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/drs/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccDRSReplicationConfigurationTemplate_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -232,9 +231,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -294,9 +293,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -344,9 +343,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -424,9 +423,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_EmptyTag_OnCreate(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -514,9 +513,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_EmptyTag_OnUpdate_Add(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -653,9 +652,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_EmptyTag_OnUpdate_Replace(t
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy:             testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -743,9 +742,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_providerOnly(t 
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -924,9 +923,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_nonOverlapping(
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1084,9 +1083,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_overlapping(t *
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1260,9 +1259,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_updateToProvide
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1350,9 +1349,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_updateToResourc
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1439,9 +1438,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_emptyResourceTa
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1505,9 +1504,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_emptyProviderOn
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1563,9 +1562,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_nullOverlapping
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1632,9 +1631,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_DefaultTags_nullNonOverlapp
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1703,9 +1702,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_ComputedTag_OnCreate(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1758,9 +1757,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_ComputedTag_OnUpdate_Add(t 
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1855,9 +1854,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_ComputedTag_OnUpdate_Replac
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -1942,9 +1941,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_IgnoreTags_Overlap_DefaultT
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),
@@ -2104,9 +2103,9 @@ func testAccDRSReplicationConfigurationTemplate_tags_IgnoreTags_Overlap_Resource
 	ctx := acctest.Context(t)
 	var v awstypes.ReplicationConfigurationTemplate
 	resourceName := "aws_drs_replication_configuration_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DRSServiceID),
 		CheckDestroy: testAccCheckReplicationConfigurationTemplateDestroy(ctx),

--- a/internal/service/dsql/cluster_tags_gen_test.go
+++ b/internal/service/dsql/cluster_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/dsql"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDSQLCluster_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccDSQLCluster_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccDSQLCluster_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -327,9 +326,9 @@ func TestAccDSQLCluster_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -409,9 +408,9 @@ func TestAccDSQLCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -646,9 +645,9 @@ func TestAccDSQLCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy:             testAccCheckClusterDestroy(ctx),
@@ -738,9 +737,9 @@ func TestAccDSQLCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -927,9 +926,9 @@ func TestAccDSQLCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1093,9 +1092,9 @@ func TestAccDSQLCluster_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1275,9 +1274,9 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1367,9 +1366,9 @@ func TestAccDSQLCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1458,9 +1457,9 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccDSQLCluster_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccDSQLCluster_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1657,9 +1656,9 @@ func TestAccDSQLCluster_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1730,9 +1729,9 @@ func TestAccDSQLCluster_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1787,9 +1786,9 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1886,9 +1885,9 @@ func TestAccDSQLCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -1975,9 +1974,9 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),
@@ -2137,9 +2136,9 @@ func TestAccDSQLCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v dsql.GetClusterOutput
 	resourceName := "aws_dsql_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DSQLServiceID),
 		CheckDestroy: testAccCheckClusterDestroy(ctx),

--- a/internal/service/dynamodb/table_data_source_tags_gen_test.go
+++ b/internal/service/dynamodb/table_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccDynamoDBTableDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccDynamoDBTableDataSource_tags(t *testing.T) {
 func TestAccDynamoDBTableDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccDynamoDBTableDataSource_tags_NullMap(t *testing.T) {
 func TestAccDynamoDBTableDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccDynamoDBTableDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccDynamoDBTableDataSource_tags_DefaultTags_nonOverlapping(t *testing.T
 func TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func TestAccDynamoDBTableDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/dynamodb/table_replica_tags_gen_test.go
+++ b/internal/service/dynamodb/table_replica_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccDynamoDBTableReplica_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccDynamoDBTableReplica_tags(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -286,9 +285,9 @@ func TestAccDynamoDBTableReplica_tags_null(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -353,9 +352,9 @@ func TestAccDynamoDBTableReplica_tags_EmptyMap(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -438,9 +437,9 @@ func TestAccDynamoDBTableReplica_tags_AddOnUpdate(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -533,9 +532,9 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -678,9 +677,9 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -771,9 +770,9 @@ func TestAccDynamoDBTableReplica_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -959,9 +958,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1124,9 +1123,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1305,9 +1304,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1397,9 +1396,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToProviderOnly(t *testin
 func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1488,9 +1487,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_updateToResourceOnly(t *testin
 func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1554,9 +1553,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyResourceTag(t *testing.T)
 func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1612,9 +1611,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 func TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1675,9 +1674,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nullOverlappingResourceTag(t *
 func TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1738,9 +1737,9 @@ func TestAccDynamoDBTableReplica_tags_DefaultTags_nullNonOverlappingResourceTag(
 func TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1794,9 +1793,9 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1893,9 +1892,9 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -1982,9 +1981,9 @@ func TestAccDynamoDBTableReplica_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),
@@ -2146,9 +2145,9 @@ func TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccDynamoDBTableReplica_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_dynamodb_table_replica.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableReplicaDestroy(ctx),

--- a/internal/service/dynamodb/table_tags_gen_test.go
+++ b/internal/service/dynamodb/table_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccDynamoDBTable_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccDynamoDBTable_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccDynamoDBTable_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccDynamoDBTable_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccDynamoDBTable_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccDynamoDBTable_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy:             testAccCheckTableDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccDynamoDBTable_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccDynamoDBTable_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccDynamoDBTable_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccDynamoDBTable_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccDynamoDBTable_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TableDescription
 	resourceName := "aws_dynamodb_table.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.DynamoDBServiceID),
 		CheckDestroy: testAccCheckTableDestroy(ctx),

--- a/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_data_source_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccEC2InstanceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -49,7 +49,7 @@ func TestAccEC2InstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccEC2InstanceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -93,7 +93,7 @@ func TestAccEC2InstanceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccEC2InstanceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -159,7 +159,7 @@ func TestAccEC2InstanceDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/ec2_instance_tags_gen_test.go
+++ b/internal/service/ec2/ec2_instance_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccEC2Instance_tags(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -206,7 +206,7 @@ func TestAccEC2Instance_tags_null(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -272,7 +272,7 @@ func TestAccEC2Instance_tags_EmptyMap(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -334,7 +334,7 @@ func TestAccEC2Instance_tags_AddOnUpdate(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -414,7 +414,7 @@ func TestAccEC2Instance_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -504,7 +504,7 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -641,7 +641,7 @@ func TestAccEC2Instance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckInstanceDestroy(ctx),
@@ -729,7 +729,7 @@ func TestAccEC2Instance_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -913,7 +913,7 @@ func TestAccEC2Instance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1075,7 +1075,7 @@ func TestAccEC2Instance_tags_DefaultTags_overlapping(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1253,7 +1253,7 @@ func TestAccEC2Instance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1342,7 +1342,7 @@ func TestAccEC2Instance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1430,7 +1430,7 @@ func TestAccEC2Instance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1495,7 +1495,7 @@ func TestAccEC2Instance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1552,7 +1552,7 @@ func TestAccEC2Instance_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1614,7 +1614,7 @@ func TestAccEC2Instance_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1676,7 +1676,7 @@ func TestAccEC2Instance_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1731,7 +1731,7 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1827,7 +1827,7 @@ func TestAccEC2Instance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -1913,7 +1913,7 @@ func TestAccEC2Instance_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),
@@ -2071,7 +2071,7 @@ func TestAccEC2Instance_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v awstypes.Instance
 	resourceName := "aws_instance.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckInstanceDestroy(ctx),

--- a/internal/service/ec2/vpc_block_public_access_exclusion_tags_gen_test.go
+++ b/internal/service/ec2/vpc_block_public_access_exclusion_tags_gen_test.go
@@ -19,7 +19,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -191,7 +191,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -249,7 +249,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -295,7 +295,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -370,7 +370,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -454,7 +454,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_EmptyTag_OnUpdate_Add(t *testing.
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -586,7 +586,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_EmptyTag_OnUpdate_Replace(t *test
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -671,7 +671,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_providerOnly(t *testi
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -842,7 +842,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_nonOverlapping(t *tes
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -994,7 +994,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_overlapping(t *testin
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1162,7 +1162,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_updateToProviderOnly(
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1247,7 +1247,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_updateToResourceOnly(
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1331,7 +1331,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_emptyResourceTag(t *t
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_emptyProviderOnlyTag(
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1447,7 +1447,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_nullOverlappingResour
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1512,7 +1512,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_DefaultTags_nullNonOverlappingRes
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1579,7 +1579,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_ComputedTag_OnCreate(t *testing.T
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1630,7 +1630,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_ComputedTag_OnUpdate_Add(t *testi
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1722,7 +1722,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_ComputedTag_OnUpdate_Replace(t *t
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1804,7 +1804,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_IgnoreTags_Overlap_DefaultTag(t *
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),
@@ -1961,7 +1961,7 @@ func TestAccVPCBlockPublicAccessExclusion_tags_IgnoreTags_Overlap_ResourceTag(t 
 	ctx := acctest.Context(t)
 	resourceName := "aws_vpc_block_public_access_exclusion.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckBlockPublicAccessExclusionDestroy(ctx),

--- a/internal/service/ec2/vpc_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_data_source_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccVPCVPCDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -49,7 +49,7 @@ func TestAccVPCVPCDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccVPCVPCDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -93,7 +93,7 @@ func TestAccVPCVPCDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccVPCVPCDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -159,7 +159,7 @@ func TestAccVPCVPCDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/vpc_route_table_tags_gen_test.go
+++ b/internal/service/ec2/vpc_route_table_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccVPCRouteTable_tags(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccVPCRouteTable_tags_null(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccVPCRouteTable_tags_EmptyMap(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccVPCRouteTable_tags_AddOnUpdate(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccVPCRouteTable_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccVPCRouteTable_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccVPCRouteTable_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckRouteTableDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_overlapping(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccVPCRouteTable_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccVPCRouteTable_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccVPCRouteTable_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccVPCRouteTable_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccVPCRouteTable_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccVPCRouteTable_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v awstypes.RouteTable
 	resourceName := "aws_route_table.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckRouteTableDestroy(ctx),

--- a/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccVPCSecurityGroupDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccVPCSecurityGroupDataSource_tags(t *testing.T) {
 func TestAccVPCSecurityGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccVPCSecurityGroupDataSource_tags_NullMap(t *testing.T) {
 func TestAccVPCSecurityGroupDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccVPCSecurityGroupDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccVPCSecurityGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccVPCSecurityGroupDataSource_tags_DefaultTags_nonOverlapping(t *testin
 func TestAccVPCSecurityGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccVPCSecurityGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 func TestAccVPCSecurityGroupDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/vpc_security_group_egress_rule_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_egress_rule_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCSecurityGroupEgressRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_EmptyTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_EmptyTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_providerOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_nonOverlapping(t *testin
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_overlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_updateToProviderOnly(t *
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_updateToResourceOnly(t *
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_emptyResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_emptyProviderOnlyTag(t *
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_nullOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_DefaultTags_nullNonOverlappingResour
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_ComputedTag_OnUpdate_Add(t *testing.
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_ComputedTag_OnUpdate_Replace(t *test
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccVPCSecurityGroupEgressRule_tags_IgnoreTags_Overlap_ResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_egress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupEgressRuleDestroy(ctx),

--- a/internal/service/ec2/vpc_security_group_ingress_rule_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_ingress_rule_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCSecurityGroupIngressRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_EmptyTag_OnUpdate_Replace(t *testin
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_providerOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_nonOverlapping(t *testi
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_overlapping(t *testing.
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_updateToProviderOnly(t 
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_updateToResourceOnly(t 
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_emptyResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_emptyProviderOnlyTag(t 
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_nullOverlappingResource
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_DefaultTags_nullNonOverlappingResou
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_ComputedTag_OnCreate(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_ComputedTag_OnUpdate_Add(t *testing
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_ComputedTag_OnUpdate_Replace(t *tes
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_IgnoreTags_Overlap_DefaultTag(t *te
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccVPCSecurityGroupIngressRule_tags_IgnoreTags_Overlap_ResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.SecurityGroupRule
 	resourceName := "aws_vpc_security_group_ingress_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupIngressRuleDestroy(ctx),

--- a/internal/service/ec2/vpc_security_group_tags_gen_test.go
+++ b/internal/service/ec2/vpc_security_group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCSecurityGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccVPCSecurityGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccVPCSecurityGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccVPCSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccVPCSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccVPCSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccVPCSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSecurityGroupDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccVPCSecurityGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccVPCSecurityGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccVPCSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccVPCSecurityGroup_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccVPCSecurityGroup_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SecurityGroup
 	resourceName := "aws_security_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSecurityGroupDestroy(ctx),

--- a/internal/service/ec2/vpc_subnet_data_source_tags_gen_test.go
+++ b/internal/service/ec2/vpc_subnet_data_source_tags_gen_test.go
@@ -23,7 +23,7 @@ func TestAccVPCSubnetDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -49,7 +49,7 @@ func TestAccVPCSubnetDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -71,7 +71,7 @@ func TestAccVPCSubnetDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -93,7 +93,7 @@ func TestAccVPCSubnetDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{
@@ -159,7 +159,7 @@ func TestAccVPCSubnetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.EC2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ec2/vpc_subnet_tags_gen_test.go
+++ b/internal/service/ec2/vpc_subnet_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccVPCSubnet_tags(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccVPCSubnet_tags_null(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccVPCSubnet_tags_EmptyMap(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccVPCSubnet_tags_AddOnUpdate(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccVPCSubnet_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccVPCSubnet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckSubnetDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccVPCSubnet_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccVPCSubnet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccVPCSubnet_tags_DefaultTags_overlapping(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccVPCSubnet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccVPCSubnet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccVPCSubnet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccVPCSubnet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccVPCSubnet_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccVPCSubnet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccVPCSubnet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccVPCSubnet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v types.Subnet
 	resourceName := "aws_subnet.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckSubnetDestroy(ctx),

--- a/internal/service/ec2/vpc_tags_gen_test.go
+++ b/internal/service/ec2/vpc_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccVPCVPC_tags(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccVPCVPC_tags_null(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccVPCVPC_tags_EmptyMap(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccVPCVPC_tags_AddOnUpdate(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccVPCVPC_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccVPCVPC_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy:             testAccCheckVPCDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccVPCVPC_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccVPCVPC_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccVPCVPC_tags_DefaultTags_overlapping(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccVPCVPC_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccVPCVPC_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccVPCVPC_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccVPCVPC_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccVPCVPC_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccVPCVPC_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) 
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccVPCVPC_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccVPCVPC_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccVPCVPC_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccVPCVPC_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v awstypes.Vpc
 	resourceName := "aws_vpc.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.EC2ServiceID),
 		CheckDestroy: testAccCheckVPCDestroy(ctx),

--- a/internal/service/elbv2/listener_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/listener_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccELBV2ListenerDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccELBV2ListenerDataSource_tags(t *testing.T) {
 func TestAccELBV2ListenerDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccELBV2ListenerDataSource_tags_NullMap(t *testing.T) {
 func TestAccELBV2ListenerDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccELBV2ListenerDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccELBV2ListenerDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccELBV2ListenerDataSource_tags_DefaultTags_nonOverlapping(t *testing.T
 func TestAccELBV2ListenerDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccELBV2ListenerDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func TestAccELBV2ListenerDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/elbv2/listener_rule_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/listener_rule_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccELBV2ListenerRuleDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccELBV2ListenerRuleDataSource_tags(t *testing.T) {
 func TestAccELBV2ListenerRuleDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccELBV2ListenerRuleDataSource_tags_NullMap(t *testing.T) {
 func TestAccELBV2ListenerRuleDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccELBV2ListenerRuleDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccELBV2ListenerRuleDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccELBV2ListenerRuleDataSource_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccELBV2ListenerRuleDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccELBV2ListenerRuleDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccELBV2ListenerRuleDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/elbv2/listener_rule_tags_gen_test.go
+++ b/internal/service/elbv2/listener_rule_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccELBV2ListenerRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccELBV2ListenerRule_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccELBV2ListenerRule_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccELBV2ListenerRule_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccELBV2ListenerRule_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccELBV2ListenerRule_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccELBV2ListenerRule_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerRuleDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccELBV2ListenerRule_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccELBV2ListenerRule_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccELBV2ListenerRule_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccELBV2ListenerRule_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccELBV2ListenerRule_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccELBV2ListenerRule_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Rule
 	resourceName := "aws_lb_listener_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerRuleDestroy(ctx),

--- a/internal/service/elbv2/listener_tags_gen_test.go
+++ b/internal/service/elbv2/listener_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccELBV2Listener_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccELBV2Listener_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccELBV2Listener_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccELBV2Listener_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccELBV2Listener_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccELBV2Listener_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckListenerDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccELBV2Listener_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccELBV2Listener_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccELBV2Listener_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccELBV2Listener_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccELBV2Listener_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccELBV2Listener_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccELBV2Listener_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccELBV2Listener_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccELBV2Listener_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccELBV2Listener_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccELBV2Listener_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccELBV2Listener_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccELBV2Listener_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Listener
 	resourceName := "aws_lb_listener.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckListenerDestroy(ctx),

--- a/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/load_balancer_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccELBV2LoadBalancerDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccELBV2LoadBalancerDataSource_tags(t *testing.T) {
 func TestAccELBV2LoadBalancerDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccELBV2LoadBalancerDataSource_tags_NullMap(t *testing.T) {
 func TestAccELBV2LoadBalancerDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccELBV2LoadBalancerDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccELBV2LoadBalancerDataSource_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccELBV2LoadBalancerDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/elbv2/load_balancer_tags_gen_test.go
+++ b/internal/service/elbv2/load_balancer_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccELBV2LoadBalancer_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccELBV2LoadBalancer_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccELBV2LoadBalancer_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccELBV2LoadBalancer_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccELBV2LoadBalancer_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccELBV2LoadBalancer_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccELBV2LoadBalancer_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckLoadBalancerDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccELBV2LoadBalancer_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccELBV2LoadBalancer_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccELBV2LoadBalancer_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccELBV2LoadBalancer_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccELBV2LoadBalancer_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccELBV2LoadBalancer_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.LoadBalancer
 	resourceName := "aws_lb.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckLoadBalancerDestroy(ctx),

--- a/internal/service/elbv2/target_group_data_source_tags_gen_test.go
+++ b/internal/service/elbv2/target_group_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccELBV2TargetGroupDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccELBV2TargetGroupDataSource_tags(t *testing.T) {
 func TestAccELBV2TargetGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccELBV2TargetGroupDataSource_tags_NullMap(t *testing.T) {
 func TestAccELBV2TargetGroupDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccELBV2TargetGroupDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccELBV2TargetGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccELBV2TargetGroupDataSource_tags_DefaultTags_nonOverlapping(t *testin
 func TestAccELBV2TargetGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccELBV2TargetGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 func TestAccELBV2TargetGroupDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/elbv2/target_group_tags_gen_test.go
+++ b/internal/service/elbv2/target_group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccELBV2TargetGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccELBV2TargetGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccELBV2TargetGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccELBV2TargetGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccELBV2TargetGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccELBV2TargetGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccELBV2TargetGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTargetGroupDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccELBV2TargetGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccELBV2TargetGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccELBV2TargetGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccELBV2TargetGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccELBV2TargetGroup_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccELBV2TargetGroup_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TargetGroup
 	resourceName := "aws_lb_target_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTargetGroupDestroy(ctx),

--- a/internal/service/elbv2/trust_store_tags_gen_test.go
+++ b/internal/service/elbv2/trust_store_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccELBV2TrustStore_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccELBV2TrustStore_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccELBV2TrustStore_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccELBV2TrustStore_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccELBV2TrustStore_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccELBV2TrustStore_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccELBV2TrustStore_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy:             testAccCheckTrustStoreDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccELBV2TrustStore_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccELBV2TrustStore_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccELBV2TrustStore_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccELBV2TrustStore_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccELBV2TrustStore_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccELBV2TrustStore_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.TrustStore
 	resourceName := "aws_lb_trust_store.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ELBV2ServiceID),
 		CheckDestroy: testAccCheckTrustStoreDestroy(ctx),

--- a/internal/service/fms/policy_tags_gen_test.go
+++ b/internal/service/fms/policy_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccFMSPolicy_tagsSerial(t *testing.T) {
 func testAccFMSPolicy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -241,9 +240,9 @@ func testAccFMSPolicy_tags(t *testing.T) {
 func testAccFMSPolicy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -310,9 +309,9 @@ func testAccFMSPolicy_tags_null(t *testing.T) {
 func testAccFMSPolicy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -375,9 +374,9 @@ func testAccFMSPolicy_tags_EmptyMap(t *testing.T) {
 func testAccFMSPolicy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -458,9 +457,9 @@ func testAccFMSPolicy_tags_AddOnUpdate(t *testing.T) {
 func testAccFMSPolicy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -552,9 +551,9 @@ func testAccFMSPolicy_tags_EmptyTag_OnCreate(t *testing.T) {
 func testAccFMSPolicy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -694,9 +693,9 @@ func testAccFMSPolicy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func testAccFMSPolicy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -785,9 +784,9 @@ func testAccFMSPolicy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -977,9 +976,9 @@ func testAccFMSPolicy_tags_DefaultTags_providerOnly(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1145,9 +1144,9 @@ func testAccFMSPolicy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1329,9 +1328,9 @@ func testAccFMSPolicy_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1421,9 +1420,9 @@ func testAccFMSPolicy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1512,9 +1511,9 @@ func testAccFMSPolicy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1579,9 +1578,9 @@ func testAccFMSPolicy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1638,9 +1637,9 @@ func testAccFMSPolicy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func testAccFMSPolicy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1702,9 +1701,9 @@ func testAccFMSPolicy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 func testAccFMSPolicy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1766,9 +1765,9 @@ func testAccFMSPolicy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 func testAccFMSPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1823,9 +1822,9 @@ func testAccFMSPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccFMSPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1922,9 +1921,9 @@ func testAccFMSPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func testAccFMSPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -2011,9 +2010,9 @@ func testAccFMSPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func testAccFMSPolicy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -2172,9 +2171,9 @@ func testAccFMSPolicy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func testAccFMSPolicy_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_fms_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),

--- a/internal/service/fms/resource_set_tags_gen_test.go
+++ b/internal/service/fms/resource_set_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/fms"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccFMSResourceSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -232,9 +231,9 @@ func testAccFMSResourceSet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -294,9 +293,9 @@ func testAccFMSResourceSet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -344,9 +343,9 @@ func testAccFMSResourceSet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -424,9 +423,9 @@ func testAccFMSResourceSet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -514,9 +513,9 @@ func testAccFMSResourceSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -653,9 +652,9 @@ func testAccFMSResourceSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy:             testAccCheckResourceSetDestroy(ctx),
@@ -743,9 +742,9 @@ func testAccFMSResourceSet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -924,9 +923,9 @@ func testAccFMSResourceSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1084,9 +1083,9 @@ func testAccFMSResourceSet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1260,9 +1259,9 @@ func testAccFMSResourceSet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1350,9 +1349,9 @@ func testAccFMSResourceSet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1439,9 +1438,9 @@ func testAccFMSResourceSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1505,9 +1504,9 @@ func testAccFMSResourceSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1563,9 +1562,9 @@ func testAccFMSResourceSet_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1632,9 +1631,9 @@ func testAccFMSResourceSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1703,9 +1702,9 @@ func testAccFMSResourceSet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1758,9 +1757,9 @@ func testAccFMSResourceSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1855,9 +1854,9 @@ func testAccFMSResourceSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -1942,9 +1941,9 @@ func testAccFMSResourceSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),
@@ -2104,9 +2103,9 @@ func testAccFMSResourceSet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v fms.GetResourceSetOutput
 	resourceName := "aws_fms_resource_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.FMSServiceID),
 		CheckDestroy: testAccCheckResourceSetDestroy(ctx),

--- a/internal/service/guardduty/detector_data_source_tags_gen_test.go
+++ b/internal/service/guardduty/detector_data_source_tags_gen_test.go
@@ -38,7 +38,7 @@ func testAccGuardDutyDetectorDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -64,7 +64,7 @@ func testAccGuardDutyDetectorDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -86,7 +86,7 @@ func testAccGuardDutyDetectorDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -108,7 +108,7 @@ func testAccGuardDutyDetectorDataSource_tags_DefaultTags_nonOverlapping(t *testi
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		Steps: []resource.TestStep{
@@ -138,7 +138,7 @@ func testAccGuardDutyDetectorDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		Steps: []resource.TestStep{
@@ -174,7 +174,7 @@ func testAccGuardDutyDetectorDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *t
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.GuardDutyServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/guardduty/detector_tags_gen_test.go
+++ b/internal/service/guardduty/detector_tags_gen_test.go
@@ -48,7 +48,7 @@ func testAccGuardDutyDetector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -223,7 +223,7 @@ func testAccGuardDutyDetector_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -288,7 +288,7 @@ func testAccGuardDutyDetector_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -349,7 +349,7 @@ func testAccGuardDutyDetector_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -428,7 +428,7 @@ func testAccGuardDutyDetector_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -514,7 +514,7 @@ func testAccGuardDutyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -647,7 +647,7 @@ func testAccGuardDutyDetector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -734,7 +734,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -908,7 +908,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1063,7 +1063,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1234,7 +1234,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1322,7 +1322,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1409,7 +1409,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1473,7 +1473,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1529,7 +1529,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1590,7 +1590,7 @@ func testAccGuardDutyDetector_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1651,7 +1651,7 @@ func testAccGuardDutyDetector_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1705,7 +1705,7 @@ func testAccGuardDutyDetector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1800,7 +1800,7 @@ func testAccGuardDutyDetector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1885,7 +1885,7 @@ func testAccGuardDutyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -2045,7 +2045,7 @@ func testAccGuardDutyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_detector.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)

--- a/internal/service/guardduty/filter_tags_gen_test.go
+++ b/internal/service/guardduty/filter_tags_gen_test.go
@@ -50,7 +50,7 @@ func testAccGuardDutyFilter_tags(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -226,7 +226,7 @@ func testAccGuardDutyFilter_tags_null(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -292,7 +292,7 @@ func testAccGuardDutyFilter_tags_EmptyMap(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -354,7 +354,7 @@ func testAccGuardDutyFilter_tags_AddOnUpdate(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -434,7 +434,7 @@ func testAccGuardDutyFilter_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -521,7 +521,7 @@ func testAccGuardDutyFilter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -655,7 +655,7 @@ func testAccGuardDutyFilter_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -743,7 +743,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_providerOnly(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -918,7 +918,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1074,7 +1074,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_overlapping(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1246,7 +1246,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1335,7 +1335,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1423,7 +1423,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1488,7 +1488,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1545,7 +1545,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1607,7 +1607,7 @@ func testAccGuardDutyFilter_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1669,7 +1669,7 @@ func testAccGuardDutyFilter_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1724,7 +1724,7 @@ func testAccGuardDutyFilter_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1820,7 +1820,7 @@ func testAccGuardDutyFilter_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1906,7 +1906,7 @@ func testAccGuardDutyFilter_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -2067,7 +2067,7 @@ func testAccGuardDutyFilter_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	var v guardduty.GetFilterOutput
 	resourceName := "aws_guardduty_filter.test"
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)

--- a/internal/service/guardduty/ipset_tags_gen_test.go
+++ b/internal/service/guardduty/ipset_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccGuardDutyIPSet_tagsSerial(t *testing.T) {
 func testAccGuardDutyIPSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -232,9 +231,9 @@ func testAccGuardDutyIPSet_tags(t *testing.T) {
 func testAccGuardDutyIPSet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -301,9 +300,9 @@ func testAccGuardDutyIPSet_tags_null(t *testing.T) {
 func testAccGuardDutyIPSet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -366,9 +365,9 @@ func testAccGuardDutyIPSet_tags_EmptyMap(t *testing.T) {
 func testAccGuardDutyIPSet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -449,9 +448,9 @@ func testAccGuardDutyIPSet_tags_AddOnUpdate(t *testing.T) {
 func testAccGuardDutyIPSet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -540,9 +539,9 @@ func testAccGuardDutyIPSet_tags_EmptyTag_OnCreate(t *testing.T) {
 func testAccGuardDutyIPSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -679,9 +678,9 @@ func testAccGuardDutyIPSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func testAccGuardDutyIPSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -770,9 +769,9 @@ func testAccGuardDutyIPSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -953,9 +952,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_providerOnly(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1115,9 +1114,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1293,9 +1292,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1385,9 +1384,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1476,9 +1475,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1543,9 +1542,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1602,9 +1601,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func testAccGuardDutyIPSet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1666,9 +1665,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 func testAccGuardDutyIPSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1730,9 +1729,9 @@ func testAccGuardDutyIPSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 func testAccGuardDutyIPSet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1787,9 +1786,9 @@ func testAccGuardDutyIPSet_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccGuardDutyIPSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1886,9 +1885,9 @@ func testAccGuardDutyIPSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func testAccGuardDutyIPSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1975,9 +1974,9 @@ func testAccGuardDutyIPSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func testAccGuardDutyIPSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -2139,9 +2138,9 @@ func testAccGuardDutyIPSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func testAccGuardDutyIPSet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_ipset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)

--- a/internal/service/guardduty/malware_protection_plan_tags_gen_test.go
+++ b/internal/service/guardduty/malware_protection_plan_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/guardduty"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -206,9 +205,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -271,9 +270,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -324,9 +323,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -407,9 +406,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_EmptyTag_OnCreate(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -500,9 +499,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_EmptyTag_OnUpdate_Add(t *testing
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -642,9 +641,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_EmptyTag_OnUpdate_Replace(t *tes
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -735,9 +734,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_providerOnly(t *test
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -919,9 +918,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_nonOverlapping(t *te
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1082,9 +1081,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_overlapping(t *testi
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1261,9 +1260,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_updateToProviderOnly
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1354,9 +1353,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_updateToResourceOnly
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1446,9 +1445,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_emptyResourceTag(t *
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1515,9 +1514,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_emptyProviderOnlyTag
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1576,9 +1575,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_nullOverlappingResou
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1648,9 +1647,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_DefaultTags_nullNonOverlappingRe
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1722,9 +1721,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_ComputedTag_OnCreate(t *testing.
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1780,9 +1779,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_ComputedTag_OnUpdate_Add(t *test
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1880,9 +1879,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_ComputedTag_OnUpdate_Replace(t *
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -1970,9 +1969,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_IgnoreTags_Overlap_DefaultTag(t 
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)
@@ -2135,9 +2134,9 @@ func TestAccGuardDutyMalwareProtectionPlan_tags_IgnoreTags_Overlap_ResourceTag(t
 	ctx := acctest.Context(t)
 	var v guardduty.GetMalwareProtectionPlanOutput
 	resourceName := "aws_guardduty_malware_protection_plan.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheck(ctx, t)

--- a/internal/service/guardduty/threatintelset_tags_gen_test.go
+++ b/internal/service/guardduty/threatintelset_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccGuardDutyThreatIntelSet_tagsSerial(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -232,9 +231,9 @@ func testAccGuardDutyThreatIntelSet_tags(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -301,9 +300,9 @@ func testAccGuardDutyThreatIntelSet_tags_null(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -366,9 +365,9 @@ func testAccGuardDutyThreatIntelSet_tags_EmptyMap(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -449,9 +448,9 @@ func testAccGuardDutyThreatIntelSet_tags_AddOnUpdate(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -540,9 +539,9 @@ func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnCreate(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -679,9 +678,9 @@ func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -770,9 +769,9 @@ func testAccGuardDutyThreatIntelSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T)
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -953,9 +952,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_providerOnly(t *testing.T) 
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1115,9 +1114,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nonOverlapping(t *testing.T
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1293,9 +1292,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1385,9 +1384,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_updateToProviderOnly(t *tes
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1476,9 +1475,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_updateToResourceOnly(t *tes
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1543,9 +1542,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_emptyResourceTag(t *testing
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1602,9 +1601,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_emptyProviderOnlyTag(t *tes
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1666,9 +1665,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nullOverlappingResourceTag(
 func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1730,9 +1729,9 @@ func testAccGuardDutyThreatIntelSet_tags_DefaultTags_nullNonOverlappingResourceT
 func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1787,9 +1786,9 @@ func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1886,9 +1885,9 @@ func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) 
 func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -1975,9 +1974,9 @@ func testAccGuardDutyThreatIntelSet_tags_ComputedTag_OnUpdate_Replace(t *testing
 func testAccGuardDutyThreatIntelSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)
@@ -2139,9 +2138,9 @@ func testAccGuardDutyThreatIntelSet_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func testAccGuardDutyThreatIntelSet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_guardduty_threatintelset.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(ctx, t)
 			testAccPreCheckDetectorNotExists(ctx, t)

--- a/internal/service/iam/instance_profile_tags_gen_test.go
+++ b/internal/service/iam/instance_profile_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccIAMInstanceProfile_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccIAMInstanceProfile_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccIAMInstanceProfile_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccIAMInstanceProfile_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccIAMInstanceProfile_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccIAMInstanceProfile_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckInstanceProfileDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccIAMInstanceProfile_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccIAMInstanceProfile_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccIAMInstanceProfile_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccIAMInstanceProfile_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.InstanceProfile
 	resourceName := "aws_iam_instance_profile.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckInstanceProfileDestroy(ctx),

--- a/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccIAMOIDCProviderDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccIAMOIDCProviderDataSource_tags(t *testing.T) {
 func TestAccIAMOIDCProviderDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccIAMOIDCProviderDataSource_tags_NullMap(t *testing.T) {
 func TestAccIAMOIDCProviderDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccIAMOIDCProviderDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccIAMOIDCProviderDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccIAMOIDCProviderDataSource_tags_DefaultTags_nonOverlapping(t *testing
 func TestAccIAMOIDCProviderDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccIAMOIDCProviderDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *test
 func TestAccIAMOIDCProviderDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/iam/openid_connect_provider_tags_gen_test.go
+++ b/internal/service/iam/openid_connect_provider_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccIAMOpenIDConnectProvider_tags(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccIAMOpenIDConnectProvider_tags_null(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccIAMOpenIDConnectProvider_tags_EmptyMap(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccIAMOpenIDConnectProvider_tags_AddOnUpdate(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccIAMOpenIDConnectProvider_tags_EmptyTag_OnUpdate_Replace(t *testing.T
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_providerOnly(t *testing.T)
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_overlapping(t *testing.T) 
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToProviderOnly(t *te
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_updateToResourceOnly(t *te
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyResourceTag(t *testin
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_emptyProviderOnlyTag(t *te
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullOverlappingResourceTag
 func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccIAMOpenIDConnectProvider_tags_DefaultTags_nullNonOverlappingResource
 func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Add(t *testing.T)
 func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccIAMOpenIDConnectProvider_tags_ComputedTag_OnUpdate_Replace(t *testin
 func TestAccIAMOpenIDConnectProvider_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccIAMOpenIDConnectProvider_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccIAMOpenIDConnectProvider_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_openid_connect_provider.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckOpenIDConnectProviderDestroy(ctx),

--- a/internal/service/iam/policy_data_source_tags_gen_test.go
+++ b/internal/service/iam/policy_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccIAMPolicyDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccIAMPolicyDataSource_tags(t *testing.T) {
 func TestAccIAMPolicyDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccIAMPolicyDataSource_tags_NullMap(t *testing.T) {
 func TestAccIAMPolicyDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccIAMPolicyDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccIAMPolicyDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccIAMPolicyDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccIAMPolicyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccIAMPolicyDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 func TestAccIAMPolicyDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/iam/policy_tags_gen_test.go
+++ b/internal/service/iam/policy_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccIAMPolicy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccIAMPolicy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccIAMPolicy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccIAMPolicy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccIAMPolicy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccIAMPolicy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckPolicyDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccIAMPolicy_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccIAMPolicy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccIAMPolicy_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccIAMPolicy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccIAMPolicy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccIAMPolicy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccIAMPolicy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccIAMPolicy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccIAMPolicy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccIAMPolicy_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccIAMPolicy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccIAMPolicy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccIAMPolicy_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Policy
 	resourceName := "aws_iam_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckPolicyDestroy(ctx),

--- a/internal/service/iam/role_data_source_tags_gen_test.go
+++ b/internal/service/iam/role_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccIAMRoleDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccIAMRoleDataSource_tags(t *testing.T) {
 func TestAccIAMRoleDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccIAMRoleDataSource_tags_NullMap(t *testing.T) {
 func TestAccIAMRoleDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccIAMRoleDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccIAMRoleDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccIAMRoleDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccIAMRoleDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccIAMRoleDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccIAMRoleDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/iam/role_tags_gen_test.go
+++ b/internal/service/iam/role_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccIAMRole_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccIAMRole_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccIAMRole_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccIAMRole_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccIAMRole_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccIAMRole_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccIAMRole_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckRoleDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccIAMRole_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccIAMRole_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccIAMRole_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccIAMRole_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccIAMRole_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccIAMRole_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccIAMRole_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccIAMRole_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccIAMRole_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccIAMRole_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccIAMRole_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccIAMRole_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccIAMRole_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccIAMRole_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Role
 	resourceName := "aws_iam_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckRoleDestroy(ctx),

--- a/internal/service/iam/server_certificate_tags_gen_test.go
+++ b/internal/service/iam/server_certificate_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,11 +20,11 @@ func TestAccIAMServerCertificate_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -237,11 +236,11 @@ func TestAccIAMServerCertificate_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -316,11 +315,11 @@ func TestAccIAMServerCertificate_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -391,11 +390,11 @@ func TestAccIAMServerCertificate_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -484,11 +483,11 @@ func TestAccIAMServerCertificate_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -591,11 +590,11 @@ func TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -748,11 +747,11 @@ func TestAccIAMServerCertificate_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServerCertificateDestroy(ctx),
@@ -849,11 +848,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1064,11 +1063,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1250,11 +1249,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1452,11 +1451,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1554,11 +1553,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1655,11 +1654,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1730,11 +1729,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1797,11 +1796,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1869,11 +1868,11 @@ func TestAccIAMServerCertificate_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -1941,11 +1940,11 @@ func TestAccIAMServerCertificate_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -2006,11 +2005,11 @@ func TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -2115,11 +2114,11 @@ func TestAccIAMServerCertificate_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -2214,11 +2213,11 @@ func TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),
@@ -2384,11 +2383,11 @@ func TestAccIAMServerCertificate_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.ServerCertificate
 	resourceName := "aws_iam_server_certificate.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 	privateKeyPEM := acctest.TLSRSAPrivateKeyPEM(t, 2048)
 	certificatePEM := acctest.TLSRSAX509SelfSignedCertificatePEM(t, privateKeyPEM, acctest.RandomDomain().String())
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServerCertificateDestroy(ctx),

--- a/internal/service/iam/service_linked_role_tags_gen_test.go
+++ b/internal/service/iam/service_linked_role_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccIAMServiceLinkedRole_tags(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccIAMServiceLinkedRole_tags_null(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccIAMServiceLinkedRole_tags_EmptyMap(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccIAMServiceLinkedRole_tags_AddOnUpdate(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccIAMServiceLinkedRole_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToProviderOnly(t *testin
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_updateToResourceOnly(t *testin
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_emptyResourceTag(t *testing.T)
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_nullOverlappingResourceTag(t *
 func TestAccIAMServiceLinkedRole_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccIAMServiceLinkedRole_tags_DefaultTags_nullNonOverlappingResourceTag(
 func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccIAMServiceLinkedRole_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func TestAccIAMServiceLinkedRole_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccIAMServiceLinkedRole_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccIAMServiceLinkedRole_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_iam_service_linked_role.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckServiceLinkedRoleDestroy(ctx),

--- a/internal/service/iam/user_data_source_tags_gen_test.go
+++ b/internal/service/iam/user_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccIAMUserDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccIAMUserDataSource_tags(t *testing.T) {
 func TestAccIAMUserDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccIAMUserDataSource_tags_NullMap(t *testing.T) {
 func TestAccIAMUserDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccIAMUserDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccIAMUserDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccIAMUserDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccIAMUserDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccIAMUserDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccIAMUserDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.IAMServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/iam/user_tags_gen_test.go
+++ b/internal/service/iam/user_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccIAMUser_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccIAMUser_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccIAMUser_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccIAMUser_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccIAMUser_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccIAMUser_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccIAMUser_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckUserDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccIAMUser_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccIAMUser_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccIAMUser_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccIAMUser_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccIAMUser_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccIAMUser_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccIAMUser_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccIAMUser_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccIAMUser_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccIAMUser_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccIAMUser_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccIAMUser_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccIAMUser_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccIAMUser_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.User
 	resourceName := "aws_iam_user.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckUserDestroy(ctx),

--- a/internal/service/iam/virtual_mfa_device_tags_gen_test.go
+++ b/internal/service/iam/virtual_mfa_device_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccIAMVirtualMFADevice_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccIAMVirtualMFADevice_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccIAMVirtualMFADevice_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccIAMVirtualMFADevice_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccIAMVirtualMFADevice_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccIAMVirtualMFADevice_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy:             testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccIAMVirtualMFADevice_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccIAMVirtualMFADevice_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccIAMVirtualMFADevice_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.VirtualMFADevice
 	resourceName := "aws_iam_virtual_mfa_device.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.IAMServiceID),
 		CheckDestroy: testAccCheckVirtualMFADeviceDestroy(ctx),

--- a/internal/service/inspector2/filter_tags_gen_test.go
+++ b/internal/service/inspector2/filter_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/inspector2/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccInspector2Filter_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccInspector2Filter_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccInspector2Filter_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -327,9 +326,9 @@ func TestAccInspector2Filter_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -409,9 +408,9 @@ func TestAccInspector2Filter_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccInspector2Filter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -646,9 +645,9 @@ func TestAccInspector2Filter_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy:             testAccCheckFilterDestroy(ctx),
@@ -738,9 +737,9 @@ func TestAccInspector2Filter_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -927,9 +926,9 @@ func TestAccInspector2Filter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1093,9 +1092,9 @@ func TestAccInspector2Filter_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1275,9 +1274,9 @@ func TestAccInspector2Filter_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1367,9 +1366,9 @@ func TestAccInspector2Filter_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1458,9 +1457,9 @@ func TestAccInspector2Filter_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccInspector2Filter_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccInspector2Filter_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1657,9 +1656,9 @@ func TestAccInspector2Filter_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1730,9 +1729,9 @@ func TestAccInspector2Filter_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1787,9 +1786,9 @@ func TestAccInspector2Filter_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1886,9 +1885,9 @@ func TestAccInspector2Filter_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -1975,9 +1974,9 @@ func TestAccInspector2Filter_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),
@@ -2137,9 +2136,9 @@ func TestAccInspector2Filter_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Filter
 	resourceName := "aws_inspector2_filter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.Inspector2ServiceID),
 		CheckDestroy: testAccCheckFilterDestroy(ctx),

--- a/internal/service/kms/external_key_tags_gen_test.go
+++ b/internal/service/kms/external_key_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccKMSExternalKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccKMSExternalKey_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccKMSExternalKey_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccKMSExternalKey_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccKMSExternalKey_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccKMSExternalKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccKMSExternalKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckExternalKeyDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccKMSExternalKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccKMSExternalKey_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccKMSExternalKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccKMSExternalKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccKMSExternalKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccKMSExternalKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckExternalKeyDestroy(ctx),

--- a/internal/service/kms/key_tags_gen_test.go
+++ b/internal/service/kms/key_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccKMSKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccKMSKey_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccKMSKey_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccKMSKey_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccKMSKey_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccKMSKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccKMSKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy:             testAccCheckKeyDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccKMSKey_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccKMSKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccKMSKey_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccKMSKey_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccKMSKey_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccKMSKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccKMSKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccKMSKey_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccKMSKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccKMSKey_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccKMSKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccKMSKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccKMSKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccKMSKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckKeyDestroy(ctx),

--- a/internal/service/kms/replica_external_key_tags_gen_test.go
+++ b/internal/service/kms/replica_external_key_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccKMSReplicaExternalKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -230,9 +229,9 @@ func TestAccKMSReplicaExternalKey_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -305,9 +304,9 @@ func TestAccKMSReplicaExternalKey_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -376,9 +375,9 @@ func TestAccKMSReplicaExternalKey_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -465,9 +464,9 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -567,9 +566,9 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -719,9 +718,9 @@ func TestAccKMSReplicaExternalKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -816,9 +815,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1017,9 +1016,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nonOverlapping(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1192,9 +1191,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1383,9 +1382,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_updateToProviderOnly(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1479,9 +1478,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_updateToResourceOnly(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1574,9 +1573,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_emptyResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1644,9 +1643,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1706,9 +1705,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nullOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1773,9 +1772,9 @@ func TestAccKMSReplicaExternalKey_tags_DefaultTags_nullNonOverlappingResourceTag
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1840,9 +1839,9 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -1900,9 +1899,9 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccKMSReplicaExternalKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -2096,9 +2095,9 @@ func TestAccKMSReplicaExternalKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),
@@ -2261,9 +2260,9 @@ func TestAccKMSReplicaExternalKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_external_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaExternalKeyDestroy(ctx),

--- a/internal/service/kms/replica_key_tags_gen_test.go
+++ b/internal/service/kms/replica_key_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccKMSReplicaKey_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -230,9 +229,9 @@ func TestAccKMSReplicaKey_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -305,9 +304,9 @@ func TestAccKMSReplicaKey_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -376,9 +375,9 @@ func TestAccKMSReplicaKey_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -465,9 +464,9 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -567,9 +566,9 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -719,9 +718,9 @@ func TestAccKMSReplicaKey_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -816,9 +815,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1017,9 +1016,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1192,9 +1191,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1383,9 +1382,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1479,9 +1478,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1574,9 +1573,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1644,9 +1643,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1706,9 +1705,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1773,9 +1772,9 @@ func TestAccKMSReplicaKey_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1840,9 +1839,9 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -1900,9 +1899,9 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccKMSReplicaKey_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -2096,9 +2095,9 @@ func TestAccKMSReplicaKey_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),
@@ -2261,9 +2260,9 @@ func TestAccKMSReplicaKey_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.KeyMetadata
 	resourceName := "aws_kms_replica_key.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.KMSServiceID),
 		CheckDestroy: testAccCheckReplicaKeyDestroy(ctx),

--- a/internal/service/lambda/function_data_source_tags_gen_test.go
+++ b/internal/service/lambda/function_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccLambdaFunctionDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccLambdaFunctionDataSource_tags(t *testing.T) {
 func TestAccLambdaFunctionDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccLambdaFunctionDataSource_tags_NullMap(t *testing.T) {
 func TestAccLambdaFunctionDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccLambdaFunctionDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LambdaServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccLambdaFunctionDataSource_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LambdaServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccLambdaFunctionDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LambdaServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/lambda/function_tags_gen_test.go
+++ b/internal/service/lambda/function_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccLambdaFunction_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccLambdaFunction_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccLambdaFunction_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccLambdaFunction_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccLambdaFunction_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccLambdaFunction_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy:             testAccCheckFunctionDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccLambdaFunction_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccLambdaFunction_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccLambdaFunction_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccLambdaFunction_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccLambdaFunction_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccLambdaFunction_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccLambdaFunction_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccLambdaFunction_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccLambdaFunction_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccLambdaFunction_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccLambdaFunction_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccLambdaFunction_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccLambdaFunction_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v lambda.GetFunctionOutput
 	resourceName := "aws_lambda_function.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LambdaServiceID),
 		CheckDestroy: testAccCheckFunctionDestroy(ctx),

--- a/internal/service/logs/anomaly_detector_tags_gen_test.go
+++ b/internal/service/logs/anomaly_detector_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccLogsAnomalyDetector_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -223,9 +222,9 @@ func TestAccLogsAnomalyDetector_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -288,9 +287,9 @@ func TestAccLogsAnomalyDetector_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -341,9 +340,9 @@ func TestAccLogsAnomalyDetector_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -426,9 +425,9 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -526,9 +525,9 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -675,9 +674,9 @@ func TestAccLogsAnomalyDetector_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckAnomalyDetectorDestroy(ctx),
@@ -770,9 +769,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -971,9 +970,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1146,9 +1145,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1337,9 +1336,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1432,9 +1431,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1597,9 +1596,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1660,9 +1659,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1732,9 +1731,9 @@ func TestAccLogsAnomalyDetector_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1866,9 +1865,9 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -1968,9 +1967,9 @@ func TestAccLogsAnomalyDetector_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -2060,9 +2059,9 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),
@@ -2222,9 +2221,9 @@ func TestAccLogsAnomalyDetector_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v cloudwatchlogs.GetLogAnomalyDetectorOutput
 	resourceName := "aws_cloudwatch_log_anomaly_detector.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckAnomalyDetectorDestroy(ctx),

--- a/internal/service/logs/destination_tags_gen_test.go
+++ b/internal/service/logs/destination_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccLogsDestination_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccLogsDestination_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccLogsDestination_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccLogsDestination_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccLogsDestination_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccLogsDestination_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckDestinationDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccLogsDestination_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccLogsDestination_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccLogsDestination_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccLogsDestination_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccLogsDestination_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccLogsDestination_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccLogsDestination_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccLogsDestination_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccLogsDestination_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccLogsDestination_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccLogsDestination_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccLogsDestination_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Destination
 	resourceName := "aws_cloudwatch_log_destination.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckDestinationDestroy(ctx),

--- a/internal/service/logs/group_data_source_tags_gen_test.go
+++ b/internal/service/logs/group_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccLogsLogGroupDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccLogsLogGroupDataSource_tags(t *testing.T) {
 func TestAccLogsLogGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccLogsLogGroupDataSource_tags_NullMap(t *testing.T) {
 func TestAccLogsLogGroupDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccLogsLogGroupDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccLogsLogGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LogsServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccLogsLogGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T)
 func TestAccLogsLogGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LogsServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccLogsLogGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing
 func TestAccLogsLogGroupDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.LogsServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/logs/group_tags_gen_test.go
+++ b/internal/service/logs/group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccLogsLogGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -203,9 +202,9 @@ func TestAccLogsLogGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -270,9 +269,9 @@ func TestAccLogsLogGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -333,9 +332,9 @@ func TestAccLogsLogGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -414,9 +413,9 @@ func TestAccLogsLogGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -503,9 +502,9 @@ func TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -640,9 +639,9 @@ func TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy:             testAccCheckLogGroupDestroy(ctx, t),
@@ -729,9 +728,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -910,9 +909,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1070,9 +1069,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1246,9 +1245,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1336,9 +1335,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1425,9 +1424,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1490,9 +1489,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1547,9 +1546,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1609,9 +1608,9 @@ func TestAccLogsLogGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1671,9 +1670,9 @@ func TestAccLogsLogGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1726,9 +1725,9 @@ func TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1823,9 +1822,9 @@ func TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -1910,9 +1909,9 @@ func TestAccLogsLogGroup_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),
@@ -2072,9 +2071,9 @@ func TestAccLogsLogGroup_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.LogGroup
 	resourceName := "aws_cloudwatch_log_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.LogsServiceID),
 		CheckDestroy: testAccCheckLogGroupDestroy(ctx, t),

--- a/internal/service/m2/application_tags_gen_test.go
+++ b/internal/service/m2/application_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/m2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccM2Application_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccM2Application_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccM2Application_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccM2Application_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccM2Application_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccM2Application_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccM2Application_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccM2Application_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccM2Application_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccM2Application_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccM2Application_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccM2Application_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccM2Application_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccM2Application_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccM2Application_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccM2Application_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccM2Application_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccM2Application_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccM2Application_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccM2Application_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccM2Application_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetApplicationOutput
 	resourceName := "aws_m2_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),

--- a/internal/service/m2/environment_tags_gen_test.go
+++ b/internal/service/m2/environment_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/m2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccM2Environment_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccM2Environment_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccM2Environment_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccM2Environment_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccM2Environment_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccM2Environment_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccM2Environment_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy:             testAccCheckEnvironmentDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccM2Environment_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccM2Environment_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccM2Environment_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccM2Environment_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccM2Environment_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccM2Environment_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccM2Environment_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccM2Environment_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccM2Environment_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccM2Environment_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccM2Environment_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccM2Environment_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccM2Environment_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccM2Environment_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v m2.GetEnvironmentOutput
 	resourceName := "aws_m2_environment.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.M2ServiceID),
 		CheckDestroy: testAccCheckEnvironmentDestroy(ctx),

--- a/internal/service/medialive/channel_tags_gen_test.go
+++ b/internal/service/medialive/channel_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccMediaLiveChannel_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccMediaLiveChannel_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccMediaLiveChannel_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccMediaLiveChannel_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccMediaLiveChannel_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccMediaLiveChannel_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccMediaLiveChannel_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckChannelDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccMediaLiveChannel_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccMediaLiveChannel_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccMediaLiveChannel_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccMediaLiveChannel_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccMediaLiveChannel_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccMediaLiveChannel_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeChannelOutput
 	resourceName := "aws_medialive_channel.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckChannelDestroy(ctx),

--- a/internal/service/medialive/input_data_source_tags_gen_test.go
+++ b/internal/service/medialive/input_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccMediaLiveInputDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccMediaLiveInputDataSource_tags(t *testing.T) {
 func TestAccMediaLiveInputDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccMediaLiveInputDataSource_tags_NullMap(t *testing.T) {
 func TestAccMediaLiveInputDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccMediaLiveInputDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccMediaLiveInputDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccMediaLiveInputDataSource_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccMediaLiveInputDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccMediaLiveInputDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccMediaLiveInputDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/medialive/input_security_group_tags_gen_test.go
+++ b/internal/service/medialive/input_security_group_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccMediaLiveInputSecurityGroup_tags(t *testing.T) {
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -194,7 +194,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_null(t *testing.T) {
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -257,7 +257,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyMap(t *testing.T) {
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -316,7 +316,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_AddOnUpdate(t *testing.T) {
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -393,7 +393,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -477,7 +477,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T)
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -608,7 +608,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_EmptyTag_OnUpdate_Replace(t *testin
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputSecurityGroupDestroy(ctx),
@@ -693,7 +693,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_providerOnly(t *testing
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -865,7 +865,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nonOverlapping(t *testi
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1018,7 +1018,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_overlapping(t *testing.
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1187,7 +1187,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToProviderOnly(t 
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1273,7 +1273,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_updateToResourceOnly(t 
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1358,7 +1358,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyResourceTag(t *tes
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1420,7 +1420,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_emptyProviderOnlyTag(t 
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1474,7 +1474,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullOverlappingResource
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1533,7 +1533,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_DefaultTags_nullNonOverlappingResou
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1592,7 +1592,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnCreate(t *testing.T) 
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1644,7 +1644,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Add(t *testing
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1737,7 +1737,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_ComputedTag_OnUpdate_Replace(t *tes
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1820,7 +1820,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_IgnoreTags_Overlap_DefaultTag(t *te
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),
@@ -1978,7 +1978,7 @@ func TestAccMediaLiveInputSecurityGroup_tags_IgnoreTags_Overlap_ResourceTag(t *t
 	var v medialive.DescribeInputSecurityGroupOutput
 	resourceName := "aws_medialive_input_security_group.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputSecurityGroupDestroy(ctx),

--- a/internal/service/medialive/input_tags_gen_test.go
+++ b/internal/service/medialive/input_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccMediaLiveInput_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccMediaLiveInput_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccMediaLiveInput_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccMediaLiveInput_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccMediaLiveInput_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccMediaLiveInput_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccMediaLiveInput_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckInputDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccMediaLiveInput_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccMediaLiveInput_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccMediaLiveInput_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccMediaLiveInput_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccMediaLiveInput_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccMediaLiveInput_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeInputOutput
 	resourceName := "aws_medialive_input.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckInputDestroy(ctx),

--- a/internal/service/medialive/multiplex_tags_gen_test.go
+++ b/internal/service/medialive/multiplex_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/medialive"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccMediaLiveMultiplex_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -244,9 +243,9 @@ func testAccMediaLiveMultiplex_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -314,9 +313,9 @@ func testAccMediaLiveMultiplex_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -380,9 +379,9 @@ func testAccMediaLiveMultiplex_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -464,9 +463,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -559,9 +558,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -702,9 +701,9 @@ func testAccMediaLiveMultiplex_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy:             testAccCheckMultiplexDestroy(ctx),
@@ -794,9 +793,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -987,9 +986,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1156,9 +1155,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1341,9 +1340,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1434,9 +1433,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1526,9 +1525,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1594,9 +1593,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1654,9 +1653,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1719,9 +1718,9 @@ func testAccMediaLiveMultiplex_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1784,9 +1783,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1842,9 +1841,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -1942,9 +1941,9 @@ func testAccMediaLiveMultiplex_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -2032,9 +2031,9 @@ func testAccMediaLiveMultiplex_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),
@@ -2194,9 +2193,9 @@ func testAccMediaLiveMultiplex_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v medialive.DescribeMultiplexOutput
 	resourceName := "aws_medialive_multiplex.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaLiveServiceID),
 		CheckDestroy: testAccCheckMultiplexDestroy(ctx),

--- a/internal/service/mediapackagev2/channel_group_tags_gen_test.go
+++ b/internal/service/mediapackagev2/channel_group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/mediapackagev2"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -50,9 +49,9 @@ func testAccMediaPackageV2ChannelGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -240,9 +239,9 @@ func testAccMediaPackageV2ChannelGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -304,9 +303,9 @@ func testAccMediaPackageV2ChannelGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -356,9 +355,9 @@ func testAccMediaPackageV2ChannelGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -438,9 +437,9 @@ func testAccMediaPackageV2ChannelGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -532,9 +531,9 @@ func testAccMediaPackageV2ChannelGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -675,9 +674,9 @@ func testAccMediaPackageV2ChannelGroup_tags_EmptyTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy:             testAccCheckChannelGroupDestroy(ctx),
@@ -767,9 +766,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_providerOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -956,9 +955,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_nonOverlapping(t *testin
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1122,9 +1121,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_overlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1304,9 +1303,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_updateToProviderOnly(t *
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1396,9 +1395,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_updateToResourceOnly(t *
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1487,9 +1486,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_emptyResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1555,9 +1554,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_emptyProviderOnlyTag(t *
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1615,9 +1614,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_nullOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1686,9 +1685,9 @@ func testAccMediaPackageV2ChannelGroup_tags_DefaultTags_nullNonOverlappingResour
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1759,9 +1758,9 @@ func testAccMediaPackageV2ChannelGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1816,9 +1815,9 @@ func testAccMediaPackageV2ChannelGroup_tags_ComputedTag_OnUpdate_Add(t *testing.
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -1915,9 +1914,9 @@ func testAccMediaPackageV2ChannelGroup_tags_ComputedTag_OnUpdate_Replace(t *test
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -2004,9 +2003,9 @@ func testAccMediaPackageV2ChannelGroup_tags_IgnoreTags_Overlap_DefaultTag(t *tes
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),
@@ -2166,9 +2165,9 @@ func testAccMediaPackageV2ChannelGroup_tags_IgnoreTags_Overlap_ResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v mediapackagev2.GetChannelGroupOutput
 	resourceName := "aws_media_packagev2_channel_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.MediaPackageV2ServiceID),
 		CheckDestroy: testAccCheckChannelGroupDestroy(ctx),

--- a/internal/service/networkmonitor/monitor_tags_gen_test.go
+++ b/internal/service/networkmonitor/monitor_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccNetworkMonitorMonitor_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccNetworkMonitorMonitor_tags(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -261,9 +260,9 @@ func TestAccNetworkMonitorMonitor_tags_null(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -310,9 +309,9 @@ func TestAccNetworkMonitorMonitor_tags_EmptyMap(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -389,9 +388,9 @@ func TestAccNetworkMonitorMonitor_tags_AddOnUpdate(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -478,9 +477,9 @@ func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -616,9 +615,9 @@ func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckMonitorDestroy(ctx),
@@ -705,9 +704,9 @@ func TestAccNetworkMonitorMonitor_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -885,9 +884,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1044,9 +1043,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1219,9 +1218,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1308,9 +1307,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_updateToProviderOnly(t *testi
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1396,9 +1395,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_updateToResourceOnly(t *testi
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1461,9 +1460,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_emptyResourceTag(t *testing.T
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1518,9 +1517,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_nullOverlappingResourceTag(t 
 func TestAccNetworkMonitorMonitor_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1656,9 +1655,9 @@ func TestAccNetworkMonitorMonitor_tags_DefaultTags_nullNonOverlappingResourceTag
 func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1710,9 +1709,9 @@ func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -1892,9 +1891,9 @@ func TestAccNetworkMonitorMonitor_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 func TestAccNetworkMonitorMonitor_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),
@@ -2053,9 +2052,9 @@ func TestAccNetworkMonitorMonitor_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccNetworkMonitorMonitor_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_monitor.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckMonitorDestroy(ctx),

--- a/internal/service/networkmonitor/probe_tags_gen_test.go
+++ b/internal/service/networkmonitor/probe_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccNetworkMonitorProbe_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccNetworkMonitorProbe_tags(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -261,9 +260,9 @@ func TestAccNetworkMonitorProbe_tags_null(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -310,9 +309,9 @@ func TestAccNetworkMonitorProbe_tags_EmptyMap(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -389,9 +388,9 @@ func TestAccNetworkMonitorProbe_tags_AddOnUpdate(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -478,9 +477,9 @@ func TestAccNetworkMonitorProbe_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -616,9 +615,9 @@ func TestAccNetworkMonitorProbe_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy:             testAccCheckProbeDestroy(ctx),
@@ -705,9 +704,9 @@ func TestAccNetworkMonitorProbe_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -885,9 +884,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1044,9 +1043,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1219,9 +1218,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1308,9 +1307,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_updateToProviderOnly(t *testing
 func TestAccNetworkMonitorProbe_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1396,9 +1395,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_updateToResourceOnly(t *testing
 func TestAccNetworkMonitorProbe_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1461,9 +1460,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 func TestAccNetworkMonitorProbe_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1518,9 +1517,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 func TestAccNetworkMonitorProbe_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_nullOverlappingResourceTag(t *t
 func TestAccNetworkMonitorProbe_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1656,9 +1655,9 @@ func TestAccNetworkMonitorProbe_tags_DefaultTags_nullNonOverlappingResourceTag(t
 func TestAccNetworkMonitorProbe_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1710,9 +1709,9 @@ func TestAccNetworkMonitorProbe_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccNetworkMonitorProbe_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccNetworkMonitorProbe_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -1892,9 +1891,9 @@ func TestAccNetworkMonitorProbe_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 func TestAccNetworkMonitorProbe_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),
@@ -2053,9 +2052,9 @@ func TestAccNetworkMonitorProbe_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 func TestAccNetworkMonitorProbe_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_networkmonitor_probe.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.NetworkMonitorServiceID),
 		CheckDestroy: testAccCheckProbeDestroy(ctx),

--- a/internal/service/quicksight/analysis_data_source_tags_gen_test.go
+++ b/internal/service/quicksight/analysis_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccQuickSightAnalysisDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccQuickSightAnalysisDataSource_tags(t *testing.T) {
 func TestAccQuickSightAnalysisDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccQuickSightAnalysisDataSource_tags_NullMap(t *testing.T) {
 func TestAccQuickSightAnalysisDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccQuickSightAnalysisDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccQuickSightAnalysisDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccQuickSightAnalysisDataSource_tags_DefaultTags_nonOverlapping(t *test
 func TestAccQuickSightAnalysisDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccQuickSightAnalysisDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func TestAccQuickSightAnalysisDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/quicksight/analysis_tags_gen_test.go
+++ b/internal/service/quicksight/analysis_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightAnalysis_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightAnalysis_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightAnalysis_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightAnalysis_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightAnalysis_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightAnalysis_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightAnalysis_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckAnalysisDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightAnalysis_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightAnalysis_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightAnalysis_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightAnalysis_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightAnalysis_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightAnalysis_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Analysis
 	resourceName := "aws_quicksight_analysis.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckAnalysisDestroy(ctx),

--- a/internal/service/quicksight/dashboard_tags_gen_test.go
+++ b/internal/service/quicksight/dashboard_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightDashboard_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightDashboard_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightDashboard_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightDashboard_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightDashboard_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightDashboard_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightDashboard_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDashboardDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightDashboard_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightDashboard_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightDashboard_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightDashboard_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightDashboard_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightDashboard_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.Dashboard
 	resourceName := "aws_quicksight_dashboard.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDashboardDestroy(ctx),

--- a/internal/service/quicksight/data_set_data_source_tags_gen_test.go
+++ b/internal/service/quicksight/data_set_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccQuickSightDataSetDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccQuickSightDataSetDataSource_tags(t *testing.T) {
 func TestAccQuickSightDataSetDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccQuickSightDataSetDataSource_tags_NullMap(t *testing.T) {
 func TestAccQuickSightDataSetDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccQuickSightDataSetDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccQuickSightDataSetDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccQuickSightDataSetDataSource_tags_DefaultTags_nonOverlapping(t *testi
 func TestAccQuickSightDataSetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccQuickSightDataSetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *te
 func TestAccQuickSightDataSetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.QuickSightServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/quicksight/data_set_tags_gen_test.go
+++ b/internal/service/quicksight/data_set_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightDataSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightDataSet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightDataSet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightDataSet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightDataSet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightDataSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightDataSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSetDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_updateToProviderOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_updateToResourceOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightDataSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightDataSet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightDataSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightDataSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightDataSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightDataSet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.DataSet
 	resourceName := "aws_quicksight_data_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSetDestroy(ctx),

--- a/internal/service/quicksight/data_source_tags_gen_test.go
+++ b/internal/service/quicksight/data_source_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightDataSource_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightDataSource_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightDataSource_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightDataSource_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightDataSource_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckDataSourceDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightDataSource_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightDataSource_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightDataSource_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightDataSource_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.DataSource
 	resourceName := "aws_quicksight_data_source.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckDataSourceDestroy(ctx),

--- a/internal/service/quicksight/folder_tags_gen_test.go
+++ b/internal/service/quicksight/folder_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightFolder_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightFolder_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightFolder_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightFolder_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightFolder_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightFolder_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightFolder_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckFolderDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightFolder_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightFolder_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightFolder_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightFolder_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightFolder_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightFolder_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Folder
 	resourceName := "aws_quicksight_folder.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckFolderDestroy(ctx),

--- a/internal/service/quicksight/namespace_tags_gen_test.go
+++ b/internal/service/quicksight/namespace_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightNamespace_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightNamespace_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -267,9 +266,9 @@ func TestAccQuickSightNamespace_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -317,9 +316,9 @@ func TestAccQuickSightNamespace_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -399,9 +398,9 @@ func TestAccQuickSightNamespace_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -491,9 +490,9 @@ func TestAccQuickSightNamespace_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccQuickSightNamespace_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckNamespaceDestroy(ctx),
@@ -722,9 +721,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -903,9 +902,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1063,9 +1062,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1239,9 +1238,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_updateToProviderOnly(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1329,9 +1328,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_updateToResourceOnly(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1420,9 +1419,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1488,9 +1487,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1548,9 +1547,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_nullOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1619,9 +1618,9 @@ func TestAccQuickSightNamespace_tags_DefaultTags_nullNonOverlappingResourceTag(t
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccQuickSightNamespace_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1745,9 +1744,9 @@ func TestAccQuickSightNamespace_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1842,9 +1841,9 @@ func TestAccQuickSightNamespace_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -1929,9 +1928,9 @@ func TestAccQuickSightNamespace_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),
@@ -2091,9 +2090,9 @@ func TestAccQuickSightNamespace_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.NamespaceInfoV2
 	resourceName := "aws_quicksight_namespace.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckNamespaceDestroy(ctx),

--- a/internal/service/quicksight/template_tags_gen_test.go
+++ b/internal/service/quicksight/template_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightTemplate_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightTemplate_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightTemplate_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightTemplate_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightTemplate_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightTemplate_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightTemplate_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckTemplateDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_updateToProviderOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_updateToResourceOnly(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_nullOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightTemplate_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightTemplate_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightTemplate_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightTemplate_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightTemplate_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightTemplate_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.Template
 	resourceName := "aws_quicksight_template.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckTemplateDestroy(ctx),

--- a/internal/service/quicksight/theme_tags_gen_test.go
+++ b/internal/service/quicksight/theme_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightTheme_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightTheme_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -272,9 +271,9 @@ func TestAccQuickSightTheme_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -335,9 +334,9 @@ func TestAccQuickSightTheme_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -418,9 +417,9 @@ func TestAccQuickSightTheme_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -509,9 +508,9 @@ func TestAccQuickSightTheme_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -648,9 +647,9 @@ func TestAccQuickSightTheme_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckThemeDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -918,9 +917,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1078,9 +1077,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1254,9 +1253,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_updateToProviderOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1344,9 +1343,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_updateToResourceOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1435,9 +1434,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1561,9 +1560,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_nullOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccQuickSightTheme_tags_DefaultTags_nullNonOverlappingResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1687,9 +1686,9 @@ func TestAccQuickSightTheme_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1742,9 +1741,9 @@ func TestAccQuickSightTheme_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1839,9 +1838,9 @@ func TestAccQuickSightTheme_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -1926,9 +1925,9 @@ func TestAccQuickSightTheme_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),
@@ -2088,9 +2087,9 @@ func TestAccQuickSightTheme_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Theme
 	resourceName := "aws_quicksight_theme.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckThemeDestroy(ctx),

--- a/internal/service/quicksight/vpc_connection_tags_gen_test.go
+++ b/internal/service/quicksight/vpc_connection_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/quicksight/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccQuickSightVPCConnection_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -205,9 +204,9 @@ func TestAccQuickSightVPCConnection_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -267,9 +266,9 @@ func TestAccQuickSightVPCConnection_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -317,9 +316,9 @@ func TestAccQuickSightVPCConnection_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -399,9 +398,9 @@ func TestAccQuickSightVPCConnection_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -491,9 +490,9 @@ func TestAccQuickSightVPCConnection_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccQuickSightVPCConnection_tags_EmptyTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy:             testAccCheckVPCConnectionDestroy(ctx),
@@ -722,9 +721,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_providerOnly(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -903,9 +902,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_nonOverlapping(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1063,9 +1062,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1239,9 +1238,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_updateToProviderOnly(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1329,9 +1328,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_updateToResourceOnly(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1420,9 +1419,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_emptyResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1488,9 +1487,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_emptyProviderOnlyTag(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1548,9 +1547,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_nullOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1619,9 +1618,9 @@ func TestAccQuickSightVPCConnection_tags_DefaultTags_nullNonOverlappingResourceT
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccQuickSightVPCConnection_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1745,9 +1744,9 @@ func TestAccQuickSightVPCConnection_tags_ComputedTag_OnUpdate_Add(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1842,9 +1841,9 @@ func TestAccQuickSightVPCConnection_tags_ComputedTag_OnUpdate_Replace(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -1929,9 +1928,9 @@ func TestAccQuickSightVPCConnection_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),
@@ -2091,9 +2090,9 @@ func TestAccQuickSightVPCConnection_tags_IgnoreTags_Overlap_ResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.VPCConnection
 	resourceName := "aws_quicksight_vpc_connection.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.QuickSightServiceID),
 		CheckDestroy: testAccCheckVPCConnectionDestroy(ctx),

--- a/internal/service/rds/global_cluster_tags_gen_test.go
+++ b/internal/service/rds/global_cluster_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccRDSGlobalCluster_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccRDSGlobalCluster_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccRDSGlobalCluster_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccRDSGlobalCluster_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccRDSGlobalCluster_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccRDSGlobalCluster_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccRDSGlobalCluster_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckGlobalClusterDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccRDSGlobalCluster_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccRDSGlobalCluster_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccRDSGlobalCluster_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccRDSGlobalCluster_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccRDSGlobalCluster_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccRDSGlobalCluster_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.GlobalCluster
 	resourceName := "aws_rds_global_cluster.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckGlobalClusterDestroy(ctx),

--- a/internal/service/rds/instance_data_source_tags_gen_test.go
+++ b/internal/service/rds/instance_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccRDSDBInstanceDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccRDSDBInstanceDataSource_tags(t *testing.T) {
 func TestAccRDSDBInstanceDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccRDSDBInstanceDataSource_tags_NullMap(t *testing.T) {
 func TestAccRDSDBInstanceDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccRDSDBInstanceDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccRDSDBInstanceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.RDSServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccRDSDBInstanceDataSource_tags_DefaultTags_nonOverlapping(t *testing.T
 func TestAccRDSDBInstanceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.RDSServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccRDSDBInstanceDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 func TestAccRDSDBInstanceDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.RDSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/rds/instance_tags_gen_test.go
+++ b/internal/service/rds/instance_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccRDSDBInstance_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccRDSDBInstance_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccRDSDBInstance_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccRDSDBInstance_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccRDSDBInstance_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccRDSDBInstance_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccRDSDBInstance_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccRDSDBInstance_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccRDSDBInstance_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccRDSDBInstance_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccRDSDBInstance_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccRDSDBInstance_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccRDSDBInstance_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.DBInstance
 	resourceName := "aws_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.RDSServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),

--- a/internal/service/resiliencehub/resiliency_policy_tags_gen_test.go
+++ b/internal/service/resiliencehub/resiliency_policy_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/resiliencehub"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccResilienceHubResiliencyPolicy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -327,9 +326,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -409,9 +408,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnUpdate_Add(t *testing.
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -646,9 +645,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_EmptyTag_OnUpdate_Replace(t *test
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy:             testAccCheckResiliencyPolicyDestroy(ctx),
@@ -738,9 +737,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_providerOnly(t *testi
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -927,9 +926,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nonOverlapping(t *tes
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1093,9 +1092,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_overlapping(t *testin
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1275,9 +1274,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToProviderOnly(
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1367,9 +1366,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_updateToResourceOnly(
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1458,9 +1457,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_emptyProviderOnlyTag(
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nullOverlappingResour
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1657,9 +1656,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_DefaultTags_nullNonOverlappingRes
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1730,9 +1729,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnCreate(t *testing.T
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1787,9 +1786,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Add(t *testi
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1886,9 +1885,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_ComputedTag_OnUpdate_Replace(t *t
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -1975,9 +1974,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_DefaultTag(t *
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),
@@ -2137,9 +2136,9 @@ func TestAccResilienceHubResiliencyPolicy_tags_IgnoreTags_Overlap_ResourceTag(t 
 	ctx := acctest.Context(t)
 	var v resiliencehub.DescribeResiliencyPolicyOutput
 	resourceName := "aws_resiliencehub_resiliency_policy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ResilienceHubServiceID),
 		CheckDestroy: testAccCheckResiliencyPolicyDestroy(ctx),

--- a/internal/service/s3/bucket_object_data_source_tags_gen_test.go
+++ b/internal/service/s3/bucket_object_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccS3BucketObjectDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccS3BucketObjectDataSource_tags(t *testing.T) {
 func TestAccS3BucketObjectDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccS3BucketObjectDataSource_tags_NullMap(t *testing.T) {
 func TestAccS3BucketObjectDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccS3BucketObjectDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccS3BucketObjectDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccS3BucketObjectDataSource_tags_DefaultTags_nonOverlapping(t *testing.
 func TestAccS3BucketObjectDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccS3BucketObjectDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testi
 func TestAccS3BucketObjectDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/s3/bucket_object_tags_gen_test.go
+++ b/internal/service/s3/bucket_object_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccS3BucketObject_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccS3BucketObject_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccS3BucketObject_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccS3BucketObject_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccS3BucketObject_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccS3BucketObject_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccS3BucketObject_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketObjectDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccS3BucketObject_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccS3BucketObject_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccS3BucketObject_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccS3BucketObject_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccS3BucketObject_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccS3BucketObject_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccS3BucketObject_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccS3BucketObject_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccS3BucketObject_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccS3BucketObject_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccS3BucketObject_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccS3BucketObject_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccS3BucketObject_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccS3BucketObject_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_bucket_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketObjectDestroy(ctx),

--- a/internal/service/s3/bucket_tags_gen_test.go
+++ b/internal/service/s3/bucket_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccS3Bucket_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccS3Bucket_tags(t *testing.T) {
 func TestAccS3Bucket_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccS3Bucket_tags_null(t *testing.T) {
 func TestAccS3Bucket_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccS3Bucket_tags_EmptyMap(t *testing.T) {
 func TestAccS3Bucket_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccS3Bucket_tags_AddOnUpdate(t *testing.T) {
 func TestAccS3Bucket_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccS3Bucket_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccS3Bucket_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckBucketDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccS3Bucket_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccS3Bucket_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccS3Bucket_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccS3Bucket_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccS3Bucket_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccS3Bucket_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccS3Bucket_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccS3Bucket_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccS3Bucket_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 func TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccS3Bucket_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T
 func TestAccS3Bucket_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccS3Bucket_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccS3Bucket_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccS3Bucket_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccS3Bucket_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccS3Bucket_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckBucketDestroy(ctx),

--- a/internal/service/s3/directory_bucket_tags_gen_test.go
+++ b/internal/service/s3/directory_bucket_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccS3DirectoryBucket_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -212,9 +211,9 @@ func TestAccS3DirectoryBucket_tags(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -274,9 +273,9 @@ func TestAccS3DirectoryBucket_tags_null(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -324,9 +323,9 @@ func TestAccS3DirectoryBucket_tags_EmptyMap(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -406,9 +405,9 @@ func TestAccS3DirectoryBucket_tags_AddOnUpdate(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -501,9 +500,9 @@ func TestAccS3DirectoryBucket_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -645,9 +644,9 @@ func TestAccS3DirectoryBucket_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckDirectoryBucketDestroy(ctx),
@@ -737,9 +736,9 @@ func TestAccS3DirectoryBucket_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -929,9 +928,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1097,9 +1096,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1281,9 +1280,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1373,9 +1372,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_updateToProviderOnly(t *testing.T
 func TestAccS3DirectoryBucket_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1464,9 +1463,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_updateToResourceOnly(t *testing.T
 func TestAccS3DirectoryBucket_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1532,9 +1531,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T
 func TestAccS3DirectoryBucket_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1661,9 +1660,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_nullOverlappingResourceTag(t *tes
 func TestAccS3DirectoryBucket_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1732,9 +1731,9 @@ func TestAccS3DirectoryBucket_tags_DefaultTags_nullNonOverlappingResourceTag(t *
 func TestAccS3DirectoryBucket_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1789,9 +1788,9 @@ func TestAccS3DirectoryBucket_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1888,9 +1887,9 @@ func TestAccS3DirectoryBucket_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -1977,9 +1976,9 @@ func TestAccS3DirectoryBucket_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),
@@ -2138,9 +2137,9 @@ func TestAccS3DirectoryBucket_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccS3DirectoryBucket_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_directory_bucket.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckDirectoryBucketDestroy(ctx),

--- a/internal/service/s3/object_copy_tags_gen_test.go
+++ b/internal/service/s3/object_copy_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccS3ObjectCopy_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -156,9 +155,9 @@ func TestAccS3ObjectCopy_tags(t *testing.T) {
 func TestAccS3ObjectCopy_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccS3ObjectCopy_tags_null(t *testing.T) {
 func TestAccS3ObjectCopy_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -264,9 +263,9 @@ func TestAccS3ObjectCopy_tags_EmptyMap(t *testing.T) {
 func TestAccS3ObjectCopy_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -332,9 +331,9 @@ func TestAccS3ObjectCopy_tags_AddOnUpdate(t *testing.T) {
 func TestAccS3ObjectCopy_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -399,9 +398,9 @@ func TestAccS3ObjectCopy_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccS3ObjectCopy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -511,9 +510,9 @@ func TestAccS3ObjectCopy_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3ObjectCopy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectCopyDestroy(ctx),
@@ -587,9 +586,9 @@ func TestAccS3ObjectCopy_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -716,9 +715,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -833,9 +832,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -960,9 +959,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1035,9 +1034,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1110,9 +1109,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1158,9 +1157,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1200,9 +1199,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccS3ObjectCopy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1245,9 +1244,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 func TestAccS3ObjectCopy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1290,9 +1289,9 @@ func TestAccS3ObjectCopy_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 func TestAccS3ObjectCopy_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1333,9 +1332,9 @@ func TestAccS3ObjectCopy_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccS3ObjectCopy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1416,9 +1415,9 @@ func TestAccS3ObjectCopy_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccS3ObjectCopy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1491,9 +1490,9 @@ func TestAccS3ObjectCopy_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccS3ObjectCopy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),
@@ -1652,9 +1651,9 @@ func TestAccS3ObjectCopy_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccS3ObjectCopy_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_s3_object_copy.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectCopyDestroy(ctx),

--- a/internal/service/s3/object_data_source_tags_gen_test.go
+++ b/internal/service/s3/object_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccS3ObjectDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccS3ObjectDataSource_tags(t *testing.T) {
 func TestAccS3ObjectDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccS3ObjectDataSource_tags_NullMap(t *testing.T) {
 func TestAccS3ObjectDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccS3ObjectDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccS3ObjectDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccS3ObjectDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccS3ObjectDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccS3ObjectDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func TestAccS3ObjectDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.S3ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/s3/object_tags_gen_test.go
+++ b/internal/service/s3/object_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccS3Object_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccS3Object_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccS3Object_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccS3Object_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccS3Object_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccS3Object_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccS3Object_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy:             testAccCheckObjectDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccS3Object_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccS3Object_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccS3Object_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccS3Object_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccS3Object_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccS3Object_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccS3Object_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccS3Object_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccS3Object_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccS3Object_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccS3Object_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccS3Object_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccS3Object_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccS3Object_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v s3.GetObjectOutput
 	resourceName := "aws_s3_object.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.S3ServiceID),
 		CheckDestroy: testAccCheckObjectDestroy(ctx),

--- a/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
+++ b/internal/service/secretsmanager/secret_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSecretsManagerSecretDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSecretsManagerSecretDataSource_tags(t *testing.T) {
 func TestAccSecretsManagerSecretDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSecretsManagerSecretDataSource_tags_NullMap(t *testing.T) {
 func TestAccSecretsManagerSecretDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSecretsManagerSecretDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSecretsManagerSecretDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSecretsManagerSecretDataSource_tags_DefaultTags_nonOverlapping(t *te
 func TestAccSecretsManagerSecretDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSecretsManagerSecretDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 func TestAccSecretsManagerSecretDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/secretsmanager/secret_tags_gen_test.go
+++ b/internal/service/secretsmanager/secret_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccSecretsManagerSecret_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccSecretsManagerSecret_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccSecretsManagerSecret_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccSecretsManagerSecret_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccSecretsManagerSecret_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccSecretsManagerSecret_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy:             testAccCheckSecretDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccSecretsManagerSecret_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccSecretsManagerSecret_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccSecretsManagerSecret_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccSecretsManagerSecret_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccSecretsManagerSecret_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v secretsmanager.DescribeSecretOutput
 	resourceName := "aws_secretsmanager_secret.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SecretsManagerServiceID),
 		CheckDestroy: testAccCheckSecretDestroy(ctx),

--- a/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/portfolio_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccServiceCatalogPortfolioDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccServiceCatalogPortfolioDataSource_tags(t *testing.T) {
 func TestAccServiceCatalogPortfolioDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccServiceCatalogPortfolioDataSource_tags_NullMap(t *testing.T) {
 func TestAccServiceCatalogPortfolioDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccServiceCatalogPortfolioDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccServiceCatalogPortfolioDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccServiceCatalogPortfolioDataSource_tags_DefaultTags_nonOverlapping(t 
 func TestAccServiceCatalogPortfolioDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccServiceCatalogPortfolioDataSource_tags_IgnoreTags_Overlap_DefaultTag
 func TestAccServiceCatalogPortfolioDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_portfolio.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/servicecatalog/portfolio_tags_gen_test.go
+++ b/internal/service/servicecatalog/portfolio_tags_gen_test.go
@@ -28,7 +28,7 @@ func TestAccServiceCatalogPortfolio_tags(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -210,7 +210,7 @@ func TestAccServiceCatalogPortfolio_tags_null(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -277,7 +277,7 @@ func TestAccServiceCatalogPortfolio_tags_EmptyMap(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -340,7 +340,7 @@ func TestAccServiceCatalogPortfolio_tags_AddOnUpdate(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -423,7 +423,7 @@ func TestAccServiceCatalogPortfolio_tags_EmptyTag_OnCreate(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -514,7 +514,7 @@ func TestAccServiceCatalogPortfolio_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -653,7 +653,7 @@ func TestAccServiceCatalogPortfolio_tags_EmptyTag_OnUpdate_Replace(t *testing.T)
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckPortfolioDestroy(ctx),
@@ -742,7 +742,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_providerOnly(t *testing.T) 
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -923,7 +923,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_nonOverlapping(t *testing.T
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1083,7 +1083,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_overlapping(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1259,7 +1259,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_updateToProviderOnly(t *tes
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1349,7 +1349,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_updateToResourceOnly(t *tes
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1440,7 +1440,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_emptyResourceTag(t *testing
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1507,7 +1507,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_emptyProviderOnlyTag(t *tes
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1564,7 +1564,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_nullOverlappingResourceTag(
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1626,7 +1626,7 @@ func TestAccServiceCatalogPortfolio_tags_DefaultTags_nullNonOverlappingResourceT
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1688,7 +1688,7 @@ func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnCreate(t *testing.T) {
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1743,7 +1743,7 @@ func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Add(t *testing.T) 
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1840,7 +1840,7 @@ func TestAccServiceCatalogPortfolio_tags_ComputedTag_OnUpdate_Replace(t *testing
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -1927,7 +1927,7 @@ func TestAccServiceCatalogPortfolio_tags_IgnoreTags_Overlap_DefaultTag(t *testin
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),
@@ -2089,7 +2089,7 @@ func TestAccServiceCatalogPortfolio_tags_IgnoreTags_Overlap_ResourceTag(t *testi
 	resourceName := "aws_servicecatalog_portfolio.test"
 	rName := sdkacctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckPortfolioDestroy(ctx),

--- a/internal/service/servicecatalog/product_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalog/product_data_source_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -23,9 +22,9 @@ import (
 func TestAccServiceCatalogProductDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -51,9 +50,9 @@ func TestAccServiceCatalogProductDataSource_tags(t *testing.T) {
 func TestAccServiceCatalogProductDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -75,9 +74,9 @@ func TestAccServiceCatalogProductDataSource_tags_NullMap(t *testing.T) {
 func TestAccServiceCatalogProductDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -99,9 +98,9 @@ func TestAccServiceCatalogProductDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccServiceCatalogProductDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{
@@ -131,9 +130,9 @@ func TestAccServiceCatalogProductDataSource_tags_DefaultTags_nonOverlapping(t *t
 func TestAccServiceCatalogProductDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{
@@ -169,9 +168,9 @@ func TestAccServiceCatalogProductDataSource_tags_IgnoreTags_Overlap_DefaultTag(t
 func TestAccServiceCatalogProductDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/servicecatalog/product_tags_gen_test.go
+++ b/internal/service/servicecatalog/product_tags_gen_test.go
@@ -8,7 +8,6 @@ import (
 	"unique"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -24,9 +23,9 @@ import (
 func TestAccServiceCatalogProduct_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -217,9 +216,9 @@ func TestAccServiceCatalogProduct_tags(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -286,9 +285,9 @@ func TestAccServiceCatalogProduct_tags_null(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccServiceCatalogProduct_tags_EmptyMap(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -436,9 +435,9 @@ func TestAccServiceCatalogProduct_tags_EmptyTag_OnCreate(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -532,9 +531,9 @@ func TestAccServiceCatalogProduct_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -676,9 +675,9 @@ func TestAccServiceCatalogProduct_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProductDestroy(ctx),
@@ -767,9 +766,9 @@ func TestAccServiceCatalogProduct_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -959,9 +958,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccServiceCatalogProduct_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1311,9 +1310,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1403,9 +1402,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_updateToProviderOnly(t *testi
 func TestAccServiceCatalogProduct_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1496,9 +1495,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_emptyResourceTag(t *testing.T
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1624,9 +1623,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 func TestAccServiceCatalogProduct_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1688,9 +1687,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_nullOverlappingResourceTag(t 
 func TestAccServiceCatalogProduct_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1752,9 +1751,9 @@ func TestAccServiceCatalogProduct_tags_DefaultTags_nullNonOverlappingResourceTag
 func TestAccServiceCatalogProduct_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1809,9 +1808,9 @@ func TestAccServiceCatalogProduct_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1908,9 +1907,9 @@ func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -1997,9 +1996,9 @@ func TestAccServiceCatalogProduct_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 func TestAccServiceCatalogProduct_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),
@@ -2158,9 +2157,9 @@ func TestAccServiceCatalogProduct_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccServiceCatalogProduct_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalog_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProductDestroy(ctx),

--- a/internal/service/servicecatalog/provisioned_product_tags_gen_test.go
+++ b/internal/service/servicecatalog/provisioned_product_tags_gen_test.go
@@ -9,7 +9,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/servicecatalog/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -26,9 +25,9 @@ func TestAccServiceCatalogProvisionedProduct_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -224,9 +223,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -294,9 +293,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -360,9 +359,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -446,9 +445,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_EmptyTag_OnCreate(t *testing.T
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -543,9 +542,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_EmptyTag_OnUpdate_Add(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -688,9 +687,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_EmptyTag_OnUpdate_Replace(t *t
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy:             testAccCheckProvisionedProductDestroy(ctx),
@@ -780,9 +779,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_providerOnly(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -977,9 +976,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nonOverlapping(t *
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1148,9 +1147,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_overlapping(t *tes
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1333,9 +1332,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_updateToProviderOn
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1426,9 +1425,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_updateToResourceOn
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1520,9 +1519,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_emptyResourceTag(t
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1590,9 +1589,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_emptyProviderOnlyT
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1650,9 +1649,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nullOverlappingRes
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1715,9 +1714,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_DefaultTags_nullNonOverlapping
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1780,9 +1779,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnCreate(t *testin
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1838,9 +1837,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnUpdate_Add(t *te
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -1938,9 +1937,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_ComputedTag_OnUpdate_Replace(t
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -2028,9 +2027,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_IgnoreTags_Overlap_DefaultTag(
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),
@@ -2190,9 +2189,9 @@ func TestAccServiceCatalogProvisionedProduct_tags_IgnoreTags_Overlap_ResourceTag
 	ctx := acctest.Context(t)
 	var v awstypes.ProvisionedProductDetail
 	resourceName := "aws_servicecatalog_provisioned_product.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogServiceID),
 		CheckDestroy: testAccCheckProvisionedProductDestroy(ctx),

--- a/internal/service/servicecatalogappregistry/application_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalogappregistry/application_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccServiceCatalogAppRegistryApplicationDataSource_tags(t *testing.T) {
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_NullMap(t *testi
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_EmptyMap(t *test
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_DefaultTags_nonO
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_IgnoreTags_Overl
 func TestAccServiceCatalogAppRegistryApplicationDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/servicecatalogappregistry/application_tags_gen_test.go
+++ b/internal/service/servicecatalogappregistry/application_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccServiceCatalogAppRegistryApplication_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags(t *testing.T) {
 func TestAccServiceCatalogAppRegistryApplication_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -261,9 +260,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_null(t *testing.T) {
 func TestAccServiceCatalogAppRegistryApplication_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -310,9 +309,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_EmptyMap(t *testing.T) {
 func TestAccServiceCatalogAppRegistryApplication_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -389,9 +388,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_AddOnUpdate(t *testing.T) 
 func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -478,9 +477,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnCreate(t *testi
 func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -616,9 +615,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnUpdate_Add(t *t
 func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckApplicationDestroy(ctx),
@@ -705,9 +704,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_EmptyTag_OnUpdate_Replace(
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -885,9 +884,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_providerOnly(t
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1044,9 +1043,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nonOverlapping
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1219,9 +1218,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_overlapping(t 
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1308,9 +1307,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_updateToProvid
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1396,9 +1395,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_updateToResour
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1461,9 +1460,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_emptyResourceT
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1518,9 +1517,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_emptyProviderO
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nullOverlappin
 func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1656,9 +1655,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_DefaultTags_nullNonOverlap
 func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1710,9 +1709,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnCreate(t *te
 func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1806,9 +1805,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnUpdate_Add(t
 func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -1892,9 +1891,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_ComputedTag_OnUpdate_Repla
 func TestAccServiceCatalogAppRegistryApplication_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),
@@ -2053,9 +2052,9 @@ func TestAccServiceCatalogAppRegistryApplication_tags_IgnoreTags_Overlap_Default
 func TestAccServiceCatalogAppRegistryApplication_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_servicecatalogappregistry_application.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckApplicationDestroy(ctx),

--- a/internal/service/servicecatalogappregistry/attribute_group_data_source_tags_gen_test.go
+++ b/internal/service/servicecatalogappregistry/attribute_group_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags(t *testing.T)
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_NullMap(t *te
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_EmptyMap(t *t
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_DefaultTags_n
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_IgnoreTags_Ov
 func TestAccServiceCatalogAppRegistryAttributeGroupDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/servicecatalogappregistry/attribute_group_tags_gen_test.go
+++ b/internal/service/servicecatalogappregistry/attribute_group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/servicecatalogappregistry"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_EmptyMap(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_AddOnUpdate(t *testing.
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_EmptyTag_OnCreate(t *te
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_EmptyTag_OnUpdate_Add(t
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_EmptyTag_OnUpdate_Repla
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy:             testAccCheckAttributeGroupDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_providerOnl
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_nonOverlapp
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_overlapping
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_updateToPro
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_updateToRes
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_emptyResour
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_emptyProvid
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_nullOverlap
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_DefaultTags_nullNonOver
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_ComputedTag_OnCreate(t 
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_ComputedTag_OnUpdate_Ad
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_ComputedTag_OnUpdate_Re
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_IgnoreTags_Overlap_Defa
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccServiceCatalogAppRegistryAttributeGroup_tags_IgnoreTags_Overlap_Reso
 	ctx := acctest.Context(t)
 	var v servicecatalogappregistry.GetAttributeGroupOutput
 	resourceName := "aws_servicecatalogappregistry_attribute_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.ServiceCatalogAppRegistryServiceID),
 		CheckDestroy: testAccCheckAttributeGroupDestroy(ctx),

--- a/internal/service/sesv2/configuration_set_data_source_tags_gen_test.go
+++ b/internal/service/sesv2/configuration_set_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSESV2ConfigurationSetDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSESV2ConfigurationSetDataSource_tags(t *testing.T) {
 func TestAccSESV2ConfigurationSetDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSESV2ConfigurationSetDataSource_tags_NullMap(t *testing.T) {
 func TestAccSESV2ConfigurationSetDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSESV2ConfigurationSetDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2ConfigurationSetDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSESV2ConfigurationSetDataSource_tags_DefaultTags_nonOverlapping(t *t
 func TestAccSESV2ConfigurationSetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSESV2ConfigurationSetDataSource_tags_IgnoreTags_Overlap_DefaultTag(t
 func TestAccSESV2ConfigurationSetDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/sesv2/configuration_set_tags_gen_test.go
+++ b/internal/service/sesv2/configuration_set_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccSESV2ConfigurationSet_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccSESV2ConfigurationSet_tags(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccSESV2ConfigurationSet_tags_null(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccSESV2ConfigurationSet_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccSESV2ConfigurationSet_tags_AddOnUpdate(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckConfigurationSetDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccSESV2ConfigurationSet_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_nonOverlapping(t *testing.T) 
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_updateToProviderOnly(t *testi
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_updateToResourceOnly(t *testi
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_emptyResourceTag(t *testing.T
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_emptyProviderOnlyTag(t *testi
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_nullOverlappingResourceTag(t 
 func TestAccSESV2ConfigurationSet_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccSESV2ConfigurationSet_tags_DefaultTags_nullNonOverlappingResourceTag
 func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccSESV2ConfigurationSet_tags_ComputedTag_OnUpdate_Replace(t *testing.T
 func TestAccSESV2ConfigurationSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccSESV2ConfigurationSet_tags_IgnoreTags_Overlap_DefaultTag(t *testing.
 func TestAccSESV2ConfigurationSet_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_configuration_set.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckConfigurationSetDestroy(ctx),

--- a/internal/service/sesv2/contact_list_tags_gen_test.go
+++ b/internal/service/sesv2/contact_list_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccSESV2ContactList_tagsSerial(t *testing.T) {
 func testAccSESV2ContactList_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -229,9 +228,9 @@ func testAccSESV2ContactList_tags(t *testing.T) {
 func testAccSESV2ContactList_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -295,9 +294,9 @@ func testAccSESV2ContactList_tags_null(t *testing.T) {
 func testAccSESV2ContactList_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -357,9 +356,9 @@ func testAccSESV2ContactList_tags_EmptyMap(t *testing.T) {
 func testAccSESV2ContactList_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -437,9 +436,9 @@ func testAccSESV2ContactList_tags_AddOnUpdate(t *testing.T) {
 func testAccSESV2ContactList_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -525,9 +524,9 @@ func testAccSESV2ContactList_tags_EmptyTag_OnCreate(t *testing.T) {
 func testAccSESV2ContactList_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -661,9 +660,9 @@ func testAccSESV2ContactList_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func testAccSESV2ContactList_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckContactListDestroy(ctx),
@@ -749,9 +748,9 @@ func testAccSESV2ContactList_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func testAccSESV2ContactList_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -929,9 +928,9 @@ func testAccSESV2ContactList_tags_DefaultTags_providerOnly(t *testing.T) {
 func testAccSESV2ContactList_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1088,9 +1087,9 @@ func testAccSESV2ContactList_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func testAccSESV2ContactList_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1263,9 +1262,9 @@ func testAccSESV2ContactList_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccSESV2ContactList_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1352,9 +1351,9 @@ func testAccSESV2ContactList_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 func testAccSESV2ContactList_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1440,9 +1439,9 @@ func testAccSESV2ContactList_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 func testAccSESV2ContactList_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1504,9 +1503,9 @@ func testAccSESV2ContactList_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func testAccSESV2ContactList_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1560,9 +1559,9 @@ func testAccSESV2ContactList_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 func testAccSESV2ContactList_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1621,9 +1620,9 @@ func testAccSESV2ContactList_tags_DefaultTags_nullOverlappingResourceTag(t *test
 func testAccSESV2ContactList_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1682,9 +1681,9 @@ func testAccSESV2ContactList_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 func testAccSESV2ContactList_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1736,9 +1735,9 @@ func testAccSESV2ContactList_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccSESV2ContactList_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1832,9 +1831,9 @@ func testAccSESV2ContactList_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func testAccSESV2ContactList_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -1918,9 +1917,9 @@ func testAccSESV2ContactList_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func testAccSESV2ContactList_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),
@@ -2079,9 +2078,9 @@ func testAccSESV2ContactList_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func testAccSESV2ContactList_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_contact_list.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckContactListDestroy(ctx),

--- a/internal/service/sesv2/dedicated_ip_pool_data_source_tags_gen_test.go
+++ b/internal/service/sesv2/dedicated_ip_pool_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSESV2DedicatedIPPoolDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSESV2DedicatedIPPoolDataSource_tags(t *testing.T) {
 func TestAccSESV2DedicatedIPPoolDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSESV2DedicatedIPPoolDataSource_tags_NullMap(t *testing.T) {
 func TestAccSESV2DedicatedIPPoolDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSESV2DedicatedIPPoolDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2DedicatedIPPoolDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSESV2DedicatedIPPoolDataSource_tags_DefaultTags_nonOverlapping(t *te
 func TestAccSESV2DedicatedIPPoolDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSESV2DedicatedIPPoolDataSource_tags_IgnoreTags_Overlap_DefaultTag(t 
 func TestAccSESV2DedicatedIPPoolDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/sesv2/dedicated_ip_pool_tags_gen_test.go
+++ b/internal/service/sesv2/dedicated_ip_pool_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccSESV2DedicatedIPPool_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccSESV2DedicatedIPPool_tags(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccSESV2DedicatedIPPool_tags_null(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccSESV2DedicatedIPPool_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccSESV2DedicatedIPPool_tags_AddOnUpdate(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccSESV2DedicatedIPPool_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_updateToProviderOnly(t *testin
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_updateToResourceOnly(t *testin
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_emptyResourceTag(t *testing.T)
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nullOverlappingResourceTag(t *
 func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccSESV2DedicatedIPPool_tags_DefaultTags_nullNonOverlappingResourceTag(
 func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccSESV2DedicatedIPPool_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 func TestAccSESV2DedicatedIPPool_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccSESV2DedicatedIPPool_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 func TestAccSESV2DedicatedIPPool_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_dedicated_ip_pool.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckDedicatedIPPoolDestroy(ctx),

--- a/internal/service/sesv2/email_identity_data_source_tags_gen_test.go
+++ b/internal/service/sesv2/email_identity_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSESV2EmailIdentityDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSESV2EmailIdentityDataSource_tags(t *testing.T) {
 func TestAccSESV2EmailIdentityDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSESV2EmailIdentityDataSource_tags_NullMap(t *testing.T) {
 func TestAccSESV2EmailIdentityDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSESV2EmailIdentityDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2EmailIdentityDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSESV2EmailIdentityDataSource_tags_DefaultTags_nonOverlapping(t *test
 func TestAccSESV2EmailIdentityDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSESV2EmailIdentityDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func TestAccSESV2EmailIdentityDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SESV2ServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/sesv2/email_identity_tags_gen_test.go
+++ b/internal/service/sesv2/email_identity_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccSESV2EmailIdentity_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccSESV2EmailIdentity_tags(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccSESV2EmailIdentity_tags_null(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccSESV2EmailIdentity_tags_EmptyMap(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccSESV2EmailIdentity_tags_AddOnUpdate(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccSESV2EmailIdentity_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccSESV2EmailIdentity_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy:             testAccCheckEmailIdentityDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccSESV2EmailIdentity_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_updateToProviderOnly(t *testing.
 func TestAccSESV2EmailIdentity_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_updateToResourceOnly(t *testing.
 func TestAccSESV2EmailIdentity_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 func TestAccSESV2EmailIdentity_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_nullOverlappingResourceTag(t *te
 func TestAccSESV2EmailIdentity_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccSESV2EmailIdentity_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 func TestAccSESV2EmailIdentity_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccSESV2EmailIdentity_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccSESV2EmailIdentity_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccSESV2EmailIdentity_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSESV2EmailIdentity_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccSESV2EmailIdentity_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func TestAccSESV2EmailIdentity_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_sesv2_email_identity.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SESV2ServiceID),
 		CheckDestroy: testAccCheckEmailIdentityDestroy(ctx),

--- a/internal/service/sns/topic_data_source_tags_gen_test.go
+++ b/internal/service/sns/topic_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSNSTopicDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSNSTopicDataSource_tags(t *testing.T) {
 func TestAccSNSTopicDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSNSTopicDataSource_tags_NullMap(t *testing.T) {
 func TestAccSNSTopicDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSNSTopicDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSNSTopicDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SNSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSNSTopicDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSNSTopicDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SNSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSNSTopicDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func TestAccSNSTopicDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SNSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/sns/topic_tags_gen_test.go
+++ b/internal/service/sns/topic_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -20,9 +19,9 @@ func TestAccSNSTopic_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -202,9 +201,9 @@ func TestAccSNSTopic_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -269,9 +268,9 @@ func TestAccSNSTopic_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -332,9 +331,9 @@ func TestAccSNSTopic_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -413,9 +412,9 @@ func TestAccSNSTopic_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -502,9 +501,9 @@ func TestAccSNSTopic_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -639,9 +638,9 @@ func TestAccSNSTopic_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy:             testAccCheckTopicDestroy(ctx),
@@ -728,9 +727,9 @@ func TestAccSNSTopic_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -909,9 +908,9 @@ func TestAccSNSTopic_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1069,9 +1068,9 @@ func TestAccSNSTopic_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1245,9 +1244,9 @@ func TestAccSNSTopic_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1335,9 +1334,9 @@ func TestAccSNSTopic_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1424,9 +1423,9 @@ func TestAccSNSTopic_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1489,9 +1488,9 @@ func TestAccSNSTopic_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1546,9 +1545,9 @@ func TestAccSNSTopic_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1608,9 +1607,9 @@ func TestAccSNSTopic_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1670,9 +1669,9 @@ func TestAccSNSTopic_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1725,9 +1724,9 @@ func TestAccSNSTopic_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1822,9 +1821,9 @@ func TestAccSNSTopic_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -1909,9 +1908,9 @@ func TestAccSNSTopic_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),
@@ -2071,9 +2070,9 @@ func TestAccSNSTopic_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[string]string
 	resourceName := "aws_sns_topic.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SNSServiceID),
 		CheckDestroy: testAccCheckTopicDestroy(ctx),

--- a/internal/service/sqs/queue_data_source_tags_gen_test.go
+++ b/internal/service/sqs/queue_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -18,9 +17,9 @@ import (
 func TestAccSQSQueueDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -46,9 +45,9 @@ func TestAccSQSQueueDataSource_tags(t *testing.T) {
 func TestAccSQSQueueDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -70,9 +69,9 @@ func TestAccSQSQueueDataSource_tags_NullMap(t *testing.T) {
 func TestAccSQSQueueDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -94,9 +93,9 @@ func TestAccSQSQueueDataSource_tags_EmptyMap(t *testing.T) {
 func TestAccSQSQueueDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SQSServiceID),
 		Steps: []resource.TestStep{
@@ -126,9 +125,9 @@ func TestAccSQSQueueDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSQSQueueDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SQSServiceID),
 		Steps: []resource.TestStep{
@@ -164,9 +163,9 @@ func TestAccSQSQueueDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func TestAccSQSQueueDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SQSServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/sqs/queue_tags_gen_test.go
+++ b/internal/service/sqs/queue_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccSQSQueue_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccSQSQueue_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccSQSQueue_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccSQSQueue_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccSQSQueue_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccSQSQueue_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccSQSQueue_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy:             testAccCheckQueueDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccSQSQueue_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccSQSQueue_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccSQSQueue_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccSQSQueue_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccSQSQueue_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccSQSQueue_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccSQSQueue_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccSQSQueue_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccSQSQueue_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccSQSQueue_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccSQSQueue_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccSQSQueue_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccSQSQueue_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccSQSQueue_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v map[awstypes.QueueAttributeName]string
 	resourceName := "aws_sqs_queue.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SQSServiceID),
 		CheckDestroy: testAccCheckQueueDestroy(ctx),

--- a/internal/service/ssm/activation_tags_gen_test.go
+++ b/internal/service/ssm/activation_tags_gen_test.go
@@ -9,7 +9,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -26,9 +25,9 @@ func TestAccSSMActivation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -220,9 +219,9 @@ func TestAccSSMActivation_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -290,9 +289,9 @@ func TestAccSSMActivation_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -356,9 +355,9 @@ func TestAccSSMActivation_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -440,9 +439,9 @@ func TestAccSSMActivation_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -535,9 +534,9 @@ func TestAccSSMActivation_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -678,9 +677,9 @@ func TestAccSSMActivation_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckActivationDestroy(ctx),
@@ -770,9 +769,9 @@ func TestAccSSMActivation_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -963,9 +962,9 @@ func TestAccSSMActivation_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1132,9 +1131,9 @@ func TestAccSSMActivation_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1317,9 +1316,9 @@ func TestAccSSMActivation_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccSSMActivation_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1502,9 +1501,9 @@ func TestAccSSMActivation_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1570,9 +1569,9 @@ func TestAccSSMActivation_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1630,9 +1629,9 @@ func TestAccSSMActivation_tags_DefaultTags_nullOverlappingResourceTag(t *testing
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1695,9 +1694,9 @@ func TestAccSSMActivation_tags_DefaultTags_nullNonOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1760,9 +1759,9 @@ func TestAccSSMActivation_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1818,9 +1817,9 @@ func TestAccSSMActivation_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -1918,9 +1917,9 @@ func TestAccSSMActivation_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -2008,9 +2007,9 @@ func TestAccSSMActivation_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),
@@ -2170,9 +2169,9 @@ func TestAccSSMActivation_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Activation
 	resourceName := "aws_ssm_activation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckActivationDestroy(ctx),

--- a/internal/service/ssm/association_tags_gen_test.go
+++ b/internal/service/ssm/association_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccSSMAssociation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccSSMAssociation_tags(t *testing.T) {
 func TestAccSSMAssociation_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccSSMAssociation_tags_null(t *testing.T) {
 func TestAccSSMAssociation_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccSSMAssociation_tags_EmptyMap(t *testing.T) {
 func TestAccSSMAssociation_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccSSMAssociation_tags_AddOnUpdate(t *testing.T) {
 func TestAccSSMAssociation_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccSSMAssociation_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccSSMAssociation_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccSSMAssociation_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccSSMAssociation_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckAssociationDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccSSMAssociation_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccSSMAssociation_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccSSMAssociation_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccSSMAssociation_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccSSMAssociation_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccSSMAssociation_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccSSMAssociation_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccSSMAssociation_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccSSMAssociation_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccSSMAssociation_tags_DefaultTags_nullOverlappingResourceTag(t *testin
 func TestAccSSMAssociation_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccSSMAssociation_tags_DefaultTags_nullNonOverlappingResourceTag(t *tes
 func TestAccSSMAssociation_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccSSMAssociation_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccSSMAssociation_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccSSMAssociation_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccSSMAssociation_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccSSMAssociation_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSSMAssociation_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccSSMAssociation_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccSSMAssociation_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckAssociationDestroy(ctx),

--- a/internal/service/ssm/document_tags_gen_test.go
+++ b/internal/service/ssm/document_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -19,9 +18,9 @@ import (
 func TestAccSSMDocument_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -200,9 +199,9 @@ func TestAccSSMDocument_tags(t *testing.T) {
 func TestAccSSMDocument_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -266,9 +265,9 @@ func TestAccSSMDocument_tags_null(t *testing.T) {
 func TestAccSSMDocument_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -328,9 +327,9 @@ func TestAccSSMDocument_tags_EmptyMap(t *testing.T) {
 func TestAccSSMDocument_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -408,9 +407,9 @@ func TestAccSSMDocument_tags_AddOnUpdate(t *testing.T) {
 func TestAccSSMDocument_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -496,9 +495,9 @@ func TestAccSSMDocument_tags_EmptyTag_OnCreate(t *testing.T) {
 func TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -632,9 +631,9 @@ func TestAccSSMDocument_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 func TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckDocumentDestroy(ctx),
@@ -720,9 +719,9 @@ func TestAccSSMDocument_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -900,9 +899,9 @@ func TestAccSSMDocument_tags_DefaultTags_providerOnly(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1059,9 +1058,9 @@ func TestAccSSMDocument_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1234,9 +1233,9 @@ func TestAccSSMDocument_tags_DefaultTags_overlapping(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1323,9 +1322,9 @@ func TestAccSSMDocument_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1411,9 +1410,9 @@ func TestAccSSMDocument_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1475,9 +1474,9 @@ func TestAccSSMDocument_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1531,9 +1530,9 @@ func TestAccSSMDocument_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 func TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1592,9 +1591,9 @@ func TestAccSSMDocument_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T
 func TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1653,9 +1652,9 @@ func TestAccSSMDocument_tags_DefaultTags_nullNonOverlappingResourceTag(t *testin
 func TestAccSSMDocument_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1707,9 +1706,9 @@ func TestAccSSMDocument_tags_ComputedTag_OnCreate(t *testing.T) {
 func TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1803,9 +1802,9 @@ func TestAccSSMDocument_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -1889,9 +1888,9 @@ func TestAccSSMDocument_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),
@@ -2050,9 +2049,9 @@ func TestAccSSMDocument_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 func TestAccSSMDocument_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssm_document.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckDocumentDestroy(ctx),

--- a/internal/service/ssm/maintenance_window_tags_gen_test.go
+++ b/internal/service/ssm/maintenance_window_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccSSMMaintenanceWindow_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccSSMMaintenanceWindow_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccSSMMaintenanceWindow_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccSSMMaintenanceWindow_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccSSMMaintenanceWindow_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccSSMMaintenanceWindow_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccSSMMaintenanceWindow_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckMaintenanceWindowDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_updateToProviderOnly(t *testin
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_updateToResourceOnly(t *testin
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_emptyResourceTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_emptyProviderOnlyTag(t *testin
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_nullOverlappingResourceTag(t *
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccSSMMaintenanceWindow_tags_DefaultTags_nullNonOverlappingResourceTag(
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccSSMMaintenanceWindow_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccSSMMaintenanceWindow_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccSSMMaintenanceWindow_tags_ComputedTag_OnUpdate_Replace(t *testing.T)
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccSSMMaintenanceWindow_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccSSMMaintenanceWindow_tags_IgnoreTags_Overlap_ResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v ssm.GetMaintenanceWindowOutput
 	resourceName := "aws_ssm_maintenance_window.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckMaintenanceWindowDestroy(ctx),

--- a/internal/service/ssm/parameter_tags_gen_test.go
+++ b/internal/service/ssm/parameter_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccSSMParameter_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccSSMParameter_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -285,9 +284,9 @@ func TestAccSSMParameter_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -351,9 +350,9 @@ func TestAccSSMParameter_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -435,9 +434,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -530,9 +529,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -673,9 +672,9 @@ func TestAccSSMParameter_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckParameterDestroy(ctx),
@@ -765,9 +764,9 @@ func TestAccSSMParameter_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -958,9 +957,9 @@ func TestAccSSMParameter_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1127,9 +1126,9 @@ func TestAccSSMParameter_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1312,9 +1311,9 @@ func TestAccSSMParameter_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1405,9 +1404,9 @@ func TestAccSSMParameter_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1497,9 +1496,9 @@ func TestAccSSMParameter_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1565,9 +1564,9 @@ func TestAccSSMParameter_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1625,9 +1624,9 @@ func TestAccSSMParameter_tags_DefaultTags_nullOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1690,9 +1689,9 @@ func TestAccSSMParameter_tags_DefaultTags_nullNonOverlappingResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1755,9 +1754,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1813,9 +1812,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccSSMParameter_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -2003,9 +2002,9 @@ func TestAccSSMParameter_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),
@@ -2165,9 +2164,9 @@ func TestAccSSMParameter_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.Parameter
 	resourceName := "aws_ssm_parameter.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckParameterDestroy(ctx),

--- a/internal/service/ssm/patch_baseline_tags_gen_test.go
+++ b/internal/service/ssm/patch_baseline_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccSSMPatchBaseline_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccSSMPatchBaseline_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccSSMPatchBaseline_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccSSMPatchBaseline_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccSSMPatchBaseline_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccSSMPatchBaseline_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy:             testAccCheckPatchBaselineDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccSSMPatchBaseline_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccSSMPatchBaseline_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccSSMPatchBaseline_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccSSMPatchBaseline_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v ssm.GetPatchBaselineOutput
 	resourceName := "aws_ssm_patch_baseline.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMServiceID),
 		CheckDestroy: testAccCheckPatchBaselineDestroy(ctx),

--- a/internal/service/ssmcontacts/contact_data_source_tags_gen_test.go
+++ b/internal/service/ssmcontacts/contact_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -33,9 +32,9 @@ func testAccSSMContactsContactDataSource_tagsSerial(t *testing.T) {
 func testAccSSMContactsContactDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -61,9 +60,9 @@ func testAccSSMContactsContactDataSource_tags(t *testing.T) {
 func testAccSSMContactsContactDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -85,9 +84,9 @@ func testAccSSMContactsContactDataSource_tags_NullMap(t *testing.T) {
 func testAccSSMContactsContactDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -109,9 +108,9 @@ func testAccSSMContactsContactDataSource_tags_EmptyMap(t *testing.T) {
 func testAccSSMContactsContactDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{
@@ -141,9 +140,9 @@ func testAccSSMContactsContactDataSource_tags_DefaultTags_nonOverlapping(t *test
 func testAccSSMContactsContactDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{
@@ -179,9 +178,9 @@ func testAccSSMContactsContactDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *t
 func testAccSSMContactsContactDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ssmcontacts/contact_tags_gen_test.go
+++ b/internal/service/ssmcontacts/contact_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccSSMContactsContact_tagsSerial(t *testing.T) {
 func testAccSSMContactsContact_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -231,9 +230,9 @@ func testAccSSMContactsContact_tags_null(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -297,9 +296,9 @@ func testAccSSMContactsContact_tags_null(t *testing.T) {
 func testAccSSMContactsContact_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -359,9 +358,9 @@ func testAccSSMContactsContact_tags_EmptyMap(t *testing.T) {
 func testAccSSMContactsContact_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -441,9 +440,9 @@ func testAccSSMContactsContact_tags_EmptyTag_OnCreate(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -531,9 +530,9 @@ func testAccSSMContactsContact_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -669,9 +668,9 @@ func testAccSSMContactsContact_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckContactDestroy(ctx),
@@ -757,9 +756,9 @@ func testAccSSMContactsContact_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func testAccSSMContactsContact_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -937,9 +936,9 @@ func testAccSSMContactsContact_tags_DefaultTags_providerOnly(t *testing.T) {
 func testAccSSMContactsContact_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1096,9 +1095,9 @@ func testAccSSMContactsContact_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func testAccSSMContactsContact_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1271,9 +1270,9 @@ func testAccSSMContactsContact_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccSSMContactsContact_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1360,9 +1359,9 @@ func testAccSSMContactsContact_tags_DefaultTags_updateToProviderOnly(t *testing.
 func testAccSSMContactsContact_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1450,9 +1449,9 @@ func testAccSSMContactsContact_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1516,9 +1515,9 @@ func testAccSSMContactsContact_tags_DefaultTags_emptyProviderOnlyTag(t *testing.
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1574,9 +1573,9 @@ func testAccSSMContactsContact_tags_DefaultTags_nullOverlappingResourceTag(t *te
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1637,9 +1636,9 @@ func testAccSSMContactsContact_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1698,9 +1697,9 @@ func testAccSSMContactsContact_tags_DefaultTags_nullNonOverlappingResourceTag(t 
 func testAccSSMContactsContact_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1752,9 +1751,9 @@ func testAccSSMContactsContact_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccSSMContactsContact_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1848,9 +1847,9 @@ func testAccSSMContactsContact_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func testAccSSMContactsContact_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -1934,9 +1933,9 @@ func testAccSSMContactsContact_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 func testAccSSMContactsContact_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),
@@ -2095,9 +2094,9 @@ func testAccSSMContactsContact_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) 
 func testAccSSMContactsContact_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_contact.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckContactDestroy(ctx),

--- a/internal/service/ssmcontacts/rotation_data_source_tags_gen_test.go
+++ b/internal/service/ssmcontacts/rotation_data_source_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
@@ -33,9 +32,9 @@ func testAccSSMContactsRotationDataSource_tagsSerial(t *testing.T) {
 func testAccSSMContactsRotationDataSource_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -61,9 +60,9 @@ func testAccSSMContactsRotationDataSource_tags(t *testing.T) {
 func testAccSSMContactsRotationDataSource_tags_NullMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -85,9 +84,9 @@ func testAccSSMContactsRotationDataSource_tags_NullMap(t *testing.T) {
 func testAccSSMContactsRotationDataSource_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
@@ -109,9 +108,9 @@ func testAccSSMContactsRotationDataSource_tags_EmptyMap(t *testing.T) {
 func testAccSSMContactsRotationDataSource_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{
@@ -141,9 +140,9 @@ func testAccSSMContactsRotationDataSource_tags_DefaultTags_nonOverlapping(t *tes
 func testAccSSMContactsRotationDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{
@@ -179,9 +178,9 @@ func testAccSSMContactsRotationDataSource_tags_IgnoreTags_Overlap_DefaultTag(t *
 func testAccSSMContactsRotationDataSource_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	dataSourceName := "data.aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:   func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck: acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		Steps: []resource.TestStep{

--- a/internal/service/ssmcontacts/rotation_tags_gen_test.go
+++ b/internal/service/ssmcontacts/rotation_tags_gen_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -48,9 +47,9 @@ func testAccSSMContactsRotation_tagsSerial(t *testing.T) {
 func testAccSSMContactsRotation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -231,9 +230,9 @@ func testAccSSMContactsRotation_tags_null(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -292,9 +291,9 @@ func testAccSSMContactsRotation_tags_null(t *testing.T) {
 func testAccSSMContactsRotation_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -341,9 +340,9 @@ func testAccSSMContactsRotation_tags_EmptyMap(t *testing.T) {
 func testAccSSMContactsRotation_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -422,9 +421,9 @@ func testAccSSMContactsRotation_tags_EmptyTag_OnCreate(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -513,9 +512,9 @@ func testAccSSMContactsRotation_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -653,9 +652,9 @@ func testAccSSMContactsRotation_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy:             testAccCheckRotationDestroy(ctx),
@@ -742,9 +741,9 @@ func testAccSSMContactsRotation_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 func testAccSSMContactsRotation_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -922,9 +921,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_providerOnly(t *testing.T) {
 func testAccSSMContactsRotation_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1081,9 +1080,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_nonOverlapping(t *testing.T) {
 func testAccSSMContactsRotation_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1256,9 +1255,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_overlapping(t *testing.T) {
 func testAccSSMContactsRotation_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1345,9 +1344,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_updateToProviderOnly(t *testing
 func testAccSSMContactsRotation_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1435,9 +1434,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_emptyResourceTag(t *testing.T) 
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1502,9 +1501,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_emptyProviderOnlyTag(t *testing
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1561,9 +1560,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_nullOverlappingResourceTag(t *t
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1631,9 +1630,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_nullNonOverlappingResourceTag(t
 
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1701,9 +1700,9 @@ func testAccSSMContactsRotation_tags_DefaultTags_nullNonOverlappingResourceTag(t
 func testAccSSMContactsRotation_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1755,9 +1754,9 @@ func testAccSSMContactsRotation_tags_ComputedTag_OnCreate(t *testing.T) {
 func testAccSSMContactsRotation_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1851,9 +1850,9 @@ func testAccSSMContactsRotation_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 func testAccSSMContactsRotation_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -1937,9 +1936,9 @@ func testAccSSMContactsRotation_tags_ComputedTag_OnUpdate_Replace(t *testing.T) 
 func testAccSSMContactsRotation_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),
@@ -2098,9 +2097,9 @@ func testAccSSMContactsRotation_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T)
 func testAccSSMContactsRotation_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	resourceName := "aws_ssmcontacts_rotation.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.Test(t, resource.TestCase{
+	acctest.Test(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.SSMContactsServiceID),
 		CheckDestroy: testAccCheckRotationDestroy(ctx),

--- a/internal/service/timestreaminfluxdb/db_instance_tags_gen_test.go
+++ b/internal/service/timestreaminfluxdb/db_instance_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/timestreaminfluxdb"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -215,9 +214,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -278,9 +277,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -329,9 +328,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -412,9 +411,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -508,9 +507,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_EmptyTag_OnUpdate_Add(t *testing.T
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -653,9 +652,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_EmptyTag_OnUpdate_Replace(t *testi
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy:             testAccCheckDBInstanceDestroy(ctx),
@@ -746,9 +745,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_providerOnly(t *testin
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -939,9 +938,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_nonOverlapping(t *test
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1108,9 +1107,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_overlapping(t *testing
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1293,9 +1292,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_updateToProviderOnly(t
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1386,9 +1385,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_updateToResourceOnly(t
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1478,9 +1477,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_emptyResourceTag(t *te
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_emptyProviderOnlyTag(t
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1608,9 +1607,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_nullOverlappingResourc
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1678,9 +1677,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_DefaultTags_nullNonOverlappingReso
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1750,9 +1749,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_ComputedTag_OnCreate(t *testing.T)
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1808,9 +1807,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_ComputedTag_OnUpdate_Add(t *testin
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1908,9 +1907,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_ComputedTag_OnUpdate_Replace(t *te
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -1998,9 +1997,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_IgnoreTags_Overlap_DefaultTag(t *t
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),
@@ -2160,9 +2159,9 @@ func TestAccTimestreamInfluxDBDBInstance_tags_IgnoreTags_Overlap_ResourceTag(t *
 	ctx := acctest.Context(t)
 	var v timestreaminfluxdb.GetDbInstanceOutput
 	resourceName := "aws_timestreaminfluxdb_db_instance.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.TimestreamInfluxDBServiceID),
 		CheckDestroy: testAccCheckDBInstanceDestroy(ctx),

--- a/internal/service/vpclattice/resource_configuration_tags_gen_test.go
+++ b/internal/service/vpclattice/resource_configuration_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCLatticeResourceConfiguration_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnCreate(t *testing.T)
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Add(t *testin
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_EmptyTag_OnUpdate_Replace(t *te
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceConfigurationDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_providerOnly(t *tes
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nonOverlapping(t *t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_overlapping(t *test
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToProviderOnl
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_updateToResourceOnl
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyResourceTag(t 
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_emptyProviderOnlyTa
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullOverlappingReso
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_DefaultTags_nullNonOverlappingR
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnCreate(t *testing
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Add(t *tes
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_ComputedTag_OnUpdate_Replace(t 
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_DefaultTag(t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccVPCLatticeResourceConfiguration_tags_IgnoreTags_Overlap_ResourceTag(
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceConfigurationOutput
 	resourceName := "aws_vpclattice_resource_configuration.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceConfigurationDestroy(ctx),

--- a/internal/service/vpclattice/resource_gateway_tags_gen_test.go
+++ b/internal/service/vpclattice/resource_gateway_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCLatticeResourceGateway_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccVPCLatticeResourceGateway_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccVPCLatticeResourceGateway_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccVPCLatticeResourceGateway_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccVPCLatticeResourceGateway_tags_EmptyTag_OnUpdate_Replace(t *testing.
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckResourceGatewayDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_providerOnly(t *testing.T
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_nonOverlapping(t *testing
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_overlapping(t *testing.T)
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToProviderOnly(t *t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_updateToResourceOnly(t *t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyResourceTag(t *testi
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_emptyProviderOnlyTag(t *t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullOverlappingResourceTa
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccVPCLatticeResourceGateway_tags_DefaultTags_nullNonOverlappingResourc
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Add(t *testing.T
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccVPCLatticeResourceGateway_tags_ComputedTag_OnUpdate_Replace(t *testi
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_DefaultTag(t *test
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccVPCLatticeResourceGateway_tags_IgnoreTags_Overlap_ResourceTag(t *tes
 	ctx := acctest.Context(t)
 	var v vpclattice.GetResourceGatewayOutput
 	resourceName := "aws_vpclattice_resource_gateway.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckResourceGatewayDestroy(ctx),

--- a/internal/service/vpclattice/service_network_resource_association_tags_gen_test.go
+++ b/internal/service/vpclattice/service_network_resource_association_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/vpclattice"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_null(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -265,9 +264,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyMap(t *testing
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -315,9 +314,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_AddOnUpdate(t *test
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -395,9 +394,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnCreate(t
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -485,9 +484,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_A
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -624,9 +623,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_EmptyTag_OnUpdate_R
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy:             testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -714,9 +713,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_provide
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -895,9 +894,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nonOver
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1055,9 +1054,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_overlap
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1231,9 +1230,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateT
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1321,9 +1320,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_updateT
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1410,9 +1409,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyRe
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1476,9 +1475,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_emptyPr
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1534,9 +1533,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullOve
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1603,9 +1602,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_DefaultTags_nullNon
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1674,9 +1673,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnCreat
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1729,9 +1728,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdat
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1826,9 +1825,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_ComputedTag_OnUpdat
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -1913,9 +1912,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),
@@ -2075,9 +2074,9 @@ func TestAccVPCLatticeServiceNetworkResourceAssociation_tags_IgnoreTags_Overlap_
 	ctx := acctest.Context(t)
 	var v vpclattice.GetServiceNetworkResourceAssociationOutput
 	resourceName := "aws_vpclattice_service_network_resource_association.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.VPCLatticeServiceID),
 		CheckDestroy: testAccCheckServiceNetworkResourceAssociationDestroy(ctx),

--- a/internal/service/workspacesweb/browser_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/browser_settings_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags(t *testing.T) {
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -202,7 +202,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_null(t *testing.T) {
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -263,7 +263,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_EmptyMap(t *testing.T) {
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -312,7 +312,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_AddOnUpdate(t *testing.T) {
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -390,7 +390,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -479,7 +479,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_EmptyTag_OnUpdate_Add(t *testing.T
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -616,7 +616,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_EmptyTag_OnUpdate_Replace(t *testi
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckBrowserSettingsDestroy(ctx),
@@ -704,7 +704,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_providerOnly(t *testin
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -884,7 +884,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_nonOverlapping(t *test
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1043,7 +1043,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_overlapping(t *testing
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1218,7 +1218,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_updateToProviderOnly(t
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1306,7 +1306,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_updateToResourceOnly(t
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_emptyResourceTag(t *te
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1458,7 +1458,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_emptyProviderOnlyTag(t
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1515,7 +1515,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_nullOverlappingResourc
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1583,7 +1583,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_DefaultTags_nullNonOverlappingReso
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1653,7 +1653,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_ComputedTag_OnCreate(t *testing.T)
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1707,7 +1707,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_ComputedTag_OnUpdate_Add(t *testin
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1802,7 +1802,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_ComputedTag_OnUpdate_Replace(t *te
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -1887,7 +1887,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_IgnoreTags_Overlap_DefaultTag(t *t
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),
@@ -2045,7 +2045,7 @@ func TestAccWorkSpacesWebBrowserSettings_tags_IgnoreTags_Overlap_ResourceTag(t *
 	var v types.BrowserSettings
 	resourceName := "aws_workspacesweb_browser_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckBrowserSettingsDestroy(ctx),

--- a/internal/service/workspacesweb/data_protection_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/data_protection_settings_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags(t *testing.T) {
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -202,7 +202,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_null(t *testing.T) {
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -263,7 +263,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_EmptyMap(t *testing.T) {
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -312,7 +312,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_AddOnUpdate(t *testing.T) {
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -390,7 +390,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_EmptyTag_OnCreate(t *testin
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -479,7 +479,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_EmptyTag_OnUpdate_Add(t *te
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -616,7 +616,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_EmptyTag_OnUpdate_Replace(t
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -704,7 +704,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_providerOnly(t 
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -884,7 +884,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_nonOverlapping(
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1043,7 +1043,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_overlapping(t *
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1218,7 +1218,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_updateToProvide
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1306,7 +1306,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_updateToResourc
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_emptyResourceTa
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1458,7 +1458,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_emptyProviderOn
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1515,7 +1515,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_nullOverlapping
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1583,7 +1583,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_DefaultTags_nullNonOverlapp
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1653,7 +1653,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_ComputedTag_OnCreate(t *tes
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1707,7 +1707,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_ComputedTag_OnUpdate_Add(t 
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1802,7 +1802,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_ComputedTag_OnUpdate_Replac
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -1887,7 +1887,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_IgnoreTags_Overlap_DefaultT
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),
@@ -2045,7 +2045,7 @@ func TestAccWorkSpacesWebDataProtectionSettings_tags_IgnoreTags_Overlap_Resource
 	var v types.DataProtectionSettings
 	resourceName := "aws_workspacesweb_data_protection_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckDataProtectionSettingsDestroy(ctx),

--- a/internal/service/workspacesweb/ip_access_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/ip_access_settings_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags(t *testing.T) {
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -202,7 +202,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_null(t *testing.T) {
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -263,7 +263,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_EmptyMap(t *testing.T) {
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -312,7 +312,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_AddOnUpdate(t *testing.T) {
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -390,7 +390,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -479,7 +479,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_EmptyTag_OnUpdate_Add(t *testing.
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -616,7 +616,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_EmptyTag_OnUpdate_Replace(t *test
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckIPAccessSettingsDestroy(ctx),
@@ -704,7 +704,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_providerOnly(t *testi
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -884,7 +884,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_nonOverlapping(t *tes
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1043,7 +1043,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_overlapping(t *testin
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1218,7 +1218,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_updateToProviderOnly(
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1306,7 +1306,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_updateToResourceOnly(
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_emptyResourceTag(t *t
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1458,7 +1458,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_emptyProviderOnlyTag(
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1515,7 +1515,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_nullOverlappingResour
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1583,7 +1583,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_DefaultTags_nullNonOverlappingRes
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1653,7 +1653,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_ComputedTag_OnCreate(t *testing.T
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1707,7 +1707,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_ComputedTag_OnUpdate_Add(t *testi
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1802,7 +1802,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_ComputedTag_OnUpdate_Replace(t *t
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -1887,7 +1887,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_IgnoreTags_Overlap_DefaultTag(t *
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),
@@ -2045,7 +2045,7 @@ func TestAccWorkSpacesWebIPAccessSettings_tags_IgnoreTags_Overlap_ResourceTag(t 
 	var v types.IpAccessSettings
 	resourceName := "aws_workspacesweb_ip_access_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckIPAccessSettingsDestroy(ctx),

--- a/internal/service/workspacesweb/network_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/network_settings_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags(t *testing.T) {
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -202,7 +202,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_null(t *testing.T) {
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -263,7 +263,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_EmptyMap(t *testing.T) {
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -312,7 +312,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_AddOnUpdate(t *testing.T) {
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -390,7 +390,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -479,7 +479,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_EmptyTag_OnUpdate_Add(t *testing.T
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -616,7 +616,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_EmptyTag_OnUpdate_Replace(t *testi
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckNetworkSettingsDestroy(ctx),
@@ -704,7 +704,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_providerOnly(t *testin
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -884,7 +884,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_nonOverlapping(t *test
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1043,7 +1043,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_overlapping(t *testing
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1218,7 +1218,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_updateToProviderOnly(t
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1306,7 +1306,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_updateToResourceOnly(t
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_emptyResourceTag(t *te
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1458,7 +1458,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_emptyProviderOnlyTag(t
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1515,7 +1515,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_nullOverlappingResourc
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1583,7 +1583,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_DefaultTags_nullNonOverlappingReso
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1653,7 +1653,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_ComputedTag_OnCreate(t *testing.T)
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1707,7 +1707,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_ComputedTag_OnUpdate_Add(t *testin
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1802,7 +1802,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_ComputedTag_OnUpdate_Replace(t *te
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -1887,7 +1887,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_IgnoreTags_Overlap_DefaultTag(t *t
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),
@@ -2045,7 +2045,7 @@ func TestAccWorkSpacesWebNetworkSettings_tags_IgnoreTags_Overlap_ResourceTag(t *
 	var v types.NetworkSettings
 	resourceName := "aws_workspacesweb_network_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckNetworkSettingsDestroy(ctx),

--- a/internal/service/workspacesweb/user_access_logging_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/user_access_logging_settings_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/workspacesweb/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -211,9 +210,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -275,9 +274,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -327,9 +326,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_AddOnUpdate(t *testing.T
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -409,9 +408,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_EmptyTag_OnCreate(t *tes
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_EmptyTag_OnUpdate_Add(t 
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -646,9 +645,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_EmptyTag_OnUpdate_Replac
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -738,9 +737,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_providerOnly
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -927,9 +926,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_nonOverlappi
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1093,9 +1092,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_overlapping(
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1275,9 +1274,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_updateToProv
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1367,9 +1366,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_updateToReso
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1458,9 +1457,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_emptyResourc
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1526,9 +1525,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_emptyProvide
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1586,9 +1585,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_nullOverlapp
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1657,9 +1656,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_DefaultTags_nullNonOverl
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1730,9 +1729,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_ComputedTag_OnCreate(t *
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1787,9 +1786,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_ComputedTag_OnUpdate_Add
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1886,9 +1885,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_ComputedTag_OnUpdate_Rep
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -1975,9 +1974,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_IgnoreTags_Overlap_Defau
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),
@@ -2137,9 +2136,9 @@ func TestAccWorkSpacesWebUserAccessLoggingSettings_tags_IgnoreTags_Overlap_Resou
 	ctx := acctest.Context(t)
 	var v types.UserAccessLoggingSettings
 	resourceName := "aws_workspacesweb_user_access_logging_settings.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserAccessLoggingSettingsDestroy(ctx),

--- a/internal/service/workspacesweb/user_settings_tags_gen_test.go
+++ b/internal/service/workspacesweb/user_settings_tags_gen_test.go
@@ -21,7 +21,7 @@ func TestAccWorkSpacesWebUserSettings_tags(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -202,7 +202,7 @@ func TestAccWorkSpacesWebUserSettings_tags_null(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -263,7 +263,7 @@ func TestAccWorkSpacesWebUserSettings_tags_EmptyMap(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -312,7 +312,7 @@ func TestAccWorkSpacesWebUserSettings_tags_AddOnUpdate(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -390,7 +390,7 @@ func TestAccWorkSpacesWebUserSettings_tags_EmptyTag_OnCreate(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -479,7 +479,7 @@ func TestAccWorkSpacesWebUserSettings_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -616,7 +616,7 @@ func TestAccWorkSpacesWebUserSettings_tags_EmptyTag_OnUpdate_Replace(t *testing.
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy:             testAccCheckUserSettingsDestroy(ctx),
@@ -704,7 +704,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_providerOnly(t *testing.T
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -884,7 +884,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_nonOverlapping(t *testing
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1043,7 +1043,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_overlapping(t *testing.T)
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1218,7 +1218,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_updateToProviderOnly(t *t
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1306,7 +1306,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_updateToResourceOnly(t *t
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1393,7 +1393,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_emptyResourceTag(t *testi
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1458,7 +1458,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_emptyProviderOnlyTag(t *t
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1515,7 +1515,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_nullOverlappingResourceTa
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1583,7 +1583,7 @@ func TestAccWorkSpacesWebUserSettings_tags_DefaultTags_nullNonOverlappingResourc
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1653,7 +1653,7 @@ func TestAccWorkSpacesWebUserSettings_tags_ComputedTag_OnCreate(t *testing.T) {
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1707,7 +1707,7 @@ func TestAccWorkSpacesWebUserSettings_tags_ComputedTag_OnUpdate_Add(t *testing.T
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1802,7 +1802,7 @@ func TestAccWorkSpacesWebUserSettings_tags_ComputedTag_OnUpdate_Replace(t *testi
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -1887,7 +1887,7 @@ func TestAccWorkSpacesWebUserSettings_tags_IgnoreTags_Overlap_DefaultTag(t *test
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),
@@ -2045,7 +2045,7 @@ func TestAccWorkSpacesWebUserSettings_tags_IgnoreTags_Overlap_ResourceTag(t *tes
 	var v types.UserSettings
 	resourceName := "aws_workspacesweb_user_settings.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.WorkSpacesWebServiceID),
 		CheckDestroy: testAccCheckUserSettingsDestroy(ctx),

--- a/internal/service/xray/group_tags_gen_test.go
+++ b/internal/service/xray/group_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccXRayGroup_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccXRayGroup_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccXRayGroup_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccXRayGroup_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccXRayGroup_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccXRayGroup_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccXRayGroup_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckGroupDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccXRayGroup_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccXRayGroup_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccXRayGroup_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccXRayGroup_tags_DefaultTags_updateToProviderOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccXRayGroup_tags_DefaultTags_updateToResourceOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccXRayGroup_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccXRayGroup_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccXRayGroup_tags_DefaultTags_nullOverlappingResourceTag(t *testing.T) 
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccXRayGroup_tags_DefaultTags_nullNonOverlappingResourceTag(t *testing.
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccXRayGroup_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccXRayGroup_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccXRayGroup_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccXRayGroup_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccXRayGroup_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.Group
 	resourceName := "aws_xray_group.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckGroupDestroy(ctx),

--- a/internal/service/xray/sampling_rule_tags_gen_test.go
+++ b/internal/service/xray/sampling_rule_tags_gen_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/xray/types"
 	"github.com/hashicorp/terraform-plugin-testing/config"
-	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -21,9 +20,9 @@ func TestAccXRaySamplingRule_tags(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -203,9 +202,9 @@ func TestAccXRaySamplingRule_tags_null(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -270,9 +269,9 @@ func TestAccXRaySamplingRule_tags_EmptyMap(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -333,9 +332,9 @@ func TestAccXRaySamplingRule_tags_AddOnUpdate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -414,9 +413,9 @@ func TestAccXRaySamplingRule_tags_EmptyTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -503,9 +502,9 @@ func TestAccXRaySamplingRule_tags_EmptyTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -640,9 +639,9 @@ func TestAccXRaySamplingRule_tags_EmptyTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:               acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy:             testAccCheckSamplingRuleDestroy(ctx),
@@ -729,9 +728,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_providerOnly(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -910,9 +909,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_nonOverlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1070,9 +1069,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_overlapping(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1246,9 +1245,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_updateToProviderOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1336,9 +1335,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_updateToResourceOnly(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1425,9 +1424,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_emptyResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1490,9 +1489,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_emptyProviderOnlyTag(t *testing.T)
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1547,9 +1546,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_nullOverlappingResourceTag(t *test
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1609,9 +1608,9 @@ func TestAccXRaySamplingRule_tags_DefaultTags_nullNonOverlappingResourceTag(t *t
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1671,9 +1670,9 @@ func TestAccXRaySamplingRule_tags_ComputedTag_OnCreate(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1726,9 +1725,9 @@ func TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Add(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1823,9 +1822,9 @@ func TestAccXRaySamplingRule_tags_ComputedTag_OnUpdate_Replace(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -1910,9 +1909,9 @@ func TestAccXRaySamplingRule_tags_IgnoreTags_Overlap_DefaultTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),
@@ -2072,9 +2071,9 @@ func TestAccXRaySamplingRule_tags_IgnoreTags_Overlap_ResourceTag(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v types.SamplingRule
 	resourceName := "aws_xray_sampling_rule.test"
-	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
 
-	resource.ParallelTest(t, resource.TestCase{
+	acctest.ParallelTest(ctx, t, resource.TestCase{
 		PreCheck:     func() { acctest.PreCheck(ctx, t) },
 		ErrorCheck:   acctest.ErrorCheck(t, names.XRayServiceID),
 		CheckDestroy: testAccCheckSamplingRuleDestroy(ctx),


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This change makes the following VCR-aware replacements in the tagstest templates for resources and data sources:

- `resource.Test` to `acctest.Test`
- `resource.ParallelTest` to `acctest.ParallelTest`
- `sdkacctest.RandomWithPrefix` with `acctest.RandomWithPrefix`

In order to be fully support go-vcr, the "check exists" and "check destroy" helpers also need to include a `testing.T` argument. The generator already includes optional `existsTakesT` and `destroyTakesT` annotations, which can be set on new resources as they become VCR enabled over time.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43335
Relates #25602 


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=logs TESTS="TestAccLogsLogGroup_tags"
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/logs/... -v -count 1 -parallel 20 -run='TestAccLogsLogGroup_tags'  -timeout 360m -vet=off
2025/07/15 10:17:35 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 10:17:35 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccLogsLogGroup_tags_DefaultTags_emptyResourceTag (59.44s)
=== CONT  TestAccLogsLogGroup_tags_DefaultTags_nullNonOverlappingResourceTag
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_emptyProviderOnlyTag (60.35s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_nullOverlappingResourceTag (62.23s)
--- PASS: TestAccLogsLogGroup_tags_ComputedTag_OnCreate (62.70s)
--- PASS: TestAccLogsLogGroup_tags_EmptyMap (77.83s)
--- PASS: TestAccLogsLogGroup_tags_null (79.77s)
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Replace (82.95s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_updateToProviderOnly (83.20s)
--- PASS: TestAccLogsLogGroup_tags_AddOnUpdate (84.95s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_updateToResourceOnly (85.10s)
--- PASS: TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Add (86.44s)
--- PASS: TestAccLogsLogGroup_tags_ComputedTag_OnUpdate_Replace (86.77s)
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnCreate (90.72s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_nullNonOverlappingResourceTag (34.14s)
--- PASS: TestAccLogsLogGroup_tags_IgnoreTags_Overlap_DefaultTag (94.28s)
--- PASS: TestAccLogsLogGroup_tags_EmptyTag_OnUpdate_Add (99.73s)
--- PASS: TestAccLogsLogGroup_tags_IgnoreTags_Overlap_ResourceTag (102.33s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_nonOverlapping (106.98s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_overlapping (107.78s)
--- PASS: TestAccLogsLogGroup_tags_DefaultTags_providerOnly (119.71s)
--- PASS: TestAccLogsLogGroup_tags (120.13s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/logs       126.123s
```
