### PR TITLE
New Attribute for r/wafv2_rule_group: rule_json attribute

### DIFF
--- a/.changelog/433245.txt
+++ b/.changelog/433245.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/wafv2_rule_group: Add `rules_json` attribute. 
+```

--- a/.changelog/433245.txt
+++ b/.changelog/433245.txt
@@ -1,3 +1,3 @@
 ```release-note:enhancement
-resource/wafv2_rule_group: Add `rules_json` attribute. 
+resource/aws_wafv2_rule_group: Add `rules_json` argument
 ```

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1091,7 +1091,7 @@ func expandRuleGroupRulesJSON(rawRules string) ([]awstypes.Rule, error) {
 	}
 
 	for _, v := range temp {
-		walkRuleGroupJSON(reflect.ValueOf(v))
+		walkRulesGroupJSON(reflect.ValueOf(v))
 	}
 
 	out, err := tfjson.EncodeToBytes(temp)
@@ -1160,7 +1160,7 @@ func walkWebACLJSON(v reflect.Value) {
 	}
 }
 
-func walkRuleGroupJSON(v reflect.Value) {
+func walkRulesGroupJSON(v reflect.Value) {
 	m := map[string][]struct {
 		key        string
 		outputType any
@@ -1196,12 +1196,12 @@ func walkRuleGroupJSON(v reflect.Value) {
 					}
 				}
 			} else {
-				walkRuleGroupJSON(v.MapIndex(k))
+				walkRulesGroupJSON(v.MapIndex(k))
 			}
 		}
 	case reflect.Array, reflect.Slice:
 		for i := range v.Len() {
-			walkRuleGroupJSON(v.Index(i))
+			walkRulesGroupJSON(v.Index(i))
 		}
 	default:
 	}

--- a/internal/service/wafv2/flex.go
+++ b/internal/service/wafv2/flex.go
@@ -1078,6 +1078,41 @@ func expandWebACLRulesJSON(rawRules string) ([]awstypes.Rule, error) {
 	return rules, nil
 }
 
+func expandRuleGroupRulesJSON(rawRules string) ([]awstypes.Rule, error) {
+	// Backwards compatibility.
+	if rawRules == "" {
+		return nil, errors.New("decoding JSON: unexpected end of JSON input")
+	}
+
+	var temp []any
+	err := tfjson.DecodeFromBytes([]byte(rawRules), &temp)
+	if err != nil {
+		return nil, fmt.Errorf("decoding JSON: %w", err)
+	}
+
+	for _, v := range temp {
+		walkRuleGroupJSON(reflect.ValueOf(v))
+	}
+
+	out, err := tfjson.EncodeToBytes(temp)
+	if err != nil {
+		return nil, err
+	}
+
+	var rules []awstypes.Rule
+	err = tfjson.DecodeFromBytes(out, &rules)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, r := range rules {
+		if reflect.ValueOf(r).IsZero() {
+			return nil, fmt.Errorf("invalid Rule Group Rule supplied at index (%d)", i)
+		}
+	}
+	return rules, nil
+}
+
 func walkWebACLJSON(v reflect.Value) {
 	m := map[string][]struct {
 		key        string
@@ -1120,6 +1155,53 @@ func walkWebACLJSON(v reflect.Value) {
 	case reflect.Array, reflect.Slice:
 		for i := range v.Len() {
 			walkWebACLJSON(v.Index(i))
+		}
+	default:
+	}
+}
+
+func walkRuleGroupJSON(v reflect.Value) {
+	m := map[string][]struct {
+		key        string
+		outputType any
+	}{
+		"ByteMatchStatement": {
+			{key: "SearchString", outputType: []byte{}},
+		},
+	}
+
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			if val, ok := m[k.String()]; ok {
+				st := v.MapIndex(k).Interface().(map[string]any)
+				for _, va := range val {
+					if st[va.key] == nil {
+						continue
+					}
+					str := st[va.key]
+					switch reflect.ValueOf(va.outputType).Kind() {
+					case reflect.Slice, reflect.Array:
+						switch reflect.ValueOf(va.outputType).Type().Elem().Kind() {
+						case reflect.Uint8:
+							base64String := itypes.Base64Encode([]byte(str.(string)))
+							st[va.key] = base64String
+						default:
+						}
+					default:
+					}
+				}
+			} else {
+				walkRuleGroupJSON(v.MapIndex(k))
+			}
+		}
+	case reflect.Array, reflect.Slice:
+		for i := range v.Len() {
+			walkRuleGroupJSON(v.Index(i))
 		}
 	default:
 	}

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -100,7 +100,7 @@ func resourceRuleGroup() *schema.Resource {
 						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]+$`), "must contain only alphanumeric hyphen and underscore characters"),
 					),
 				},
