### PR TITLE
Update templates to expand by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/00_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/00_bug_report.yml
@@ -98,7 +98,7 @@ body:
 
         For convenience, we pre-populate this section such that configurations pasted between the backticks (\```) will be contained within a disclosure triangle and have syntax highlighting as appropriate for HCL in the resulting issue. Where appropriate, feel free to delete this.
       value: |
-        <details>
+        <details open>
         <summary>Click to expand configuration</summary>
 
         ```hcl
@@ -130,7 +130,7 @@ body:
 
         For convenience, we pre-populate this section such that logs pasted between the backticks (\```) will be contained within a disclosure triangle and have syntax highlighting associated with console output in the resulting issue.
       value: |
-        <details>
+        <details open>
         <summary>Click to expand log output</summary>
 
         ```console

--- a/.github/ISSUE_TEMPLATE/05_beta_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/05_beta_feedback.yml
@@ -104,7 +104,7 @@ body:
 
         When providing more general feedback, where this section may not be relevent, feel free to clear out the pre-populated text and enter "n/a" to satisfy this being a required field.
       value: |
-        <details>
+        <details open>
         <summary>Click to expand configuration</summary>
 
         ```hcl
@@ -138,7 +138,7 @@ body:
 
         When providing more general feedback, where this section may not be relevent, feel free to clear out the pre-populated text and enter "n/a" to satisfy this being a required field.
       value: |
-        <details>
+        <details open>
         <summary>Click to expand log output</summary>
 
         ```console


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

None

### Description

Updates the bug report and beta feedback issue templates to expand the `<details>` sections by default

### References

[GitHub: Organizing information with collapsed sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections#creating-a-collapsed-section)


### Output from Acceptance Testing

N/a, templates
