### PR TITLE
Add authentication_method and service_access_role_arn to postgres_settings for aws_dms_endpoint

### DIFF
--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -370,6 +370,10 @@ func resourceEndpoint() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+						"authentication_method": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"babelfish_database_name": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -423,6 +427,10 @@ func resourceEndpoint() *schema.Resource {
 							Optional: true,
 						},
 						"plugin_name": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"service_access_role_arn": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -1922,6 +1930,9 @@ func expandPostgreSQLSettings(tfMap map[string]any) *awstypes.PostgreSQLSettings
 	if v, ok := tfMap["after_connect_script"].(string); ok && v != "" {
 		apiObject.AfterConnectScript = aws.String(v)
 	}
+	if v, ok := tfMap["authentication_method"].(string); ok && v != "" {
+		apiObject.AuthenticationMethod = awstypes.PostgreSQLAuthenticationMethod(v)
+	}
 	if v, ok := tfMap["babelfish_database_name"].(string); ok && v != "" {
 		apiObject.BabelfishDatabaseName = aws.String(v)
 	}
@@ -1964,6 +1975,9 @@ func expandPostgreSQLSettings(tfMap map[string]any) *awstypes.PostgreSQLSettings
 	if v, ok := tfMap["plugin_name"].(string); ok && v != "" {
 		apiObject.PluginName = awstypes.PluginNameValue(v)
 	}
+	if v, ok := tfMap["service_access_role_arn"].(string); ok && v != "" {
+		apiObject.ServiceAccessRoleArn = aws.String(v)
+	}
 	if v, ok := tfMap["slot_name"].(string); ok && v != "" {
 		apiObject.SlotName = aws.String(v)
 	}
