### PR TITLE
r/aws_s3_bucket_public_access_block: add `skip_destroy` argument

### DIFF
--- a/.changelog/43415.txt
+++ b/.changelog/43415.txt
@@ -1,0 +1,3 @@
+```release-note:enhancement
+resource/aws_s3_bucket_public_access_block: Add `skip_destroy` argument
+```

--- a/internal/service/s3/bucket_public_access_block.go
+++ b/internal/service/s3/bucket_public_access_block.go
@@ -58,6 +58,10 @@ func resourceBucketPublicAccessBlock() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			names.AttrSkipDestroy: {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -180,6 +184,11 @@ func resourceBucketPublicAccessBlockDelete(ctx context.Context, d *schema.Resour
 	bucket := d.Id()
 	if isDirectoryBucket(bucket) {
 		conn = meta.(*conns.AWSClient).S3ExpressClient(ctx)
+	}
+
+	if v, ok := d.GetOk(names.AttrSkipDestroy); ok && v.(bool) {
+		log.Printf("[DEBUG] Skipping destruction of S3 Bucket Public Access Block: %s", d.Id())
+		return diags
 	}
 
 	log.Printf("[DEBUG] Deleting S3 Bucket Public Access Block: %s", d.Id())

--- a/internal/service/s3/bucket_public_access_block_test.go
+++ b/internal/service/s3/bucket_public_access_block_test.go
@@ -270,6 +270,52 @@ func TestAccS3BucketPublicAccessBlock_restrictPublicBuckets(t *testing.T) {
 	})
 }
 
