### PR TITLE
docs: add missing code block identifiers for aws_ssm_association resource documentation

### DIFF
--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -182,7 +182,7 @@ resource "aws_ssm_association" "database_association" {
 # EC2 Instance 1 - Web Server with "ServerType" tag
 resource "aws_instance" "web_server" {
   ami                    = data.aws_ami.amazon_linux.id
-  instance_type          = var.instance_type
+  instance_type          = "t3.micro"
   subnet_id              = data.aws_subnet.default.id
   vpc_security_group_ids = [aws_security_group.ec2_sg.id]
   iam_instance_profile   = aws_iam_instance_profile.ec2_ssm_profile.name
@@ -214,7 +214,7 @@ resource "aws_instance" "web_server" {
 # EC2 Instance 2 - Database Server with "Role" tag
 resource "aws_instance" "database_server" {
   ami                    = data.aws_ami.amazon_linux.id
-  instance_type          = var.instance_type
+  instance_type          = "t3.micro"
   subnet_id              = data.aws_subnet.default.id
   vpc_security_group_ids = [aws_security_group.ec2_sg.id]
   iam_instance_profile   = aws_iam_instance_profile.ec2_ssm_profile.name

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -170,7 +170,7 @@ resource "aws_ssm_association" "database_association" {
   name = aws_ssm_document.system_update.name # Use the name of the document as the association name
   targets {
     key    = "tag:Role"
-    values = ["WebServer","Database"]
+    values = ["WebServer", "Database"]
   }
 
   parameters = {

--- a/website/docs/r/ssm_association.html.markdown
+++ b/website/docs/r/ssm_association.html.markdown
@@ -81,7 +81,7 @@ resource "aws_ssm_association" "example" {
 
 ### Create an association with multiple instances with their instance ids
 
-```
+```terraform
 # Removed EC2 provisioning dependencies for brevity
 
 resource "aws_ssm_association" "system_update" {
@@ -164,7 +164,7 @@ resource "aws_instance" "web_server_2" {
 
 ### Create an association with multiple instances with their values matching their tags
 
-```
+```terraform
 # SSM Association for Webbased Servers
 resource "aws_ssm_association" "database_association" {
   name = aws_ssm_document.system_update.name # Use the name of the document as the association name


### PR DESCRIPTION
## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls are applied

### Description

The code blocks for the examples 
- [Create an association with multiple instances with their instance ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association#create-an-association-with-multiple-instances-with-their-instance-ids) and 
- [Create an association with multiple instances with their values matching their tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association#create-an-association-with-multiple-instances-with-their-values-matching-their-tags) 

are missing the language identifier `terraform`. Hence the HTML rendering is not as expected.


This PR ass the required identifiers.

### Relations

none

### References

- [Entry point to resource documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_association)


### Output from Acceptance Testing

Not applicable. Only documentation is updated.