### PR TITLE
[Enhancement] aws_codebuild_fleet: Support custom instance type in the fleet

### DIFF
--- a/.changelog/43449.txt
+++ b/.changelog/43449.txt
@@ -1,0 +1,7 @@
+```release-note:enhancement
+resource/aws_codebuild_fleet: Add `instance_type` argument in `compute_configuration` block to support custom instance types
+```
+
+```release-note:enhancement
+data-source/aws_codebuild_fleet: Add `instance_type` attribute in `compute_configuration` block
+```

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -58,6 +58,11 @@ func resourceFleet() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
 						"machine_type": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -585,6 +590,10 @@ func expandComputeConfiguration(tfMap map[string]any) *types.ComputeConfiguratio
 		apiObject.MachineType = types.MachineType(v)
 	}
 
+	if v, ok := tfMap["instance_type"].(string); ok && v != "" {
+		apiObject.InstanceType = aws.String(v)
+	}
+
 	if v, ok := tfMap["memory"].(int); ok {
 		apiObject.Memory = aws.Int64(int64(v))
 	}
@@ -672,6 +681,10 @@ func flattenComputeConfiguration(apiObject *types.ComputeConfiguration) map[stri
 
 	if v := apiObject.MachineType; v != "" {
 		tfMap["machine_type"] = v
+	}
+
+	if v := apiObject.InstanceType; v != nil {
+		tfMap["instance_type"] = aws.ToString(v)
 	}
 
 	if v := apiObject.Memory; v != nil {

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -66,6 +66,7 @@ func resourceFleet() *schema.Resource {
 						"machine_type": {
 							Type:             schema.TypeString,
 							Optional:         true,
+							Computed:         true,
 							ValidateDiagFunc: enum.Validate[types.MachineType](),
 						},
 						"memory": {

--- a/internal/service/codebuild/fleet.go
+++ b/internal/service/codebuild/fleet.go
@@ -58,7 +58,7 @@ func resourceFleet() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
-						"instance_type": {
+						names.AttrInstanceType: {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -591,7 +591,7 @@ func expandComputeConfiguration(tfMap map[string]any) *types.ComputeConfiguratio
 		apiObject.MachineType = types.MachineType(v)
 	}
 
-	if v, ok := tfMap["instance_type"].(string); ok && v != "" {
+	if v, ok := tfMap[names.AttrInstanceType].(string); ok && v != "" {
 		apiObject.InstanceType = aws.String(v)
 	}
 
@@ -685,7 +685,7 @@ func flattenComputeConfiguration(apiObject *types.ComputeConfiguration) map[stri
 	}
 
 	if v := apiObject.InstanceType; v != nil {
-		tfMap["instance_type"] = aws.ToString(v)
+		tfMap[names.AttrInstanceType] = aws.ToString(v)
 	}
 
 	if v := apiObject.Memory; v != nil {

--- a/internal/service/codebuild/fleet_data_source.go
+++ b/internal/service/codebuild/fleet_data_source.go
@@ -40,6 +40,10 @@ func dataSourceFleet() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
+						"instance_type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"machine_type": {
 							Type:     schema.TypeString,
 							Computed: true,

--- a/internal/service/codebuild/fleet_data_source.go
+++ b/internal/service/codebuild/fleet_data_source.go
@@ -40,7 +40,7 @@ func dataSourceFleet() *schema.Resource {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
-						"instance_type": {
+						names.AttrInstanceType: {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/internal/service/codebuild/fleet_data_source_test.go
+++ b/internal/service/codebuild/fleet_data_source_test.go
@@ -46,6 +46,37 @@ func TestAccCodeBuildFleetDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccCodeBuildFleetDataSource_customInstanceType(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+	datasourceName := "data.aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetDataSourceConfig_customInstanceType(rName, "t3.medium"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrARN, resourceName, names.AttrARN),
+					resource.TestCheckResourceAttrPair(datasourceName, "base_capacity", resourceName, "base_capacity"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_configuration.0.disk", resourceName, "compute_configuration.0.disk"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_configuration.0.instance_type", resourceName, "compute_configuration.0.instance_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "compute_type", resourceName, "compute_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, "created", resourceName, "created"),
+					resource.TestCheckResourceAttrPair(datasourceName, "environment_type", resourceName, "environment_type"),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrID, resourceName, names.AttrID),
+					resource.TestCheckResourceAttrPair(datasourceName, "last_modified", resourceName, "last_modified"),
+					resource.TestCheckResourceAttrPair(datasourceName, names.AttrName, resourceName, names.AttrName),
+					resource.TestCheckResourceAttrPair(datasourceName, "overflow_behavior", resourceName, "overflow_behavior"),
+				),
+			},
+		},
+	})
+}
+
 func testAccFleetDataSourceConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_fleet" "test" {
@@ -68,4 +99,23 @@ data "aws_codebuild_fleet" "test" {
   name = aws_codebuild_fleet.test.name
 }
 `, rName)
+}
+
+func testAccFleetDataSourceConfig_customInstanceType(rName, instanceType string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "CUSTOM_INSTANCE_TYPE"
+  compute_configuration {
+    instance_type = %[2]q
+  }
+  environment_type  = "LINUX_CONTAINER"
+  name              = %[1]q
+  overflow_behavior = "QUEUE"
+}
+
+data "aws_codebuild_fleet" "test" {
+  name = aws_codebuild_fleet.test.name
+}
+`, rName, instanceType)
 }

--- a/internal/service/codebuild/fleet_data_source_test.go
+++ b/internal/service/codebuild/fleet_data_source_test.go
@@ -104,8 +104,8 @@ data "aws_codebuild_fleet" "test" {
 func testAccFleetDataSourceConfig_customInstanceType(rName, instanceType string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_fleet" "test" {
-  base_capacity     = 1
-  compute_type      = "CUSTOM_INSTANCE_TYPE"
+  base_capacity = 1
+  compute_type  = "CUSTOM_INSTANCE_TYPE"
   compute_configuration {
     instance_type = %[2]q
   }

--- a/internal/service/codebuild/fleet_test.go
+++ b/internal/service/codebuild/fleet_test.go
@@ -720,8 +720,8 @@ resource "aws_codebuild_fleet" "test" {
 func testAccFleetConfig_customInstanceType(rName, instanceType string) string {
 	return fmt.Sprintf(`
 resource "aws_codebuild_fleet" "test" {
-  base_capacity     = 1
-  compute_type      = "CUSTOM_INSTANCE_TYPE"
+  base_capacity = 1
+  compute_type  = "CUSTOM_INSTANCE_TYPE"
   compute_configuration {
     instance_type = %[2]q
   }

--- a/internal/service/codebuild/fleet_test.go
+++ b/internal/service/codebuild/fleet_test.go
@@ -359,6 +359,53 @@ func TestAccCodeBuildFleet_vpcConfig(t *testing.T) {
 	})
 }
 
+func TestAccCodeBuildFleet_customInstanceType(t *testing.T) {
+	ctx := acctest.Context(t)
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+	resourceName := "aws_codebuild_fleet.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(ctx, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, names.CodeBuildServiceID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckFleetDestroy(ctx),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFleetConfig_customInstanceType(rName, "t3.medium"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_configuration.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_configuration.0.disk", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_configuration.0.instance_type", "t3.medium"),
+					resource.TestCheckResourceAttr(resourceName, "compute_configuration.0.machine_type", "GENERAL"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "CUSTOM_INSTANCE_TYPE"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "QUEUE"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccFleetConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFleetExists(ctx, resourceName),
+					resource.TestCheckResourceAttr(resourceName, "base_capacity", "1"),
+					resource.TestCheckResourceAttr(resourceName, "compute_configuration.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "compute_type", "BUILD_GENERAL1_SMALL"),
+					resource.TestCheckResourceAttr(resourceName, "environment_type", "LINUX_CONTAINER"),
+					resource.TestCheckResourceAttr(resourceName, names.AttrName, rName),
+					resource.TestCheckResourceAttr(resourceName, "overflow_behavior", "ON_DEMAND"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFleetDestroy(ctx context.Context) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := acctest.Provider.Meta().(*conns.AWSClient).CodeBuildClient(ctx)
@@ -668,4 +715,19 @@ resource "aws_codebuild_fleet" "test" {
   }
 }
 `, rName, tagKey1, tagValue1, tagKey2, tagValue2)
+}
+
+func testAccFleetConfig_customInstanceType(rName, instanceType string) string {
+	return fmt.Sprintf(`
+resource "aws_codebuild_fleet" "test" {
+  base_capacity     = 1
+  compute_type      = "CUSTOM_INSTANCE_TYPE"
+  compute_configuration {
+    instance_type = %[2]q
+  }
+  environment_type  = "LINUX_CONTAINER"
+  name              = %[1]q
+  overflow_behavior = "QUEUE"
+}
+`, rName, instanceType)
 }

--- a/website/docs/d/codebuild_fleet.html.markdown
+++ b/website/docs/d/codebuild_fleet.html.markdown
@@ -59,6 +59,7 @@ This data source exports the following attributes in addition to the arguments a
 * `base_capacity` - Number of machines allocated to the ﬂeet.
 * `compute_configuration` - Compute configuration of the compute fleet.
     * `disk` - Amount of disk space of the instance type included in the fleet.
+    * `instance_type` - EC2 instance type in the fleet.
     * `machine_type` - Machine type of the instance type included in the fleet.
     * `memory` - Amount of memory of the instance type included in the fleet.
     * `vcpu` - Number of vCPUs of the instance type included in the fleet.

--- a/website/docs/r/codebuild_fleet.html.markdown
+++ b/website/docs/r/codebuild_fleet.html.markdown
@@ -52,7 +52,7 @@ The following arguments are required:
 The following arguments are optional:
 
 * `region` - (Optional) Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-* `compute_configuration` - (Optional) The compute configuration of the compute fleet. This is only required if `compute_type` is set to `ATTRIBUTE_BASED_COMPUTE`. See [`compute_configuration`](#compute_configuration) below.
+* `compute_configuration` - (Optional) The compute configuration of the compute fleet. This is only required if `compute_type` is set to `ATTRIBUTE_BASED_COMPUTE` or `CUSTOM_INSTANCE_TYPE`. See [`compute_configuration`](#compute_configuration) below.
 * `fleet_service_role` - (Optional) The service role associated with the compute fleet.
 * `image_id` - (Optional) The Amazon Machine Image (AMI) of the compute fleet.
 * `overflow_behavior` - (Optional) Overflow behavior for compute fleet. Valid values: `ON_DEMAND`, `QUEUE`.
@@ -63,9 +63,10 @@ The following arguments are optional:
 ### compute_configuration
 
 * `disk` - (Optional) Amount of disk space of the instance type included in the fleet.
-* `machine_type` - (Optional) Machine type of the instance type included in the fleet. Valid values: `GENERAL`, `NVME`.
-* `memory` - (Optional) Amount of memory of the instance type included in the fleet.
-* `vcpu` - (Optional) Number of vCPUs of the instance type included in the fleet.
+* `instance_type` - (Optional) EC2 instance type to be launched in the fleet. Specify only if `compute_type` is set to `CUSTOM_INSTANCE_TYPE`. See [Supported instance families](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-compute-types.html#environment-reserved-capacity.instance-types).
+* `machine_type` - (Optional) Machine type of the instance type included in the fleet. Valid values: `GENERAL`, `NVME`. Specify only if `compute_type` is set to `ATTRIBUTE_BASED_COMPUTE`.
+* `memory` - (Optional) Amount of memory of the instance type included in the fleet. Specify only if `compute_type` is set to `ATTRIBUTE_BASED_COMPUTE`.
+* `vcpu` - (Optional) Number of vCPUs of the instance type included in the fleet. Specify only if `compute_type` is set to `ATTRIBUTE_BASED_COMPUTE`.
 
 ### scaling_configuration
 


### PR DESCRIPTION
<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

### Description

* Added the `instance_type` argument to the `compute_configuration` block of the `aws_codebuild_fleet` resource, as well as to the `aws_codebuild_fleet` data source, to support custom instance types in fleets.

### Relations

Closes #43384 

### References
https://docs.aws.amazon.com/codebuild/latest/APIReference/API_CreateFleet.html

### Output from Acceptance Testing
```console
$ make testacc TESTS=TestAccCodeBuildFleet_ PKG=codebuild               
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildFleet_'  -timeout 360m -vet=off
2025/07/19 00:30:39 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/19 00:30:39 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildFleet_Identity_Basic
=== PAUSE TestAccCodeBuildFleet_Identity_Basic
=== RUN   TestAccCodeBuildFleet_Identity_RegionOverride
=== PAUSE TestAccCodeBuildFleet_Identity_RegionOverride
=== RUN   TestAccCodeBuildFleet_Identity_ExistingResource
=== PAUSE TestAccCodeBuildFleet_Identity_ExistingResource
=== RUN   TestAccCodeBuildFleet_basic
=== PAUSE TestAccCodeBuildFleet_basic
=== RUN   TestAccCodeBuildFleet_disappears
=== PAUSE TestAccCodeBuildFleet_disappears
=== RUN   TestAccCodeBuildFleet_tags
=== PAUSE TestAccCodeBuildFleet_tags
=== RUN   TestAccCodeBuildFleet_baseCapacity
=== PAUSE TestAccCodeBuildFleet_baseCapacity
=== RUN   TestAccCodeBuildFleet_computeConfiguration
=== PAUSE TestAccCodeBuildFleet_computeConfiguration
=== RUN   TestAccCodeBuildFleet_computeType
=== PAUSE TestAccCodeBuildFleet_computeType
=== RUN   TestAccCodeBuildFleet_environmentType
=== PAUSE TestAccCodeBuildFleet_environmentType
=== RUN   TestAccCodeBuildFleet_imageId
=== PAUSE TestAccCodeBuildFleet_imageId
=== RUN   TestAccCodeBuildFleet_scalingConfiguration
=== PAUSE TestAccCodeBuildFleet_scalingConfiguration
=== RUN   TestAccCodeBuildFleet_vpcConfig
=== PAUSE TestAccCodeBuildFleet_vpcConfig
=== RUN   TestAccCodeBuildFleet_customInstanceType
=== PAUSE TestAccCodeBuildFleet_customInstanceType
=== CONT  TestAccCodeBuildFleet_Identity_Basic
=== CONT  TestAccCodeBuildFleet_computeConfiguration
=== CONT  TestAccCodeBuildFleet_disappears
=== CONT  TestAccCodeBuildFleet_Identity_ExistingResource
=== CONT  TestAccCodeBuildFleet_basic
=== CONT  TestAccCodeBuildFleet_baseCapacity
=== CONT  TestAccCodeBuildFleet_tags
=== CONT  TestAccCodeBuildFleet_Identity_RegionOverride
=== CONT  TestAccCodeBuildFleet_scalingConfiguration
=== CONT  TestAccCodeBuildFleet_customInstanceType
=== CONT  TestAccCodeBuildFleet_vpcConfig
=== CONT  TestAccCodeBuildFleet_environmentType
=== CONT  TestAccCodeBuildFleet_imageId
=== CONT  TestAccCodeBuildFleet_computeType
--- PASS: TestAccCodeBuildFleet_basic (72.85s)
--- PASS: TestAccCodeBuildFleet_imageId (74.17s)
--- PASS: TestAccCodeBuildFleet_Identity_Basic (83.46s)
--- PASS: TestAccCodeBuildFleet_Identity_RegionOverride (93.28s)
--- PASS: TestAccCodeBuildFleet_disappears (93.44s)
--- PASS: TestAccCodeBuildFleet_baseCapacity (99.45s)
--- PASS: TestAccCodeBuildFleet_computeType (99.45s)
--- PASS: TestAccCodeBuildFleet_customInstanceType (99.68s)
--- PASS: TestAccCodeBuildFleet_computeConfiguration (114.58s)
--- PASS: TestAccCodeBuildFleet_environmentType (117.57s)
--- PASS: TestAccCodeBuildFleet_tags (135.14s)
--- PASS: TestAccCodeBuildFleet_vpcConfig (138.59s)
--- PASS: TestAccCodeBuildFleet_scalingConfiguration (141.31s)
--- PASS: TestAccCodeBuildFleet_Identity_ExistingResource (149.62s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  153.771s
```

```console
$ make testacc TESTS=TestAccCodeBuildFleetDataSource_ PKG=codebuild               
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go1.24.5 test ./internal/service/codebuild/... -v -count 1 -parallel 20 -run='TestAccCodeBuildFleetDataSource_'  -timeout 360m -vet=off
2025/07/19 00:36:00 Creating Terraform AWS Provider (SDKv2-style)...
2025/07/19 00:36:00 Initializing Terraform AWS Provider (SDKv2-style)...
=== RUN   TestAccCodeBuildFleetDataSource_basic
=== PAUSE TestAccCodeBuildFleetDataSource_basic
=== RUN   TestAccCodeBuildFleetDataSource_customInstanceType
=== PAUSE TestAccCodeBuildFleetDataSource_customInstanceType
=== CONT  TestAccCodeBuildFleetDataSource_basic
=== CONT  TestAccCodeBuildFleetDataSource_customInstanceType
--- PASS: TestAccCodeBuildFleetDataSource_basic (49.41s)
--- PASS: TestAccCodeBuildFleetDataSource_customInstanceType (49.72s)
PASS
ok      github.com/hashicorp/terraform-provider-aws/internal/service/codebuild  53.347s

```