### PR TITLE
resource/aws_ec2_transit_gateway_route_table_propagation: Fix deleting and recreating resource when dependencies changes don't require the resource be recreated.

### DIFF
--- a/.changelog/43405.txt
+++ b/.changelog/43405.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+resource/aws_ec2_transit_gateway_route_table_propagation: Fix deleting and recreating resource when dependencies changes don't require the resource be recreated.
+```

--- a/.changelog/43405.txt
+++ b/.changelog/43405.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-resource/aws_ec2_transit_gateway_route_table_propagation: Fix deleting and recreating resource when dependencies changes don't require the resource be recreated.
+resource/aws_ec2_transit_gateway_route_table_propagation: Don't mark `transit_gateway_attachment_id` as [ForceNew](https://developer.hashicorp.com/terraform/plugin/sdkv2/schemas/schema-behaviors#forcenew) if the value is known not to change
 ```

--- a/internal/service/ec2/transitgateway_route_table_propagation.go
+++ b/internal/service/ec2/transitgateway_route_table_propagation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/hashicorp/aws-sdk-go-base/v2/tfawserr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -44,7 +45,6 @@ func resourceTransitGatewayRouteTablePropagation() *schema.Resource {
 			names.AttrTransitGatewayAttachmentID: {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
 			"transit_gateway_route_table_id": {
@@ -54,6 +54,42 @@ func resourceTransitGatewayRouteTablePropagation() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, d *schema.ResourceDiff, meta any) error {
+				if !d.HasChange(names.AttrTransitGatewayAttachmentID) {
+					return nil
+				}
+
+				// See https://github.com/hashicorp/terraform-provider-aws/issues/30085
+				// In all cases, changes should force new except:
+				//   o is not empty string AND
+				//   n is empty string AND
+				//   plan is unknown AND
+				//   state is known
+				o, n := d.GetChange(names.AttrTransitGatewayAttachmentID)
+				if o.(string) == "" || n.(string) != "" {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				rawPlan := d.GetRawPlan()
+				plan := rawPlan.GetAttr(names.AttrTransitGatewayAttachmentID)
+				if plan.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				rawState := d.GetRawState()
+				if rawState.IsNull() || !rawState.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				state := rawState.GetAttr(names.AttrTransitGatewayAttachmentID)
+				if !state.IsKnown() {
+					return d.ForceNew(names.AttrTransitGatewayAttachmentID)
+				}
+
+				return nil
+			},
+		),
 	}
 }
 

--- a/internal/service/ec2/transitgateway_route_table_propagation_test.go
+++ b/internal/service/ec2/transitgateway_route_table_propagation_test.go
@@ -6,11 +6,13 @@ package ec2_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	awstypes "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	sdkacctest "github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/hashicorp/terraform-provider-aws/internal/acctest"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
@@ -80,6 +82,50 @@ func testAccTransitGatewayRouteTablePropagation_disappears(t *testing.T, semapho
 					acctest.CheckResourceDisappears(ctx, acctest.Provider, tfec2.ResourceTransitGatewayRouteTablePropagation(), resourceName),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccTransitGatewayRouteTablePropagtion_notRecreatedDXGateway(t *testing.T, semaphore tfsync.Semaphore) {
+	if testing.Short() {
+		t.Skip("skipping long-running test in short mode")
+	}
+
+	ctx := acctest.Context(t)
+	var a awstypes.TransitGatewayRouteTablePropagation
+	resourceName := "aws_ec2_transit_gateway_route_table_propagation.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	rBGPASN := sdkacctest.RandIntRange(4200000000, 4294967294)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckTransitGatewaySynchronize(t, semaphore)
+			acctest.PreCheck(ctx, t)
+			testAccPreCheckTransitGateway(ctx, t)
+		},
+		ErrorCheck:               acctest.ErrorCheck(t, names.EC2ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckTransitGatewayRouteTablePropagationDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTransitGatewayRouteTablePropagationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTablePropagationExists(ctx, resourceName, &a),
+				),
+			},
+			{
+				Config: testAccTransitGatewayRouteTablePropagationConfig_recreationByDXGateway(rName, rBGPASN, []string{"10.255.255.0/30", "10.255.255.8/30"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTransitGatewayRouteTablePropagationExists(ctx, resourceName, &a),
+				),
+				// Calling a NotRecreated function, such as testAccCheckRouteTableAssociationNotRecreated, as is typical,
+				// won't work here because the recreated resource ID will be the same, because it's two IDs pegged together.
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 			},
 		},
 	})
