### PR TITLE
[Docs (small fix)] aws_cloudfront_distribution: Add the tag "LogDeliveryEnabled" to the example of Firehose logging

### DIFF
--- a/website/docs/r/cloudfront_distribution.html.markdown
+++ b/website/docs/r/cloudfront_distribution.html.markdown
@@ -294,6 +294,12 @@ resource "aws_cloudfront_distribution" "example" {
 
 resource "aws_kinesis_firehose_delivery_stream" "cloudfront_logs" {
   region = "us-east-1"
+  # The tag named "LogDeliveryEnabled" must be set to "true" to allow the service-linked role "AWSServiceRoleForLogDelivery"
+  # to perform permitted actions on your behalf.
+  # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-logs-infrastructure-Firehose
+  tags = {
+    LogDeliveryEnabled = "true"
+  }
 
   # other config
 }


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* When the example for Firehose logging of CloudFront Distribution was added in the PR #43398, the configuration of `aws_kinesis_firehose_delivery_stream` was omitted.
* In fact, the tag `LogDeliveryEnabled = "true"` must be set for the delivery stream to allow the service-linked role `AWSServiceRoleForLogDelivery`, which is used by `delivery.logs.amazonaws.com` to deliver logs to Firehose, to perform permitted actions.
* Since this requirement is not obvious, I have added the tag to the example configuration.

### Relations

Relates #43398

### References
https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-logs-infrastructure-Firehose

