### PR TITLE
[fix]DataSync Location Object Storage with empty and no agent ARNs

### DIFF
--- a/internal/service/datasync/location_object_storage.go
+++ b/internal/service/datasync/location_object_storage.go
@@ -49,7 +49,7 @@ func resourceLocationObjectStorage() *schema.Resource {
 			},
 			"agent_arns": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: verify.ValidARN,
@@ -114,11 +114,14 @@ func resourceLocationObjectStorageCreate(ctx context.Context, d *schema.Resource
 	conn := meta.(*conns.AWSClient).DataSyncClient(ctx)
 
 	input := &datasync.CreateLocationObjectStorageInput{
-		AgentArns:      flex.ExpandStringValueSet(d.Get("agent_arns").(*schema.Set)),
 		BucketName:     aws.String(d.Get(names.AttrBucketName).(string)),
 		ServerHostname: aws.String(d.Get("server_hostname").(string)),
 		Subdirectory:   aws.String(d.Get("subdirectory").(string)),
 		Tags:           getTagsIn(ctx),
+	}
+
+	if v, ok := d.GetOk("agent_arns"); ok {
+		input.AgentArns = flex.ExpandStringValueSet(v.(*schema.Set))
 	}
 
 	if v, ok := d.GetOk(names.AttrAccessKey); ok {
@@ -202,7 +205,9 @@ func resourceLocationObjectStorageUpdate(ctx context.Context, d *schema.Resource
 		}
 
 		if d.HasChange("agent_arns") {
-			input.AgentArns = flex.ExpandStringValueSet(d.Get("agent_arns").(*schema.Set))
+			if v, ok := d.GetOk("agent_arns"); ok {
+				input.AgentArns = flex.ExpandStringValueSet(v.(*schema.Set))
+			}
 
 			// Access key must be specified when updating agent ARNs
 			input.AccessKey = aws.String("")


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

Make `agent_arns` field optional in `aws_datasync_location_object_storage` resource.

Currently, the `agent_arns` field is marked as required in Terraform, which prevents users from creating DataSync Object Storage locations without specifying agent ARNs. However, the AWS Console allows creating these locations without agents, and when importing such console-created resources into Terraform, the `agent_arns` field appears as an empty array `[]`.

This change allows users to create DataSync Object Storage locations without specifying agent ARNs, which is useful for scenarios where agents are not required or will be configured separately. This aligns the Terraform resource behavior with the AWS Console and API capabilities.

**Changes made:**
- Changed `agent_arns` field from `Required: true` to `Optional: true`
- Added conditional logic to set `AgentArns` only when the field is specified
- Updated both `Create` and `Update` operations to handle empty `agent_arns`
- Added comprehensive test coverage for both empty array and omitted field scenarios

<!---
Please provide a helpful description of what change this pull request will introduce.
--->


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->

### Output from Acceptance Testing

```console
% TF_ACC=1 go test -v -timeout=60m -run "TestAccDataSyncLocationObjectStorage_emptyAgentArns" ./internal/service/datasync/

=== RUN   TestAccDataSyncLocationObjectStorage_emptyAgentArns
=== PAUSE TestAccDataSyncLocationObjectStorage_emptyAgentArns
=== CONT  TestAccDataSyncLocationObjectStorage_emptyAgentArns
--- PASS: TestAccDataSyncLocationObjectStorage_emptyAgentArns (11.74s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   21.194s
```

```console
% TF_ACC=1 go test -v -timeout=60m -run "TestAccDataSyncLocationObjectStorage_noAgentArns" ./internal/service/datasync/

=== RUN   TestAccDataSyncLocationObjectStorage_noAgentArns
=== PAUSE TestAccDataSyncLocationObjectStorage_noAgentArns
=== CONT  TestAccDataSyncLocationObjectStorage_noAgentArns
--- PASS: TestAccDataSyncLocationObjectStorage_noAgentArns (9.99s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/datasync   19.420s
```

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