@@ -167,4 +213,52 @@ resource "aws_ec2_transit_gateway_route_table_propagation" "test" {
   transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
 }
 `)
+}
+
+func testAccTransitGatewayRouteTablePropagationConfig_recreationByDXGateway(rName string, rBGPASN int, allowedPrefixes []string) string {
+	return fmt.Sprintf(`
+resource "aws_dx_gateway" "test" {
+  amazon_side_asn = "%[2]d"
+  name            = %[1]q
+}
+
+resource "aws_ec2_transit_gateway" "test" {
+  default_route_table_association = "disable"
+  default_route_table_propagation = "disable"
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_ec2_transit_gateway_route_table" "test" {
+  transit_gateway_id = aws_ec2_transit_gateway.test.id
+
+  tags = {
+    Name = %[1]q
+  }
+}
+
+resource "aws_dx_gateway_association" "test" {
+  dx_gateway_id         = aws_dx_gateway.test.id
+  associated_gateway_id = aws_ec2_transit_gateway.test.id
+
+  allowed_prefixes = ["%[3]s"]
+}
+
+data "aws_ec2_transit_gateway_dx_gateway_attachment" "test" {
+  transit_gateway_id = aws_dx_gateway_association.test.associated_gateway_id
+  dx_gateway_id      = aws_dx_gateway_association.test.dx_gateway_id
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "test" {
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_dx_gateway_attachment.test.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
+}
+
+resource "aws_ec2_transit_gateway_route_table_propagation" "test" {
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_dx_gateway_attachment.test.id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.test.id
+}
+`, rName, rBGPASN, strings.Join(allowedPrefixes, `", "`))
 }

--- a/internal/service/ec2/transitgateway_test.go
+++ b/internal/service/ec2/transitgateway_test.go
@@ -148,8 +148,9 @@ func TestAccTransitGateway_serial(t *testing.T) {
 			"notRecreatedDXGateway":      testAccTransitGatewayRouteTableAssociation_notRecreatedDXGateway,
 		},
 		"RouteTablePropagation": {
-			acctest.CtBasic:      testAccTransitGatewayRouteTablePropagation_basic,
-			acctest.CtDisappears: testAccTransitGatewayRouteTablePropagation_disappears,
+			acctest.CtBasic:         testAccTransitGatewayRouteTablePropagation_basic,
+			acctest.CtDisappears:    testAccTransitGatewayRouteTablePropagation_disappears,
+			"notRecreatedDXGateway": testAccTransitGatewayRouteTablePropagtion_notRecreatedDXGateway,
 		},
 		"VPCAttachment": {
 			acctest.CtBasic:                   testAccTransitGatewayVPCAttachment_basic,


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Apply the same change as done to associations some time back to make sure propagations aren't re-created when not required avoiding outages.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Relates: #41292
Closes #36889

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make t T='TestAccTransitGateway_serial/RouteTablePropagation_' K=ec2
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/ec2/... -v -count 1 -parallel 20 -run='TestAccTransitGateway_serial/RouteTablePropagation_'  -timeout 360m -vet=off
2025/07/16 11:48:48 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/16 11:48:48 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccTransitGateway_serial
=== PAUSE TestAccTransitGateway_serial
=== CONT  TestAccTransitGateway_serial
=== RUN   TestAccTransitGateway_serial/RouteTablePropagation_basic
=== PAUSE TestAccTransitGateway_serial/RouteTablePropagation_basic
=== RUN   TestAccTransitGateway_serial/RouteTablePropagation_disappears
=== PAUSE TestAccTransitGateway_serial/RouteTablePropagation_disappears
=== RUN   TestAccTransitGateway_serial/RouteTablePropagation_notRecreatedDXGateway
=== PAUSE TestAccTransitGateway_serial/RouteTablePropagation_notRecreatedDXGateway
=== RUN   TestAccTransitGateway_serial/DefaultRouteTablePropagation_basic
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTablePropagation_basic
=== RUN   TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappears
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappears
=== RUN   TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappearsTransitGateway
=== PAUSE TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappearsTransitGateway
=== CONT  TestAccTransitGateway_serial/RouteTablePropagation_basic
=== CONT  TestAccTransitGateway_serial/DefaultRouteTablePropagation_basic
=== CONT  TestAccTransitGateway_serial/RouteTablePropagation_notRecreatedDXGateway
=== CONT  TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappearsTransitGateway
=== CONT  TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappears
=== CONT  TestAccTransitGateway_serial/RouteTablePropagation_disappears
--- PASS: TestAccTransitGateway_serial (0.00s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappears (204.16s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTablePropagation_disappearsTransitGateway (232.42s)
    --- PASS: TestAccTransitGateway_serial/RouteTablePropagation_disappears (384.52s)
    --- PASS: TestAccTransitGateway_serial/RouteTablePropagation_basic (407.41s)
    --- PASS: TestAccTransitGateway_serial/DefaultRouteTablePropagation_basic (445.28s)
    --- PASS: TestAccTransitGateway_serial/RouteTablePropagation_notRecreatedDXGateway (1900.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/ec2        1904.614s

```
