### PR TITLE
r/aws_cloudwatch_log_account_policy: add sweeper

### DIFF
--- a/internal/service/logs/sweep.go
+++ b/internal/service/logs/sweep.go
@@ -13,6 +13,7 @@ import (
 	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
+	"github.com/hashicorp/terraform-provider-aws/internal/enum"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/awsv2"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep/framework"
@@ -75,7 +76,7 @@ func sweepAccountPolicies(ctx context.Context, client *conns.AWSClient) ([]sweep
 
 	// Make one Describe call per policy type
 	var inputs []*cloudwatchlogs.DescribeAccountPoliciesInput
-	for _, pt := range awstypes.PolicyType("").Values() {
+	for _, pt := range enum.EnumValues[awstypes.PolicyType]() {
 		inputs = append(inputs, &cloudwatchlogs.DescribeAccountPoliciesInput{
 			PolicyType: pt,
 		})

--- a/internal/service/logs/sweep.go
+++ b/internal/service/logs/sweep.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-provider-aws/internal/conns"
 	"github.com/hashicorp/terraform-provider-aws/internal/sweep"
@@ -19,6 +20,8 @@ import (
 )
 
 func RegisterSweepers() {
+	awsv2.Register("aws_cloudwatch_log_account_policy", sweepAccountPolicies)
+
 	awsv2.Register("aws_cloudwatch_log_anomaly_detector", sweepAnomalyDetectors)
 
 	awsv2.Register("aws_cloudwatch_log_delivery", sweepDeliveries)
@@ -64,6 +67,43 @@ func RegisterSweepers() {
 		Name: "aws_cloudwatch_log_resource_policy",
 		F:    sweepResourcePolicies,
 	})
+}
+
+func sweepAccountPolicies(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {
+	conn := client.LogsClient(ctx)
+	sweepResources := make([]sweep.Sweepable, 0)
+
+	// Make one Describe call per policy type
+	var inputs []*cloudwatchlogs.DescribeAccountPoliciesInput
+	for _, pt := range awstypes.PolicyType("").Values() {
+		inputs = append(inputs, &cloudwatchlogs.DescribeAccountPoliciesInput{
+			PolicyType: pt,
+		})
+	}
+
+	for _, input := range inputs {
+		err := describeAccountPoliciesPages(ctx, conn, input, func(page *cloudwatchlogs.DescribeAccountPoliciesOutput, lastPage bool) bool {
+			if page == nil {
+				return !lastPage
+			}
+
+			for _, v := range page.AccountPolicies {
+				r := resourceAccountPolicy()
+				d := r.Data(nil)
+				d.SetId(aws.ToString(v.PolicyName))
+				d.Set("policy_type", v.PolicyType)
+
+				sweepResources = append(sweepResources, sweep.NewSweepResource(r, d, client))
+			}
+
+			return !lastPage
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sweepResources, nil
 }
 
 func sweepAnomalyDetectors(ctx context.Context, client *conns.AWSClient) ([]sweep.Sweepable, error) {


### PR DESCRIPTION


<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
Adds a sweeper for the `aws_cloudwatch_log_account_policy` resource.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Detected while testing #43332 

### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make sweep SWEEPARGS="-sweep-run=aws_cloudwatch_log_account_policy"
WARNING: This will destroy infrastructure. Use only in development accounts.
go1.24.5 test ./internal/sweep -v -sweep=us-west-2,us-east-1,us-east-2,us-west-1 -sweep-run=aws_cloudwatch_log_account_policy -timeout 360m -vet=off
2025/07/16 09:45:55 [DEBUG] Running Sweepers for region (us-west-2):
2025/07/16 09:45:55 [DEBUG] Running Sweeper (aws_cloudwatch_log_account_policy) in region (us-west-2)
2025/07/16 09:45:55 [DEBUG] sweeper: Configuring Terraform AWS Provider: tf_resource_type=aws_cloudwatch_log_account_policy sweeper_region=us-west-2

<snip>

2025/07/16 09:45:58 Completed Sweepers for region (us-west-1) in 1.1991145s
2025/07/16 09:45:58 Sweeper Tests for region (us-west-1) ran successfully:
2025/07/16 09:45:58     - aws_cloudwatch_log_account_policy
ok      github.com/hashicorp/terraform-provider-aws/internal/sweep      9.150s
```
