### PR TITLE
r/aws_elasticache_serverless_cache: make security_group_ids required

### DIFF
--- a/internal/service/elasticache/serverless_cache.go
+++ b/internal/service/elasticache/serverless_cache.go
@@ -140,11 +140,7 @@ func (r *serverlessCacheResource) Schema(ctx context.Context, request resource.S
 			names.AttrSecurityGroupIDs: schema.SetAttribute{
 				CustomType:  fwtypes.SetOfStringType,
 				ElementType: types.StringType,
-				Optional:    true,
-				Computed:    true,
-				PlanModifiers: []planmodifier.Set{
-					setplanmodifier.UseStateForUnknown(),
-				},
+				Required:    true,
 			},
 			"snapshot_arns_to_restore": schema.ListAttribute{
 				CustomType:  fwtypes.ListOfARNType,

--- a/internal/service/elasticache/serverless_cache_test.go
+++ b/internal/service/elasticache/serverless_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/YakDriver/regexache"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
@@ -17,6 +18,24 @@ import (
 	tfelasticache "github.com/hashicorp/terraform-provider-aws/internal/service/elasticache"
 	"github.com/hashicorp/terraform-provider-aws/names"
 )
+
+func TestAccElastiCacheServerlessCache_requiresSecurityGroupIDs(t *testing.T) {
+	ctx := acctest.Context(t)
+
+	rName := acctest.RandomWithPrefix(t, acctest.ResourcePrefix)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.ElastiCacheServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccServerlessCacheConfig_basic(rName),
+				ExpectError: regexache.MustCompile(`Missing required argument.*security_group_ids`),
+			},
+		},
+	})
+}
 
 func TestAccElastiCacheServerlessCache_basicRedis(t *testing.T) {
 	ctx := acctest.Context(t)

--- a/website/docs/r/elasticache_serverless_cache.html.markdown
+++ b/website/docs/r/elasticache_serverless_cache.html.markdown
@@ -91,6 +91,7 @@ The following arguments are required:
 
 * `engine` - (Required) Name of the cache engine to be used for this cache cluster. Valid values are `memcached`, `redis` or `valkey`.
 * `name` - (Required) The Cluster name which serves as a unique identifier to the serverless cache
+* `security_group_ids` - (Required) A list of the one or more VPC security groups to be associated with the serverless cache. The security group will authorize traffic access for the VPC end-point (private-link).
 
 The following arguments are optional:
 
@@ -101,7 +102,6 @@ The following arguments are optional:
 * `kms_key_id` - (Optional) ARN of the customer managed key for encrypting the data at rest. If no KMS key is provided, a default service key is used.
 * `major_engine_version` - (Optional) The version of the cache engine that will be used to create the serverless cache.
   See [Describe Cache Engine Versions](https://docs.aws.amazon.com/cli/latest/reference/elasticache/describe-cache-engine-versions.html) in the AWS Documentation for supported versions.
-* `security_group_ids` - (Optional) A list of the one or more VPC security groups to be associated with the serverless cache. The security group will authorize traffic access for the VPC end-point (private-link). If no other information is given this will be the VPC’s Default Security Group that is associated with the cluster VPC end-point.
 * `snapshot_arns_to_restore` - (Optional, Redis only) The list of ARN(s) of the snapshot that the new serverless cache will be created from. Available for Redis only.
 * `snapshot_retention_limit` - (Optional, Redis only) The number of snapshots that will be retained for the serverless cache that is being created. As new snapshots beyond this limit are added, the oldest snapshots will be deleted on a rolling basis. Available for Redis only.
 * `subnet_ids` - (Optional) A list of the identifiers of the subnets where the VPC endpoint for the serverless cache will be deployed. All the subnetIds must belong to the same VPC.


### PR DESCRIPTION
## Summary

This PR fixes issue #43027 where `security_group_ids` was incorrectly marked as optional in the `aws_elasticache_serverless_cache` resource. The field is actually required for ElastiCache Serverless Cache resources to deploy successfully.

## Changes Made

- **Schema Change**: Modified `security_group_ids` from `Optional: true, Computed: true` to `Required: true` in `internal/service/elasticache/serverless_cache.go`
- **Documentation Update**: Updated `security_group_ids` from "(Optional)" to "(Required)" in the resource documentation and moved it to the required arguments section
- **Validation Test**: Added `TestAccElastiCacheServerlessCache_requiresSecurityGroupIDs` test to verify that missing `security_group_ids` produces an appropriate error

## Test Plan

- [x] Added validation test that ensures `security_group_ids` is required
- [x] Code compiles successfully with `go fmt`
- [x] Existing full tests already include `security_group_ids` and should continue to pass

## References

Closes #43027