+// This test can be safely run at all times as the dangling public access
+// block left behind by skipped destruction will ultimately be cleaned up
+// by destruction of the associated bucket.
+func TestAccS3BucketPublicAccessBlock_skipDestroy(t *testing.T) {
+	ctx := acctest.Context(t)
+	var config types.PublicAccessBlockConfiguration
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_s3_bucket_public_access_block.test"
+	bucketResourceName := "aws_s3_bucket.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.S3ServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckBucketPublicAccessBlockDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBucketPublicAccessBlockConfig_skipDestroy(rName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, bucketResourceName),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, names.AttrBucket, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrSkipDestroy, acctest.CtFalse),
+				),
+			},
+			{
+				Config: testAccBucketPublicAccessBlockConfig_skipDestroy(rName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, bucketResourceName),
+					testAccCheckBucketPublicAccessBlockExists(ctx, resourceName, &config),
+					resource.TestCheckResourceAttr(resourceName, names.AttrBucket, rName),
+					resource.TestCheckResourceAttr(resourceName, names.AttrSkipDestroy, acctest.CtTrue),
+				),
+			},
+			// Remove the public access block resource from configuration
+			{
+				Config: testAccBucketPublicAccessBlockConfig_skipDestroy_postRemoval(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists(ctx, bucketResourceName),
+					testAccCheckBucketPublicAccessBlockExistsByName(ctx, rName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccS3BucketPublicAccessBlock_directoryBucket(t *testing.T) {
 	ctx := acctest.Context(t)
 	name := fmt.Sprintf("tf-test-bucket-%d", sdkacctest.RandInt())
@@ -342,6 +388,21 @@ func testAccCheckBucketPublicAccessBlockExists(ctx context.Context, n string, v 
 	}
 }
 
+// testAccCheckProvisionedConcurrencyConfigExistsByName is a helper to verify a
+// public access block is in place for a given bucket.
+//
+// This variant of the test check exists function which accepts bucket name
+// directly to support skip_destroy checks where the public access block
+// resource is removed from state, but should still exist remotely.
+func testAccCheckBucketPublicAccessBlockExistsByName(ctx context.Context, rName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := acctest.Provider.Meta().(*conns.AWSClient).S3Client(ctx)
+
+		_, err := tfs3.FindPublicAccessBlockConfiguration(ctx, conn, rName)
+		return err
+	}
+}
+
 func testAccBucketPublicAccessBlockConfig_basic(bucketName string, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets bool) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "test" {
@@ -357,6 +418,33 @@ resource "aws_s3_bucket_public_access_block" "test" {
   restrict_public_buckets = %[5]t
 }
 `, bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets)
+}
+
+func testAccBucketPublicAccessBlockConfig_skipDestroy(bucketName string, skipDestroy bool) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+
+resource "aws_s3_bucket_public_access_block" "test" {
+  bucket = aws_s3_bucket.test.bucket
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  skip_destroy = %[2]t
+}
+`, bucketName, skipDestroy)
+}
+
+func testAccBucketPublicAccessBlockConfig_skipDestroy_postRemoval(bucketName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "test" {
+  bucket = %[1]q
+}
+`, bucketName)
 }
 
 func testAccBucketPublicAccessBlockConfig_directoryBucket(bucketName, blockPublicAcls, blockPublicPolicy, ignorePublicAcls, restrictPublicBuckets string) string {

--- a/website/docs/r/s3_bucket_public_access_block.html.markdown
+++ b/website/docs/r/s3_bucket_public_access_block.html.markdown
@@ -12,6 +12,8 @@ Manages S3 bucket-level Public Access Block configuration. For more information 
 
 -> This resource cannot be used with S3 directory buckets.
 
+~> Setting `skip_destroy` to `true` means that the AWS Provider will not destroy a public access block, even when running `terraform destroy`. The configuration is thus an intentional dangling resource that is not managed by Terraform and will remain in-place in your AWS account.
+
 ## Example Usage
 
 ```terraform
@@ -36,7 +38,7 @@ This resource supports the following arguments:
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
 * `bucket` - (Required) S3 Bucket to which this Public Access Block configuration should be applied.
 * `block_public_acls` - (Optional) Whether Amazon S3 should block public ACLs for this bucket. Defaults to `false`. Enabling this setting does not affect existing policies or ACLs. When set to `true` causes the following behavior:
-    * PUT Bucket acl and PUT Object acl calls will fail if the specified ACL allows public access.
+    * PUT Bucket ACL and PUT Object ACL calls will fail if the specified ACL allows public access.
     * PUT Object calls will fail if the request includes an object ACL.
 * `block_public_policy` - (Optional) Whether Amazon S3 should block public bucket policies for this bucket. Defaults to `false`. Enabling this setting does not affect the existing bucket policy. When set to `true` causes Amazon S3 to:
     * Reject calls to PUT Bucket policy if the specified bucket policy allows public access.
@@ -44,6 +46,7 @@ This resource supports the following arguments:
     * Ignore public ACLs on this bucket and any objects that it contains.
 * `restrict_public_buckets` - (Optional) Whether Amazon S3 should restrict public bucket policies for this bucket. Defaults to `false`. Enabling this setting does not affect the previously stored bucket policy, except that public and cross-account access within the public bucket policy, including non-public delegation to specific accounts, is blocked. When set to `true`:
     * Only the bucket owner and AWS Services can access this buckets if it has a public policy.
+* `skip_destroy` - (Optional) Whether to retain the public access block upon destruction. If set to `true`, the resource is simply removed from state instead. This may be desirable in certain scenarios to prevent the removal of a public access block before deletion of the associated bucket.
 
 ## Attribute Reference
 


### PR DESCRIPTION

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->
This optional argument will enable use cases where practitioners want to leave a public access block in-place during a `destroy` operation. Setting `skip_destroy` to `true` can replace the manual `terraform state rm` operations many users have reported utilizing in the linked issue related to GuardDuty alerts.

For example:

```hcl
resource "aws_s3_bucket_public_access_block" "test" {
  bucket = aws_s3_bucket.test.bucket

  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true

  skip_destroy = true
}
```


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #12153


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc PKG=s3 TESTS=TestAccS3BucketPublicAccessBlock_
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/s3/... -v -count 1 -parallel 20 -run='TestAccS3BucketPublicAccessBlock_'  -timeout 360m -vet=off
2025/07/16 11:18:28 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/16 11:18:28 Initializing Terraform AWS Provider (SDKv2-style)...

--- PASS: TestAccS3BucketPublicAccessBlock_directoryBucket (11.64s)
--- PASS: TestAccS3BucketPublicAccessBlock_Disappears_bucket (19.07s)
--- PASS: TestAccS3BucketPublicAccessBlock_disappears (21.69s)
--- PASS: TestAccS3BucketPublicAccessBlock_basic (23.84s)
--- PASS: TestAccS3BucketPublicAccessBlock_skipDestroy (41.96s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicACLs (45.22s)
--- PASS: TestAccS3BucketPublicAccessBlock_restrictPublicBuckets (47.00s)
--- PASS: TestAccS3BucketPublicAccessBlock_blockPublicPolicy (47.59s)
--- PASS: TestAccS3BucketPublicAccessBlock_ignorePublicACLs (47.59s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/s3 53.577s
```
