### PR TITLE
[Docs] aws_lambda_function: Add an example for delivering function logs to S3 or Data  Firehose

### DIFF
--- a/website/docs/r/lambda_function.html.markdown
+++ b/website/docs/r/lambda_function.html.markdown
@@ -264,18 +264,18 @@ resource "aws_lambda_function" "example" {
 * An S3 bucket or Data Firehose delivery stream to store the logs.
 * A CloudWatch Log Group with:
 
-  * `log_group_class = "DELIVERY"`
-  * A subscription filter whose `destination_arn` points to the S3 bucket or the Data Firehose delivery stream.
+    * `log_group_class = "DELIVERY"`
+    * A subscription filter whose `destination_arn` points to the S3 bucket or the Data Firehose delivery stream.
 
 * IAM roles:
 
-  * Assumed by the `logs.amazonaws.com` service to deliver logs to the S3 bucket or Data Firehose delivery stream.
-  * Assumed by the `lambda.amazonaws.com` service to send logs to CloudWatch Logs
+    * Assumed by the `logs.amazonaws.com` service to deliver logs to the S3 bucket or Data Firehose delivery stream.
+    * Assumed by the `lambda.amazonaws.com` service to send logs to CloudWatch Logs
 
 * A Lambda function:
 
-  * In the `logging_configuration`, specify the name of the Log Group created above using the `log_group` field
-  * No special configuration is required to use S3 or Firehose as the log destination
+    * In the `logging_configuration`, specify the name of the Log Group created above using the `log_group` field
+    * No special configuration is required to use S3 or Firehose as the log destination
 
 For more details, see [Sending Lambda function logs to Amazon S3](https://docs.aws.amazon.com/lambda/latest/dg/logging-with-s3.html).
 


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
* Added an example for delivering Lambda function logs to an S3 bucket or Data Firehose.

  * Full example: https://github.com/hashicorp/terraform-provider-aws/issues/42573#issuecomment-2888110380

### Relations

Closes #42573
Relates #42658 

### References
https://docs.aws.amazon.com/lambda/latest/dg/logging-with-s3.html
