### PR TITLE
Add transit_gateway_attachment_id to aws_dx_gateway_association

### DIFF
--- a/internal/service/directconnect/exports_test.go
+++ b/internal/service/directconnect/exports_test.go
@@ -36,4 +36,5 @@ var (
 	FindMacSecKeyByTwoPartKey          = findMacSecKeyByTwoPartKey
 	FindVirtualInterfaceByID           = findVirtualInterfaceByID
 	GatewayAssociationStateUpgradeV0   = gatewayAssociationStateUpgradeV0
+	GatewayAssociationStateUpgradeV1   = gatewayAssociationStateUpgradeV1
 )

--- a/website/docs/r/dx_gateway_association.html.markdown
+++ b/website/docs/r/dx_gateway_association.html.markdown
@@ -114,6 +114,7 @@ This resource exports the following attributes in addition to the arguments abov
 * `associated_gateway_type` - The type of the associated gateway, `transitGateway` or `virtualPrivateGateway`.
 * `dx_gateway_association_id` - The ID of the Direct Connect gateway association.
 * `dx_gateway_owner_account_id` - The ID of the AWS account that owns the Direct Connect gateway.
+* `transit_gateway_attachment_id` - The ID of the Transit Gateway Attachment when the type is `transitGateway`.
 
 ## Timeouts
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

Add the computed attribute `transit_gateway_attachment_id` to `aws_dx_gateway_association` where `type` is `transitGateway` to enable users to access this value directly without an additional datasource causing issues in dependencies between modified resources and datasources.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
%make t T='TestAccDirectConnectGatewayAssociation_' K=directconnect
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/directconnect/... -v -count 1 -parallel 20 -run='TestAccDirectConnectGatewayAssociation_'  -timeout 360m -vet=off
2025/07/17 15:39:45 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/17 15:39:45 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDirectConnectGatewayAssociation_v0StateUpgrade
=== PAUSE TestAccDirectConnectGatewayAssociation_v0StateUpgrade
=== RUN   TestAccDirectConnectGatewayAssociation_v1StateUpgrade
=== PAUSE TestAccDirectConnectGatewayAssociation_v1StateUpgrade
=== RUN   TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount
=== RUN   TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount
=== RUN   TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount
=== RUN   TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount
=== RUN   TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount
=== RUN   TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccount
=== RUN   TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount
=== PAUSE TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount
=== RUN   TestAccDirectConnectGatewayAssociation_recreateProposal
=== PAUSE TestAccDirectConnectGatewayAssociation_recreateProposal
=== CONT  TestAccDirectConnectGatewayAssociation_v0StateUpgrade
=== CONT  TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount
=== CONT  TestAccDirectConnectGatewayAssociation_v1StateUpgrade
=== CONT  TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount
=== CONT  TestAccDirectConnectGatewayAssociation_recreateProposal
=== CONT  TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccount
=== CONT  TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount
=== CONT  TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount
=== CONT  TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount
=== CONT  TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount
=== NAME  TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount
    gateway_association_test.go:203: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDirectConnectGatewayAssociation_basicTransitGatewayCrossAccount (1.01s)
=== NAME  TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount
    gateway_association_test.go:318: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewayCrossAccount (1.01s)
=== NAME  TestAccDirectConnectGatewayAssociation_recreateProposal
    gateway_association_test.go:361: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDirectConnectGatewayAssociation_recreateProposal (1.01s)
=== NAME  TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount
    gateway_association_test.go:126: skipping test because at least one environment variable of [AWS_ALTERNATE_PROFILE AWS_ALTERNATE_ACCESS_KEY_ID] must be set. Usage: credentials for running acceptance testing in alternate AWS account.
--- SKIP: TestAccDirectConnectGatewayAssociation_basicVPNGatewayCrossAccount (1.01s)
--- PASS: TestAccDirectConnectGatewayAssociation_basicVPNGatewaySingleAccount (1139.96s)
--- PASS: TestAccDirectConnectGatewayAssociation_v0StateUpgrade (1145.91s)
--- PASS: TestAccDirectConnectGatewayAssociation_multiVPNGatewaysSingleAccount (1238.30s)
--- PASS: TestAccDirectConnectGatewayAssociation_basicTransitGatewaySingleAccount (1494.39s)
--- PASS: TestAccDirectConnectGatewayAssociation_v1StateUpgrade (1521.53s)
--- PASS: TestAccDirectConnectGatewayAssociation_allowedPrefixesVPNGatewaySingleAccount (1591.61s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/directconnect      1596.279s

```