@@ -1981,6 +1995,7 @@ func flattenPostgreSQLSettings(apiObject *awstypes.PostgreSQLSettings) []map[str
 	if v := apiObject.AfterConnectScript; v != nil {
 		tfMap["after_connect_script"] = aws.ToString(v)
 	}
+	tfMap["authentication_method"] = string(apiObject.AuthenticationMethod)
 	if v := apiObject.BabelfishDatabaseName; v != nil {
 		tfMap["babelfish_database_name"] = aws.ToString(v)
 	}
@@ -2017,6 +2032,9 @@ func flattenPostgreSQLSettings(apiObject *awstypes.PostgreSQLSettings) []map[str
 		tfMap["max_file_size"] = aws.ToInt32(v)
 	}
 	tfMap["plugin_name"] = string(apiObject.PluginName)
+	if v := apiObject.ServiceAccessRoleArn; v != nil {
+		tfMap["service_access_role_arn"] = aws.ToString(v)
+	}
 	if v := apiObject.SlotName; v != nil {
 		tfMap["slot_name"] = aws.ToString(v)
 	}

--- a/internal/service/dms/endpoint_data_source.go
+++ b/internal/service/dms/endpoint_data_source.go
@@ -262,6 +262,10 @@ func dataSourceEndpoint() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"authentication_method": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"babelfish_database_name": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -315,6 +319,10 @@ func dataSourceEndpoint() *schema.Resource {
 							Computed: true,
 						},
 						"plugin_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"service_access_role_arn": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/service/dms/endpoint_test.go
+++ b/internal/service/dms/endpoint_test.go
@@ -1133,6 +1133,7 @@ func TestAccDMSEndpoint_PostgreSQL_settings_source(t *testing.T) {
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.after_connect_script", "SET search_path TO pg_catalog,public;"),
+					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.authentication_method", "iam"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.capture_ddls", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.ddl_artifacts_schema", acctest.CtTrue),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.execute_timeout", "100"),
@@ -1145,6 +1146,7 @@ func TestAccDMSEndpoint_PostgreSQL_settings_source(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.map_long_varchar_as", "wstring"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.max_file_size", "1024"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.plugin_name", "pglogical"),
+					resource.TestCheckResourceAttrSet(resourceName, "postgres_settings.0.service_access_role_arn"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.slot_name", "test"),
 				),
 			},
@@ -1169,6 +1171,7 @@ func TestAccDMSEndpoint_PostgreSQL_settings_target(t *testing.T) {
 					testAccCheckEndpointExists(ctx, resourceName),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.after_connect_script", "SET search_path TO pg_catalog,public;"),
+					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.authentication_method", "password"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.babelfish_database_name", "babelfish"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.database_mode", "babelfish"),
 					resource.TestCheckResourceAttr(resourceName, "postgres_settings.0.execute_timeout", "100"),
@@ -3094,6 +3097,29 @@ resource "aws_dms_endpoint" "test" {
 
 func testAccEndpointConfig_postgreSQLSourceSettings(rName string) string {
 	return fmt.Sprintf(`
+
+data "aws_region" "current" {}
+data "aws_partition" "current" {}
+
+resource "aws_iam_role" "test" {
+  name               = %[1]q
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dms.${data.aws_region.current.region}.${data.aws_partition.current.dns_suffix}"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
 resource "aws_dms_endpoint" "test" {
   endpoint_id                 = %[1]q
   endpoint_type               = "source"
@@ -3108,6 +3134,7 @@ resource "aws_dms_endpoint" "test" {
 
   postgres_settings {
     after_connect_script         = "SET search_path TO pg_catalog,public;"
+    authentication_method        = "iam"
     capture_ddls                 = true
     ddl_artifacts_schema         = true
     execute_timeout              = 100
@@ -3120,6 +3147,7 @@ resource "aws_dms_endpoint" "test" {
     map_long_varchar_as          = "wstring"
     max_file_size                = 1024
     plugin_name                  = "pglogical"
+    service_access_role_arn      = aws_iam_role.test.arn
     slot_name                    = "test"
   }
 }
@@ -3142,6 +3170,7 @@ resource "aws_dms_endpoint" "test" {
 
   postgres_settings {
     after_connect_script    = "SET search_path TO pg_catalog,public;"
+    authentication_method   = "password"
     babelfish_database_name = "babelfish"
     database_mode           = "babelfish"
     execute_timeout         = 100

--- a/website/docs/r/dms_endpoint.html.markdown
+++ b/website/docs/r/dms_endpoint.html.markdown
@@ -138,6 +138,7 @@ The following arguments are optional:
 -> Additional information can be found in the [Using PostgreSQL as a Source for AWS DMS documentation](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html).
 
 * `after_connect_script` - (Optional) For use with change data capture (CDC) only, this attribute has AWS DMS bypass foreign keys and user triggers to reduce the time it takes to bulk load data.
+* `authentication_method` - (Optional) Specifies the authentication method. Valid values: `password`, `iam`.
 * `babelfish_database_name` - (Optional) The Babelfish for Aurora PostgreSQL database name for the endpoint.
 * `capture_ddls` - (Optional) To capture DDL events, AWS DMS creates various artifacts in the PostgreSQL database when the task starts.
 * `database_mode` - (Optional) Specifies the default behavior of the replication's handling of PostgreSQL- compatible endpoints that require some additional configuration, such as Babelfish endpoints.
@@ -152,6 +153,7 @@ The following arguments are optional:
 * `map_long_varchar_as` - Optional When true, DMS migrates LONG values as VARCHAR.
 * `max_file_size` - (Optional) Specifies the maximum size (in KB) of any .csv file used to transfer data to PostgreSQL. Default is `32,768 KB`.
 * `plugin_name` - (Optional) Specifies the plugin to use to create a replication slot. Valid values: `pglogical`, `test_decoding`.
+* `service_access_role_arn` - (Optional) Specifies the IAM role to use to authenticate the connection.
 * `slot_name` - (Optional) Sets the name of a previously created logical replication slot for a CDC load of the PostgreSQL source instance.
 
 ### redis_settings


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds the `authentication_method` and `service_access_role_arn` settings to the `postgres_settings` block for `aws_dms_endpoint`. These are necessary for using IAM authentication with a DMS Endpoint.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #43289

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
% make testacc TESTS=TestAccDMSEndpoint_PostgreSQL_settings PKG=dms

make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/dms/... -v -count 1 -parallel 20 -run='TestAccDMSEndpoint_PostgreSQL_settings'  -timeout 360m -vet=off
2025/07/17 23:15:15 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/17 23:15:15 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccDMSEndpoint_PostgreSQL_settings_source
=== PAUSE TestAccDMSEndpoint_PostgreSQL_settings_source
=== RUN   TestAccDMSEndpoint_PostgreSQL_settings_target
=== PAUSE TestAccDMSEndpoint_PostgreSQL_settings_target
=== CONT  TestAccDMSEndpoint_PostgreSQL_settings_source
=== CONT  TestAccDMSEndpoint_PostgreSQL_settings_target
--- PASS: TestAccDMSEndpoint_PostgreSQL_settings_target (123.34s)
--- PASS: TestAccDMSEndpoint_PostgreSQL_settings_source (123.71s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/dms        128.146s
```