-				"rule_json": {
+				"rules_json": {
 					Type:             schema.TypeString,
 					Optional:         true,
 					ConflictsWith:    []string{names.AttrRule},
@@ -114,7 +114,7 @@ func resourceRuleGroup() *schema.Resource {
 				names.AttrRule: {
 					Type:          schema.TypeSet,
 					Optional:      true,
-					ConflictsWith: []string{"rule_json"},
+					ConflictsWith: []string{"rules_json"},
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrAction: {
@@ -178,7 +178,7 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 		input.Rules = expandRules(v.(*schema.Set).List())
 	}
 
-	if v, ok := d.GetOk("rule_json"); ok {
+	if v, ok := d.GetOk("rules_json"); ok {
 		rules, err := expandRuleGroupRulesJSON(v.(string))
 		if err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
@@ -237,12 +237,12 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("lock_token", output.LockToken)
 	d.Set(names.AttrName, ruleGroup.Name)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(ruleGroup.Name)))
-	if _, ok := d.GetOk("rule_json"); !ok {
+	if _, ok := d.GetOk("rules_json"); !ok {
 		if err := d.Set(names.AttrRule, flattenRules(ruleGroup.Rules)); err != nil {
 			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
 		}
 	} else {
-		d.Set("rule_json", d.Get("rule_json"))
+		d.Set("rules_json", d.Get("rules_json"))
 		d.Set(names.AttrRule, nil)
 	}
 	if err := d.Set("visibility_config", flattenVisibilityConfig(ruleGroup.VisibilityConfig)); err != nil {
@@ -269,7 +269,7 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 			input.Rules = expandRules(v.(*schema.Set).List())
 		}
 
-		if v, ok := d.GetOk("rule_json"); ok {
+		if v, ok := d.GetOk("rules_json"); ok {
 			rules, err := expandRuleGroupRulesJSON(v.(string))
 			if err != nil {
 				return sdkdiag.AppendErrorf(diags, "expanding WAFv2 RuleGroup JSON rule (%s): %s", d.Id(), err)

--- a/internal/service/wafv2/rule_group.go
+++ b/internal/service/wafv2/rule_group.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/create"
@@ -26,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/errs/sdkdiag"
 	tftags "github.com/hashicorp/terraform-provider-aws/internal/tags"
 	"github.com/hashicorp/terraform-provider-aws/internal/tfresource"
+	"github.com/hashicorp/terraform-provider-aws/internal/verify"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
 
@@ -98,9 +100,21 @@ func resourceRuleGroup() *schema.Resource {
 						validation.StringMatch(regexache.MustCompile(`^[0-9A-Za-z_-]+$`), "must contain only alphanumeric hyphen and underscore characters"),
 					),
 				},
+				"rule_json": {
+					Type:             schema.TypeString,
+					Optional:         true,
+					ConflictsWith:    []string{names.AttrRule},
+					ValidateFunc:     validation.StringIsJSON,
+					DiffSuppressFunc: verify.SuppressEquivalentJSONDiffs,
+					StateFunc: func(v any) string {
+						json, _ := structure.NormalizeJsonString(v)
+						return json
+					},
+				},
 				names.AttrRule: {
-					Type:     schema.TypeSet,
-					Optional: true,
+					Type:          schema.TypeSet,
+					Optional:      true,
+					ConflictsWith: []string{"rule_json"},
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
 							names.AttrAction: {
@@ -155,10 +169,21 @@ func resourceRuleGroupCreate(ctx context.Context, d *schema.ResourceData, meta a
 	input := &wafv2.CreateRuleGroupInput{
 		Capacity:         aws.Int64(int64(d.Get("capacity").(int))),
 		Name:             aws.String(name),
-		Rules:            expandRules(d.Get(names.AttrRule).(*schema.Set).List()),
 		Scope:            awstypes.Scope(d.Get(names.AttrScope).(string)),
 		Tags:             getTagsIn(ctx),
 		VisibilityConfig: expandVisibilityConfig(d.Get("visibility_config").([]any)),
+	}
+
+	if v, ok := d.GetOk(names.AttrRule); ok {
+		input.Rules = expandRules(v.(*schema.Set).List())
+	}
+
+	if v, ok := d.GetOk("rule_json"); ok {
+		rules, err := expandRuleGroupRulesJSON(v.(string))
+		if err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+		}
+		input.Rules = rules
 	}
 
 	if v, ok := d.GetOk("custom_response_body"); ok && v.(*schema.Set).Len() > 0 {
@@ -212,8 +237,13 @@ func resourceRuleGroupRead(ctx context.Context, d *schema.ResourceData, meta any
 	d.Set("lock_token", output.LockToken)
 	d.Set(names.AttrName, ruleGroup.Name)
 	d.Set(names.AttrNamePrefix, create.NamePrefixFromName(aws.ToString(ruleGroup.Name)))
-	if err := d.Set(names.AttrRule, flattenRules(ruleGroup.Rules)); err != nil {
-		return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+	if _, ok := d.GetOk("rule_json"); !ok {
+		if err := d.Set(names.AttrRule, flattenRules(ruleGroup.Rules)); err != nil {
+			return sdkdiag.AppendErrorf(diags, "setting rule: %s", err)
+		}
+	} else {
+		d.Set("rule_json", d.Get("rule_json"))
+		d.Set(names.AttrRule, nil)
 	}
 	if err := d.Set("visibility_config", flattenVisibilityConfig(ruleGroup.VisibilityConfig)); err != nil {
 		return sdkdiag.AppendErrorf(diags, "setting visibility_config: %s", err)
@@ -231,9 +261,20 @@ func resourceRuleGroupUpdate(ctx context.Context, d *schema.ResourceData, meta a
 			Id:               aws.String(d.Id()),
 			LockToken:        aws.String(d.Get("lock_token").(string)),
 			Name:             aws.String(d.Get(names.AttrName).(string)),
-			Rules:            expandRules(d.Get(names.AttrRule).(*schema.Set).List()),
 			Scope:            awstypes.Scope(d.Get(names.AttrScope).(string)),
 			VisibilityConfig: expandVisibilityConfig(d.Get("visibility_config").([]any)),
+		}
+
+		if v, ok := d.GetOk(names.AttrRule); ok {
+			input.Rules = expandRules(v.(*schema.Set).List())
+		}
+
+		if v, ok := d.GetOk("rule_json"); ok {
+			rules, err := expandRuleGroupRulesJSON(v.(string))
+			if err != nil {
+				return sdkdiag.AppendErrorf(diags, "expanding WAFv2 RuleGroup JSON rule (%s): %s", d.Id(), err)
+			}
+			input.Rules = rules
 		}
 
 		if v, ok := d.GetOk("custom_response_body"); ok && v.(*schema.Set).Len() > 0 {

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5701,3 +5701,75 @@ resource "aws_wafv2_rule_group" "test" {
 }
 `, rName)
 }
+func TestAccWAFV2RuleGroup_ruleJSON(t *testing.T) {
+	ctx := acctest.Context(t)
+	var v awstypes.RuleGroup
+	ruleGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_wafv2_rule_group.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t); testAccPreCheckScopeRegional(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.WAFV2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRuleGroupConfig_ruleJSON(ruleGroupName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRuleGroupExists(ctx, resourceName, &v),
+					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
+					resource.TestCheckResourceAttrSet(resourceName, "rule_json"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"rule_json", names.AttrRule},
+				ImportStateIdFunc:       testAccRuleGroupImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccRuleGroupConfig_ruleJSON(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_wafv2_rule_group" "test" {
+  capacity = 100
+  name     = %[1]q
+  scope    = "REGIONAL"
+
+  rule_json = jsonencode([{
+    Name     = "rule-1",
+    Priority = 1,
+    Action = {
+      Count = {}
+    },
+    Statement = {
+      ByteMatchStatement = {
+        SearchString         = "badbot",
+        FieldToMatch = {
+          UriPath = {}
+        },
+        TextTransformations = [{
+          Priority = 1,
+          Type     = "NONE"
+        }],
+        PositionalConstraint = "CONTAINS"
+      }
+    },
+    VisibilityConfig = {
+      CloudwatchMetricsEnabled = false,
+      MetricName               = "friendly-rule-metric-name",
+      SampledRequestsEnabled   = false,
+    },
+  }])
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+`, rName)
+}

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5701,7 +5701,7 @@ resource "aws_wafv2_rule_group" "test" {
 }
 `, rName)
 }
-func TestAccWAFV2RuleGroup_rulesJson(t *testing.T) {
+func TestAccWAFV2RuleGroup_rulesJSON(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.RuleGroup
 	ruleGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -5714,7 +5714,7 @@ func TestAccWAFV2RuleGroup_rulesJson(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleGroupConfig_rulesJson(ruleGroupName),
+				Config: testAccRuleGroupConfig_rulesJSON(ruleGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
@@ -5732,7 +5732,7 @@ func TestAccWAFV2RuleGroup_rulesJson(t *testing.T) {
 	})
 }
 
-func testAccRuleGroupConfig_rulesJson(rName string) string {
+func testAccRuleGroupConfig_rulesJSON(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 100

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5701,7 +5701,7 @@ resource "aws_wafv2_rule_group" "test" {
 }
 `, rName)
 }
-func TestAccWAFV2RuleGroup_ruleJSON(t *testing.T) {
+func TestAccWAFV2RuleGroup_rulesJson(t *testing.T) {
 	ctx := acctest.Context(t)
 	var v awstypes.RuleGroup
 	ruleGroupName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -5714,7 +5714,7 @@ func TestAccWAFV2RuleGroup_ruleJSON(t *testing.T) {
 		CheckDestroy:             testAccCheckRuleGroupDestroy(ctx),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccRuleGroupConfig_ruleJSON(ruleGroupName),
+				Config: testAccRuleGroupConfig_rulesJson(ruleGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
@@ -5732,7 +5732,7 @@ func TestAccWAFV2RuleGroup_ruleJSON(t *testing.T) {
 	})
 }
 
-func testAccRuleGroupConfig_ruleJSON(rName string) string {
+func testAccRuleGroupConfig_rulesJson(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_wafv2_rule_group" "test" {
   capacity = 100

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5718,14 +5718,14 @@ func TestAccWAFV2RuleGroup_ruleJSON(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRuleGroupExists(ctx, resourceName, &v),
 					acctest.MatchResourceAttrRegionalARN(ctx, resourceName, names.AttrARN, "wafv2", regexache.MustCompile(`regional/rulegroup/.+$`)),
-					resource.TestCheckResourceAttrSet(resourceName, "rule_json"),
+					resource.TestCheckResourceAttrSet(resourceName, "rules_json"),
 				),
 			},
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"rule_json", names.AttrRule},
+				ImportStateVerifyIgnore: []string{"rules_json", names.AttrRule},
 				ImportStateIdFunc:       testAccRuleGroupImportStateIdFunc(resourceName),
 			},
 		},
@@ -5739,7 +5739,7 @@ resource "aws_wafv2_rule_group" "test" {
   name     = %[1]q
   scope    = "REGIONAL"
 
-  rule_json = jsonencode([{
+  rules_json = jsonencode([{
     Name     = "rule-1"
     Priority = 1
     Action = {

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5740,29 +5740,29 @@ resource "aws_wafv2_rule_group" "test" {
   scope    = "REGIONAL"
 
   rule_json = jsonencode([{
-    Name     = "rule-1",
-    Priority = 1,
+    Name     = "rule-1"
+    Priority = 1
     Action = {
       Count = {}
-    },
+    }
     Statement = {
       ByteMatchStatement = {
-        SearchString         = "badbot",
+        SearchString         = "badbot"
         FieldToMatch = {
           UriPath = {}
-        },
+        }
         TextTransformations = [{
-          Priority = 1,
+          Priority = 1
           Type     = "NONE"
-        }],
+        }]
         PositionalConstraint = "CONTAINS"
       }
-    },
+    }
     VisibilityConfig = {
-      CloudwatchMetricsEnabled = false,
-      MetricName               = "friendly-rule-metric-name",
-      SampledRequestsEnabled   = false,
-    },
+      CloudwatchMetricsEnabled = false
+      MetricName               = "friendly-rule-metric-name"
+      SampledRequestsEnabled   = false
+    }
   }])
 
   visibility_config {

--- a/internal/service/wafv2/rule_group_test.go
+++ b/internal/service/wafv2/rule_group_test.go
@@ -5747,7 +5747,7 @@ resource "aws_wafv2_rule_group" "test" {
     }
     Statement = {
       ByteMatchStatement = {
-        SearchString         = "badbot"
+        SearchString = "badbot"
         FieldToMatch = {
           UriPath = {}
         }

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -328,7 +328,7 @@ resource "aws_wafv2_rule_group" "example" {
     }
     Statement = {
       ByteMatchStatement = {
-        SearchString         = "badbot"
+        SearchString = "badbot"
         FieldToMatch = {
           UriPath = {}
         }

--- a/website/docs/r/wafv2_rule_group.html.markdown
+++ b/website/docs/r/wafv2_rule_group.html.markdown
@@ -312,6 +312,48 @@ resource "aws_wafv2_rule_group" "example" {
 }
 ```
 
+### Using rule_json
+
+```terraform
+resource "aws_wafv2_rule_group" "example" {
+  name     = "example-rule-group"
+  scope    = "REGIONAL"
+  capacity = 100
+
+  rule_json = jsonencode([{
+    Name     = "rule-1"
+    Priority = 1
+    Action = {
+      Count = {}
+    }
+    Statement = {
+      ByteMatchStatement = {
+        SearchString         = "badbot"
+        FieldToMatch = {
+          UriPath = {}
+        }
+        TextTransformations = [{
+          Priority = 1
+          Type     = "NONE"
+        }]
+        PositionalConstraint = "CONTAINS"
+      }
+    }
+    VisibilityConfig = {
+      CloudwatchMetricsEnabled = false
+      MetricName               = "friendly-rule-metric-name"
+      SampledRequestsEnabled   = false
+    }
+  }])
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}
+```
+
 ## Argument Reference
 
 This resource supports the following arguments:
@@ -323,6 +365,7 @@ This resource supports the following arguments:
 * `name` - (Required, Forces new resource) A friendly name of the rule group.
 * `name_prefix` - (Optional) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `rule` - (Optional) The rule blocks used to identify the web requests that you want to `allow`, `block`, or `count`. See [Rules](#rules) below for details.
+* `rule_json` - (Optional) Raw JSON string to allow more than three nested statements. Conflicts with `rule` attribute. This is for advanced use cases where more than 3 levels of nested statements are required. **There is no drift detection at this time**. If you use this attribute instead of `rule`, you will be foregoing drift detection. Additionally, importing an existing rule group into a configuration with `rule_json` set will result in a one time in-place update as the remote rule configuration is initially written to the `rule` attribute. See the AWS [documentation](https://docs.aws.amazon.com/waf/latest/APIReference/API_CreateRuleGroup.html) for the JSON structure.
 * `scope` - (Required, Forces new resource) Specifies whether this is for an AWS CloudFront distribution or for a regional application. Valid values are `CLOUDFRONT` or `REGIONAL`. To work with CloudFront, you must also specify the region `us-east-1` (N. Virginia) on the AWS provider.
 * `tags` - (Optional) An array of key:value pairs to associate with the resource. If configured with a provider [`default_tags` configuration block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#default_tags-configuration-block) present, tags with matching keys will overwrite those defined at the provider-level.
 * `visibility_config` - (Required) Defines and enables Amazon CloudWatch metrics and web request sample collection. See [Visibility Configuration](#visibility-configuration) below for details.


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Added `rule_json` attribute  to the `aws_wafv2_rule_group` resource.
### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates #38309

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
TF_ACC=1 go1.24.4 test ./internal/service/wafv2/... -v -count 1 -parallel 20 -run='TestAccWAFV2RuleGroup'  -timeout 360m -vet=off
2025/07/15 15:10:10 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/15 15:10:10 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccWAFV2RuleGroupDataSource_basic
=== PAUSE TestAccWAFV2RuleGroupDataSource_basic
=== RUN   TestAccWAFV2RuleGroup_basic
=== PAUSE TestAccWAFV2RuleGroup_basic
=== RUN   TestAccWAFV2RuleGroup_nameGenerated
=== PAUSE TestAccWAFV2RuleGroup_nameGenerated
=== RUN   TestAccWAFV2RuleGroup_namePrefix
=== PAUSE TestAccWAFV2RuleGroup_namePrefix
=== RUN   TestAccWAFV2RuleGroup_updateRule
=== PAUSE TestAccWAFV2RuleGroup_updateRule
=== RUN   TestAccWAFV2RuleGroup_updateRuleProperties
=== PAUSE TestAccWAFV2RuleGroup_updateRuleProperties
=== RUN   TestAccWAFV2RuleGroup_byteMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_byteMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== PAUSE TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
=== RUN   TestAccWAFV2RuleGroup_changeNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeNameForceNew
=== RUN   TestAccWAFV2RuleGroup_changeCapacityForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeCapacityForceNew
=== RUN   TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== PAUSE TestAccWAFV2RuleGroup_changeMetricNameForceNew
=== RUN   TestAccWAFV2RuleGroup_disappears
=== PAUSE TestAccWAFV2RuleGroup_disappears
=== RUN   TestAccWAFV2RuleGroup_RuleLabels
=== PAUSE TestAccWAFV2RuleGroup_RuleLabels
=== RUN   TestAccWAFV2RuleGroup_geoMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_geoMatchStatement
=== RUN   TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== PAUSE TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== RUN   TestAccWAFV2RuleGroup_LabelMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_LabelMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== PAUSE TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== RUN   TestAccWAFV2RuleGroup_logicalRuleStatements
=== PAUSE TestAccWAFV2RuleGroup_logicalRuleStatements
=== RUN   TestAccWAFV2RuleGroup_minimal
=== PAUSE TestAccWAFV2RuleGroup_minimal
=== RUN   TestAccWAFV2RuleGroup_regexMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_regexMatchStatement
=== RUN   TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== PAUSE TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
=== RUN   TestAccWAFV2RuleGroup_ruleAction
=== PAUSE TestAccWAFV2RuleGroup_ruleAction
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
=== RUN   TestAccWAFV2RuleGroup_RuleAction_customResponse
=== PAUSE TestAccWAFV2RuleGroup_RuleAction_customResponse
=== RUN   TestAccWAFV2RuleGroup_sizeConstraintStatement
=== PAUSE TestAccWAFV2RuleGroup_sizeConstraintStatement
=== RUN   TestAccWAFV2RuleGroup_sqliMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_sqliMatchStatement
=== RUN   TestAccWAFV2RuleGroup_tags
=== PAUSE TestAccWAFV2RuleGroup_tags
=== RUN   TestAccWAFV2RuleGroup_xssMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_xssMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement
=== RUN   TestAccWAFV2RuleGroup_RateBased_maxNested
=== PAUSE TestAccWAFV2RuleGroup_RateBased_maxNested
=== RUN   TestAccWAFV2RuleGroup_Operators_maxNested
=== PAUSE TestAccWAFV2RuleGroup_Operators_maxNested
=== RUN   TestAccWAFV2RuleGroup_ASNMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_ASNMatchStatement
=== RUN   TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== PAUSE TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== RUN   TestAccWAFV2RuleGroup_ruleJSON
=== PAUSE TestAccWAFV2RuleGroup_ruleJSON
=== CONT  TestAccWAFV2RuleGroupDataSource_basic
=== CONT  TestAccWAFV2RuleGroup_logicalRuleStatements
=== CONT  TestAccWAFV2RuleGroup_changeCapacityForceNew
=== CONT  TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP
=== CONT  TestAccWAFV2RuleGroup_geoMatchStatement
=== CONT  TestAccWAFV2RuleGroup_ruleJSON
=== CONT  TestAccWAFV2RuleGroup_RuleLabels
=== CONT  TestAccWAFV2RuleGroup_disappears
=== CONT  TestAccWAFV2RuleGroup_RateBased_maxNested
=== CONT  TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement
=== CONT  TestAccWAFV2RuleGroup_rateBasedStatement
=== CONT  TestAccWAFV2RuleGroup_ipSetReferenceStatement
=== CONT  TestAccWAFV2RuleGroup_LabelMatchStatement
=== CONT  TestAccWAFV2RuleGroup_updateRuleProperties
=== CONT  TestAccWAFV2RuleGroup_namePrefix
=== CONT  TestAccWAFV2RuleGroup_nameGenerated
=== CONT  TestAccWAFV2RuleGroup_ASNMatchStatement
=== CONT  TestAccWAFV2RuleGroup_Operators_maxNested
=== CONT  TestAccWAFV2RuleGroup_xssMatchStatement
--- PASS: TestAccWAFV2RuleGroupDataSource_basic (26.87s)
=== CONT  TestAccWAFV2RuleGroup_sqliMatchStatement
--- PASS: TestAccWAFV2RuleGroup_namePrefix (29.41s)
=== CONT  TestAccWAFV2RuleGroup_sizeConstraintStatement
--- PASS: TestAccWAFV2RuleGroup_ruleJSON (30.54s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customResponse
--- PASS: TestAccWAFV2RuleGroup_RateBased_maxNested (42.88s)
=== CONT  TestAccWAFV2RuleGroup_RuleAction_customRequestHandling
--- PASS: TestAccWAFV2RuleGroup_changeCapacityForceNew (42.92s)
=== CONT  TestAccWAFV2RuleGroup_ruleAction
--- PASS: TestAccWAFV2RuleGroup_ASNMatchStatement (43.16s)
=== CONT  TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement
--- PASS: TestAccWAFV2RuleGroup_geoMatchStatement (48.07s)
=== CONT  TestAccWAFV2RuleGroup_regexMatchStatement
--- PASS: TestAccWAFV2RuleGroup_disappears (56.37s)
=== CONT  TestAccWAFV2RuleGroup_minimal
--- PASS: TestAccWAFV2RuleGroup_RuleLabels (60.43s)
=== CONT  TestAccWAFV2RuleGroup_updateRule
--- PASS: TestAccWAFV2RuleGroup_ipSetReferenceStatement (66.37s)
=== CONT  TestAccWAFV2RuleGroup_changeMetricNameForceNew
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement_ASNMatchStatement (67.94s)
=== CONT  TestAccWAFV2RuleGroup_basic
--- PASS: TestAccWAFV2RuleGroup_LabelMatchStatement (73.66s)
=== CONT  TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch
--- PASS: TestAccWAFV2RuleGroup_regexPatternSetReferenceStatement (44.97s)
=== CONT  TestAccWAFV2RuleGroup_changeNameForceNew
--- PASS: TestAccWAFV2RuleGroup_nameGenerated (89.69s)
=== CONT  TestAccWAFV2RuleGroup_byteMatchStatement
--- PASS: TestAccWAFV2RuleGroup_GeoMatchStatement_forwardedIP (93.43s)
=== CONT  TestAccWAFV2RuleGroup_tags
--- PASS: TestAccWAFV2RuleGroup_minimal (37.24s)
--- PASS: TestAccWAFV2RuleGroup_regexMatchStatement (47.39s)
--- PASS: TestAccWAFV2RuleGroup_Operators_maxNested (96.32s)
--- PASS: TestAccWAFV2RuleGroup_sqliMatchStatement (71.90s)
--- PASS: TestAccWAFV2RuleGroup_updateRuleProperties (100.47s)
--- PASS: TestAccWAFV2RuleGroup_sizeConstraintStatement (74.20s)
--- PASS: TestAccWAFV2RuleGroup_xssMatchStatement (104.92s)
--- PASS: TestAccWAFV2RuleGroup_basic (38.40s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customRequestHandling (74.18s)
--- PASS: TestAccWAFV2RuleGroup_changeMetricNameForceNew (52.73s)
--- PASS: TestAccWAFV2RuleGroup_RuleAction_customResponse (88.83s)
--- PASS: TestAccWAFV2RuleGroup_logicalRuleStatements (122.31s)
--- PASS: TestAccWAFV2RuleGroup_IPSetReferenceStatement_ipsetForwardedIP (124.69s)
--- PASS: TestAccWAFV2RuleGroup_ruleAction (84.05s)
--- PASS: TestAccWAFV2RuleGroup_updateRule (67.42s)
--- PASS: TestAccWAFV2RuleGroup_changeNameForceNew (40.66s)
--- PASS: TestAccWAFV2RuleGroup_byteMatchStatement (44.13s)
--- PASS: TestAccWAFV2RuleGroup_tags (48.69s)
--- PASS: TestAccWAFV2RuleGroup_rateBasedStatement (212.07s)
--- PASS: TestAccWAFV2RuleGroup_ByteMatchStatement_fieldToMatch (170.54s)
PASS
```
